### PR TITLE
Log absolute times

### DIFF
--- a/common/js/src/logging/log-formatting.js
+++ b/common/js/src/logging/log-formatting.js
@@ -33,7 +33,7 @@ const GSC = GoogleSmartCard;
  * @type {!goog.debug.TextFormatter}
  */
 const textFormatter = new goog.debug.TextFormatter();
-textFormatter.showAbsoluteTime = false;
+textFormatter.showAbsoluteTime = true;
 textFormatter.showSeverityLevel = true;
 
 /**

--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -282,6 +282,7 @@ function reloadApp() {
 
 function setupConsoleLogging() {
   var console = new goog.debug.Console;
+  console.getFormatter().showAbsoluteTime = true;
   console.setCapturing(true);
 }
 


### PR DESCRIPTION
Having real clock times being logged will simplify understanding logs, especially in the situation when two instances of the same app work simultaneously (one inside the user session and another in the login screen profile).