### PR TITLE
Fix PIP installation in webports

### DIFF
--- a/third_party/webports/src/src/build_tools/pip_install.sh
+++ b/third_party/webports/src/src/build_tools/pip_install.sh
@@ -17,6 +17,7 @@ export PYTHONUSERBASE=$PWD/out/pip
 pip_bin_dir=$PYTHONUSERBASE/bin
 pip_bin=$pip_bin_dir/pip
 export PATH=$pip_bin_dir:$PATH
+unset PYTHONNOUSERSITE
 
 if [ ! -f "$pip_bin" ]; then
   # On first run install pip directly from the network


### PR DESCRIPTION
Work around the issue with PIP installation during "webports" "gclient
sync" command, which manifests itself as import failures when running
PIP despite it being installed just before this command.

The hack is to unset the "PYTHONNOUSERSITE" environment variable which
is set by gclient/vpython: for some reason, having this variable set
makes PIP being not found.

This is a quick hack solution, in order to unblock developers - an ideal
solution would be to find out what's wrong in the way how we install
PIP.

This fixes #115.