### PR TITLE
Remove unused imports from JavaScript code

### DIFF
--- a/common/js/src/deferred-processor.js
+++ b/common/js/src/deferred-processor.js
@@ -25,7 +25,6 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PromiseHelpers');
 goog.require('goog.Disposable');
 goog.require('goog.Promise');
-goog.require('goog.log.Logger');
 goog.require('goog.structs.Queue');
 
 goog.scope(function() {

--- a/common/js/src/logging/debug-dump.js
+++ b/common/js/src/logging/debug-dump.js
@@ -22,13 +22,11 @@
 goog.provide('GoogleSmartCard.DebugDump');
 
 goog.require('goog.array');
-goog.require('goog.functions');
 goog.require('goog.iter');
 goog.require('goog.json');
 goog.require('goog.math');
 goog.require('goog.object');
 goog.require('goog.string');
-goog.require('goog.structs');
 
 goog.scope(function() {
 

--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -44,9 +44,7 @@ goog.require('goog.debug');
 goog.require('goog.debug.Console');
 goog.require('goog.log');
 goog.require('goog.log.Level');
-goog.require('goog.log.LogRecord');
 goog.require('goog.log.Logger');
-goog.require('goog.string');
 
 goog.scope(function() {
 

--- a/common/js/src/messaging/port-message-channel.js
+++ b/common/js/src/messaging/port-message-channel.js
@@ -29,7 +29,6 @@ goog.require('GoogleSmartCard.MessageChannelPinging.PingResponder');
 goog.require('GoogleSmartCard.MessageChannelPinging.Pinger');
 goog.require('GoogleSmartCard.TypedMessage');
 goog.require('goog.asserts');
-goog.require('goog.events');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 

--- a/common/js/src/messaging/single-message-based-channel-unittest.js
+++ b/common/js/src/messaging/single-message-based-channel-unittest.js
@@ -19,7 +19,6 @@ goog.require('GoogleSmartCard.MessageChannelPinging.Pinger');
 goog.require('GoogleSmartCard.SingleMessageBasedChannel');
 goog.require('GoogleSmartCard.TypedMessage');
 goog.require('goog.Promise');
-goog.require('goog.async.Delay');
 goog.require('goog.testing.PropertyReplacer');
 goog.require('goog.testing.jsunit');
 goog.require('goog.testing.mockmatchers');

--- a/common/js/src/nacl-module/nacl-module.js
+++ b/common/js/src/nacl-module/nacl-module.js
@@ -27,7 +27,6 @@ goog.require('GoogleSmartCard.NaclModuleMessageChannel');
 goog.require('GoogleSmartCard.TypedMessage');
 goog.require('goog.Disposable');
 goog.require('goog.Promise');
-goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.events');
 goog.require('goog.log.Logger');

--- a/common/js/src/popup-window/client.js
+++ b/common/js/src/popup-window/client.js
@@ -27,13 +27,11 @@ goog.provide('GoogleSmartCard.PopupWindow.Client');
 
 goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
-goog.require('goog.dom');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
 goog.require('goog.events.KeyCodes');
 goog.require('goog.log.Logger');
 goog.require('goog.object');
-goog.require('goog.string');
 
 goog.scope(function() {
 

--- a/common/js/src/popup-window/server.js
+++ b/common/js/src/popup-window/server.js
@@ -26,7 +26,6 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('goog.Promise');
 goog.require('goog.log.Logger');
 goog.require('goog.object');
-goog.require('goog.promise.Resolver');
 
 goog.scope(function() {
 

--- a/common/js/src/requesting/requester-unittest.js
+++ b/common/js/src/requesting/requester-unittest.js
@@ -18,7 +18,6 @@ goog.require('GoogleSmartCard.Requester');
 goog.require('GoogleSmartCard.RequesterMessage');
 goog.require('GoogleSmartCard.RequesterMessage.RequestMessageData');
 goog.require('GoogleSmartCard.RequesterMessage.ResponseMessageData');
-goog.require('goog.Promise');
 goog.require('goog.testing.MockControl');
 goog.require('goog.testing.jsunit');
 goog.require('goog.testing.messaging.MockMessageChannel');

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
@@ -31,7 +31,6 @@ goog.require('GoogleSmartCard.RequestReceiver');
 goog.require('GoogleSmartCard.Requester');
 goog.require('goog.Disposable');
 goog.require('goog.array');
-goog.require('goog.asserts');
 goog.require('goog.log.Logger');
 
 goog.scope(function() {

--- a/smart_card_connector_app/src/window-logs-exporting.js
+++ b/smart_card_connector_app/src/window-logs-exporting.js
@@ -25,7 +25,6 @@ goog.require('GoogleSmartCard.Clipboard');
 goog.require('GoogleSmartCard.Logging');
 goog.require('goog.Timer');
 goog.require('goog.dom');
-goog.require('goog.dom.classlist');
 goog.require('goog.events.EventType');
 goog.require('goog.log.Logger');
 

--- a/third_party/pcsc-lite/naclport/js_demo/src/demo.js
+++ b/third_party/pcsc-lite/naclport/js_demo/src/demo.js
@@ -36,7 +36,6 @@ goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PcscLiteClient.API');
 goog.require('goog.array');
-goog.require('goog.asserts');
 goog.require('goog.iter');
 goog.require('goog.log.Logger');
 goog.require('goog.object');

--- a/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
+++ b/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
@@ -33,7 +33,6 @@ goog.require('GoogleSmartCard.TypedMessage');
 goog.require('goog.Promise');
 goog.require('goog.Timer');
 goog.require('goog.array');
-goog.require('goog.asserts');
 goog.require('goog.iter');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
@@ -38,7 +38,6 @@ goog.require('GoogleSmartCard.RequestReceiver');
 goog.require('GoogleSmartCard.Requester');
 goog.require('goog.Disposable');
 goog.require('goog.Promise');
-goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.iter');
 goog.require('goog.iter.Iterator');

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittest.js
@@ -20,7 +20,6 @@ goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsCheckin
 goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.UserPromptingChecker');
 goog.require('GoogleSmartCard.PopupWindow.Server');
 goog.require('goog.Promise');
-goog.require('goog.json');
 goog.require('goog.testing');
 goog.require('goog.testing.MockControl');
 goog.require('goog.testing.jsunit');

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
@@ -33,13 +33,10 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.KnownAppsRegistry');
 goog.require('GoogleSmartCard.PopupWindow.Server');
 goog.require('goog.Promise');
-goog.require('goog.array');
-goog.require('goog.functions');
 goog.require('goog.iter');
 goog.require('goog.log.Logger');
 goog.require('goog.object');
 goog.require('goog.promise.Resolver');
-goog.require('goog.structs');
 
 goog.scope(function() {
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/readiness-tracker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/readiness-tracker.js
@@ -31,7 +31,6 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PromiseHelpers');
 goog.require('goog.Disposable');
 goog.require('goog.Promise');
-goog.require('goog.functions');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 goog.require('goog.promise.Resolver');


### PR DESCRIPTION
Small cleanup: stop importing things in JavaScript code that aren't used
in the code.

These unused imports were collected using the
"--jscomp_error=extraRequire" Closure Compiler flag. (We don't use this
flag by default, since it also produces lots of false positives.)