### PR TITLE
Wrap Chrome --pack-extension run into Xvfb

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -257,6 +257,8 @@ Apps:
 
 *   **OpenSSL** (version 1.0+ is recommended).
 
+*   **Xvfb**.
+
 *   (for 64-bit Linux) **32-bit version of libstdc++**.
 
     For example, on Ubuntu it's provided by the libstdc++6:i386 package.

--- a/common/make/app_building_common.mk
+++ b/common/make/app_building_common.mk
@@ -75,7 +75,8 @@ $(TARGET).p8:
 
 $(TARGET).crx: all $(TARGET).p8
 	@rm -f $(TARGET).crx
-	$(CHROME_ENV) $(CHROME_PATH) \
+	xvfb-run \
+		$(CHROME_ENV) $(CHROME_PATH) \
 		--pack-extension="$(abspath $(OUT_DIR_PATH))" \
 		--pack-extension-key="$(TARGET).p8"
 	@mv $(OUT_DIR_PATH).crx $(TARGET).crx


### PR DESCRIPTION
Run the Chrome binary, in case when it's called by the build scripts
just to produce a CRX file and not to draw any UI, via the xvfb-run
binary.

This allows to build the CRX files on systems that don't have an X11
server running (e.g., remote virtual machines).

Without this change, Chrome fails with an error like this without
producing the CRX file:

  Gtk-WARNING **: 12:00:00.000: cannot open display

This change is a follow-up to #69.