### PR TITLE
Skip compiling Boost naclport by default

### DIFF
--- a/env/constants.sh
+++ b/env/constants.sh
@@ -20,4 +20,4 @@ DEPOT_TOOLS_REPOSITORY_URL="https://chromium.googlesource.com/chromium/tools/dep
 NACL_SDK_VERSION="47"
 
 WEBPORTS_REPOSITORY_URL="https://chromium.googlesource.com/webports.git"
-WEBPORTS_TARGETS="glibc-compat boost openssl"
+WEBPORTS_TARGETS="glibc-compat openssl"


### PR DESCRIPTION
Don't request the compilation of the NaCl port of the Boost C++
library in the env/initialize.sh script.

The Boost C++ library isn't used in this project anymore since
commit 4c06512.