### PR TITLE
C++ example: Reload app on NaCl module crash

### DIFF
--- a/example_cpp_smart_card_client_app/src/background.js
+++ b/example_cpp_smart_card_client_app/src/background.js
@@ -89,6 +89,22 @@ var logger = GSC.Logging.getLogger(
 var naclModule = new GSC.NaclModule(
     'nacl_module.nmf', GSC.NaclModule.Type.PNACL);
 
+// Reload the self app when the NaCl module is disposed of (e.g., due to a
+// crash).
+
+/**
+ * Called when the NaCl module is disposed of.
+ */
+function naclModuleDisposedListener() {
+  if (!goog.DEBUG) {
+    // Trigger the fatal error in the Release mode, which will emit an error
+    // message and trigger the app reload.
+    GSC.Logging.failWithLogger(logger, 'NaCl module was disposed of');
+  }
+}
+
+naclModule.addOnDisposeCallback(naclModuleDisposedListener);
+
 /**
  * Translator of all PC/SC-Lite client API requests received from the NaCl
  * module into the JavaScript PC/SC-Lite client API method calls (see the

--- a/example_cpp_smart_card_client_app/src/background.js
+++ b/example_cpp_smart_card_client_app/src/background.js
@@ -89,20 +89,20 @@ var logger = GSC.Logging.getLogger(
 var naclModule = new GSC.NaclModule(
     'nacl_module.nmf', GSC.NaclModule.Type.PNACL);
 
-// Reload the self app when the NaCl module is disposed of (e.g., due to a
-// crash).
-
 /**
  * Called when the NaCl module is disposed of.
  */
 function naclModuleDisposedListener() {
   if (!goog.DEBUG) {
     // Trigger the fatal error in the Release mode, which will emit an error
-    // message and trigger the app reload.
+    // message and cause the app reload (see the GSC.Logging.fail() function
+    // implementation in //common/js/src/logging/logging.js).
     GSC.Logging.failWithLogger(logger, 'NaCl module was disposed of');
   }
 }
 
+// Reload our app when the NaCl module is disposed of (e.g., due to a crash) and
+// we're in the Release mode.
 naclModule.addOnDisposeCallback(naclModuleDisposedListener);
 
 /**


### PR DESCRIPTION
Add code into the example C++ client app that triggers a self
reload when a fatal error with the NaCl module happens (e.g.,
when it crashes).