### PR TITLE
Fix type annotation in known-apps-registry.js

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/known-apps-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/known-apps-registry.js
@@ -133,7 +133,7 @@ KnownAppsRegistry.prototype.getById = function(id) {
  * containing either the information for the i-th app in |idList| or |null| if
  * the app isn't present in the config.
  * @param {!Array.<string>} idList
- * @return {!goog.Promise.<!Array.<KnownApp>>}
+ * @return {!goog.Promise.<!Array.<?KnownApp>>}
  */
 KnownAppsRegistry.prototype.tryGetByIds = function(idList) {
   var promiseResolver = goog.Promise.withResolver();


### PR DESCRIPTION
Explicitly mark the nullable type, making the style checks built into
the current version of Closure Compiler happy.

Before this CL, the following error was generated:

  [JSC_MISSING_NULLABILITY_MODIFIER_JSDOC] KnownApp is a reference
  type with no nullability modifier, which is disallowed by the style
  guide.
  Please add a ! to make it explicitly non-nullable, or a ? to make
  it explicitly nullable.