### PR TITLE
Handle more Xhrio failures

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
@@ -191,14 +191,16 @@ TrustedClientsRegistryImpl.prototype.jsonLoadedCallback_ = function(e) {
   /** @type {!goog.net.XhrIo} */
   const xhrio = e.target;
 
-  if (!xhrio.isSuccess()) {
+  if (!xhrio.isSuccess() || !xhrio.getResponseText()) {
     this.promiseResolver_.reject(
         new Error('Failed to load the trusted clients registry'));
+    const errorReason = xhrio.isSuccess() ?
+        'the request completed with no data' :
+        xhrio.getLastError();
     GSC.Logging.failWithLogger(
         this.logger,
-        'Failed to load the trusted clients registry from JSON file (URL: "' +
-            JSON_CONFIG_URL +
-            '") with the following error: ' + xhrio.getLastError());
+        `Failed to load the trusted clients registry from JSON file (URL: "${
+            JSON_CONFIG_URL}") with the following error: ${errorReason}`);
   }
 
   // Note: not using the xhrio.getResponseJson method as it breaks in the Chrome


### PR DESCRIPTION
Detect cases in KnownAppsRegistry when goog.net.XhrIo reports
isSuccess()==true, but at the same time getResponseText()==''. As
it turned out, this is also a possible way of signaling an error from
XhrIo.

This is a generic cleanup, since in production we don't expect any
errors happening there (because the fetched URL belong to our
own CRX).