### PR TITLE
Forward JS logs to NaCl stderr in Connector app

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -28,6 +28,7 @@ ROOT_SOURCES_SUBDIR := google_smart_card_common
 SOURCES_PATH := $(ROOT_SOURCES_PATH)/$(ROOT_SOURCES_SUBDIR)
 
 SOURCES := \
+	$(SOURCES_PATH)/external_logs_printer.cc \
 	$(SOURCES_PATH)/formatting.cc \
 	$(SOURCES_PATH)/logging/function_call_tracer.cc \
 	$(SOURCES_PATH)/logging/hex_dumping.cc \
@@ -64,6 +65,7 @@ $(eval $(call NACL_LIBRARY_BUILD_RULE,$(SOURCES)))
 
 
 INSTALLING_HEADERS := \
+	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):external_logs_printer.h \
 	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):formatting.h \
 	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):logging/function_call_tracer.h \
 	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):logging/hex_dumping.h \

--- a/common/cpp/src/google_smart_card_common/external_logs_printer.cc
+++ b/common/cpp/src/google_smart_card_common/external_logs_printer.cc
@@ -25,14 +25,13 @@ namespace google_smart_card {
 
 namespace {
 
-// The structure represents the message data contents for the client handler
-// creation message.
+// The structure represents the message handled by the external logs printer.
 struct ExternalLogMessageData {
   std::string formatted_log_message;
 };
 
 void PrintExternalLogMessage(const ExternalLogMessageData& message_data) {
-  // Note: Intentionally not using the GOOGLE_SMART_CARD_LOG() macro and
+  // Note: Intentionally not using the GOOGLE_SMART_CARD_LOG*() macros and
   // related here, in order to avoid delivering them to the JS side and
   // therefore likely duplicating them.
   std::cerr << message_data.formatted_log_message;

--- a/common/cpp/src/google_smart_card_common/external_logs_printer.cc
+++ b/common/cpp/src/google_smart_card_common/external_logs_printer.cc
@@ -1,0 +1,79 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google_smart_card_common/external_logs_printer.h>
+
+#include <iostream>
+#include <string>
+
+#include <google_smart_card_common/logging/logging.h>
+#include <google_smart_card_common/messaging/typed_message_listener.h>
+#include <google_smart_card_common/pp_var_utils/struct_converter.h>
+
+namespace google_smart_card {
+
+namespace {
+
+// The structure represents the message data contents for the client handler
+// creation message.
+struct ExternalLogMessageData {
+  std::string formatted_log_message;
+};
+
+void PrintExternalLogMessage(const ExternalLogMessageData& message_data) {
+  // Note: Intentionally not using the GOOGLE_SMART_CARD_LOG() macro and
+  // related here, in order to avoid delivering them to the JS side and
+  // therefore likely duplicating them.
+  std::cerr << message_data.formatted_log_message;
+  std::cerr.flush();
+}
+
+}  // namespace
+
+template <>
+constexpr const char*
+StructConverter<ExternalLogMessageData>::GetStructTypeName() {
+  return "ExternalLogMessageData";
+}
+
+template <>
+template <typename Callback>
+void StructConverter<ExternalLogMessageData>::VisitFields(
+    const ExternalLogMessageData& value, Callback callback) {
+  callback(&value.formatted_log_message, "formatted_log_message");
+}
+
+ExternalLogsPrinter::ExternalLogsPrinter(
+    const std::string& listened_message_type)
+  : listened_message_type_(listened_message_type) {}
+
+ExternalLogsPrinter::~ExternalLogsPrinter() = default;
+
+std::string ExternalLogsPrinter::GetListenedMessageType() const {
+  return listened_message_type_;
+}
+
+bool ExternalLogsPrinter::OnTypedMessageReceived(const pp::Var& data) {
+  ExternalLogMessageData message_data;
+  std::string error_message;
+  if (!StructConverter<ExternalLogMessageData>::ConvertFromVar(
+           data, &message_data, &error_message)) {
+    GOOGLE_SMART_CARD_LOG_FATAL << "Failed to parse external log message: " <<
+        error_message;
+  }
+  PrintExternalLogMessage(message_data);
+  return true;
+}
+
+}  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/external_logs_printer.h
+++ b/common/cpp/src/google_smart_card_common/external_logs_printer.h
@@ -1,0 +1,42 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains definitions that allow handling and printing logs received
+// from an external message pipe.
+
+#ifndef GOOGLE_SMART_CARD_COMMON_EXTERNAL_LOGS_PRINTER_H_
+#define GOOGLE_SMART_CARD_COMMON_EXTERNAL_LOGS_PRINTER_H_
+
+#include <google_smart_card_common/messaging/typed_message_listener.h>
+
+namespace google_smart_card {
+
+class ExternalLogsPrinter final : public TypedMessageListener {
+ public:
+  ExternalLogsPrinter(const std::string& listened_message_type);
+  ExternalLogsPrinter(const ExternalLogsPrinter&) = delete;
+  ExternalLogsPrinter& operator=(const ExternalLogsPrinter&) = delete;
+  ~ExternalLogsPrinter() override;
+
+  // TypedMessageListener:
+  std::string GetListenedMessageType() const override;
+  bool OnTypedMessageReceived(const pp::Var& data) override;
+
+ private:
+   const std::string listened_message_type_;
+};
+
+}  // namespace google_smart_card
+
+#endif  // GOOGLE_SMART_CARD_COMMON_EXTERNAL_LOGS_PRINTER_H_

--- a/common/cpp/src/google_smart_card_common/external_logs_printer.h
+++ b/common/cpp/src/google_smart_card_common/external_logs_printer.h
@@ -18,6 +18,8 @@
 #ifndef GOOGLE_SMART_CARD_COMMON_EXTERNAL_LOGS_PRINTER_H_
 #define GOOGLE_SMART_CARD_COMMON_EXTERNAL_LOGS_PRINTER_H_
 
+#include <string>
+
 #include <google_smart_card_common/messaging/typed_message_listener.h>
 
 namespace google_smart_card {

--- a/common/cpp/src/google_smart_card_common/external_logs_printer.h
+++ b/common/cpp/src/google_smart_card_common/external_logs_printer.h
@@ -34,7 +34,7 @@ class ExternalLogsPrinter final : public TypedMessageListener {
   bool OnTypedMessageReceived(const pp::Var& data) override;
 
  private:
-   const std::string listened_message_type_;
+  const std::string listened_message_type_;
 };
 
 }  // namespace google_smart_card

--- a/common/js/src/logging/log-buffer-forwarder.js
+++ b/common/js/src/logging/log-buffer-forwarder.js
@@ -1,0 +1,153 @@
+/** @license
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview This file contains definitions that allow forwarding contents
+ * of a log buffer to some recipient.
+ */
+
+goog.provide('GoogleSmartCard.LogBufferForwarder');
+
+goog.require('GoogleSmartCard.LogBuffer');
+goog.require('GoogleSmartCard.LogFormatting');
+goog.require('GoogleSmartCard.Logging');
+goog.require('goog.log.LogRecord');
+goog.require('goog.messaging.AbstractChannel');
+goog.require('goog.structs.CircularBuffer');
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+const POSTPONING_BUFFER_CAPACITY = 100;
+
+/**
+ * This class observes log messages that are put into the given log buffer and
+ * forwards them to the message channel specified via startForwarding(). The
+ * message format is |{formatted_log_message: string}|.
+ *
+ * Log messages observed before the call to startForwarding() are accumulated
+ * and forwarded as soon as it's called.
+ *
+ * NOTE: It's the responsibility of the caller to make sure that the specified
+ * message channel doesn't emit logs when sending a message or that they are
+ * filtered out - failing to guarantee that can result in infinite recursion.
+ * (This class provides some heuristical protection against synchronous
+ * failures, but it won't help when the problematic logs are emitted
+ * asynchronously.)
+ *
+ * NOTE 2: It's expected that startForwarding() is called "soon", because this
+ * class has only limited capacity for storing messages before that.
+ * @param {!GSC.LogBuffer} logBuffer
+ * @param {string} messageChannelServiceName
+ * @constructor
+ */
+GSC.LogBufferForwarder = function(logBuffer, messageChannelServiceName) {
+  /**
+   * @type {string}
+   * @private
+   */
+  this.messageChannelServiceName_ = messageChannelServiceName;
+  /**
+   * @type {!Set}
+   * @private
+   */
+  this.filteredLoggerNames_ = new Set();
+  /**
+   * @type {?goog.messaging.AbstractChannel}
+   * @private
+   */
+  this.messageChannel_ = null;
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.logCapturingEnabled_ = true;
+  /**
+   * @type {!goog.structs.CircularBuffer<string>}
+   * @private
+   */
+  this.postponedLogRecords_ = new goog.structs.CircularBuffer();
+
+  logBuffer.addObserver(this.onLogRecordObserved_.bind(this));
+};
+
+const LogBufferForwarder = GSC.LogBufferForwarder;
+
+goog.exportSymbol('GoogleSmartCard.LogBufferForwarder', LogBufferForwarder);
+
+/**
+ * Sets up forwarding of the log records to the specified message channel.
+ *
+ * Also immediately sends the log records that have been accumulated so far.
+ * @param {!goog.messaging.AbstractChannel} messageChannel
+ */
+LogBufferForwarder.prototype.startForwarding = function(messageChannel) {
+  this.messageChannel_ = messageChannel;
+
+  for (const logRecord of this.postponedLogRecords_.getValues())
+    this.sendLogRecord_(logRecord);
+  this.postponedLogRecords_.clear();
+};
+
+/**
+ * Adds a logger whose messages have to be ignored.
+ *
+ * This only affects the messages collected after the call. This does NOT affect
+ * messages from children of the specified logger.
+ * @param {string} loggerName
+ */
+LogBufferForwarder.prototype.addFilter = function(loggerName) {
+  this.filteredLoggerNames_.add(loggerName);
+};
+
+/**
+ * @param {string} documentLocation
+ * @param {!goog.log.LogRecord} logRecord
+ * @private
+ */
+LogBufferForwarder.prototype.onLogRecordObserved_ = function(
+    documentLocation, logRecord) {
+  if (!this.logCapturingEnabled_ ||
+      this.filteredLoggerNames_.has(logRecord.getLoggerName())) {
+    return;
+  }
+  const formattedLogRecord = GSC.LogFormatting.formatLogRecord(
+      documentLocation, logRecord);
+  if (!this.messageChannel_) {
+    this.postponedLogRecords_.add(formattedLogRecord);
+    return;
+  }
+  this.sendLogRecord_(formattedLogRecord);
+};
+
+/**
+ * @param {string} formattedLogRecord
+ * @private
+ */
+LogBufferForwarder.prototype.sendLogRecord_ = function(formattedLogRecord) {
+  // Ignore log messages emitted while sending the log, to minimize the risk of
+  // infinite recursion if the message channel emits an unfiltered message.
+  this.logCapturingEnabled_ = false;
+
+  GSC.Logging.check(this.messageChannel_);
+  const message = {formatted_log_message: formattedLogRecord};
+  this.messageChannel_.send(this.messageChannelServiceName_, message);
+
+  this.logCapturingEnabled_ = true;
+};
+
+});

--- a/common/js/src/logging/log-buffer.js
+++ b/common/js/src/logging/log-buffer.js
@@ -21,8 +21,8 @@
 
 goog.provide('GoogleSmartCard.LogBuffer');
 
+goog.require('GoogleSmartCard.LogFormatting');
 goog.require('goog.array');
-goog.require('goog.debug.TextFormatter');
 goog.require('goog.iter');
 goog.require('goog.log.LogRecord');
 goog.require('goog.log.Logger');
@@ -65,6 +65,11 @@ GSC.LogBuffer = function(capacity) {
    * @private
    */
   this.formattedLogsPrefix_ = [];
+  /**
+   * @type {!Array.<function(string, !goog.log.LogRecord)>}
+   * @private
+   */
+  this.observers_ = [];
 
   /**
    * @type {!goog.structs.CircularBuffer.<string>}
@@ -72,11 +77,6 @@ GSC.LogBuffer = function(capacity) {
    */
   this.formattedLogsSuffix_ = new goog.structs.CircularBuffer(
       capacity - this.logsPrefixCapacity_);
-
-  /** @private */
-  this.textFormatter_ = new goog.debug.TextFormatter;
-  this.textFormatter_.showAbsoluteTime = false;
-  this.textFormatter_.showSeverityLevel = true;
 };
 
 /** @const */
@@ -96,11 +96,10 @@ goog.exportProperty(
 
 /**
  * @param {!goog.log.Logger} logger
- * @param {string} documentLocationPathname
+ * @param {string} documentLocation
  */
-LogBuffer.prototype.attachToLogger = function(
-    logger, documentLocationPathname) {
-  logger.addHandler(this.addLogRecord_.bind(this, documentLocationPathname));
+LogBuffer.prototype.attachToLogger = function(logger, documentLocation) {
+  logger.addHandler(this.onLogRecordObserved_.bind(this, documentLocation));
 };
 
 goog.exportProperty(
@@ -170,63 +169,40 @@ goog.exportProperty(
     LogBuffer.prototype, 'getState', LogBuffer.prototype.getState);
 
 /**
- * @param {string} documentLocationPathname
+ * Adds an observer for captured log records.
+ * @param {function(string, !goog.log.LogRecord)} observer
+ */
+LogBuffer.prototype.addObserver = function(observer) {
+  this.observers_.push(observer);
+};
+
+/**
+ * @param {function(string, !goog.log.LogRecord)} observer
+ */
+LogBuffer.prototype.removeObserver = function(observer) {
+  this.observers_ = this.observers_.filter((value) => {
+    return value !== observer;
+  });
+};
+
+/**
+ * @param {string} documentLocation
  * @param {!goog.log.LogRecord} logRecord
  * @private
  */
-LogBuffer.prototype.addLogRecord_ = function(
-    documentLocationPathname, logRecord) {
-  var formattedLogRecord = this.formatLogRecord_(this.prefixLogRecord_(
-      logRecord, documentLocationPathname));
+LogBuffer.prototype.onLogRecordObserved_ = function(
+    documentLocation, logRecord) {
+  for (const observer of this.observers_)
+    observer(documentLocation, logRecord);
+
+  var formattedLogRecord = GSC.LogFormatting.formatLogRecordCompact(
+      documentLocation, logRecord);
 
   if (this.formattedLogsPrefix_.length < this.logsPrefixCapacity_)
     this.formattedLogsPrefix_.push(formattedLogRecord);
   else
     this.formattedLogsSuffix_.add(formattedLogRecord);
   ++this.size_;
-};
-
-/**
- * @param {!goog.log.LogRecord} logRecord
- * @param {string} documentLocationPathname
- * @return {!goog.log.LogRecord}
- * @private
- */
-LogBuffer.prototype.prefixLogRecord_ = function(
-    logRecord, documentLocationPathname) {
-  var loggerNameParts = [];
-  loggerNameParts.push(this.getLogMessagePrefix_(documentLocationPathname));
-  if (logRecord.getLoggerName())
-    loggerNameParts.push(logRecord.getLoggerName());
-  var prefixedLoggerName = loggerNameParts.join('.');
-
-  return new goog.log.LogRecord(
-      logRecord.getLevel(),
-      logRecord.getMessage(),
-      prefixedLoggerName,
-      logRecord.getMillis(),
-      logRecord.getSequenceNumber());
-};
-
-/**
- * @param {!goog.log.LogRecord} logRecord
- * @return {string}
- * @private
- */
-LogBuffer.prototype.formatLogRecord_ = function(logRecord) {
-  return this.textFormatter_.formatRecord(logRecord);
-};
-
-/**
- * @param {string} documentLocationPathname
- * @return {string}
- * @private
- */
-LogBuffer.prototype.getLogMessagePrefix_ = function(documentLocationPathname) {
-  var documentTitle = documentLocationPathname;
-  if (documentTitle == '/_generated_background_page.html')
-    documentTitle = 'background page';
-  return '<' + documentTitle + '>';
 };
 
 });  // goog.scope

--- a/common/js/src/logging/log-formatting.js
+++ b/common/js/src/logging/log-formatting.js
@@ -1,0 +1,109 @@
+/** @license
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview This file contains definitions that allow formatting log
+ * messages.
+ */
+
+goog.provide('GoogleSmartCard.LogFormatting');
+
+goog.require('goog.Uri');
+goog.require('goog.debug.TextFormatter');
+goog.require('goog.log.LogRecord');
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+/**
+ * @type {!goog.debug.TextFormatter}
+ */
+const textFormatter = new goog.debug.TextFormatter();
+textFormatter.showAbsoluteTime = false;
+textFormatter.showSeverityLevel = true;
+
+/**
+ * @param {string} documentLocation
+ * @param {boolean} isCompact
+ * @return {string}
+ */
+function getFormattedDocumentLocation(documentLocation, isCompact) {
+  if (!isCompact)
+    return documentLocation;
+  let uri;
+  try {
+    uri = goog.Uri.parse(documentLocation);
+  } catch (URIError) {
+    return documentLocation;
+  }
+  if (uri.getPath() == '/_generated_background_page.html')
+    return 'background page';
+  return uri.getPath();
+}
+
+/**
+ * @param {string} documentLocation
+ * @param {!goog.log.LogRecord} logRecord
+ * @param {boolean} isCompact
+ * @return {!goog.log.LogRecord}
+ */
+function prefixLogRecord(documentLocation, logRecord, isCompact) {
+  const formattedDocumentLocation = getFormattedDocumentLocation(
+      documentLocation, isCompact);
+  var loggerNameParts = [];
+  loggerNameParts.push('<' + formattedDocumentLocation + '>');
+  if (logRecord.getLoggerName())
+    loggerNameParts.push(logRecord.getLoggerName());
+  var prefixedLoggerName = loggerNameParts.join('.');
+
+  return new goog.log.LogRecord(
+      logRecord.getLevel(),
+      logRecord.getMessage(),
+      prefixedLoggerName,
+      logRecord.getMillis(),
+      logRecord.getSequenceNumber());
+}
+
+/**
+ * Returns a formatted representation of the log record collected at the given
+ * document.
+ * @param {string} documentLocation
+ * @param {!goog.log.LogRecord} logRecord
+ * @return {string}
+ */
+GSC.LogFormatting.formatLogRecord = function(documentLocation, logRecord) {
+  return textFormatter.formatRecord(prefixLogRecord(
+      documentLocation, logRecord, /*isCompact=*/false));
+};
+
+/**
+ * Returns a formatted compact representation of the log record collected at the
+ * given document.
+ *
+ * The compact representation omits detailed context information, e.g. the
+ * extension ID.
+ * @param {string} documentLocation
+ * @param {!goog.log.LogRecord} logRecord
+ * @return {string}
+ */
+GSC.LogFormatting.formatLogRecordCompact = function(
+    documentLocation, logRecord) {
+  return textFormatter.formatRecord(prefixLogRecord(
+      documentLocation, logRecord, /*isCompact=*/true));
+};
+
+});

--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -304,7 +304,7 @@ function setupLogBuffer() {
         'Created a new log buffer instance, attaching it to the root logger');
   }
 
-  logBuffer.attachToLogger(rootLogger, document.location.pathname);
+  logBuffer.attachToLogger(rootLogger, document.location.href);
 }
 
 GSC.Logging.setupLogging();

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -66,7 +66,7 @@ naclModule.getLoadPromise().then(() => {
   // Skip forwarding logs that were received from the NaCl module or generated
   // while sending messages to it, in order to avoid duplication and/or infinite
   // recursion.
-  logBufferForwarderToNaclModule.addFilter(
+  logBufferForwarderToNaclModule.ignoreLogger(
       naclModule.logMessagesReceiver.logger.getName());
   // Start forwarding all future log messages collected on the JS side, but also
   // immediately post the messages that have been accumulated so far.

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -18,6 +18,7 @@ goog.provide('GoogleSmartCard.ConnectorApp.BackgroundMain');
 
 goog.require('GoogleSmartCard.ConnectorApp.Background.MainWindowManaging');
 goog.require('GoogleSmartCard.Libusb.ChromeUsbBackend');
+goog.require('GoogleSmartCard.LogBufferForwarder');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.MessageChannelPair');
 goog.require('GoogleSmartCard.MessageChannelPool');
@@ -34,11 +35,20 @@ goog.scope(function() {
 /** @const */
 var GSC = GoogleSmartCard;
 
+const JS_LOGS_HANDLER_MESSAGE_TYPE = 'js_logs_handler';
+
 /**
  * @type {!goog.log.Logger}
  * @const
  */
 var logger = GSC.Logging.getScopedLogger('ConnectorApp.BackgroundMain');
+
+// Used to forward logs collected on the JS side to the NaCl module's stdout, in
+// order to simplify accessing them in some configurations.
+// Note that this object needs to be created as early as possible, in order to
+// not miss any important log.
+const logBufferForwarderToNaclModule = new GSC.LogBufferForwarder(
+    GSC.Logging.getLogBuffer(), JS_LOGS_HANDLER_MESSAGE_TYPE);
 
 const extensionManifest = chrome.runtime.getManifest();
 const formattedStartupTime = (new Date()).toLocaleString();
@@ -51,6 +61,17 @@ logger.info(
 var naclModule = new GSC.NaclModule(
     'nacl_module.nmf', GSC.NaclModule.Type.PNACL);
 naclModule.addOnDisposeCallback(naclModuleDisposedListener);
+
+naclModule.getLoadPromise().then(() => {
+  // Skip forwarding logs that were received from the NaCl module or generated
+  // while sending messages to it, in order to avoid duplication and/or infinite
+  // recursion.
+  logBufferForwarderToNaclModule.addFilter(
+      naclModule.logMessagesReceiver.logger.getName());
+  // Start forwarding all future log messages collected on the JS side, but also
+  // immediately post the messages that have been accumulated so far.
+  logBufferForwarderToNaclModule.startForwarding(naclModule.messageChannel);
+});
 
 var libusbChromeUsbBackend = new GSC.Libusb.ChromeUsbBackend(
     naclModule.messageChannel);


### PR DESCRIPTION
This makes sure that the logs that are collected on the JavaScript side
are also available in the NaCl process stderr. This should make
accessing these logs much simpler in some situations, because NaCl
process stderr is captured at /var/log/ (at least in test Chrome OS
images for non-guest users).

Before this change, the JS logs were only available via DevTools or via
the "Export logs" UI button. Neither works on Chrome OS login screen (at
least out of the box), therefore piping the logs to the log file will
simplify debugging QA/customer issues.