### PR TITLE
Avoid dumping non-struct classes for logging

### DIFF
--- a/common/js/src/logging/debug-dump.js
+++ b/common/js/src/logging/debug-dump.js
@@ -21,6 +21,7 @@
 
 goog.provide('GoogleSmartCard.DebugDump');
 
+goog.require('goog.Disposable');
 goog.require('goog.array');
 goog.require('goog.iter');
 goog.require('goog.json');
@@ -197,6 +198,11 @@ function dump(value) {
     // DOM-related types.
     return '<Node>';
   }
+
+  // Fast exit for types that are likely non-struct classes, in order to avoid
+  // cyclic references or huge meaningless debug dumps.
+  if (value instanceof goog.Disposable)
+    return '<Class>';
 
   if (value === undefined)
     return 'undefined';

--- a/common/js/src/logging/log-buffer.js
+++ b/common/js/src/logging/log-buffer.js
@@ -22,6 +22,7 @@
 goog.provide('GoogleSmartCard.LogBuffer');
 
 goog.require('GoogleSmartCard.LogFormatting');
+goog.require('goog.Disposable');
 goog.require('goog.array');
 goog.require('goog.iter');
 goog.require('goog.log.LogRecord');
@@ -50,8 +51,11 @@ var GSC = GoogleSmartCard;
  * the crucial information.
  * @param {number} capacity The maximum number of stored log messages.
  * @constructor
+ * @extends {goog.Disposable}
  */
 GSC.LogBuffer = function(capacity) {
+  LogBuffer.base(this, 'constructor');
+
   /** @private */
   this.capacity_ = capacity;
 
@@ -81,6 +85,8 @@ GSC.LogBuffer = function(capacity) {
 
 /** @const */
 var LogBuffer = GSC.LogBuffer;
+
+goog.inherits(LogBuffer, goog.Disposable);
 
 goog.exportSymbol('GoogleSmartCard.LogBuffer', LogBuffer);
 


### PR DESCRIPTION
Add a heuristic check that omits performing recursive dumping for
objects that inherit from goog.Disposable, since such objects are most
likely classes that aren't useful to be logged (as they are not pure
containers for data) and are expensive to be logged (as they may contain
non-trivial state).

Also, in accordance with this heuristic, make the
GoogleSmartCard.LogBuffer class inherit from goog.Disposable - since
objects of this class are one of the most heavy-weight objects in the
whole extension, and we definitely want to avoid it being debug-dumped
at any time.