### PR TITLE
Use the pinned webports repository

### DIFF
--- a/env/constants.sh
+++ b/env/constants.sh
@@ -19,5 +19,4 @@ DEPOT_TOOLS_REPOSITORY_URL="https://chromium.googlesource.com/chromium/tools/dep
 
 NACL_SDK_VERSION="47"
 
-WEBPORTS_REPOSITORY_URL="https://chromium.googlesource.com/webports.git"
 WEBPORTS_TARGETS="glibc-compat openssl"

--- a/env/initialize.sh
+++ b/env/initialize.sh
@@ -50,13 +50,11 @@ initialize_nacl_sdk() {
 initialize_webports() {
   log_message "Installing webports (with building the following libraries: ${WEBPORTS_TARGETS})..."
   rm -rf webports
-  mkdir webports
-  cd ${SCRIPTPATH}/webports
-  gclient config --unmanaged --name=src "${WEBPORTS_REPOSITORY_URL}"
-  gclient sync --with_branch_heads
-  cd ${SCRIPTPATH}/webports/src
-  git checkout -b pepper_${NACL_SDK_VERSION} origin/pepper_${NACL_SDK_VERSION}
-  gclient sync
+  cp -r ../third_party/webports/src webports
+  cd webports
+  tar -zxf git.tar.gz
+  gclient runhooks
+  cd src
   local failed_targets=
   for target in ${WEBPORTS_TARGETS}; do
     if ! NACL_ARCH=pnacl TOOLCHAIN=pnacl make ${target} ; then

--- a/third_party/webports/README.google
+++ b/third_party/webports/README.google
@@ -5,3 +5,6 @@ License File: LICENSE
 Description:
 Collection of open source libraries and applications that have been ported to
 Native Client, along with set to tools for building and maintaining them.
+Local Modifications:
+Changed the PIP installation script to work around the import error.
+Added the git.tar.gz archive with the Git repository contents.

--- a/third_party/webports/README.google
+++ b/third_party/webports/README.google
@@ -6,5 +6,5 @@ Description:
 Collection of open source libraries and applications that have been ported to
 Native Client, along with set to tools for building and maintaining them.
 Local Modifications:
-Changed the PIP installation script to work around the import error.
+Changed the PIP installation script to work around an import error.
 Added the git.tar.gz archive with the Git repository contents.


### PR DESCRIPTION
Change the env/initialize.sh script to use the version of the "webports"
repository that is committed and pinned under //third_party/.

This completes the fix #115, by making use of the local patch that works
around the PIP installation issue.