### PR TITLE
Trusted clients registry unit tests

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry-unittest.js
@@ -21,7 +21,6 @@ goog.require('goog.Promise');
 goog.require('goog.json');
 goog.require('goog.net.HttpStatus');
 goog.require('goog.testing');
-goog.require('goog.testing.PropertyReplacer');
 goog.require('goog.testing.jsunit');
 goog.require('goog.testing.net.XhrIo');
 
@@ -41,19 +40,8 @@ const FAKE_TRUSTED_CLIENTS = {
   [FAKE_APP_1_ORIGIN]: {'name': FAKE_APP_1_NAME},
 };
 
-const propertyReplacer = new goog.testing.PropertyReplacer();
 /** @type {TrustedClientsRegistryImpl?} */
 let registry;
-
-/**
- * Set up the mock for goog.net.XhrIo.
- *
- * This allows mocking out network requests.
- * @param {!goog.testing.PropertyReplacer} propertyReplacer
- */
-function setUpXhrioMock(propertyReplacer) {
-  propertyReplacer.setPath('goog.net.XhrIo.send', goog.testing.net.XhrIo.send);
-}
 
 /**
  * Simulates the response delivery for a previously created mock Xhrio request.
@@ -73,17 +61,15 @@ function simulateXhrioResponse() {
 
 goog.exportSymbol('testTrustedClientsRegistry', {
   'setUp': function() {
-    const propertyReplacer = new goog.testing.PropertyReplacer();
-    setUpXhrioMock(propertyReplacer);
-
+    TrustedClientsRegistryImpl.overrideSendForTesting(
+        goog.testing.net.XhrIo.send);
     registry = new TrustedClientsRegistryImpl();
-
     simulateXhrioResponse();
   },
 
   'tearDown': function() {
     registry = null;
-    propertyReplacer.reset();
+    TrustedClientsRegistryImpl.overrideSendForTesting(null);
   },
 
   'testGetByOrigin_success': async function() {

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry-unittest.js
@@ -1,0 +1,130 @@
+/** @license
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientInfo');
+goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientsRegistryImpl');
+goog.require('goog.Promise');
+goog.require('goog.json');
+goog.require('goog.net.HttpStatus');
+goog.require('goog.testing');
+goog.require('goog.testing.PropertyReplacer');
+goog.require('goog.testing.jsunit');
+goog.require('goog.testing.net.XhrIo');
+
+goog.setTestOnly();
+
+goog.scope(function() {
+
+/** @const */
+var GSC = GoogleSmartCard;
+
+/** @const */
+var TrustedClientsRegistryImpl = GSC.PcscLiteServer.TrustedClientsRegistryImpl;
+
+/** @const */
+var FAKE_APP_1_ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+/** @const */
+var FAKE_APP_1_NAME = 'App Name 1';
+/** @const */
+var FAKE_APP_2_ID = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+/** @const */
+var FAKE_TRUSTED_CLIENTS = {
+  [FAKE_APP_1_ID]: {
+    'name': FAKE_APP_1_NAME
+  }
+};
+
+/**
+ * Set up the mock for goog.net.XhrIo.
+ *
+ * This allows mocking out network requests.
+ * @param {!goog.testing.PropertyReplacer} propertyReplacer
+ */
+function setUpXhrioMock(propertyReplacer) {
+  propertyReplacer.setPath('goog.net.XhrIo.send', goog.testing.net.XhrIo.send);
+}
+
+/**
+ * Simulates the response delivery for a previously created mock Xhrio request.
+ *
+ * The response contains a fake trusted clients JSON.
+ */
+function simulateXhrioResponse() {
+  var sentXhrios = goog.testing.net.XhrIo.getSendInstances();
+  assertEquals(1, sentXhrios.length);
+  var xhrio = sentXhrios[0];
+  assertEquals(xhrio.getLastUri(),
+               'pcsc_lite_server_clients_management/known_client_apps.json');
+  var response = goog.json.serialize(FAKE_TRUSTED_CLIENTS);
+  xhrio.simulateResponse(goog.net.HttpStatus.OK, response);
+}
+
+goog.exportSymbol('test_TrustedClientsRegistry_GetByOrigin_Success', function() {
+  var propertyReplacer = new goog.testing.PropertyReplacer;
+  setUpXhrioMock(propertyReplacer);
+
+  var registry = new TrustedClientsRegistryImpl;
+
+  simulateXhrioResponse();
+
+  var requestPromise = registry.getByOrigin(FAKE_APP_1_ID);
+  var testAssertionPromise = requestPromise.then(function(trustedClient) {
+    assertEquals(trustedClient.origin, FAKE_APP_1_ID);
+    assertEquals(trustedClient.name, FAKE_APP_1_NAME);
+  });
+
+  return testAssertionPromise.thenAlways(
+      propertyReplacer.reset, propertyReplacer);
+});
+
+goog.exportSymbol('test_TrustedClientsRegistry_GetByOrigin_Failure', function() {
+  var propertyReplacer = new goog.testing.PropertyReplacer;
+  setUpXhrioMock(propertyReplacer);
+
+  var registry = new TrustedClientsRegistryImpl;
+
+  simulateXhrioResponse();
+
+  var requestPromise = registry.getByOrigin(FAKE_APP_2_ID);
+  var testAssertionPromise = requestPromise.then(function() {
+    fail('Unexpected successful response');
+  }, function() {});
+
+  return testAssertionPromise.thenAlways(
+      propertyReplacer.reset, propertyReplacer);
+});
+
+goog.exportSymbol('test_TrustedClientsRegistry_TryGetByOrigins', function() {
+  var propertyReplacer = new goog.testing.PropertyReplacer;
+  setUpXhrioMock(propertyReplacer);
+
+  var registry = new TrustedClientsRegistryImpl;
+
+  simulateXhrioResponse();
+
+  var requestPromise = registry.tryGetByOrigins([FAKE_APP_1_ID, FAKE_APP_2_ID]);
+  var testAssertionPromise = requestPromise.then(function(trustedClients) {
+    assertEquals(trustedClients.length, 2);
+    assertEquals(trustedClients[0].origin, FAKE_APP_1_ID);
+    assertEquals(trustedClients[0].name, FAKE_APP_1_NAME);
+    assertNull(trustedClients[1]);
+  });
+
+  return testAssertionPromise.thenAlways(
+      propertyReplacer.reset, propertyReplacer);
+});
+
+});  // goog.scope

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry-unittest.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2019 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,22 +30,21 @@ goog.setTestOnly();
 goog.scope(function() {
 
 /** @const */
-var GSC = GoogleSmartCard;
+const GSC = GoogleSmartCard;
 
 /** @const */
-var TrustedClientsRegistryImpl = GSC.PcscLiteServer.TrustedClientsRegistryImpl;
+const TrustedClientsRegistryImpl =
+    GSC.PcscLiteServer.TrustedClientsRegistryImpl;
 
 /** @const */
-var FAKE_APP_1_ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const FAKE_APP_1_ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 /** @const */
-var FAKE_APP_1_NAME = 'App Name 1';
+const FAKE_APP_1_NAME = 'App Name 1';
 /** @const */
-var FAKE_APP_2_ID = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const FAKE_APP_2_ID = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 /** @const */
-var FAKE_TRUSTED_CLIENTS = {
-  [FAKE_APP_1_ID]: {
-    'name': FAKE_APP_1_NAME
-  }
+const FAKE_TRUSTED_CLIENTS = {
+  [FAKE_APP_1_ID]: {'name': FAKE_APP_1_NAME}
 };
 
 /**
@@ -63,60 +63,66 @@ function setUpXhrioMock(propertyReplacer) {
  * The response contains a fake trusted clients JSON.
  */
 function simulateXhrioResponse() {
-  var sentXhrios = goog.testing.net.XhrIo.getSendInstances();
+  const sentXhrios = goog.testing.net.XhrIo.getSendInstances();
   assertEquals(1, sentXhrios.length);
-  var xhrio = sentXhrios[0];
-  assertEquals(xhrio.getLastUri(),
-               'pcsc_lite_server_clients_management/known_client_apps.json');
-  var response = goog.json.serialize(FAKE_TRUSTED_CLIENTS);
+  const xhrio = sentXhrios[0];
+  assertEquals(
+      xhrio.getLastUri(),
+      'pcsc_lite_server_clients_management/known_client_apps.json');
+  const response = goog.json.serialize(FAKE_TRUSTED_CLIENTS);
   xhrio.simulateResponse(goog.net.HttpStatus.OK, response);
 }
 
-goog.exportSymbol('test_TrustedClientsRegistry_GetByOrigin_Success', function() {
-  var propertyReplacer = new goog.testing.PropertyReplacer;
-  setUpXhrioMock(propertyReplacer);
+goog.exportSymbol(
+    'test_TrustedClientsRegistry_GetByOrigin_Success', function() {
+      const propertyReplacer = new goog.testing.PropertyReplacer();
+      setUpXhrioMock(propertyReplacer);
 
-  var registry = new TrustedClientsRegistryImpl;
+      const registry = new TrustedClientsRegistryImpl();
 
-  simulateXhrioResponse();
+      simulateXhrioResponse();
 
-  var requestPromise = registry.getByOrigin(FAKE_APP_1_ID);
-  var testAssertionPromise = requestPromise.then(function(trustedClient) {
-    assertEquals(trustedClient.origin, FAKE_APP_1_ID);
-    assertEquals(trustedClient.name, FAKE_APP_1_NAME);
-  });
+      const requestPromise = registry.getByOrigin(FAKE_APP_1_ID);
+      const testAssertionPromise = requestPromise.then(function(trustedClient) {
+        assertEquals(trustedClient.origin, FAKE_APP_1_ID);
+        assertEquals(trustedClient.name, FAKE_APP_1_NAME);
+      });
 
-  return testAssertionPromise.thenAlways(
-      propertyReplacer.reset, propertyReplacer);
-});
+      return testAssertionPromise.thenAlways(
+          propertyReplacer.reset, propertyReplacer);
+    });
 
-goog.exportSymbol('test_TrustedClientsRegistry_GetByOrigin_Failure', function() {
-  var propertyReplacer = new goog.testing.PropertyReplacer;
-  setUpXhrioMock(propertyReplacer);
+goog.exportSymbol(
+    'test_TrustedClientsRegistry_GetByOrigin_Failure', function() {
+      const propertyReplacer = new goog.testing.PropertyReplacer();
+      setUpXhrioMock(propertyReplacer);
 
-  var registry = new TrustedClientsRegistryImpl;
+      const registry = new TrustedClientsRegistryImpl();
 
-  simulateXhrioResponse();
+      simulateXhrioResponse();
 
-  var requestPromise = registry.getByOrigin(FAKE_APP_2_ID);
-  var testAssertionPromise = requestPromise.then(function() {
-    fail('Unexpected successful response');
-  }, function() {});
+      const requestPromise = registry.getByOrigin(FAKE_APP_2_ID);
+      const testAssertionPromise = requestPromise.then(
+          function() {
+            fail('Unexpected successful response');
+          },
+          function() {});
 
-  return testAssertionPromise.thenAlways(
-      propertyReplacer.reset, propertyReplacer);
-});
+      return testAssertionPromise.thenAlways(
+          propertyReplacer.reset, propertyReplacer);
+    });
 
 goog.exportSymbol('test_TrustedClientsRegistry_TryGetByOrigins', function() {
-  var propertyReplacer = new goog.testing.PropertyReplacer;
+  const propertyReplacer = new goog.testing.PropertyReplacer();
   setUpXhrioMock(propertyReplacer);
 
-  var registry = new TrustedClientsRegistryImpl;
+  const registry = new TrustedClientsRegistryImpl();
 
   simulateXhrioResponse();
 
-  var requestPromise = registry.tryGetByOrigins([FAKE_APP_1_ID, FAKE_APP_2_ID]);
-  var testAssertionPromise = requestPromise.then(function(trustedClients) {
+  const requestPromise =
+      registry.tryGetByOrigins([FAKE_APP_1_ID, FAKE_APP_2_ID]);
+  const testAssertionPromise = requestPromise.then(function(trustedClients) {
     assertEquals(trustedClients.length, 2);
     assertEquals(trustedClients[0].origin, FAKE_APP_1_ID);
     assertEquals(trustedClients[0].name, FAKE_APP_1_NAME);
@@ -126,5 +132,4 @@ goog.exportSymbol('test_TrustedClientsRegistry_TryGetByOrigins', function() {
   return testAssertionPromise.thenAlways(
       propertyReplacer.reset, propertyReplacer);
 });
-
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry-unittest.js
@@ -34,11 +34,11 @@ const GSC = GoogleSmartCard;
 const TrustedClientsRegistryImpl =
     GSC.PcscLiteServer.TrustedClientsRegistryImpl;
 
-const FAKE_APP_1_ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const FAKE_APP_1_ORIGIN = 'chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const FAKE_APP_1_NAME = 'App Name 1';
-const FAKE_APP_2_ID = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const FAKE_APP_2_ORIGIN = `chrome-extension://bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`;
 const FAKE_TRUSTED_CLIENTS = {
-  [FAKE_APP_1_ID]: {'name': FAKE_APP_1_NAME}
+  [FAKE_APP_1_ORIGIN]: {'name': FAKE_APP_1_NAME}
 };
 
 /**
@@ -76,9 +76,9 @@ goog.exportSymbol(
 
       simulateXhrioResponse();
 
-      const requestPromise = registry.getByOrigin(FAKE_APP_1_ID);
+      const requestPromise = registry.getByOrigin(FAKE_APP_1_ORIGIN);
       const testAssertionPromise = requestPromise.then(function(trustedClient) {
-        assertEquals(trustedClient.origin, FAKE_APP_1_ID);
+        assertEquals(trustedClient.origin, FAKE_APP_1_ORIGIN);
         assertEquals(trustedClient.name, FAKE_APP_1_NAME);
       });
 
@@ -95,7 +95,7 @@ goog.exportSymbol(
 
       simulateXhrioResponse();
 
-      const requestPromise = registry.getByOrigin(FAKE_APP_2_ID);
+      const requestPromise = registry.getByOrigin(FAKE_APP_2_ORIGIN);
       const testAssertionPromise = requestPromise.then(
           function() {
             fail('Unexpected successful response');
@@ -115,10 +115,10 @@ goog.exportSymbol('test_TrustedClientsRegistry_TryGetByOrigins', function() {
   simulateXhrioResponse();
 
   const requestPromise =
-      registry.tryGetByOrigins([FAKE_APP_1_ID, FAKE_APP_2_ID]);
+      registry.tryGetByOrigins([FAKE_APP_1_ORIGIN, FAKE_APP_2_ORIGIN]);
   const testAssertionPromise = requestPromise.then(function(trustedClients) {
     assertEquals(trustedClients.length, 2);
-    assertEquals(trustedClients[0].origin, FAKE_APP_1_ID);
+    assertEquals(trustedClients[0].origin, FAKE_APP_1_ORIGIN);
     assertEquals(trustedClients[0].name, FAKE_APP_1_NAME);
     assertNull(trustedClients[1]);
   });

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry-unittest.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2019 Google Inc. All Rights Reserved.
+ * Copyright 2023 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry-unittest.js
@@ -29,20 +29,14 @@ goog.setTestOnly();
 
 goog.scope(function() {
 
-/** @const */
 const GSC = GoogleSmartCard;
 
-/** @const */
 const TrustedClientsRegistryImpl =
     GSC.PcscLiteServer.TrustedClientsRegistryImpl;
 
-/** @const */
 const FAKE_APP_1_ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-/** @const */
 const FAKE_APP_1_NAME = 'App Name 1';
-/** @const */
 const FAKE_APP_2_ID = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
-/** @const */
 const FAKE_TRUSTED_CLIENTS = {
   [FAKE_APP_1_ID]: {'name': FAKE_APP_1_NAME}
 };

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
@@ -53,6 +53,12 @@ const AUTOAPPROVE_FIELD = 'autoapprove';
 const GSC = GoogleSmartCard;
 
 /**
+ * Test-only override of `goog.net.XhrIo.send()`.
+ * @type {function(string, function(this: goog.net.XhrIo))|null}
+ */
+let sendOverrideForTesting;
+
+/**
  * This structure holds the information about a trusted client.
  * @param {string} origin
  * @param {string} name
@@ -178,12 +184,20 @@ TrustedClientsRegistryImpl.prototype.tryGetByOrigins = function(originList) {
   return promiseResolver.promise;
 };
 
+/**
+ * @param {function(string, function(this: goog.net.XhrIo))|null} sendOverride
+ */
+TrustedClientsRegistryImpl.overrideSendForTesting = function(sendOverride) {
+  sendOverrideForTesting = sendOverride;
+};
+
 /** @private */
 TrustedClientsRegistryImpl.prototype.startLoadingJson_ = function() {
   goog.log.fine(
       this.logger,
       'Loading registry from JSON file (URL: "' + JSON_CONFIG_URL + '")...');
-  goog.net.XhrIo.send(JSON_CONFIG_URL, this.jsonLoadedCallback_.bind(this));
+  const sender = sendOverrideForTesting || goog.net.XhrIo.send;
+  sender(JSON_CONFIG_URL, this.jsonLoadedCallback_.bind(this));
 };
 
 /** @private */


### PR DESCRIPTION
Add unit tests for the TrustedClientsRegistry
class which is responsible for querying information about the trusted client
application origins from the bundled JSON config.