### PR TITLE
Make local storage data not crash the app

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittest.js
@@ -288,4 +288,37 @@ goog.exportSymbol(
         return userPromptingChecker.check(FAKE_APP_2_ID);
       }));
 
+// Regression test for issue #57.
+goog.exportSymbol(
+    'test_UserPromptingChecker_CorruptedStorage_NonObject', makeTest(
+      {[STORAGE_KEY]: 'foo'}  /* fakeInitialStorageData */,
+      {[STORAGE_KEY]: {[FAKE_APP_1_ID]: true}}
+          /* expectedStorageDataToBeWritten */,
+      MockedDialogBehavior.USER_APPROVES  /* mockedDialogBehavior */,
+      function(userPromptingChecker) {
+        return userPromptingChecker.check(FAKE_APP_1_ID);
+      }));
+
+// Regression test for issue #57.
+goog.exportSymbol(
+    'test_UserPromptingChecker_CorruptedStorage_BadItem', makeTest(
+      {[STORAGE_KEY]: {[FAKE_APP_1_ID]: 'foo'}}  /* fakeInitialStorageData */,
+      {[STORAGE_KEY]: {[FAKE_APP_1_ID]: true}}
+          /* expectedStorageDataToBeWritten */,
+      MockedDialogBehavior.USER_APPROVES  /* mockedDialogBehavior */,
+      function(userPromptingChecker) {
+        return userPromptingChecker.check(FAKE_APP_1_ID);
+      }));
+
+// Regression test for issue #57.
+goog.exportSymbol(
+    'test_UserPromptingChecker_CorruptedStorage_BadOtherItem', makeTest(
+      {[STORAGE_KEY]: {[FAKE_APP_1_ID]: true, [FAKE_APP_2_ID]: 'foo'}}
+          /* fakeInitialStorageData */,
+      null  /* expectedStorageDataToBeWritten */,
+      MockedDialogBehavior.NOT_RUN  /* mockedDialogBehavior */,
+      function(userPromptingChecker) {
+        return userPromptingChecker.check(FAKE_APP_1_ID);
+      }));
+
 });  // goog.scope


### PR DESCRIPTION
The Connector app shouldn't crash due to invalid data
loaded from the local storage. Errors are logged, but
invalid entries are just ignored.

This fixes #57.