### PR TITLE
Add gitignore for libusb JS unittests

### DIFF
--- a/third_party/libusb/naclport/build/js_unittests/.gitignore
+++ b/third_party/libusb/naclport/build/js_unittests/.gitignore
@@ -1,0 +1,2 @@
+/js_build/
+/out/


### PR DESCRIPTION
Skip the build artifacts from being tracked in the version control
system - those files are just mental noise.