### PR TITLE
C++ example: More verbose logging of PIN requests

### DIFF
--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
@@ -115,7 +115,7 @@ class ApiBridge final : public google_smart_card::RequestHandler {
   // otherwise it would block receiving of the incoming messages and,
   // consequently, it would lock forever. (Actually, the validity of the current
   // thread is asserted inside.)
-  bool RequestPin(RequestPinOptions options, std::string* pin);
+  bool RequestPin(const RequestPinOptions& options, std::string* pin);
 
   // Stops the PIN request that was previously started by the RequestPin()
   // function.
@@ -124,7 +124,7 @@ class ApiBridge final : public google_smart_card::RequestHandler {
   // otherwise it would block receiving of the incoming messages and,
   // consequently, it would lock forever. (Actually, the validity of the current
   // thread is asserted inside.)
-  void StopPinRequest(StopPinRequestOptions options);
+  void StopPinRequest(const StopPinRequestOptions& options);
 
  private:
   // google_smart_card::RequestHandler:


### PR DESCRIPTION
Log every invocation of requestPin/stopPinRequest functions even
in Release mode, together will their input parameters and whether
the operation succeeds.

This should help in investigating bug reports in the third-party
extensions in the future.

The only piece of information that is intentionally NOT logged is
the actual PIN.