### PR TITLE
Remove smart-ssh from the list of known clients

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/known_client_apps.json
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/known_client_apps.json
@@ -56,9 +56,6 @@
   "algkcnfjnajfhgimadimbjhmpaeohhln": {
     "name": "Secure Shell Extension (dev)"
   },
-  "gdbjpffhcollcplpbjehfhpfcpdoicob": {
-    "name": "smart-ssh"
-  },
   "njjeilfpkekklihppohcbbanjlcibolf": {
     "name": "Xtralogic RDP Client (Stable Channel)"
   },


### PR DESCRIPTION
The functionality of smart-ssh has meanwhile been integrated into the Secure Shell app. As a result, smart-ssh is now deprecated and no longer listed on the web store. I think that it is time to remove it from the list.