### PR TITLE
Fix error in cert provider bridge under Linux

### DIFF
--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
@@ -131,11 +131,12 @@ if (goog.DEBUG) {
 
 /** @override */
 Backend.prototype.disposeInternal = function() {
-  chrome.certificateProvider.onSignDigestRequested.removeListener(
-      this.boundSignDigestRequestListener_);
-
-  chrome.certificateProvider.onCertificatesRequested.removeListener(
-      this.boundCertificatesRequestListener_);
+  if (chrome.certificateProvider) {
+    chrome.certificateProvider.onSignDigestRequested.removeListener(
+        this.boundSignDigestRequestListener_);
+    chrome.certificateProvider.onCertificatesRequested.removeListener(
+        this.boundCertificatesRequestListener_);
+  }
 
   this.requester_.dispose();
   this.requester_ = null;


### PR DESCRIPTION
Fix the TypeError exception during the
CertificateProviderBridge.Backend disposal when the
chrome.certificateProvider API is unavailable (e.g., when the
extension is run on Linux) :

  TypeError: Cannot read property 'onSignDigestRequested' of undefined

This just is a minor cleanup, since normally the Backend instance is
never disposed of - this only happens when another fatal error occurs
(e.g., when the NaCl module crashes). So this fix only avoids
emitting an additional spurious error which could hamper the
investigation of the original root cause.