### PR TITLE
Allow logging the PC/SC-Lite API call results

### DIFF
--- a/third_party/pcsc-lite/naclport/cpp_client/src/nacl-client-backend.js
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/nacl-client-backend.js
@@ -310,27 +310,38 @@ NaclClientBackend.prototype.startRequest_ = function(
   var resultPromise = method.apply(
       this.api_, remoteCallMessage.functionArguments);
   resultPromise.then(
-      this.apiMethodResolvedCallback_.bind(this, promiseResolver),
-      this.apiMethodRejectedCallback_.bind(this, promiseResolver));
+      this.apiMethodResolvedCallback_.bind(
+          this, remoteCallMessage, promiseResolver),
+      this.apiMethodRejectedCallback_.bind(
+          this, remoteCallMessage, promiseResolver));
 };
 
 /**
+ * @param {!GSC.RemoteCallMessage} remoteCallMessage
  * @param {!goog.promise.Resolver} promiseResolver
  * @param {!GSC.PcscLiteClient.API.ResultOrErrorCode} apiMethodResult
  * @private
  */
 NaclClientBackend.prototype.apiMethodResolvedCallback_ = function(
-    promiseResolver, apiMethodResult) {
+    remoteCallMessage, promiseResolver, apiMethodResult) {
+  this.logger.fine(
+      'The remote call completed: ' +
+      remoteCallMessage.getDebugRepresentation() + ' with the result: ' +
+      apiMethodResult.getDebugRepresentation());
   promiseResolver.resolve(apiMethodResult.responseItems);
 };
 
 /**
+ * @param {!GSC.RemoteCallMessage} remoteCallMessage
  * @param {!goog.promise.Resolver} promiseResolver
  * @param {*} apiMethodError
  * @private
  */
 NaclClientBackend.prototype.apiMethodRejectedCallback_ = function(
-    promiseResolver, apiMethodError) {
+    remoteCallMessage, promiseResolver, apiMethodError) {
+  this.logger.fine(
+      'The remote call failed: ' + remoteCallMessage.getDebugRepresentation() +
+      ' with the error: ' + apiMethodError);
   promiseResolver.reject(apiMethodError);
 };
 

--- a/third_party/pcsc-lite/naclport/js_client/src/api.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/api.js
@@ -2211,16 +2211,22 @@ goog.exportProperty(
  * structure.
  *
  * This function is safe to be used in Release builds, because all potentially
- * privacy-sensitive data is stripped away from the resulting text.
+ * security/privacy-sensitive data is stripped away from the resulting text.
  *
  * @return {string}
  */
 API.ResultOrErrorCode.prototype.getDebugRepresentation = function() {
   if (this.errorCode == API.SCARD_S_SUCCESS) {
+    // Apply debugDump() to all result values except the error code, since they
+    // can contain sensitive information in them (like the contents of the
+    // digital signature). The debugDump() function dumps the values only when
+    // goog.DEBUG is true, and otherwise shows only the number of values.
     const dumpedItems = this.resultItems && this.resultItems.length ?
         ' ' + GSC.DebugDump.debugDump(this.resultItems) : '';
     return 'SCARD_S_SUCCESS' + dumpedItems;
   }
+  // Dump the error code regardless of whether the mode is Debug or Release,
+  // since there's no sensitive information in it.
   return 'error ' + GSC.DebugDump.dump(this.errorCode);
 };
 

--- a/third_party/pcsc-lite/naclport/js_client/src/api.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/api.js
@@ -48,6 +48,7 @@ goog.provide('GoogleSmartCard.PcscLiteClient.API.SCardSetAttribResult');
 goog.provide('GoogleSmartCard.PcscLiteClient.API.SCardStatusResult');
 goog.provide('GoogleSmartCard.PcscLiteClient.API.SCardTransmitResult');
 
+goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.FixedSizeInteger');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PcscLiteCommon.Constants');
@@ -2204,6 +2205,29 @@ goog.exportProperty(
     API.ResultOrErrorCode.prototype,
     'getResult',
     API.ResultOrErrorCode.prototype.getResult);
+
+/**
+ * Generates a debug textual representation of the remote call message
+ * structure.
+ *
+ * This function is safe to be used in Release builds, because all potentially
+ * privacy-sensitive data is stripped away from the resulting text.
+ *
+ * @return {string}
+ */
+API.ResultOrErrorCode.prototype.getDebugRepresentation = function() {
+  if (this.errorCode == API.SCARD_S_SUCCESS) {
+    const dumpedItems = this.resultItems && this.resultItems.length ?
+        ' ' + GSC.DebugDump.debugDump(this.resultItems) : '';
+    return 'SCARD_S_SUCCESS' + dumpedItems;
+  }
+  return 'error ' + GSC.DebugDump.dump(this.errorCode);
+};
+
+goog.exportProperty(
+    API.ResultOrErrorCode.prototype,
+    'getDebugRepresentation',
+    API.ResultOrErrorCode.prototype.getDebugRepresentation);
 
 
 /**

--- a/third_party/pcsc-lite/naclport/js_client/src/api.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/api.js
@@ -2207,7 +2207,7 @@ goog.exportProperty(
     API.ResultOrErrorCode.prototype.getResult);
 
 /**
- * Generates a debug textual representation of the remote call message
+ * Generates a debug textual representation of the PC/SC-Lite call result
  * structure.
  *
  * This function is safe to be used in Release builds, because all potentially


### PR DESCRIPTION
Add the implementation of logging the results of the PC/SC-Lite API
calls that are made from a NaCl module. This should aid in the
future in the investigation of bugs in third-party middleware
extensions.

The implementation is disabled by default, since even under normal
circumstances a typical smart card middleware makes dozens of
PC/SC-Lite requests per single certificates listing / signature
operation.

This additional logging can be enabled by running these snippets in
the JavaScript console of the extension's background page:

* enabling the logging of return codes:

  $jscomp.scope.pcscLiteNaclClientBackend.logger.setLevel(goog.log.Level.FINE)

* additionally, enabling the dumping of all values and buffers (use
  with care - this may include privacy/security-sensitive data) :

  goog.DEBUG=true