### PR TITLE
C++ example: Log versions and time on startup

### DIFF
--- a/example_cpp_smart_card_client_app/src/background.js
+++ b/example_cpp_smart_card_client_app/src/background.js
@@ -83,7 +83,7 @@ var logger = GSC.Logging.getLogger(
     goog.DEBUG ? goog.log.Level.FINE : goog.log.Level.INFO);
 
 logger.info(
-    'The app (id "' + chrome.runtime.id + '", version ' +
+    'The extension (id "' + chrome.runtime.id + '", version ' +
     chrome.runtime.getManifest()['version'] + ') background script started. ' +
     'Browser version: "' + window.navigator.appVersion + '". System time: "' +
     (new Date()).toLocaleString() + '"');

--- a/example_cpp_smart_card_client_app/src/background.js
+++ b/example_cpp_smart_card_client_app/src/background.js
@@ -82,6 +82,12 @@ var logger = GSC.Logging.getLogger(
     'SmartCardClientApp',
     goog.DEBUG ? goog.log.Level.FINE : goog.log.Level.INFO);
 
+logger.info(
+    'The app (id "' + chrome.runtime.id + '", version ' +
+    chrome.runtime.getManifest()['version'] + ') background script started. ' +
+    'Browser version: "' + window.navigator.appVersion + '". System time: "' +
+    (new Date()).toLocaleString() + '"');
+
 /**
  * Holder of the NaCl module containing the actual smart card client code.
  * @const

--- a/example_cpp_smart_card_client_app/src/background.js
+++ b/example_cpp_smart_card_client_app/src/background.js
@@ -82,11 +82,13 @@ var logger = GSC.Logging.getLogger(
     'SmartCardClientApp',
     goog.DEBUG ? goog.log.Level.FINE : goog.log.Level.INFO);
 
+const extensionManifest = chrome.runtime.getManifest();
+const formattedStartupTime = (new Date()).toLocaleString();
 logger.info(
-    'The extension (id "' + chrome.runtime.id + '", version ' +
-    chrome.runtime.getManifest()['version'] + ') background script started. ' +
-    'Browser version: "' + window.navigator.appVersion + '". System time: "' +
-    (new Date()).toLocaleString() + '"');
+    `The extension (id "${chrome.runtime.id}", version ` +
+    `${extensionManifest.version}) background script started. Browser ` +
+    `version: "${window.navigator.appVersion}". System time: ` +
+    `"${formattedStartupTime}"`);
 
 /**
  * Holder of the NaCl module containing the actual smart card client code.

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -40,11 +40,13 @@ var GSC = GoogleSmartCard;
  */
 var logger = GSC.Logging.getScopedLogger('ConnectorApp.BackgroundMain');
 
+const extensionManifest = chrome.runtime.getManifest();
+const formattedStartupTime = (new Date()).toLocaleString();
 logger.info(
-    'The Smart Card Connector app (id "' + chrome.runtime.id + '", version ' +
-    chrome.runtime.getManifest()['version'] + ') background script started. ' +
-    'Browser version: "' + window.navigator.appVersion + '". System time: "' +
-    (new Date()).toLocaleString() + '"');
+    `The Smart Card Connector app (id "${chrome.runtime.id}", version ` +
+    `${extensionManifest.version}) background script started. Browser ` +
+    `version: "${window.navigator.appVersion}". System time: ` +
+    `"${formattedStartupTime}"`);
 
 var naclModule = new GSC.NaclModule(
     'nacl_module.nmf', GSC.NaclModule.Type.PNACL);


### PR DESCRIPTION
Add a bit more logging into the C++ example middleware app, to
make it slightly easier to investigate bug reports from the users
(since many users forget to specify some important information).