### PR TITLE
Workaround for NaCl init issue on desktops

### DIFF
--- a/common/make/nacl_module_building_common.mk
+++ b/common/make/nacl_module_building_common.mk
@@ -253,3 +253,11 @@ endif
 #
 
 $(foreach toolchain,$(VALID_TOOLCHAINS),$(eval $(call CLEAN_RULE,$(toolchain))))
+
+
+#
+# Use a common Chrome profile directory, in order to avoid repeatedly going
+# through trouble of setting up a new profile on every run.
+#
+
+CHROME_ARGS += --user-data-dir=$(ROOT_PATH)/env/chrome_launcher_user_data_dir

--- a/env/.gitignore
+++ b/env/.gitignore
@@ -1,4 +1,5 @@
 /activate
+/chrome_launcher_user_data_dir/
 /depot_tools/
 /nacl_sdk/
 /webports/


### PR DESCRIPTION
This makes using the "make run"/"make test" commands slightly more
convenient for development/testing on a desktop OS, by reusing the same
Chrome profile directory (--user-data-dir) for all executions.

This partially solves the trouble caused by the asynchronous
installation of the NaCl component in desktop Chrome browsers, which was
manifesting in form of the following error on every run:

  NaCl module load failed: The Portable Native Client (pnacl) component
  is not installed.

While this commit doesn't fix the underlying issue per se, it makes this
error appear only on the first run, therefore streamlining the
developer experience.