### PR TITLE
Update crxmake.sh to produce CRX3 format

### DIFF
--- a/third_party/crxmake/README.google
+++ b/third_party/crxmake/README.google
@@ -7,3 +7,5 @@ Shell script that builds the extension's CRX package.
 Local Modifications:
 LICENSE file has been created for compliance purposes. Not included in original
 distribution.
+The script was partially rewritten to produce the file in the CRX3 format
+(instead of the deprecated CRX2).

--- a/third_party/crxmake/src/crxmake.sh
+++ b/third_party/crxmake/src/crxmake.sh
@@ -14,29 +14,45 @@ crx="$name.crx"
 pub="$name.pub"
 sig="$name.sig"
 zip="$name.zip"
-trap 'rm -f "$pub" "$sig" "$zip"' EXIT
+id="$name.id"
+payload="$name.payload"
+trap 'rm -f "$pub" "$sig" "$zip" "$id" "$payload"' EXIT
 
 # zip up the crx dir
 cwd=$(pwd -P)
 (cd "$dir" && zip -qr -9 -X "$cwd/$zip" .)
 
+# generate crx id
+openssl rsa -in "$key" -pubout -outform der | \
+  openssl dgst -sha256 -binary -out "$id"
+truncate -s 16 "$id"
+
+# generate payload to be signed
+(
+  printf "CRX3 SignedData"
+  echo "0012 0000 000A 10" | xxd -r -p # "\x00" + signed_header_size + header_of_SignedData_protobuf
+  cat "$id"
+  cat "$zip"
+) > "$payload"
+
 # signature
-openssl sha1 -sha1 -binary -sign "$key" < "$zip" > "$sig"
+openssl dgst -sha256 -binary -sign "$key" < "$payload" > "$sig"
 
 # public key
-openssl rsa -pubout -outform DER < "$key" > "$pub" 2>/dev/null
-
-byte_swap () {
-  # Take "abcdefgh" and return it as "ghefcdab"
-  echo "${1:6:2}${1:4:2}${1:2:2}${1:0:2}"
-}
+openssl rsa -pubout -outform der < "$key" > "$pub" 2>/dev/null
 
 crmagic_hex="4372 3234" # Cr24
-version_hex="0200 0000" # 2
-pub_len_hex=$(byte_swap $(printf '%08x\n' $(ls -l "$pub" | awk '{print $5}')))
-sig_len_hex=$(byte_swap $(printf '%08x\n' $(ls -l "$sig" | awk '{print $5}')))
+version_hex="0300 0000" # 3
+header_1="4502 0000 12AC 040A A602" # header_length + header_of_CrxFileHeader + header_of_AsymmetricKeyProof + header_of_public_key
+header_2="1280 02" # header_of_signature
+header_3="82F1 0412 0A10" # header_of_signed_header_data
 (
-  echo "$crmagic_hex $version_hex $pub_len_hex $sig_len_hex" | xxd -r -p
-  cat "$pub" "$sig" "$zip"
+  echo "$crmagic_hex $version_hex $header_1" | xxd -r -p
+  cat "$pub"
+  echo "$header_2" | xxd -r -p
+  cat "$sig"
+  echo "$header_3" | xxd -r -p
+  cat "$id"
+  cat "$zip"
 ) > "$crx"
 echo "Wrote $crx"


### PR DESCRIPTION
Since M73, Chrome only allows installation of extension packages in the
CRX3 format. The previously used CRX2 format is now deprecated.

This CL changes the crxmake.sh script to produce the .crx file in the
new format. Unfortunately, the original distribution of this shell
script - the developer.chrome.com article - doesn't provide the new
version of the crxmake.sh file, so I had to fix it manually to produce
the file in the new format.