### PR TITLE
Prepare for Closure Compiler 20191111 update

### DIFF
--- a/common/make/js_building_common.mk
+++ b/common/make/js_building_common.mk
@@ -77,7 +77,6 @@ JS_BUILD_COMPILATION_FLAGS += \
 	--dependency_mode=STRICT \
 	--jscomp_error=accessControls \
 	--jscomp_error=ambiguousFunctionDecl \
-	--jscomp_error=checkEventfulObjectDisposal \
 	--jscomp_error=checkRegExp \
 	--jscomp_error=checkTypes \
 	--jscomp_error=checkVars \


### PR DESCRIPTION
Update the code to work with the release 20191111 of Closure Compiler:

* The "--jscomp_error=checkEventfulObjectDisposal" diagnostics seems to
  be broken in Debug builds.