### PR TITLE
Prepare for Import Closure Library 20191111 update

### DIFF
--- a/common/js/src/container-helpers.js
+++ b/common/js/src/container-helpers.js
@@ -33,7 +33,7 @@ var GSC = GoogleSmartCard;
 GSC.ContainerHelpers.buildObjectFromMap = function(map) {
   let obj = {};
   for (let [key, value] of map) {
-    GSC.Logging.check(goog.isString(key) || goog.isNumber(key),
+    GSC.Logging.check(typeof key === 'string' || typeof key === 'number',
                       'Invalid type for object key');
     obj[key] = value;
   }

--- a/common/js/src/logging/debug-dump.js
+++ b/common/js/src/logging/debug-dump.js
@@ -54,7 +54,7 @@ function guessIntegerBitLength(value) {
   goog.array.forEach(BIT_LENGTHS, function(bitLength) {
     var signedBegin = -Math.pow(2, bitLength - 1);
     var unsignedEnd = Math.pow(2, bitLength);
-    if (signedBegin <= value && value < unsignedEnd && goog.isNull(result))
+    if (signedBegin <= value && value < unsignedEnd && result === null)
       result = bitLength;
   });
   return result;
@@ -200,13 +200,13 @@ function dump(value) {
     return '<Node>';
   }
 
-  if (!goog.isDef(value))
+  if (value === undefined)
     return 'undefined';
-  if (goog.isNull(value))
+  if (value === null)
     return 'null';
-  if (goog.isNumber(value))
+  if (typeof value === 'number')
     return dumpNumber(value);
-  if (goog.isString(value))
+  if (typeof value === 'string')
     return dumpString(value);
   if (goog.isArray(value))
     return dumpArray(value);

--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -235,7 +235,7 @@ GSC.Logging.fail = function(opt_message, var_args) {
  */
 GSC.Logging.failWithLogger = function(logger, opt_message, var_args) {
   var messagePrefix = 'Failure in ' + logger.getName();
-  if (goog.isDef(opt_message)) {
+  if (opt_message !== undefined) {
     var transformedMessage = messagePrefix + ': ' + opt_message;
     var args = Array.prototype.slice.call(arguments, 2);
     GSC.Logging.fail.apply(

--- a/common/js/src/messaging/message-channel-pinging.js
+++ b/common/js/src/messaging/message-channel-pinging.js
@@ -96,7 +96,7 @@ GSC.MessageChannelPinging.Pinger = function(
       PingResponder.SERVICE_NAME, this.serviceCallback_.bind(this), true);
 
   /** @private */
-  this.onEstablished_ = goog.isDef(opt_onEstablished) ?
+  this.onEstablished_ = opt_onEstablished !== undefined ?
       opt_onEstablished : null;
 
   /**
@@ -187,14 +187,14 @@ Pinger.prototype.serviceCallback_ = function(messageData) {
     return;
   }
   var channelId = messageData[CHANNEL_ID_MESSAGE_KEY];
-  if (!goog.isNumber(channelId)) {
+  if (typeof channelId !== 'number') {
     this.logger.warning('Received pong message has wrong format: channel id ' +
                         'is not a number. Disposing...');
     this.disposeChannelAndSelf_();
     return;
   }
 
-  if (goog.isNull(this.previousRemoteEndChannelId_)) {
+  if (this.previousRemoteEndChannelId_ === null) {
     this.logger.fine(
         'Received the first pong response (remote channel id is ' + channelId +
         '). The message channel is considered established');
@@ -240,7 +240,7 @@ Pinger.prototype.schedulePostingPingMessage_ = function() {
 
 /** @private */
 Pinger.prototype.scheduleTimeoutTimer_ = function() {
-  GSC.Logging.checkWithLogger(this.logger, goog.isNull(this.timeoutTimerId_));
+  GSC.Logging.checkWithLogger(this.logger, this.timeoutTimerId_ === null);
   this.timeoutTimerId_ = goog.Timer.callOnce(
       this.timeoutCallback_.bind(this),
       Pinger.TIMEOUT_MILLISECONDS,
@@ -249,7 +249,7 @@ Pinger.prototype.scheduleTimeoutTimer_ = function() {
 
 /** @private */
 Pinger.prototype.clearTimeoutTimer_ = function() {
-  if (!goog.isNull(this.timeoutTimerId_)) {
+  if (this.timeoutTimerId_ !== null) {
     goog.Timer.clear(this.timeoutTimerId_);
     this.timeoutTimerId_ = null;
   }

--- a/common/js/src/messaging/message-channel-pool.js
+++ b/common/js/src/messaging/message-channel-pool.js
@@ -106,7 +106,7 @@ MessageChannelPool.prototype.addOnUpdateListener = function(
     listener, opt_scope) {
   this.logger.fine('Added an OnUpdateListener');
   this.onUpdateListeners_.push(
-      goog.isDef(opt_scope) ? goog.bind(listener, opt_scope) : listener);
+      opt_scope !== undefined ? goog.bind(listener, opt_scope) : listener);
   // Fire it once immediately to update.
   this.fireOnUpdateListeners_();
 };

--- a/common/js/src/messaging/port-message-channel.js
+++ b/common/js/src/messaging/port-message-channel.js
@@ -75,7 +75,7 @@ GSC.PortMessageChannel = function(port, opt_onEstablished) {
    */
   this.logger = GSC.Logging.getScopedLogger(
       'PortMessageChannel<"' + port.name + '"' +
-      (goog.isNull(this.extensionId) ? '' : ', id="' + this.extensionId + '"') +
+      (this.extensionId === null ? '' : ', id="' + this.extensionId + '"') +
       '>');
 
   /** @private */
@@ -156,15 +156,15 @@ PortMessageChannel.prototype.getPortExtensionId_ = function(port) {
   if (!goog.object.containsKey(port, 'sender'))
     return null;
   var sender = port['sender'];
-  if (!goog.isDef(sender))
+  if (sender === undefined)
     return null;
   GSC.Logging.checkWithLogger(this.logger, goog.isObject(sender));
   if (!goog.object.containsKey(sender, 'id'))
     return null;
   var senderId = sender['id'];
-  if (!goog.isDef(senderId))
+  if (senderId === undefined)
     return null;
-  GSC.Logging.checkWithLogger(this.logger, goog.isString(senderId));
+  GSC.Logging.checkWithLogger(this.logger, typeof senderId === 'string');
   return senderId;
 };
 

--- a/common/js/src/messaging/typed-message.js
+++ b/common/js/src/messaging/typed-message.js
@@ -63,7 +63,7 @@ TypedMessage.parseTypedMessage = function(message) {
   if (!goog.isObject(message) ||
       goog.object.getCount(message) != 2 ||
       !goog.object.containsKey(message, TYPE_MESSAGE_KEY) ||
-      !goog.isString(message[TYPE_MESSAGE_KEY]) ||
+      typeof message[TYPE_MESSAGE_KEY] !== 'string' ||
       !goog.object.containsKey(message, DATA_MESSAGE_KEY) ||
       !goog.isObject(message[DATA_MESSAGE_KEY])) {
     return null;

--- a/common/js/src/nacl-module/nacl-module-log-messages-receiver.js
+++ b/common/js/src/nacl-module/nacl-module-log-messages-receiver.js
@@ -97,7 +97,7 @@ NaclModuleLogMessagesReceiver.prototype.extractLogMessageLevel_ = function(
       this.logger, goog.object.containsKey(messageData, LOG_LEVEL_MESSAGE_KEY));
   var value = messageData[LOG_LEVEL_MESSAGE_KEY];
 
-  GSC.Logging.checkWithLogger(this.logger, goog.isString(value));
+  GSC.Logging.checkWithLogger(this.logger, typeof value === 'string');
   goog.asserts.assertString(value);
 
   var result = goog.log.Level.getPredefinedLevel(value);
@@ -121,7 +121,7 @@ NaclModuleLogMessagesReceiver.prototype.extractLogMessageText_ = function(
       this.logger, goog.object.containsKey(messageData, TEXT_MESSAGE_KEY));
   var value = messageData[TEXT_MESSAGE_KEY];
 
-  GSC.Logging.checkWithLogger(this.logger, goog.isString(value));
+  GSC.Logging.checkWithLogger(this.logger, typeof value === 'string');
   goog.asserts.assertString(value);
 
   return value;

--- a/common/js/src/popup-window/client.js
+++ b/common/js/src/popup-window/client.js
@@ -112,7 +112,8 @@ GSC.PopupWindow.Client.setWindowHeightToFitContent = function() {
   var wholeContentHeight = document.documentElement['offsetHeight'];
   GSC.Logging.checkWithLogger(
       logger,
-      goog.isDef(wholeContentHeight) && goog.isNumber(wholeContentHeight));
+      wholeContentHeight !== undefined &&
+          typeof wholeContentHeight === 'number');
   logger.fine('Resizing the window size to ' + wholeContentHeight + 'px');
   chrome.app.window.current().innerBounds.height = wholeContentHeight;
 };

--- a/common/js/src/popup-window/server.js
+++ b/common/js/src/popup-window/server.js
@@ -60,7 +60,7 @@ GSC.PopupWindow.Server.createWindow = function(
   var createdWindowExtends = {};
   createdWindowExtends[GSC.Logging.GLOBAL_LOG_BUFFER_VARIABLE_NAME] =
       GSC.Logging.getLogBuffer();
-  if (goog.isDef(opt_data))
+  if (opt_data !== undefined)
     createdWindowExtends['passedData'] = opt_data;
 
   logger.fine(
@@ -101,7 +101,7 @@ GSC.PopupWindow.Server.runModalDialog = function(
         !goog.object.containsKey(opt_createWindowOptionsOverrides, 'id'),
         '"id" window option is disallowed for the modal dialogs (as this ' +
         'option may result in not creating the new modal dialog)');
-    goog.object.extend(createWindowOptions, opt_createWindowOptionsOverrides);
+    Object.assign(createWindowOptions, opt_createWindowOptionsOverrides);
   }
 
   var promiseResolver = goog.Promise.withResolver();
@@ -110,8 +110,8 @@ GSC.PopupWindow.Server.runModalDialog = function(
     'resolveModalDialog': promiseResolver.resolve,
     'rejectModalDialog': promiseResolver.reject
   };
-  if (goog.isDef(opt_data))
-    goog.object.extend(dataWithDialogCallbacks, opt_data);
+  if (opt_data !== undefined)
+    Object.assign(dataWithDialogCallbacks, opt_data);
 
   GSC.PopupWindow.Server.createWindow(
       url, createWindowOptions, dataWithDialogCallbacks);
@@ -136,7 +136,7 @@ function createWindowCallback(createdWindowExtends, createdWindow) {
       'The popup window callback is executed, injecting the following data ' +
       'into the created window: ' +
       GSC.DebugDump.debugDump(createdWindowExtends));
-  goog.object.extend(createdWindowScope, createdWindowExtends);
+  Object.assign(createdWindowScope, createdWindowExtends);
 }
 
 });  // goog.scope

--- a/common/js/src/requesting/remote-call-message.js
+++ b/common/js/src/requesting/remote-call-message.js
@@ -68,7 +68,7 @@ var RemoteCallMessage = GSC.RemoteCallMessage;
 RemoteCallMessage.parseRequestPayload = function(requestPayload) {
   if (goog.object.getCount(requestPayload) != 2 ||
       !goog.object.containsKey(requestPayload, FUNCTION_NAME_MESSAGE_KEY) ||
-      !goog.isString(requestPayload[FUNCTION_NAME_MESSAGE_KEY]) ||
+      typeof requestPayload[FUNCTION_NAME_MESSAGE_KEY] !== 'string' ||
       !goog.object.containsKey(requestPayload, ARGUMENTS_MESSAGE_KEY) ||
       !goog.isArray(requestPayload[ARGUMENTS_MESSAGE_KEY])) {
     return null;

--- a/common/js/src/requesting/request-receiver.js
+++ b/common/js/src/requesting/request-receiver.js
@@ -113,7 +113,7 @@ RequestReceiver.prototype.requestMessageReceivedListener_ = function(
   goog.asserts.assertObject(messageData);
 
   var requestMessageData = RequestMessageData.parseMessageData(messageData);
-  if (goog.isNull(requestMessageData)) {
+  if (requestMessageData === null) {
     if (this.shouldDisposeOnInvalidMessage_) {
       this.logger.warning(
           'Failed to parse the received request message: ' +

--- a/common/js/src/requesting/requester-message.js
+++ b/common/js/src/requesting/requester-message.js
@@ -103,7 +103,7 @@ var RequestMessageData = RequesterMessage.RequestMessageData;
 RequestMessageData.parseMessageData = function(messageData) {
   if (goog.object.getCount(messageData) != 2 ||
       !goog.object.containsKey(messageData, REQUEST_ID_MESSAGE_KEY) ||
-      !goog.isNumber(messageData[REQUEST_ID_MESSAGE_KEY]) ||
+      typeof messageData[REQUEST_ID_MESSAGE_KEY] !== 'number' ||
       !goog.object.containsKey(messageData, PAYLOAD_MESSAGE_KEY) ||
       !goog.isObject(messageData[PAYLOAD_MESSAGE_KEY])) {
     return null;
@@ -141,7 +141,7 @@ RequesterMessage.ResponseMessageData = function(
   this.errorMessage = opt_errorMessage;
 
   GSC.Logging.checkWithLogger(
-      this.logger, !goog.isDef(opt_payload) || !goog.isDef(opt_errorMessage));
+      this.logger, opt_payload === undefined || opt_errorMessage === undefined);
 };
 
 /** @const */
@@ -158,7 +158,7 @@ ResponseMessageData.prototype.logger = GSC.Logging.getScopedLogger(
  * @return {boolean}
  */
 ResponseMessageData.prototype.isSuccessful = function() {
-  return !goog.isDef(this.errorMessage);
+  return this.errorMessage === undefined;
 };
 
 /**
@@ -174,7 +174,8 @@ ResponseMessageData.prototype.getPayload = function() {
  */
 ResponseMessageData.prototype.getErrorMessage = function() {
   GSC.Logging.checkWithLogger(this.logger, !this.isSuccessful());
-  GSC.Logging.checkWithLogger(this.logger, goog.isString(this.errorMessage));
+  GSC.Logging.checkWithLogger(
+      this.logger, typeof this.errorMessage === 'string');
   goog.asserts.assertString(this.errorMessage);
   return this.errorMessage;
 };
@@ -189,7 +190,7 @@ ResponseMessageData.prototype.getErrorMessage = function() {
 ResponseMessageData.parseMessageData = function(messageData) {
   if (goog.object.getCount(messageData) != 2 ||
       !goog.object.containsKey(messageData, REQUEST_ID_MESSAGE_KEY) ||
-      !goog.isNumber(messageData[REQUEST_ID_MESSAGE_KEY])) {
+      typeof messageData[REQUEST_ID_MESSAGE_KEY] !== 'number') {
     return null;
   }
   var requestId = messageData[REQUEST_ID_MESSAGE_KEY];
@@ -197,7 +198,7 @@ ResponseMessageData.parseMessageData = function(messageData) {
     return new ResponseMessageData(requestId, messageData[PAYLOAD_MESSAGE_KEY]);
   }
   if (goog.object.containsKey(messageData, ERROR_MESSAGE_KEY) &&
-      goog.isString(messageData[ERROR_MESSAGE_KEY])) {
+      typeof messageData[ERROR_MESSAGE_KEY] === 'string') {
     return new ResponseMessageData(
         requestId, undefined, messageData[ERROR_MESSAGE_KEY]);
   }

--- a/common/js/src/requesting/requester.js
+++ b/common/js/src/requesting/requester.js
@@ -190,7 +190,7 @@ Requester.prototype.responseMessageReceivedListener_ = function(messageData) {
   }
 
   var responseMessageData = ResponseMessageData.parseMessageData(messageData);
-  if (goog.isNull(responseMessageData)) {
+  if (responseMessageData === null) {
     GSC.Logging.failWithLogger(
         this.logger,
         'Failed to parse the received response message: ' +
@@ -240,7 +240,7 @@ Requester.prototype.rejectRequest_ = function(requestId, errorMessage) {
  */
 Requester.prototype.popRequestPromiseResolver_ = function(requestId) {
   var result = this.requestIdToPromiseResolverMap_.get(requestId);
-  GSC.Logging.checkWithLogger(this.logger, goog.isDef(result));
+  GSC.Logging.checkWithLogger(this.logger, result !== undefined);
   this.requestIdToPromiseResolverMap_.delete(requestId);
   return result;
 };

--- a/example_js_smart_card_client_app/src/background.js
+++ b/example_js_smart_card_client_app/src/background.js
@@ -88,7 +88,7 @@ var context = null;
  * Initiates the PC/SC-Lite client API context initialization.
  */
 function initializeContext() {
-  GSC.Logging.checkWithLogger(logger, goog.isNull(context));
+  GSC.Logging.checkWithLogger(logger, context === null);
   context = new GSC.PcscLiteClient.Context(CLIENT_TITLE, SERVER_APP_ID);
   context.addOnInitializedCallback(contextInitializedListener);
   context.addOnDisposeCallback(contextDisposedListener);

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -112,7 +112,7 @@ function connectionListener(port) {
 function externalConnectionListener(port) {
   logger.fine('Received onConnectExternal event');
   var portMessageChannel = new GSC.PortMessageChannel(port);
-  if (goog.isNull(portMessageChannel.extensionId)) {
+  if (portMessageChannel.extensionId === null) {
     logger.warning('Ignoring the external connection as there is no sender ' +
                    'extension id specified');
     return;
@@ -130,7 +130,7 @@ function externalConnectionListener(port) {
  */
 function externalMessageListener(message, sender) {
   logger.fine('Received onMessageExternal event');
-  if (!goog.isDef(sender.id)) {
+  if (sender.id === undefined) {
     logger.warning('Ignoring the external message as there is no sender ' +
                    'extension id specified');
     return;
@@ -185,7 +185,7 @@ function getOrCreateSingleMessageBasedChannel(clientExtensionId) {
 function createClientHandler(clientMessageChannel, clientExtensionId) {
   GSC.Logging.checkWithLogger(logger, !clientMessageChannel.isDisposed());
 
-  var clientTitleForLog = goog.isDef(clientExtensionId) ?
+  var clientTitleForLog = clientExtensionId !== undefined ?
       'app "' + clientExtensionId + '"' : 'own app';
 
   if (naclModule.isDisposed() || naclModule.messageChannel.isDisposed()) {
@@ -209,7 +209,7 @@ function createClientHandler(clientMessageChannel, clientExtensionId) {
   var logMessage =
       'Created a new PC/SC-Lite client handler for ' + clientTitleForLog +
       ' (handler id ' + clientHandler.id + ')';
-  if (goog.isDef(clientExtensionId))
+  if (clientExtensionId !== undefined)
     logger.info(logMessage);
   else
     logger.fine(logMessage);

--- a/smart_card_connector_app/src/window-apps-displaying.js
+++ b/smart_card_connector_app/src/window-apps-displaying.js
@@ -73,7 +73,7 @@ var lastKnownAppsPromise = null;
 function updateAppView(knownAppsPromise, appIds, knownApps) {
   if (knownAppsPromise !== lastKnownAppsPromise) return false;
 
-  GSC.Logging.checkWithLogger(logger, !goog.isNull(appListElement));
+  GSC.Logging.checkWithLogger(logger, appListElement !== null);
   goog.asserts.assert(appListElement);
 
   goog.dom.removeChildren(appListElement);

--- a/smart_card_connector_app/src/window-devices-displaying.js
+++ b/smart_card_connector_app/src/window-devices-displaying.js
@@ -81,7 +81,7 @@ function displayReaderList(readers) {
   goog.dom.removeChildren(readersListElement);
 
   for (let reader of readers) {
-    GSC.Logging.checkWithLogger(logger, !goog.isNull(readersListElement));
+    GSC.Logging.checkWithLogger(logger, readersListElement !== null);
     goog.asserts.assert(readersListElement);
 
     var indicatorClasses = 'reader-state-indicator reader-state-indicator-' +

--- a/third_party/libusb/naclport/src/chrome_usb/chrome-usb-backend.js
+++ b/third_party/libusb/naclport/src/chrome_usb/chrome-usb-backend.js
@@ -170,7 +170,7 @@ ChromeUsbBackend.prototype.getChromeUsbFunction_ = function(functionName) {
 ChromeUsbBackend.prototype.chromeUsbApiGenericCallback_ = function(
     debugRepresentation, promiseResolver, var_args) {
   var lastError = chrome.runtime.lastError;
-  if (goog.isDef(lastError)) {
+  if (lastError !== undefined) {
     // FIXME(emaxx): Looks like the USB transfer timeouts also raise this
     // lastError flag, that is not suitable for us as we want to distinguish
     // the timeouts from the fatal errors.

--- a/third_party/pcsc-lite/naclport/cpp_client/src/nacl-client-backend.js
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/nacl-client-backend.js
@@ -165,7 +165,7 @@ NaclClientBackend.prototype.handleRequest_ = function(payload) {
     //
     // Only the last case is the case when the immediate initialization makes
     // sense.
-    if (!this.context_ && goog.isNull(this.initializationTimerId_))
+    if (!this.context_ && this.initializationTimerId_ === null)
       this.initialize_();
   }
 
@@ -207,7 +207,7 @@ NaclClientBackend.prototype.initialize_ = function() {
 /** @private */
 NaclClientBackend.prototype.contextInitializedListener_ = function(api) {
   GSC.Logging.checkWithLogger(
-      this.logger, goog.isNull(this.initializationTimerId_));
+      this.logger, this.initializationTimerId_ === null);
 
   GSC.Logging.checkWithLogger(this.logger, !this.api_);
   this.api_ = api;
@@ -223,7 +223,7 @@ NaclClientBackend.prototype.contextDisposedListener_ = function() {
       'PC/SC-Lite Client Context instance was disposed, cleaning up, ' +
       'rejecting all queued requests and scheduling reinitialization...');
   GSC.Logging.checkWithLogger(
-      this.logger, goog.isNull(this.initializationTimerId_));
+      this.logger, this.initializationTimerId_ === null);
   if (this.api_) {
     this.api_.dispose();
     this.api_ = null;

--- a/third_party/pcsc-lite/naclport/js_client/src/api.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/api.js
@@ -2049,7 +2049,7 @@ goog.exportProperty(API, 'SCARD_PCI_RAW', API.SCARD_PCI_RAW);
 API.SCARD_READERSTATE_IN = function(readerName, currentState, opt_userData) {
   this['reader_name'] = readerName;
   this['current_state'] = currentState;
-  if (goog.isDef(opt_userData))
+  if (opt_userData !== undefined)
     this['user_data'] = opt_userData;
 };
 
@@ -2095,7 +2095,7 @@ API.SCARD_READERSTATE_OUT = function(
   this['current_state'] = currentState;
   this['event_state'] = eventState;
   this['atr'] = atr;
-  if (goog.isDef(opt_userData))
+  if (opt_userData !== undefined)
     this['user_data'] = opt_userData;
 };
 
@@ -2196,7 +2196,7 @@ goog.exportProperty(
  */
 API.ResultOrErrorCode.prototype.getResult = function() {
   GSC.Logging.checkWithLogger(this.logger, this.isSuccessful());
-  GSC.Logging.checkWithLogger(this.logger, goog.isDef(this.resultItems));
+  GSC.Logging.checkWithLogger(this.logger, this.resultItems !== undefined);
   goog.asserts.assert(this.resultItems);
   return this.resultItems;
 };
@@ -2250,7 +2250,8 @@ API.prototype.pcsc_stringify_error = function(errorCode) {
       [errorCode],
       function(responseItems) {
         GSC.Logging.checkWithLogger(logger, responseItems.length == 1);
-        GSC.Logging.checkWithLogger(logger, goog.isString(responseItems[0]));
+        GSC.Logging.checkWithLogger(
+            logger, typeof responseItems[0] === 'string');
         return responseItems[0];
       });
 };
@@ -2291,9 +2292,9 @@ goog.exportProperty(
  */
 API.prototype.SCardEstablishContext = function(
     scope, opt_reserved_1, opt_reserved_2) {
-  if (!goog.isDef(opt_reserved_1))
+  if (opt_reserved_1 === undefined)
     opt_reserved_1 = null;
-  if (!goog.isDef(opt_reserved_2))
+  if (opt_reserved_2 === undefined)
     opt_reserved_2 = null;
   return this.postRequest_(
       'SCardEstablishContext',

--- a/third_party/pcsc-lite/naclport/js_client/src/context.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/context.js
@@ -77,9 +77,9 @@ GSC.PcscLiteClient.Context = function(clientTitle, opt_serverAppId) {
    * @private
    */
   this.serverAppId_ = undefined;
-  if (!goog.isDef(opt_serverAppId))
+  if (opt_serverAppId === undefined)
     this.serverAppId_ = GSC.PcscLiteCommon.Constants.SERVER_OFFICIAL_APP_ID;
-  else if (!goog.isNull(opt_serverAppId))
+  else if (opt_serverAppId !== null)
     this.serverAppId_ = opt_serverAppId;
 
   /**
@@ -123,18 +123,18 @@ goog.exportProperty(Context.prototype, 'logger', Context.prototype.logger);
  * to be used instead of opening a new port.
  */
 Context.prototype.initialize = function(opt_messageChannel) {
-  if (goog.isDef(opt_messageChannel)) {
+  if (opt_messageChannel !== undefined) {
     this.channel_ = opt_messageChannel;
     goog.async.nextTick(this.messageChannelEstablishedListener_, this);
   } else {
     this.logger.fine(
         'Opening a connection to the server app ' +
-        (goog.isDef(this.serverAppId_) ?
+        (this.serverAppId_ !== undefined ?
              '(extension id is "' + this.serverAppId_ + '")' :
              '(which is the own app)') +
         '...');
     var connectInfo = {'name': this.clientTitle};
-    if (goog.isDef(this.serverAppId_)) {
+    if (this.serverAppId_ !== undefined) {
       var port = chrome.runtime.connect(this.serverAppId_, connectInfo);
     } else {
       var port = chrome.runtime.connect(connectInfo);
@@ -159,7 +159,7 @@ goog.exportProperty(
  * @param {function()|function(!GSC.PcscLiteClient.API)} callback
  */
 Context.prototype.addOnInitializedCallback = function(callback) {
-  if (!goog.isNull(this.api))
+  if (this.api !== null)
     callback(this.api);
   else
     this.onInitializedCallbacks_.push(callback);
@@ -215,8 +215,8 @@ Context.prototype.messageChannelEstablishedListener_ = function() {
 
   this.logger.fine('Message channel was established successfully');
 
-  GSC.Logging.checkWithLogger(this.logger, goog.isNull(this.api));
-  GSC.Logging.checkWithLogger(this.logger, !goog.isNull(this.channel_));
+  GSC.Logging.checkWithLogger(this.logger, this.api === null);
+  GSC.Logging.checkWithLogger(this.logger, this.channel_ !== null);
   goog.asserts.assert(this.channel_);
   var api = new GSC.PcscLiteClient.API(this.channel_);
   this.api = api;

--- a/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
+++ b/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
@@ -261,7 +261,7 @@ TrackerThroughPcscServerHook.prototype.getReaders = function() {
       ports, this.portToReaderInfoMap_.get, this.portToReaderInfoMap_);
   // Remove null entries, as they correspond to readers that should be hidden.
   return /** @type {!Array.<!ReaderInfo>} */ (mappedReaderInfos.filter(
-      function(item) { return !goog.isNull(item); }));
+      function(item) { return item !== null; }));
 };
 
 /**
@@ -485,7 +485,7 @@ TrackerThroughPcscApi.prototype.runStatusTrackingLoop_ = function(
     // If an intermittent error was returned from the previous request, then
     // just sleep for some time and repeat the tracking loop body; otherwise -
     // block on waiting for a notification from PC/SC that something is changed.
-    if (goog.isNull(readerStates)) {
+    if (readerStates === null) {
       return goog.Timer.promise(READER_STATUS_FAILED_QUERY_DELAY_MILLISECONDS);
     } else {
       this.updateResultFromReaderStates_(readerStates);

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
@@ -186,7 +186,7 @@ GSC.PcscLiteServerClientsManagement.ClientHandler = function(
   this.id = idGenerator.next();
 
   /** @private */
-  this.clientAppId_ = goog.isDef(clientAppId) ? clientAppId : null;
+  this.clientAppId_ = clientAppId !== undefined ? clientAppId : null;
 
   /**
    * @type {!goog.log.Logger}
@@ -194,7 +194,7 @@ GSC.PcscLiteServerClientsManagement.ClientHandler = function(
    */
   this.logger = GSC.Logging.getScopedLogger(
       'PcscLiteServerClientsManagement.ClientHandler<' +
-      (goog.isNull(this.clientAppId_) ?
+      (this.clientAppId_ === null ?
            'own app' : '"' + this.clientAppId_ + '"') +
       ', id=' + this.id + '>');
 
@@ -339,7 +339,7 @@ ClientHandler.prototype.handleRequest_ = function(payload) {
  */
 ClientHandler.prototype.getPermissionsCheckPromise_ = function() {
   return permissionsChecker.check(this.clientAppId_).then(function() {
-    if (!goog.isNull(this.clientAppId_)) {
+    if (this.clientAppId_ !== null) {
       this.logger.info(
           'Client was granted permissions to issue PC/SC requests');
     }
@@ -393,7 +393,7 @@ ClientHandler.prototype.clientMessageChannelDisposedListener_ = function() {
   if (this.isDisposed())
     return;
   var logMessage = 'Client message channel was disposed, disposing...';
-  if (goog.isNull(this.clientAppId_))
+  if (this.clientAppId_ === null)
     this.logger.fine(logMessage);
   else
     this.logger.info(logMessage);
@@ -447,7 +447,7 @@ ClientHandler.prototype.createServerRequesterIfNeed_ = function() {
 
   this.sendServerCreateHandlerMessage_();
   GSC.Logging.checkWithLogger(
-      this.logger, !goog.isNull(this.serverMessageChannel_));
+      this.logger, this.serverMessageChannel_ !== null);
   goog.asserts.assert(this.serverMessageChannel_);
 
   var requesterTitle = goog.string.subs(
@@ -470,7 +470,7 @@ ClientHandler.prototype.sendServerCreateHandlerMessage_ = function() {
       this.logger, !this.serverMessageChannel_.isDisposed());
   var messageData = {};
   messageData[CLIENT_HANDLER_ID_MESSAGE_KEY] = this.id;
-  if (!goog.isNull(this.clientAppId_))
+  if (this.clientAppId_ !== null)
     messageData[CLIENT_APP_ID_MESSAGE_KEY] = this.clientAppId_;
   this.serverMessageChannel_.send(
       CREATE_CLIENT_HANDLER_SERVER_MESSAGE_SERVICE_NAME, messageData);

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/checker.js
@@ -89,7 +89,7 @@ Checker.prototype.check = function(clientAppId) {
   this.logger.finer('Checking permissions for client App with id ' +
                     GSC.DebugDump.dump(clientAppId) + '...');
 
-  if (goog.isNull(clientAppId)) {
+  if (clientAppId === null) {
     this.logger.finer('Granted permissions for client with null App id');
     return goog.Promise.resolve();
   }

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/known-apps-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/known-apps-registry.js
@@ -143,7 +143,7 @@ KnownAppsRegistry.prototype.tryGetByIds = function(idList) {
         var knownApps = [];
         for (let id of idList) {
           var knownApp = knownAppsMap.get(id);
-          knownApps.push(goog.isDef(knownApp) ? knownApp : null);
+          knownApps.push(knownApp !== undefined ? knownApp : null);
         }
         promiseResolver.resolve(knownApps);
       },
@@ -246,7 +246,7 @@ KnownAppsRegistry.prototype.tryParseKnownAppJson_ = function(key, value) {
   if (!goog.object.containsKey(value, KNOWN_CLIENT_APP_NAME_FIELD))
     return null;
   var nameField = value[KNOWN_CLIENT_APP_NAME_FIELD];
-  if (!goog.isString(nameField))
+  if (typeof nameField !== 'string')
     return null;
 
   return new KnownApp(key, nameField);

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
@@ -182,7 +182,7 @@ ManagedRegistry.prototype.setAllowedClientAppIdsFromStorageData_ = function(
   var newAllowedClientAppIds = new Set;
   var success = true;
   goog.array.forEach(storageData, function(item) {
-    if (!goog.isString(item)) {
+    if (typeof item !== 'string') {
       this.logger.warning(
           'Failed to load the allowed client App id from the managed ' +
           'storage item: expected a string, instead got: ' +

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompt-dialog-main.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompt-dialog-main.js
@@ -70,22 +70,23 @@ function prepareMessage() {
   var data = GSC.PopupWindow.Client.getData();
 
   var isClientKnown = data['is_client_known'];
-  GSC.Logging.checkWithLogger(logger, goog.isBoolean(isClientKnown));
+  GSC.Logging.checkWithLogger(logger, typeof isClientKnown === 'boolean');
   goog.asserts.assertBoolean(isClientKnown);
 
   var clientAppId = data['client_app_id'];
-  GSC.Logging.checkWithLogger(logger, goog.isString(clientAppId));
+  GSC.Logging.checkWithLogger(logger, typeof clientAppId === 'string');
   goog.asserts.assertString(clientAppId);
 
   var clientAppName = data['client_app_name'];
   if (isClientKnown) {
-    GSC.Logging.checkWithLogger(logger, goog.isString(clientAppName));
+    GSC.Logging.checkWithLogger(logger, typeof clientAppName === 'string');
     goog.asserts.assertString(clientAppName);
   } else {
     GSC.Logging.checkWithLogger(
-        logger, !goog.isDef(clientAppName) || goog.isString(clientAppName));
+        logger,
+        clientAppName === undefined || typeof clientAppName === 'string');
     goog.asserts.assert(
-        !goog.isDef(clientAppName) || goog.isString(clientAppName));
+        clientAppName === undefined || typeof clientAppName === 'string');
   }
 
   var linkTitle;

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittest.js
@@ -113,7 +113,7 @@ function setUpChromeStorageMock(
         callback(fakeInitialData);
       });
 
-  if (!goog.isNull(expectedDataToBeWritten))
+  if (expectedDataToBeWritten !== null)
     chrome.storage.local.set(expectedDataToBeWritten);
 }
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
@@ -112,7 +112,7 @@ UserPromptingChecker.prototype.check = function(clientAppId) {
                      clientAppId + '"...');
 
   var existingPromise = this.checkPromiseMap_.get(clientAppId);
-  if (goog.isDef(existingPromise)) {
+  if (existingPromise !== undefined) {
     this.logger.finest(
         'Found the existing promise for the permission checking of the ' +
         'client App with id "' + clientAppId + '", returning it');
@@ -206,7 +206,7 @@ UserPromptingChecker.prototype.parseLocalStorageUserSelections_ = function(
     return storedUserSelections;
   }
   goog.object.forEach(contents, function(userSelection, appId) {
-    if (!goog.isBoolean(userSelection)) {
+    if (typeof userSelection !== 'boolean') {
       this.logger.warning(
           'Corrupted local storage entry - expected the object value to ' +
           'be a boolean, received: ' + GSC.DebugDump.dump(userSelection));


### PR DESCRIPTION
Update the code to work with the release 20191111 of Closure Library:

* The following functions were deprecated and trigger an error now:
  + goog.isNull,
  + goog.isDef,
  + goog.isString,
  + goog.isNumber,
  + goog.isBoolean,
  + goog.object.extend.