### PR TITLE
Implement message channel for example app UI

### DIFF
--- a/example_cpp_smart_card_client_app/build/nacl_module/Makefile
+++ b/example_cpp_smart_card_client_app/build/nacl_module/Makefile
@@ -36,6 +36,7 @@ SOURCES := \
 	$(SOURCES_DIR)/chrome_certificate_provider/api_bridge.cc \
 	$(SOURCES_DIR)/chrome_certificate_provider/types.cc \
 	$(SOURCES_DIR)/pp_module.cc \
+	$(SOURCES_DIR)/ui_bridge.cc \
 
 LIBS := \
 	$(PCSC_LITE_CPP_DEMO_LIB) \

--- a/example_cpp_smart_card_client_app/src/_locales/en/messages.json
+++ b/example_cpp_smart_card_client_app/src/_locales/en/messages.json
@@ -18,5 +18,9 @@
   "windowClose": {
     "message": "Close",
     "description": "Accessibility text for close button"
+  },
+  "runTest": {
+    "message": "Test",
+    "description": "Title of the button that can be used to run the smart card test"
   }
 }

--- a/example_cpp_smart_card_client_app/src/background.js
+++ b/example_cpp_smart_card_client_app/src/background.js
@@ -165,6 +165,10 @@ var pcscLiteNaclClientBackend = new GSC.PcscLiteClient.NaclClientBackend(
 var certificateProviderBridgeBackend =
     new SmartCardClientApp.CertificateProviderBridge.Backend(naclModule);
 
+// Ignore messages sent from the NaCl module to the main window when the latter
+// is not opened.
+naclModule.messageChannel.registerService('ui', () => {});
+
 // Starts the NaCl module loading. Up to this point, the module was not actually
 // loading yet, which allowed to add all the necessary event listeners in
 // advance.
@@ -172,7 +176,9 @@ naclModule.startLoading();
 
 // Open the UI window when the user launches the app.
 chrome.app.runtime.onLaunched.addListener(() => {
-  GSC.PopupWindow.Server.createWindow(MAIN_WINDOW_URL, MAIN_WINDOW_OPTIONS);
+  GSC.PopupWindow.Server.createWindow(MAIN_WINDOW_URL, MAIN_WINDOW_OPTIONS, {
+    naclModuleMessageChannel: naclModule.messageChannel,
+  });
 });
 
 // Automatically load the App (in the background) with Chrome startup.

--- a/example_cpp_smart_card_client_app/src/ui_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/ui_bridge.cc
@@ -1,0 +1,108 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ui_bridge.h"
+
+#include <mutex>
+#include <thread>
+#include <utility>
+
+#include <ppapi/cpp/instance.h>
+#include <ppapi/cpp/var.h>
+
+#include <google_smart_card_common/logging/logging.h>
+#include <google_smart_card_common/messaging/typed_message.h>
+#include <google_smart_card_common/messaging/typed_message_router.h>
+#include <google_smart_card_common/pp_var_utils/debug_dump.h>
+#include <google_smart_card_common/thread_safe_unique_ptr.h>
+#include <google_smart_card_common/unique_ptr_utils.h>
+
+constexpr char kIncomingMessageType[] = "ui_backend";
+constexpr char kOutgoingMessageType[] = "ui";
+
+namespace gsc = google_smart_card;
+
+namespace smart_card_client {
+
+namespace {
+
+void ProcessMessageFromUi(
+    const pp::Var& data,
+    std::weak_ptr<MessageFromUiHandler> message_from_ui_handler) {
+  GOOGLE_SMART_CARD_LOG_DEBUG << "Processing message from UI: " <<
+      gsc::DebugDumpVar(data);
+  std::shared_ptr<MessageFromUiHandler> locked_handler =
+      message_from_ui_handler.lock();
+  if (!locked_handler) {
+    GOOGLE_SMART_CARD_LOG_WARNING <<
+        "Ignoring message from UI: module shut down";
+    return;
+  }
+  locked_handler->HandleMessageFromUi(data);
+}
+
+}  // namespace
+
+UiBridge::UiBridge(
+    gsc::TypedMessageRouter* typed_message_router,
+    pp::Instance* pp_instance)
+    : attached_state_(gsc::MakeUnique<AttachedState>(
+          pp_instance, typed_message_router)) {
+  typed_message_router->AddRoute(this);
+}
+
+UiBridge::~UiBridge() {
+  Detach();
+}
+
+void UiBridge::Detach() {
+  {
+    const gsc::ThreadSafeUniquePtr<AttachedState>::Locked locked_state =
+        attached_state_.Lock();
+    if (locked_state)
+      locked_state->typed_message_router->RemoveRoute(this);
+  }
+  attached_state_.Reset();
+}
+
+void UiBridge::SetHandler(std::weak_ptr<MessageFromUiHandler> handler) {
+  message_from_ui_handler_ = handler;
+}
+
+void UiBridge::RemoveHandler() {
+  message_from_ui_handler_.reset();
+}
+
+void UiBridge::SendMessageToUi(const pp::Var& message) {
+  const pp::Var typed_message = gsc::MakeTypedMessage(
+      kOutgoingMessageType, message);
+  const gsc::ThreadSafeUniquePtr<AttachedState>::Locked locked_state =
+      attached_state_.Lock();
+  if (locked_state)
+    locked_state->pp_instance->PostMessage(typed_message);
+}
+
+std::string UiBridge::GetListenedMessageType() const {
+  return kIncomingMessageType;
+}
+
+bool UiBridge::OnTypedMessageReceived(const pp::Var& data) {
+  std::thread(
+      &ProcessMessageFromUi,
+      data,
+      message_from_ui_handler_).detach();
+  return true;
+}
+
+}  // namespace smart_card_client

--- a/example_cpp_smart_card_client_app/src/ui_bridge.h
+++ b/example_cpp_smart_card_client_app/src/ui_bridge.h
@@ -64,6 +64,10 @@ class UiBridge final : public google_smart_card::TypedMessageListener {
   // Note that if the UI is currently closed, the message is silently discarded.
   void SendMessageToUi(const pp::Var& message);
 
+  // google_smart_card::TypedMessageListener:
+  std::string GetListenedMessageType() const override;
+  bool OnTypedMessageReceived(const pp::Var& data) override;
+
  private:
   struct AttachedState {
     AttachedState(pp::Instance* pp_instance,
@@ -74,10 +78,6 @@ class UiBridge final : public google_smart_card::TypedMessageListener {
     pp::Instance* const pp_instance;
     google_smart_card::TypedMessageRouter* const typed_message_router;
   };
-
-  // google_smart_card::TypedMessageListener:
-  std::string GetListenedMessageType() const override;
-  bool OnTypedMessageReceived(const pp::Var& data) override;
 
   // State associated with the attached configuration. Null after Detach() is
   // called.

--- a/example_cpp_smart_card_client_app/src/ui_bridge.h
+++ b/example_cpp_smart_card_client_app/src/ui_bridge.h
@@ -1,0 +1,91 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file provides definitions that allow to send/receive requests to/from
+// the UI.
+
+#ifndef SMART_CARD_CLIENT_UI_BRIDGE_H_
+#define SMART_CARD_CLIENT_UI_BRIDGE_H_
+
+#include <mutex>
+
+#include <ppapi/cpp/instance.h>
+#include <ppapi/cpp/var.h>
+
+#include <google_smart_card_common/messaging/typed_message_listener.h>
+#include <google_smart_card_common/messaging/typed_message_router.h>
+#include <google_smart_card_common/thread_safe_unique_ptr.h>
+
+namespace smart_card_client {
+
+// Handler of a UI message.
+class MessageFromUiHandler {
+ public:
+  virtual ~MessageFromUiHandler() = default;
+
+  virtual void HandleMessageFromUi(const pp::Var& message) = 0;
+};
+
+// This class provides a C++ bridge for sending/receiving messages to/from the
+// UI.
+class UiBridge final : public google_smart_card::TypedMessageListener {
+ public:
+  // Creates the bridge instance.
+  //
+  // On construction, registers self for receiving the messages from UI through
+  // the supplied TypedMessageRouter typed_message_router instance.
+  UiBridge(
+      google_smart_card::TypedMessageRouter* typed_message_router,
+      pp::Instance* pp_instance);
+
+  UiBridge(const UiBridge&) = delete;
+  UiBridge& operator=(const UiBridge&) = delete;
+
+  ~UiBridge() override;
+
+  void Detach();
+
+  void SetHandler(std::weak_ptr<MessageFromUiHandler> handler);
+  void RemoveHandler();
+
+  // Sends a message to UI.
+  //
+  // Note that if the UI is currently closed, the message is silently discarded.
+  void SendMessageToUi(const pp::Var& message);
+
+ private:
+  struct AttachedState {
+    AttachedState(pp::Instance* pp_instance,
+                  google_smart_card::TypedMessageRouter* typed_message_router)
+      : pp_instance(pp_instance),
+        typed_message_router(typed_message_router) {}
+
+    pp::Instance* const pp_instance;
+    google_smart_card::TypedMessageRouter* const typed_message_router;
+  };
+
+  // google_smart_card::TypedMessageListener:
+  std::string GetListenedMessageType() const override;
+  bool OnTypedMessageReceived(const pp::Var& data) override;
+
+  // State associated with the attached configuration. Null after Detach() is
+  // called.
+  google_smart_card::ThreadSafeUniquePtr<AttachedState> attached_state_;
+
+  std::weak_ptr<MessageFromUiHandler> message_from_ui_handler_;
+};
+
+}  // namespace smart_card_client
+
+#endif  // SMART_CARD_CLIENT_UI_BRIDGE_H_

--- a/example_cpp_smart_card_client_app/src/window.html
+++ b/example_cpp_smart_card_client_app/src/window.html
@@ -27,6 +27,10 @@ limitations under the License.
 
   <button id="close-window" data-i18n-aria-label="windowClose">×</button>
 
+  <button id="run-test" data-i18n="runTest"></button>
+
+  <pre id="output"></pre>
+
   <script src="window.js"></script>
 </body>
 </html>

--- a/example_cpp_smart_card_client_app/src/window.js
+++ b/example_cpp_smart_card_client_app/src/window.js
@@ -67,7 +67,7 @@ function onRunTestClicked(e) {
 // a line into the "output" <pre> element in the UI.
 function displayOutputMessage(text) {
   const outputElem = goog.dom.getElement('output');
-  outputElem.innerHTML = text + '\n' + outputElem.innerHTML;
+  outputElem.innerHTML = outputElem.innerHTML + text + '\n';
 }
 
 // Set up UI event listeners.

--- a/example_cpp_smart_card_client_app/src/window.js
+++ b/example_cpp_smart_card_client_app/src/window.js
@@ -22,8 +22,10 @@ goog.provide('SmartCardClientApp.WindowMain');
 
 goog.require('GoogleSmartCard.I18n');
 goog.require('GoogleSmartCard.Logging');
+goog.require('GoogleSmartCard.ObjectHelpers');
 goog.require('GoogleSmartCard.PopupWindow.Client');
 goog.require('goog.dom');
+goog.require('goog.messaging.MessageChannel');
 
 goog.scope(function() {
 
@@ -38,6 +40,13 @@ const logger = GSC.Logging.getLogger(
 
 logger.info('The main window is created');
 
+// Obtain the message channel that is used for communication with the NaCl
+// module.
+const naclModuleMessageChannel =
+    /** @type {!goog.messaging.MessageChannel} */
+    (GSC.ObjectHelpers.extractKey(
+         GSC.PopupWindow.Client.getData(), 'naclModuleMessageChannel'));
+
 // Load the localized strings into the HTML elements.
 GSC.I18n.adjustElementsTranslation();
 
@@ -47,11 +56,45 @@ function onCloseWindowClicked(e) {
   chrome.app.window.current().close();
 }
 
-// Set up event listeners.
+// Called when the "run test" button is clicked. Sends a command to the NaCl
+// module to start the test.
+function onRunTestClicked(e) {
+  e.preventDefault();
+  naclModuleMessageChannel.send('ui_backend', {command: 'run_test'});
+}
+
+// Called when a "output_message" message is received from the NaCl module. Adds
+// a line into the "output" <pre> element in the UI.
+function displayOutputMessage(text) {
+  const outputElem = goog.dom.getElement('output');
+  outputElem.innerHTML = text + '\n' + outputElem.innerHTML;
+}
+
+// Set up UI event listeners.
 goog.events.listen(
     goog.dom.getElement('close-window'),
     goog.events.EventType.CLICK,
     onCloseWindowClicked);
+goog.events.listen(
+    goog.dom.getElement('run-test'),
+    goog.events.EventType.CLICK,
+    onRunTestClicked);
+
+// Handle messages from the NaCl module.
+naclModuleMessageChannel.registerService('ui', (payload) => {
+  //
+  // CHANGE HERE:
+  // Place your custom code here:
+  //
+
+  if (payload['output_message'])
+    displayOutputMessage(payload['output_message']);
+}, /*opt_objectPayload=*/true);
+
+// Unregister from receiving NaCl module messages when our window is closed.
+chrome.app.window.current().onClosed.addListener(() => {
+  naclModuleMessageChannel.registerService('ui', () => {});
+});
 
 // Show the window, after all the initialization above has been done.
 GSC.PopupWindow.Client.showWindow();


### PR DESCRIPTION
Extend the C++ example code with the boilerplate that allows
to send messages between the UI JavaScript code and the
NaCl module.

Also, to demonstrate the usage of the message channel,
implement the "Run test" button to trigger some trivial
sequence of PC/SC method calls.