### PR TITLE
Suppress compiler warnings in PC/SC-Lite code

### DIFF
--- a/third_party/pcsc-lite/naclport/server/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server/build/Makefile
@@ -91,10 +91,10 @@ PCSC_LITE_COMMON_CPPFLAGS := \
 
 # Part of the list of the original PC/SC-Lite daemon source files to be
 # compiled (see also PCSC_LITE_SERVER_SVC_SOURCES,
-# PCSC_LITE_SERVER_READERFACTORY_SOURCES variables)
+# PCSC_LITE_SERVER_DEBUGLOG_SOURCES, PCSC_LITE_SERVER_READERFACTORY_SOURCES
+# variables).
 PCSC_LITE_SERVER_SOURCES := \
 	$(PCSC_LITE_SOURCES_PATH)/atrhandler.c \
-	$(PCSC_LITE_SOURCES_PATH)/debuglog.c \
 	$(PCSC_LITE_SOURCES_PATH)/error.c \
 	$(PCSC_LITE_SOURCES_PATH)/eventhandler.c \
 	$(PCSC_LITE_SOURCES_PATH)/hotplug_libusb.c \
@@ -134,12 +134,28 @@ PCSC_LITE_SERVER_SVC_SOURCES := \
 # * close redefinition makes the original PC/SC-Lite code use the function from
 #   the emulated socketpair library (because the emulated socketpair library
 #   generates fake file descriptors, and calling the real close function with
-#   them may cause bad effects)
+#   them may cause bad effects);
+# * no-return-type suppresses spurious compiler errors in cases when it doesn't
+#   recognize calls to library functions that terminate the thread or the
+#   program and bypass returning from a non-void function.
 PCSC_LITE_SERVER_SVC_CPPFLAGS := \
 	$(PCSC_LITE_SERVER_CPPFLAGS) \
 	-Dclose=ServerCloseSession \
+	-Wno-return-type \
 
 $(foreach src,$(PCSC_LITE_SERVER_SVC_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_SVC_CPPFLAGS))))
+
+# Special group just for debuglog.c.
+PCSC_LITE_SERVER_DEBUGLOG_SOURCES := \
+	$(PCSC_LITE_SOURCES_PATH)/debuglog.c \
+
+# * suppress spurious compiler errors due to usage of non-portable in printf
+#   formats.
+PCSC_LITE_SERVER_DEBUGLOG_CPPFLAGS := \
+	$(PCSC_LITE_SERVER_CPPFLAGS) \
+	-Wno-format \
+
+$(foreach src,$(PCSC_LITE_SERVER_DEBUGLOG_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_DEBUGLOG_CPPFLAGS))))
 
 # Special group just for readerfactory.c
 PCSC_LITE_SERVER_READERFACTORY_SOURCES := \
@@ -194,6 +210,7 @@ $(foreach src,$(PCSC_LITE_SERVER_NACL_SOURCES),$(eval $(call COMPILE_RULE,$(src)
 SOURCES := \
 	$(PCSC_LITE_SERVER_SOURCES) \
 	$(PCSC_LITE_SERVER_SVC_SOURCES) \
+	$(PCSC_LITE_SERVER_DEBUGLOG_SOURCES) \
 	$(PCSC_LITE_CLIENT_SOURCES) \
 	$(PCSC_LITE_SERVER_NACL_SOURCES) \
 	$(PCSC_LITE_SERVER_READERFACTORY_SOURCES) \


### PR DESCRIPTION
Compile winscard_svc.c with "-Wno-return-type" and debuglog.c with
"-Wno-format", so that the PC/SC-Lite code is able to build by the
current NaCl toolchain without warnings (any warnings are fatal).

This fixes the recent regression that prevented the code from
being compiled using the current pepper_47 SDK. Apparently, this
old SDK was updated at some point by Chromium authors without
public announcements, and the new toolchain produces compiler
warnings that were not present before.

In particular, this commit fixes the following fatal build errors:

  third_party/pcsc-lite/src/src/winscard_svc.c:809:1: error:
    control reaches end of non-void function
    [-Werror,-Wreturn-type]
  }
  ^

  third_party/pcsc-lite/src/src/debuglog.c:196:32: error:
    format specifies type 'long' but the argument has type
    'pthread_t' (aka 'struct __nc_basic_thread_data *')
    [-Werror,-Wformat]
  time_pfx, delta, time_sfx, thread_id,
                             ^~~~~~~~~