### PR TITLE
Fix incorrect storage of user selection data

### DIFF
--- a/common/js/src/container-helpers-unittest.js
+++ b/common/js/src/container-helpers-unittest.js
@@ -34,6 +34,17 @@ goog.exportSymbol('testBuildObjectFromMap', function() {
   assertObjectEquals(
       buildObjectFromMap(new Map([['key1', 'value1'], ['key2', 'value2']])),
       {key1: 'value1', key2: 'value2'});
+  // Test cases where keys and/or values are not strings.
+  assertObjectEquals(
+      buildObjectFromMap(new Map([['key', 123]])), {key: 123});
+  assertObjectEquals(
+      buildObjectFromMap(new Map([[123, 'value']])), {123: 'value'});
+  assertObjectEquals(
+      buildObjectFromMap(new Map([['key 1', {'key 2': 'value'}]])),
+      {'key 1': {'key 2': 'value'}});
+  assertThrows(function() {
+    buildObjectFromMap(new Map([[{}, 'value']]));
+  });
 });
 
 });  // goog.scope

--- a/common/js/src/container-helpers-unittest.js
+++ b/common/js/src/container-helpers-unittest.js
@@ -1,0 +1,39 @@
+/** @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.require('GoogleSmartCard.ContainerHelpers');
+goog.require('goog.testing.jsunit');
+
+goog.setTestOnly();
+
+goog.scope(function() {
+
+/** @const */
+var GSC = GoogleSmartCard;
+
+/** @const */
+var buildObjectFromMap = GSC.ContainerHelpers.buildObjectFromMap;
+
+goog.exportSymbol('testBuildObjectFromMap', function() {
+  assertObjectEquals(buildObjectFromMap(new Map), {});
+  assertObjectEquals(
+      buildObjectFromMap(new Map([['key', 'value']])), {key: 'value'});
+  assertObjectEquals(
+      buildObjectFromMap(new Map([['key1', 'value1'], ['key2', 'value2']])),
+      {key1: 'value1', key2: 'value2'});
+});
+
+});  // goog.scope

--- a/common/js/src/container-helpers.js
+++ b/common/js/src/container-helpers.js
@@ -17,8 +17,6 @@
 goog.provide('GoogleSmartCard.ContainerHelpers');
 
 goog.require('GoogleSmartCard.Logging');
-goog.require('goog.array');
-goog.require('goog.object');
 
 goog.scope(function() {
 
@@ -27,17 +25,19 @@ var GSC = GoogleSmartCard;
 
 /**
  * Converts the given Map to an Object.
+ *
+ * The Map must have only string or numeric keys.
  * @param {!Map} map
  * @return {!Object}
  */
 GSC.ContainerHelpers.buildObjectFromMap = function(map) {
-  var keyValuePairArray = Array.from(map.entries());
-  GSC.Logging.check(keyValuePairArray.length == map.size);
-  var flatKeysAndValuesArray = goog.array.flatten(keyValuePairArray);
-  GSC.Logging.check(flatKeysAndValuesArray.length == map.size * 2);
-  var object = goog.object.create(flatKeysAndValuesArray);
-  GSC.Logging.check(goog.object.getCount(object) == map.size);
-  return object;
+  let obj = {};
+  for (let [key, value] of map) {
+    GSC.Logging.check(goog.isString(key) || goog.isNumber(key),
+                      'Invalid type for object key');
+    obj[key] = value;
+  }
+  return obj;
 };
 
 });  // goog.scope

--- a/common/js/src/container-helpers.js
+++ b/common/js/src/container-helpers.js
@@ -1,0 +1,43 @@
+/** @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.provide('GoogleSmartCard.ContainerHelpers');
+
+goog.require('GoogleSmartCard.Logging');
+goog.require('goog.array');
+goog.require('goog.object');
+
+goog.scope(function() {
+
+/** @const */
+var GSC = GoogleSmartCard;
+
+/**
+ * Converts the given Map to an Object.
+ * @param {!Map} map
+ * @return {!Object}
+ */
+GSC.ContainerHelpers.buildObjectFromMap = function(map) {
+  var keyValuePairArray = Array.from(map.entries());
+  GSC.Logging.check(keyValuePairArray.length == map.size);
+  var flatKeysAndValuesArray = goog.array.flatten(keyValuePairArray);
+  GSC.Logging.check(flatKeysAndValuesArray.length == map.size * 2);
+  var object = goog.object.create(flatKeysAndValuesArray);
+  GSC.Logging.check(goog.object.getCount(object) == map.size);
+  return object;
+};
+
+});  // goog.scope

--- a/test-all.sh
+++ b/test-all.sh
@@ -29,7 +29,8 @@ set -eu
 TEST_DIRS="
   common/cpp/build
   common/js/build
-  third_party/libusb/naclport/build"
+  third_party/libusb/naclport/build
+  third_party/pcsc-lite/naclport/server_clients_management/build"
 
 CONFIGS="Release Debug"
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server_clients_management/build/Makefile
@@ -86,3 +86,12 @@ INSTALLING_HEADERS := \
 	$(INSTALLED_HEADERS_DIR_NAME):$(SOURCES_PATH)/google_smart_card_pcsc_lite_server_clients_management:ready_message.h \
 
 $(eval $(call NACL_LIBRARY_HEADERS_INSTALLATION_RULE,$(INSTALLING_HEADERS)))
+
+
+test::
+	+$(MAKE) --directory js_unittests run
+
+tests_clean::
+	+$(MAKE) --directory js_unittests clean
+
+clean: tests_clean

--- a/third_party/pcsc-lite/naclport/server_clients_management/build/js_unittests/Makefile
+++ b/third_party/pcsc-lite/naclport/server_clients_management/build/js_unittests/Makefile
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 
+#
+# This makefile builds and runs JavaScript unit tests for the
+# "server_clients_management" component of the PC/SC-Lite naclport.
+#
+
+
 TARGET := js_pcsc_lite_server_clients_management_unittests
 
 include ../../../../../../common/make/common.mk
@@ -23,6 +29,11 @@ include $(COMMON_DIR_PATH)/js/include.mk
 include ../../include.mk
 
 
+# Compile all JavaScript files rooting in the tested component's directory
+# (including test files), and also compile the common library files (excluding
+# this library's test files).
+#
+# The path constants used below come from the include.mk files.
 JS_COMPILER_INPUT_PATHS := \
 	$(PCSC_LITE_SERVER_CLIENTS_MANAGEMENT_JS_COMPILER_INPUT_DIR_PATHS) \
 	$(JS_COMMON_SOURCES_PATH) \

--- a/third_party/pcsc-lite/naclport/server_clients_management/build/js_unittests/Makefile
+++ b/third_party/pcsc-lite/naclport/server_clients_management/build/js_unittests/Makefile
@@ -1,0 +1,31 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+TARGET := js_pcsc_lite_server_clients_management_unittests
+
+include ../../../../../../common/make/common.mk
+
+include $(COMMON_DIR_PATH)/make/js_building_common.mk
+
+include $(COMMON_DIR_PATH)/js/include.mk
+include ../../include.mk
+
+
+JS_COMPILER_INPUT_PATHS := \
+	$(PCSC_LITE_SERVER_CLIENTS_MANAGEMENT_JS_COMPILER_INPUT_DIR_PATHS) \
+	$(JS_COMMON_SOURCES_PATH) \
+	!$(JS_COMMON_SOURCES_PATH)/**-unittest.js \
+
+$(eval $(call BUILD_JS_UNITTESTS,$(JS_COMPILER_INPUT_PATHS)))

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittests.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittests.js
@@ -1,0 +1,288 @@
+/** @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.require('GoogleSmartCard.ObjectHelpers');
+goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.KnownApp');
+goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.KnownAppsRegistry');
+goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.UserPromptingChecker');
+goog.require('GoogleSmartCard.PopupWindow.Server');
+goog.require('goog.Promise');
+goog.require('goog.json');
+goog.require('goog.testing');
+goog.require('goog.testing.MockControl');
+goog.require('goog.testing.jsunit');
+goog.require('goog.testing.mockmatchers');
+
+goog.setTestOnly();
+
+goog.scope(function() {
+
+/** @const */
+var GSC = GoogleSmartCard;
+
+/** @const */
+var PermissionsChecking =
+    GSC.PcscLiteServerClientsManagement.PermissionsChecking;
+/** @const */
+var KnownApp = PermissionsChecking.KnownApp;
+/** @const */
+var KnownAppsRegistry = PermissionsChecking.KnownAppsRegistry;
+/** @const */
+var UserPromptingChecker = PermissionsChecking.UserPromptingChecker;
+/** @const */
+var ignoreArgument = goog.testing.mockmatchers.ignoreArgument;
+
+/** @const */
+var FAKE_APP_1_ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+/** @const */
+var FAKE_APP_1_NAME = 'App Name 1';
+/** @const */
+var FAKE_APP_1_KNOWN_APP = new KnownApp(FAKE_APP_1_ID, FAKE_APP_1_NAME);
+/** @const */
+var FAKE_APP_2_ID = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+/** @const */
+var STORAGE_KEY = 'pcsc_lite_clients_user_selections';
+
+/**
+ * @enum {number}
+ */
+var MockedDialogBehavior = {
+  NOT_RUN: 0,
+  USER_APPROVES: 1,
+  USER_DENIES: 2,
+  USER_CANCELS: 3,
+};
+
+/**
+ * Sets up a mock instance of KnownAppsRegistry.
+ *
+ * This mock instance is only aware of |FAKE_APP_1_ID|.
+ * @param {!goog.testing.MockControl} mockControl
+ */
+function setUpKnownAppsRegistryMock(mockControl) {
+  var mockInstance = {
+    getById: function(id) {
+      if (id == FAKE_APP_1_ID)
+        return goog.Promise.resolve(FAKE_APP_1_KNOWN_APP);
+      return goog.Promise.reject();
+    }
+  };
+  /** @type {?} */
+  var mockedConstructor = mockControl.createConstructorMock(
+      PermissionsChecking, 'KnownAppsRegistry');
+  mockedConstructor().$returns(mockInstance);
+}
+
+/**
+ * Sets up mocks for get() and set() methods of the chrome.storage.local
+ * Extensions API.
+ * @param {!goog.testing.MockControl} mockControl
+ * @param {!goog.testing.PropertyReplacer} propertyReplacer
+ * @param {!Object} fakeInitialData Fake data to be returned from get().
+ * @param {Object} expectedDataToBeWritten If non-null, then the expected data
+ * to be passed into set(); if null, then set() isn't expected to be called.
+ */
+function setUpChromeStorageMock(
+    mockControl, propertyReplacer, fakeInitialData, expectedDataToBeWritten) {
+  propertyReplacer.set(
+      chrome, 'storage',
+      {local: {
+         get: mockControl.createFunctionMock('chrome.storage.local.get'),
+         set: mockControl.createFunctionMock('chrome.storage.local.set')}});
+
+  /** @type {?} */ chrome.storage.local.get;
+  chrome.storage.local.get(STORAGE_KEY, ignoreArgument).$does(
+      function(key, callback) {
+        callback(fakeInitialData);
+      });
+
+  /** @type {?} */ chrome.storage.local.set;
+  if (!goog.isNull(expectedDataToBeWritten))
+    chrome.storage.local.set(expectedDataToBeWritten);
+}
+
+/**
+ * Sets up mocks for the GSC.PopupWindow.Server.runModalDialog method.
+ * @param {!goog.testing.MockControl} mockControl
+ * @param {!MockedDialogBehavior} mockedBehavior If |NOT_RUN|, then the method
+ * is not expected to be called; otherwise, the called method will return the
+ * corresponding result.
+ */
+function setUpDialogMock(mockControl, mockedBehavior) {
+  /** @type {?} */
+  var mockedFunction = mockControl.createMethodMock(
+      GSC.PopupWindow.Server, 'runModalDialog');
+  var mockAction;
+  switch (mockedBehavior) {
+    case MockedDialogBehavior.NOT_RUN:
+      return;
+    case MockedDialogBehavior.USER_APPROVES:
+      mockAction = function() {
+        return goog.Promise.resolve(true);
+      };
+      break;
+    case MockedDialogBehavior.USER_DENIES:
+      mockAction = function() {
+        return goog.Promise.resolve(false);
+      };
+      break;
+    case MockedDialogBehavior.USER_CANCELS:
+      mockAction = function() {
+        return goog.Promise.reject();
+      };
+      break;
+  }
+  mockedFunction(ignoreArgument, ignoreArgument, ignoreArgument).$does(
+      mockAction);
+}
+
+/**
+ * Returns a negation of the given promise.
+ * @param {!goog.Promise} promise
+ * @return {!goog.Promise.<undefined>} A promise which is rejected when
+ * |promise| gets resolved, and resolved (with no data) when |promise| is
+ * rejected.
+ */
+function negatePromise(promise) {
+  return promise.then(function() {
+    fail('Unexpected successful response');
+  }, function() {
+    // Do not pass on the rejection.
+  });
+}
+
+/**
+ * Wraps the given test function, providing the necessary setup and teardown.
+ * @param {!Object} fakeInitialStorageData Fake data to be returned from
+ * chrome.storage.local.get().
+ * @param {Object} expectedStorageDataToBeWritten If non-null, then the expected
+ * data to be passed into chrome.storage.local.set(); if null, then set() isn't
+ * expected to be called.
+ * @param {!MockedDialogBehavior} mockedDialogBehavior If |NOT_RUN|, then the
+ * GSC.PopupWindow.Server.runModalDialog method is not expected to be called;
+ * otherwise, the called method will return the corresponding result.
+ * @param {function(!UserPromptingChecker):!goog.Promise} testCallback The test
+ * function to be run after the needed setup; must return a promise of the test
+ * result.
+ * @return {function():!goog.Promise} The wrapped test function, which returns a
+ * promise of the test result and the result of teardown.
+ */
+function makeTest(
+    fakeInitialStorageData, expectedStorageDataToBeWritten,
+    mockedDialogBehavior, testCallback) {
+  return function() {
+    var mockControl = new goog.testing.MockControl;
+    var propertyReplacer = new goog.testing.PropertyReplacer;
+
+    function cleanup() {
+      mockControl.$tearDown();
+      mockControl.$resetAll();
+      propertyReplacer.reset();
+    }
+
+    function verifyAndCleanup() {
+      /** @preserveTry */
+      try {
+        mockControl.$verifyAll();
+      } finally {
+        // Cleanup regardless of the mock verification outcome.
+        cleanup();
+      }
+    }
+
+    setUpKnownAppsRegistryMock(mockControl);
+    setUpChromeStorageMock(
+        mockControl, propertyReplacer, fakeInitialStorageData,
+        expectedStorageDataToBeWritten);
+    setUpDialogMock(mockControl, mockedDialogBehavior);
+
+    mockControl.$replayAll();
+
+    /** @preserveTry */
+    try {
+      var testPromise = testCallback(new UserPromptingChecker);
+    } catch (exc) {
+      // Cleanup after the test fatally failed synchronously.
+      cleanup();
+      throw exc;
+    }
+    // Verify mocks and cleanup after the test completes or fails. Note that
+    // it's crucial that the returned promise is a child promise which is tied
+    // with the success of verification and cleanup.
+    return testPromise.then(verifyAndCleanup, verifyAndCleanup);
+  };
+}
+
+goog.exportSymbol(
+    'test_UserPromptingChecker_EmptyStorage_UserApproves', makeTest(
+      {}  /* fakeInitialStorageData */,
+      {[STORAGE_KEY]: {[FAKE_APP_1_ID]: true}}
+          /* expectedStorageDataToBeWritten */,
+      MockedDialogBehavior.USER_APPROVES  /* mockedDialogBehavior */,
+      function(userPromptingChecker) {
+        return userPromptingChecker.check(FAKE_APP_1_ID);
+      }));
+
+goog.exportSymbol(
+    'test_UserPromptingChecker_EmptyStorage_UserDenies', makeTest(
+      {}  /* fakeInitialStorageData */,
+      null  /* expectedStorageDataToBeWritten */,
+      MockedDialogBehavior.USER_DENIES  /* mockedDialogBehavior */,
+      function(userPromptingChecker) {
+        return negatePromise(userPromptingChecker.check(FAKE_APP_1_ID));
+      }));
+
+goog.exportSymbol(
+    'test_UserPromptingChecker_EmptyStorage_UserCancels', makeTest(
+      {}  /* fakeInitialStorageData */,
+      null  /* expectedStorageDataToBeWritten */,
+      MockedDialogBehavior.USER_CANCELS  /* mockedDialogBehavior */,
+      function(userPromptingChecker) {
+        return negatePromise(userPromptingChecker.check(FAKE_APP_1_ID));
+      }));
+
+goog.exportSymbol(
+    'test_UserPromptingChecker_AlreadyInStorage_OneItem', makeTest(
+      {[STORAGE_KEY]: {[FAKE_APP_1_ID]: true}}  /* fakeInitialStorageData */,
+      null  /* expectedStorageDataToBeWritten */,
+      MockedDialogBehavior.NOT_RUN  /* mockedDialogBehavior */,
+      function(userPromptingChecker) {
+        return userPromptingChecker.check(FAKE_APP_1_ID);
+      }));
+
+goog.exportSymbol(
+    'test_UserPromptingChecker_AlreadyInStorage_TwoItems', makeTest(
+      {[STORAGE_KEY]: {[FAKE_APP_1_ID]: true, [FAKE_APP_2_ID]: true}}
+          /* fakeInitialStorageData */,
+      null  /* expectedStorageDataToBeWritten */,
+      MockedDialogBehavior.NOT_RUN  /* mockedDialogBehavior */,
+      function(userPromptingChecker) {
+        return goog.Promise.all([
+            userPromptingChecker.check(FAKE_APP_1_ID),
+            userPromptingChecker.check(FAKE_APP_2_ID)]);
+      }));
+
+goog.exportSymbol(
+    'test_UserPromptingChecker_OtherInStorage_UserApproves', makeTest(
+      {[STORAGE_KEY]: {[FAKE_APP_1_ID]: true}}  /* fakeInitialStorageData */,
+      {[STORAGE_KEY]: {[FAKE_APP_1_ID]: true, [FAKE_APP_2_ID] : true}}
+          /* expectedStorageDataToBeWritten */,
+      MockedDialogBehavior.USER_APPROVES  /* mockedDialogBehavior */,
+      function(userPromptingChecker) {
+        return userPromptingChecker.check(FAKE_APP_2_ID);
+      }));
+
+});  // goog.scope

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittests.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittests.js
@@ -103,13 +103,16 @@ function setUpChromeStorageMock(
          get: mockControl.createFunctionMock('chrome.storage.local.get'),
          set: mockControl.createFunctionMock('chrome.storage.local.set')}});
 
+  // Suppress compiler's signature verifications locally, to be able to use
+  // mock-specific functionality.
   /** @type {?} */ chrome.storage.local.get;
+  /** @type {?} */ chrome.storage.local.set;
+
   chrome.storage.local.get(STORAGE_KEY, ignoreArgument).$does(
       function(key, callback) {
         callback(fakeInitialData);
       });
 
-  /** @type {?} */ chrome.storage.local.set;
   if (!goog.isNull(expectedDataToBeWritten))
     chrome.storage.local.set(expectedDataToBeWritten);
 }
@@ -160,7 +163,7 @@ function negatePromise(promise) {
   return promise.then(function() {
     fail('Unexpected successful response');
   }, function() {
-    // Do not pass on the rejection.
+    // Resolve the resulting promise - by simply returning from this callback.
   });
 }
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
@@ -27,6 +27,7 @@
 
 goog.provide('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.UserPromptingChecker');
 
+goog.require('GoogleSmartCard.ContainerHelpers');
 goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.KnownAppsRegistry');
@@ -293,8 +294,8 @@ UserPromptingChecker.prototype.storeUserSelection_ =
   this.localStoragePromiseResolver_.promise.then(
       function(/** !Map */ storedUserSelections) {
         storedUserSelections.set(clientAppId, userSelection);
-        var dumpedValue = goog.object.create(Array.from(
-            storedUserSelections.entries()));
+        var dumpedValue = GSC.ContainerHelpers.buildObjectFromMap(
+            storedUserSelections);
         this.logger.finer('Storing the following data in the local storage: ' +
                           GSC.DebugDump.dump(dumpedValue));
         chrome.storage.local.set(goog.object.create(


### PR DESCRIPTION
The Connector app was incorrectly serializing the user selection data
when saving it in the local storage, in cases when the stored data
contained more than one item.

Besides corrupting the stored user selections, this bug was leading to
the app crashes and crash-restart loops, as the error was unrecoverable.

This fixes #57.