### PR TITLE
Fix unhandled exception in ChromeLoginStateHook

### DIFF
--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -79,8 +79,10 @@ var libusbChromeUsbBackend = new GSC.Libusb.ChromeUsbBackend(
 var chromeLoginStateHook = new GSC.Libusb.ChromeLoginStateHook();
 libusbChromeUsbBackend.addRequestSuccessHook(
     chromeLoginStateHook.getRequestSuccessHook());
-chromeLoginStateHook.getHookReadyPromise().thenAlways(
+// Start the backend regardless of whether the hook initialization succeeded.
+chromeLoginStateHook.getHookReadyPromise().then(() => {}, () => {}).then(
     function() { libusbChromeUsbBackend.startProcessingEvents(); });
+
 var pcscLiteReadinessTracker =
     new GSC.PcscLiteServerClientsManagement.ReadinessTracker(
         naclModule.messageChannel);


### PR DESCRIPTION
Avoid triggering an exception when the chrome.loginState API is
unavailable. The exception was triggered due to unhandled rejection of
the ChromeLoginStateHook.getHookReadyPromise() promise.

The fix is to make sure that the promise rejection is handled by using
the then() method, instead of thenAlways() that was used before.