### PR TITLE
Sequential UI commands in Example App

### DIFF
--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
@@ -94,8 +94,9 @@ ApiBridge::ApiBridge(
     gsc::TypedMessageRouter* typed_message_router,
     pp::Instance* pp_instance,
     pp::Core* pp_core,
-    bool execute_requests_sequentially)
-    : requester_(
+    std::shared_ptr<std::mutex> request_handling_mutex)
+    : request_handling_mutex_(request_handling_mutex),
+      requester_(
           kRequesterName,
           typed_message_router,
           gsc::MakeUnique<gsc::JsRequester::PpDelegateImpl>(
@@ -106,10 +107,7 @@ ApiBridge::ApiBridge(
           this,
           typed_message_router,
           gsc::MakeUnique<gsc::JsRequestReceiver::PpDelegateImpl>(
-              pp_instance))) {
-  if (execute_requests_sequentially)
-    request_handling_mutex_.reset(new std::mutex);
-}
+              pp_instance))) {}
 
 void ApiBridge::Detach() {
   requester_.Detach();

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
@@ -85,14 +85,14 @@ class ApiBridge final : public google_smart_card::RequestHandler {
   // messages through the supplied TypedMessageRouter typed_message_router
   // instance.
   //
-  // The execute_requests_sequentially parameter, when set to true, effectively
-  // disables simultaneous execution of the multiple requests: each next request
-  // will be executed only once the previous one finishes.
+  // The |request_handling_mutex| parameter, when non-null, allows to avoid
+  // simultaneous execution of multiple requests: each next request will be
+  // executed only once the previous one finishes.
   ApiBridge(
       google_smart_card::TypedMessageRouter* typed_message_router,
       pp::Instance* pp_instance,
       pp::Core* pp_core,
-      bool execute_requests_sequentially);
+      std::shared_ptr<std::mutex> request_handling_mutex);
 
   ApiBridge(const ApiBridge&) = delete;
 
@@ -140,6 +140,8 @@ class ApiBridge final : public google_smart_card::RequestHandler {
       const pp::VarArray& arguments,
       google_smart_card::RequestReceiver::ResultCallback result_callback);
 
+  std::shared_ptr<std::mutex> request_handling_mutex_;
+
   // Members related to outgoing requests:
 
   google_smart_card::JsRequester requester_;
@@ -148,7 +150,6 @@ class ApiBridge final : public google_smart_card::RequestHandler {
   // Members related to incoming requests:
 
   std::shared_ptr<google_smart_card::JsRequestReceiver> request_receiver_;
-  std::shared_ptr<std::mutex> request_handling_mutex_;
   std::weak_ptr<CertificatesRequestHandler> certificates_request_handler_;
   std::weak_ptr<SignDigestRequestHandler> sign_digest_request_handler_;
 };

--- a/example_cpp_smart_card_client_app/src/ui_bridge.h
+++ b/example_cpp_smart_card_client_app/src/ui_bridge.h
@@ -18,8 +18,6 @@
 #ifndef SMART_CARD_CLIENT_UI_BRIDGE_H_
 #define SMART_CARD_CLIENT_UI_BRIDGE_H_
 
-#include <mutex>
-
 #include <ppapi/cpp/instance.h>
 #include <ppapi/cpp/var.h>
 
@@ -45,9 +43,14 @@ class UiBridge final : public google_smart_card::TypedMessageListener {
   //
   // On construction, registers self for receiving the messages from UI through
   // the supplied TypedMessageRouter typed_message_router instance.
+  //
+  // The |request_handling_mutex| parameter, when non-null, allows to avoid
+  // simultaneous execution of multiple requests: each next request will be
+  // executed only once the previous one finishes.
   UiBridge(
       google_smart_card::TypedMessageRouter* typed_message_router,
-      pp::Instance* pp_instance);
+      pp::Instance* pp_instance,
+      std::shared_ptr<std::mutex> request_handling_mutex);
 
   UiBridge(const UiBridge&) = delete;
   UiBridge& operator=(const UiBridge&) = delete;
@@ -82,6 +85,8 @@ class UiBridge final : public google_smart_card::TypedMessageListener {
   // State associated with the attached configuration. Null after Detach() is
   // called.
   google_smart_card::ThreadSafeUniquePtr<AttachedState> attached_state_;
+
+  std::shared_ptr<std::mutex> request_handling_mutex_;
 
   std::weak_ptr<MessageFromUiHandler> message_from_ui_handler_;
 };


### PR DESCRIPTION
Make the handler of the UI messages use the same mutex as the existing
chrome.certificateProvider message handler, so that they never run
concurrently. This corresponds to the typical single-threaded model of
real-world smart card middleware applications.

Also flip the default in the Example App to make the
chrome.certificateProvider message handler sequential (it was previously
controlled by a boolean flag set to false by default).

Implementation-wise, a cleaner approach than to use mutexes would be to
have a dedicated worker thread that would be used for running all
handler jobs, but it'd be a much bigger change to introduce such a
pattern into the code.