### PR TITLE
Get rid of dependency on Boost

### DIFF
--- a/common/cpp/src/google_smart_card_common/formatting.h
+++ b/common/cpp/src/google_smart_card_common/formatting.h
@@ -20,49 +20,14 @@
 #include <cstdarg>
 #include <string>
 
-#include <boost/format.hpp>
-
 #include <google_smart_card_common/logging/logging.h>
 
 namespace google_smart_card {
 
-std::string FormatPrintfTemplate(const char* format, ...);
+std::string FormatPrintfTemplate(const char* format, ...)
+  __attribute__((format(__printf__, 1, 2)));
 
 std::string FormatPrintfTemplate(const char* format, va_list var_args);
-
-namespace internal {
-
-inline void ApplyBoostFormatArguments(
-    const std::string& format, boost::format* formatter) {
-  if (formatter->remaining_args()) {
-    GOOGLE_SMART_CARD_LOG_FATAL << "Failed to format boost format template " <<
-        "\"" << format << "\": supplied fewer arguments than it was expected";
-  }
-}
-
-template <typename Arg, typename ... Args>
-inline void ApplyBoostFormatArguments(
-    const std::string& format,
-    boost::format* formatter,
-    const Arg& arg,
-    const Args& ... args) {
-  if (!formatter->remaining_args()) {
-    GOOGLE_SMART_CARD_LOG_FATAL << "Failed to format boost format template " <<
-        "\"" << format << "\": supplied more arguments than it was expected";
-  }
-  *formatter % arg;
-  ApplyBoostFormatArguments(format, formatter, args...);
-}
-
-}  // namespace internal
-
-template <typename ... Args>
-inline std::string FormatBoostFormatTemplate(
-    const std::string& format, const Args& ... args) {
-  boost::format formatter(format);
-  internal::ApplyBoostFormatArguments(format, &formatter, args...);
-  return formatter.str();
-}
 
 }  // namespace google_smart_card
 

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_router_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_router_unittest.cc
@@ -31,7 +31,6 @@
 
 const char kSampleType1[] = "sample type 1";
 const char kSampleType2[] = "sample type 2";
-const char kSampleDataFormat[] = "sample value #%1%";
 
 using testing::_;
 using testing::Eq;
@@ -58,7 +57,7 @@ class MockTypedMessageListener final : public TypedMessageListener {
 };
 
 std::string MakeSampleData(int index) {
-  return FormatBoostFormatTemplate(kSampleDataFormat, index);
+  return FormatPrintfTemplate("sample value #%d", index);
 }
 
 std::string GetMessageDataString(const pp::Var& data) {

--- a/common/cpp/src/google_smart_card_common/numeric_conversions.cc
+++ b/common/cpp/src/google_smart_card_common/numeric_conversions.cc
@@ -16,22 +16,11 @@
 
 #include <google_smart_card_common/logging/logging.h>
 
-// Error messages
-const char kErrorDoubleOutsideExactRange[] =
-    "The real value is outside the exact integer representation range: %1% not "
-    "in [%2%; %3%]";
-
 namespace google_smart_card {
 
 namespace internal {
 
 // Definitions of the constants declared in the header file
-const char kErrorNumberOutsideTypeRange[] =
-    "The integer value is outside the range of type \"%1%\": %2% not in "
-    "[%3%; %4%] range";
-const char kErrorIntegerOutsideDoubleExactRange[] =
-    "The integer %1% cannot be converted into a floating-point double value "
-    "without loss of precision: it is outside [%2%; %3%] range";
 const int64_t kDoubleExactRangeMax = 1LL << std::numeric_limits<double>::digits;
 const int64_t kDoubleExactRangeMin = -(1LL <<
     std::numeric_limits<double>::digits);
@@ -42,8 +31,9 @@ bool CastDoubleToInt64(
     double value, int64_t* result, std::string* error_message) {
   if (!(internal::kDoubleExactRangeMin <= value &&
         value <= internal::kDoubleExactRangeMax)) {
-    *error_message = FormatBoostFormatTemplate(
-        kErrorDoubleOutsideExactRange,
+    *error_message = FormatPrintfTemplate(
+        "The real value is outside the exact integer representation range: %f "
+        "not in [%" PRId64 "; %" PRId64 "]",
         value,
         internal::kDoubleExactRangeMin,
         internal::kDoubleExactRangeMax);

--- a/common/cpp/src/google_smart_card_common/numeric_conversions.h
+++ b/common/cpp/src/google_smart_card_common/numeric_conversions.h
@@ -95,11 +95,11 @@ inline bool CastInt64ToInteger(
   }
   *error_message = FormatPrintfTemplate(
       "The integer value is outside the range of type \"%s\": %" PRId64 " not "
-      "in [%" PRId64 "; %" PRIu64 "] range",
+      "in [%" PRIdMAX "; %" PRIuMAX "] range",
       type_name.c_str(),
       value,
-      static_cast<int64_t>(std::numeric_limits<T>::min()),
-      static_cast<uint64_t>(std::numeric_limits<T>::max()));
+      static_cast<intmax_t>(std::numeric_limits<T>::min()),
+      static_cast<uintmax_t>(std::numeric_limits<T>::max()));
   return false;
 }
 
@@ -117,10 +117,10 @@ inline bool CastIntegerToDouble(
   std::string formatted_value;
   if (value >= 0) {
     formatted_value = FormatPrintfTemplate(
-        "%" PRIu64, static_cast<uint64_t>(value));
+        "%" PRIuMAX, static_cast<uintmax_t>(value));
   } else {
     formatted_value = FormatPrintfTemplate(
-        "%" PRId64, static_cast<int64_t>(value));
+        "%" PRIdMAX, static_cast<intmax_t>(value));
   }
   *error_message = FormatPrintfTemplate(
       "The integer %s cannot be converted into a floating-point double value "

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/enum_converter.h
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/enum_converter.h
@@ -80,10 +80,10 @@ class EnumConverter final {
 
     VarValueType var_value;
     if (!VarAs(var, &var_value, error_message)) {
-      *error_message = FormatBoostFormatTemplate(
-          "Failed to parse %1% enum value: value of unexpected type got: %2%",
+      *error_message = FormatPrintfTemplate(
+          "Failed to parse %s enum value: value of unexpected type got: %s",
           GetEnumTypeName(),
-          DebugDumpVar(var));
+          DebugDumpVar(var).c_str());
       return false;
     }
 
@@ -97,10 +97,10 @@ class EnumConverter final {
       }
     });
     if (!succeeded) {
-      *error_message = FormatBoostFormatTemplate(
-          "Failed to parse %1% enum value: unknown value got: %2%",
+      *error_message = FormatPrintfTemplate(
+          "Failed to parse %s enum value: unknown value got: %s",
           GetEnumTypeName(),
-          DebugDumpVar(var));
+          DebugDumpVar(var).c_str());
     }
     return succeeded;
   }

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/extraction.cc
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/extraction.cc
@@ -18,6 +18,9 @@
 
 #include <google_smart_card_common/numeric_conversions.h>
 
+const char kErrorWrongType[] =
+    "Expected a value of type \"%s\", instead got: %s";
+
 namespace google_smart_card {
 
 namespace {
@@ -36,8 +39,7 @@ bool VarAsInteger(
       return false;
   } else {
     *error_message = FormatPrintfTemplate(
-        "Expected a value of type \"%s\", instead got: %s",
-        kIntegerJsTypeTitle, DebugDumpVar(var).c_str());
+        kErrorWrongType, kIntegerJsTypeTitle, DebugDumpVar(var).c_str());
     return false;
   }
   return CastInt64ToInteger(integer, type_name, result, error_message);
@@ -97,9 +99,7 @@ bool VarAs(const pp::Var& var, float* result, std::string* error_message) {
 bool VarAs(const pp::Var& var, double* result, std::string* error_message) {
   if (!var.is_number()) {
     *error_message = FormatPrintfTemplate(
-        "Expected a value of type \"%s\", instead got: %s",
-        kIntegerJsTypeTitle,
-        DebugDumpVar(var).c_str());
+        kErrorWrongType, kIntegerJsTypeTitle, DebugDumpVar(var).c_str());
     return false;
   }
   *result = var.AsDouble();
@@ -109,9 +109,7 @@ bool VarAs(const pp::Var& var, double* result, std::string* error_message) {
 bool VarAs(const pp::Var& var, bool* result, std::string* error_message) {
   if (!var.is_bool()) {
     *error_message = FormatPrintfTemplate(
-        "Expected a value of type \"%s\", instead got: %s",
-        kBooleanJsTypeTitle,
-        DebugDumpVar(var).c_str());
+        kErrorWrongType, kBooleanJsTypeTitle, DebugDumpVar(var).c_str());
     return false;
   }
   *result = var.AsBool();
@@ -122,9 +120,7 @@ bool VarAs(
     const pp::Var& var, std::string* result, std::string* error_message) {
   if (!var.is_string()) {
     *error_message = FormatPrintfTemplate(
-        "Expected a value of type \"%s\", instead got: %s",
-        kStringJsTypeTitle,
-        DebugDumpVar(var).c_str());
+        kErrorWrongType, kStringJsTypeTitle, DebugDumpVar(var).c_str());
     return false;
   }
   *result = var.AsString();
@@ -141,9 +137,7 @@ bool VarAs(
     const pp::Var& var, pp::VarArray* result, std::string* error_message) {
   if (!var.is_array()) {
     *error_message = FormatPrintfTemplate(
-        "Expected a value of type \"%s\", instead got: %s",
-        kArrayJsTypeTitle,
-        DebugDumpVar(var).c_str());
+        kErrorWrongType, kArrayJsTypeTitle, DebugDumpVar(var).c_str());
     return false;
   }
   *result = pp::VarArray(var);
@@ -156,9 +150,7 @@ bool VarAs(
     std::string* error_message) {
   if (!var.is_array_buffer()) {
     *error_message = FormatPrintfTemplate(
-        "Expected a value of type \"%s\", instead got: %s",
-        kArrayBufferJsTypeTitle,
-        DebugDumpVar(var).c_str());
+        kErrorWrongType, kArrayBufferJsTypeTitle, DebugDumpVar(var).c_str());
     return false;
   }
   *result = pp::VarArrayBuffer(var);
@@ -169,9 +161,7 @@ bool VarAs(
     const pp::Var& var, pp::VarDictionary* result, std::string* error_message) {
   if (!var.is_dictionary()) {
     *error_message = FormatPrintfTemplate(
-        "Expected a value of type \"%s\", instead got: %s",
-        kDictionaryJsTypeTitle,
-        DebugDumpVar(var).c_str());
+        kErrorWrongType, kDictionaryJsTypeTitle, DebugDumpVar(var).c_str());
     return false;
   }
   *result = pp::VarDictionary(var);
@@ -182,9 +172,7 @@ bool VarAs(
     const pp::Var& var, pp::Var::Null* /*result*/, std::string* error_message) {
   if (!var.is_null()) {
     *error_message = FormatPrintfTemplate(
-        "Expected a value of type \"%s\", instead got: %s",
-        kNullJsTypeTitle,
-        DebugDumpVar(var).c_str());
+        kErrorWrongType, kNullJsTypeTitle, DebugDumpVar(var).c_str());
     return false;
   }
   return true;

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/extraction.cc
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/extraction.cc
@@ -18,31 +18,7 @@
 
 #include <google_smart_card_common/numeric_conversions.h>
 
-// Error messages and related bits of strings
-const char kErrorWrongType[] =
-    "Expected a value of type \"%1%\", instead got: %2%";
-const char kErrorIntegerOutsideJsNumberExactRange[] =
-    "The integer %1% cannot be converted into JavaScript Number without loss "
-    "of precision";
-const char kErrorDictKeyMissing[] = "The dictionary has no key \"%1%\"";
-
 namespace google_smart_card {
-
-namespace internal {
-
-// Definitions of the constants declared in the header file
-const char kErrorWhileDictItemExtraction[] =
-    "Failed to extract the dictionary value with key \"%1%\": %2%";
-const char kErrorWrongArraySize[] =
-    "Expected an array of size %1%, instead got: %2%";
-const char kErrorWhileArrayItemExtraction[] =
-    "Failed to extract the array item with index %1%: %2%";
-const char kErrorDictHasUnexpectedKeys[] =
-    "The dictionary contains unexpected keys: %1%";
-const char kErrorArrayOrArrayBufferExpected[] =
-    "Expected an array of unsigned bytes or ArrayBuffer, instead got: %1%";
-
-}  // namespace internal
 
 namespace {
 
@@ -59,8 +35,9 @@ bool VarAsInteger(
     if (!CastDoubleToInt64(var.AsDouble(), &integer, error_message))
       return false;
   } else {
-    *error_message = FormatBoostFormatTemplate(
-        kErrorWrongType, kIntegerJsTypeTitle, DebugDumpVar(var));
+    *error_message = FormatPrintfTemplate(
+        "Expected a value of type \"%s\", instead got: %s",
+        kIntegerJsTypeTitle, DebugDumpVar(var).c_str());
     return false;
   }
   return CastInt64ToInteger(integer, type_name, result, error_message);
@@ -119,8 +96,10 @@ bool VarAs(const pp::Var& var, float* result, std::string* error_message) {
 
 bool VarAs(const pp::Var& var, double* result, std::string* error_message) {
   if (!var.is_number()) {
-    *error_message = FormatBoostFormatTemplate(
-        kErrorWrongType, kIntegerJsTypeTitle, DebugDumpVar(var));
+    *error_message = FormatPrintfTemplate(
+        "Expected a value of type \"%s\", instead got: %s",
+        kIntegerJsTypeTitle,
+        DebugDumpVar(var).c_str());
     return false;
   }
   *result = var.AsDouble();
@@ -129,8 +108,10 @@ bool VarAs(const pp::Var& var, double* result, std::string* error_message) {
 
 bool VarAs(const pp::Var& var, bool* result, std::string* error_message) {
   if (!var.is_bool()) {
-    *error_message = FormatBoostFormatTemplate(
-        kErrorWrongType, kBooleanJsTypeTitle, DebugDumpVar(var));
+    *error_message = FormatPrintfTemplate(
+        "Expected a value of type \"%s\", instead got: %s",
+        kBooleanJsTypeTitle,
+        DebugDumpVar(var).c_str());
     return false;
   }
   *result = var.AsBool();
@@ -140,8 +121,10 @@ bool VarAs(const pp::Var& var, bool* result, std::string* error_message) {
 bool VarAs(
     const pp::Var& var, std::string* result, std::string* error_message) {
   if (!var.is_string()) {
-    *error_message = FormatBoostFormatTemplate(
-        kErrorWrongType, kStringJsTypeTitle, DebugDumpVar(var));
+    *error_message = FormatPrintfTemplate(
+        "Expected a value of type \"%s\", instead got: %s",
+        kStringJsTypeTitle,
+        DebugDumpVar(var).c_str());
     return false;
   }
   *result = var.AsString();
@@ -157,8 +140,10 @@ bool VarAs(
 bool VarAs(
     const pp::Var& var, pp::VarArray* result, std::string* error_message) {
   if (!var.is_array()) {
-    *error_message = FormatBoostFormatTemplate(
-        kErrorWrongType, kArrayJsTypeTitle, DebugDumpVar(var));
+    *error_message = FormatPrintfTemplate(
+        "Expected a value of type \"%s\", instead got: %s",
+        kArrayJsTypeTitle,
+        DebugDumpVar(var).c_str());
     return false;
   }
   *result = pp::VarArray(var);
@@ -170,8 +155,10 @@ bool VarAs(
     pp::VarArrayBuffer* result,
     std::string* error_message) {
   if (!var.is_array_buffer()) {
-    *error_message = FormatBoostFormatTemplate(
-        kErrorWrongType, kArrayBufferJsTypeTitle, DebugDumpVar(var));
+    *error_message = FormatPrintfTemplate(
+        "Expected a value of type \"%s\", instead got: %s",
+        kArrayBufferJsTypeTitle,
+        DebugDumpVar(var).c_str());
     return false;
   }
   *result = pp::VarArrayBuffer(var);
@@ -181,8 +168,10 @@ bool VarAs(
 bool VarAs(
     const pp::Var& var, pp::VarDictionary* result, std::string* error_message) {
   if (!var.is_dictionary()) {
-    *error_message = FormatBoostFormatTemplate(
-        kErrorWrongType, kDictionaryJsTypeTitle, DebugDumpVar(var));
+    *error_message = FormatPrintfTemplate(
+        "Expected a value of type \"%s\", instead got: %s",
+        kDictionaryJsTypeTitle,
+        DebugDumpVar(var).c_str());
     return false;
   }
   *result = pp::VarDictionary(var);
@@ -192,8 +181,10 @@ bool VarAs(
 bool VarAs(
     const pp::Var& var, pp::Var::Null* /*result*/, std::string* error_message) {
   if (!var.is_null()) {
-    *error_message = FormatBoostFormatTemplate(
-        kErrorWrongType, kNullJsTypeTitle, DebugDumpVar(var));
+    *error_message = FormatPrintfTemplate(
+        "Expected a value of type \"%s\", instead got: %s",
+        kNullJsTypeTitle,
+        DebugDumpVar(var).c_str());
     return false;
   }
   return true;
@@ -226,7 +217,8 @@ bool GetVarDictValue(
     pp::Var* result,
     std::string* error_message) {
   if (!var.HasKey(key)) {
-    *error_message = FormatBoostFormatTemplate(kErrorDictKeyMissing, key);
+    *error_message = FormatPrintfTemplate(
+        "The dictionary has no key \"%s\"", key.c_str());
     return false;
   }
   *result = var.Get(key);
@@ -268,8 +260,9 @@ bool VarDictValuesExtractor::GetSuccessWithNoExtraKeysAllowed(
         unexpected_keys_dump += ", ";
       unexpected_keys_dump += '"' + key + '"';
     }
-    *error_message = FormatBoostFormatTemplate(
-        internal::kErrorDictHasUnexpectedKeys, unexpected_keys_dump);
+    *error_message = FormatPrintfTemplate(
+        "The dictionary contains unexpected keys: %s",
+        unexpected_keys_dump.c_str());
     return false;
   }
   return true;
@@ -298,8 +291,10 @@ void VarDictValuesExtractor::ProcessFailedExtraction(
     // only should be enough.
     return;
   }
-  error_message_ = FormatBoostFormatTemplate(
-      internal::kErrorWhileDictItemExtraction, key, extraction_error_message);
+  error_message_ = FormatPrintfTemplate(
+      "Failed to extract the dictionary value with key \"%s\": %s",
+      key.c_str(),
+      extraction_error_message.c_str());
   failed_ = true;
 }
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
@@ -25,6 +25,7 @@
 
 #include "clients_manager.h"
 
+#include <inttypes.h>
 #include <sstream>
 #include <utility>
 
@@ -38,8 +39,6 @@
 
 const char kCreateHandlerMessageType[] = "pcsc_lite_create_client_handler";
 const char kDeleteHandlerMessageType[] = "pcsc_lite_delete_client_handler";
-const char kPcscFunctionCallRequesterNameTemplate[] =
-    "pcsc_lite_client_handler_%1%_call_function";
 const char kLoggingPrefix[] = "[PC/SC-Lite clients manager] ";
 
 namespace google_smart_card {
@@ -173,8 +172,8 @@ PcscLiteServerClientsManager::Handler::Handler(
       request_processor_(new PcscLiteClientRequestProcessor(
           handler_id, client_app_id_)),
       request_receiver_(new JsRequestReceiver(
-          FormatBoostFormatTemplate(
-              kPcscFunctionCallRequesterNameTemplate, handler_id),
+          FormatPrintfTemplate(
+              "pcsc_lite_client_handler_%" PRId64 "_call_function", handler_id),
           this,
           typed_message_router,
           MakeUnique<JsRequestReceiver::PpDelegateImpl>(pp_instance))) {}


### PR DESCRIPTION
Remove all usages of the Boost C++ library from the project.

This allows to resolve the build issues caused by some problems
with the NaCl webport of Boost:

  /usr/bin/git-secrets: line 116: /usr/lib/git-core/git: Argument list too long