### PR TITLE
add mosh to the list of known apps

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/known_client_apps.json
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/known_client_apps.json
@@ -64,5 +64,8 @@
   },
   "ekdokegjbgedabpeokeonakhdbagjokj": {
     "name": "Xtralogic RDP Client (Beta Channel)"
+  },
+  "ooiklbnjmhbcgemelgfhaeaocllobloj": {
+    "name": "Mosh"
   }
 }


### PR DESCRIPTION
this will address https://github.com/rpwoodbu/mosh-chrome/issues/177
and allow users to be able to work with smartcards on mosh also

cc @vapier