### PR TITLE
Retry connection when initial attempt fails

### DIFF
--- a/third_party/libusb/naclport/src/libusb_over_chrome_usb.cc
+++ b/third_party/libusb/naclport/src/libusb_over_chrome_usb.cc
@@ -23,7 +23,6 @@
 #include <cstring>
 #include <functional>
 #include <limits>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -508,8 +507,8 @@ int LibusbOverChromeUsb::LibusbGetDeviceDescriptor(
 
 uint8_t LibusbOverChromeUsb::LibusbGetBusNumber(libusb_device* dev) {
   auto bus_numbers_iterator = 
-      busNumbers_.find(dev->chrome_usb_device().device);
-  if (bus_numbers_iterator != busNumbers_.end()) {
+      bus_numbers_.find(dev->chrome_usb_device().device);
+  if (bus_numbers_iterator != bus_numbers_.end()) {
     return bus_numbers_iterator->second;
   }
   return kDefaultBusNumber;
@@ -538,9 +537,10 @@ int LibusbOverChromeUsb::LibusbOpen(
         "request failed: " << result.error_message();
     // Modify the devices (fake) bus number that we report so that PCSC will 
     // retry to connect to the device once it updates the device list.
-    uint32_t new_bus_number = LibusbGetBusNumber(dev) + 1;
+    uint32_t new_bus_number =
+        static_cast<uint32_t>(LibusbGetBusNumber(dev)) + 1;
     if (new_bus_number <= kMaximumBusNumber) {
-      busNumbers_[dev->chrome_usb_device().device] = new_bus_number;
+      bus_numbers_[dev->chrome_usb_device().device] = new_bus_number;
     }
     return LIBUSB_ERROR_OTHER;
   }

--- a/third_party/libusb/naclport/src/libusb_over_chrome_usb.cc
+++ b/third_party/libusb/naclport/src/libusb_over_chrome_usb.cc
@@ -507,9 +507,10 @@ int LibusbOverChromeUsb::LibusbGetDeviceDescriptor(
 }
 
 uint8_t LibusbOverChromeUsb::LibusbGetBusNumber(libusb_device* dev) {
-  auto busNumbersIterator = busNumbers_.find(dev->chrome_usb_device().device);
-  if (busNumbersIterator != busNumbers_.end()) {
-    return busNumbersIterator->second;
+  auto bus_numbers_iterator = 
+      busNumbers_.find(dev->chrome_usb_device().device);
+  if (bus_numbers_iterator != busNumbers_.end()) {
+    return bus_numbers_iterator->second;
   }
   return kDefaultBusNumber;
 }
@@ -537,9 +538,9 @@ int LibusbOverChromeUsb::LibusbOpen(
         "request failed: " << result.error_message();
     // Modify the devices (fake) bus number that we report so that PCSC will 
     // retry to connect to the device once it updates the device list.
-    uint32_t newBusNumber = LibusbGetBusNumber(dev) + 1;
-    if (newBusNumber <= kMaximumBusNumber) {
-      busNumbers_[dev->chrome_usb_device().device] = newBusNumber;
+    uint32_t new_bus_number = LibusbGetBusNumber(dev) + 1;
+    if (new_bus_number <= kMaximumBusNumber) {
+      busNumbers_[dev->chrome_usb_device().device] = new_bus_number;
     }
     return LIBUSB_ERROR_OTHER;
   }

--- a/third_party/libusb/naclport/src/libusb_over_chrome_usb.h
+++ b/third_party/libusb/naclport/src/libusb_over_chrome_usb.h
@@ -20,6 +20,7 @@
 #include <stdint.h>
 
 #include <memory>
+#include <unordered_map>
 
 #include <libusb.h>
 
@@ -139,7 +140,11 @@ class LibusbOverChromeUsb final : public LibusbInterface {
   int LibusbHandleEventsWithTimeout(
       libusb_context* context, int timeout_seconds);
 
-  std::unordered_map<int64_t, uint8_t> busNumbers_;
+  // map that holds the (fake) bus number for each device
+  // keys are libusb_device->chrome_usb_device().device
+  // if a device is not found, we return kDefaultBusNumber
+  std::unordered_map<int64_t, uint8_t> bus_numbers_;
+
   chrome_usb::ApiBridgeInterface* const chrome_usb_api_bridge_;
   LibusbContextsStorage contexts_storage_;
   const std::shared_ptr<libusb_context> default_context_;

--- a/third_party/libusb/naclport/src/libusb_over_chrome_usb.h
+++ b/third_party/libusb/naclport/src/libusb_over_chrome_usb.h
@@ -139,6 +139,7 @@ class LibusbOverChromeUsb final : public LibusbInterface {
   int LibusbHandleEventsWithTimeout(
       libusb_context* context, int timeout_seconds);
 
+  std::unordered_map<int64_t, uint8_t> busNumbers_;
   chrome_usb::ApiBridgeInterface* const chrome_usb_api_bridge_;
   LibusbContextsStorage contexts_storage_;
   const std::shared_ptr<libusb_context> default_context_;


### PR DESCRIPTION
Close issue #90

When connecting to a reader fails, we retry connecting later.
This is done by showing another Bus number for the device.
We need to fake Bus numbers anyway as chrome.usb does not let us retrieve them.
PCSC then views it as a different device from the previous one and attempts
to connect to it once a smartcard reader needs to be accessed.