### PR TITLE
Add Xtralogic RDP Client to the list of known client apps

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/known_client_apps.json
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/known_client_apps.json
@@ -58,5 +58,11 @@
   },
   "gdbjpffhcollcplpbjehfhpfcpdoicob": {
     "name": "smart-ssh"
+  },
+  "njjeilfpkekklihppohcbbanjlcibolf": {
+    "name": "Xtralogic RDP Client (Stable Channel)"
+  },
+  "ekdokegjbgedabpeokeonakhdbagjokj": {
+    "name": "Xtralogic RDP Client (Beta Channel)"
   }
 }


### PR DESCRIPTION
Add Xtralogic RDP Client, stable and beta editions, to the list of known client apps