### PR TITLE
Fix the headers in the NaCl code test launcher UI

### DIFF
--- a/common/tests_runner/src/index.html
+++ b/common/tests_runner/src/index.html
@@ -18,7 +18,7 @@ limitations under the License.
 <head>
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="-1">
-  <title>libusb ppapi Tests</title>
+  <title>NaCl code Tests</title>
   <style>
     #tests { list-style: none; }
     #tests > li { padding: 5px 0; }
@@ -117,7 +117,7 @@ limitations under the License.
   </script>
 </head>
 <body data-attrs="PS_EXIT_MESSAGE=testend" data-name="tests_runner" data-tools="pnacl" data-configs="Debug Release" data-path="." data-width="0" data-height="0">
-  <h1>libusb ppapi Tests</h1>
+  <h1>NaCl code Tests</h1>
   <div id="listener"></div>
   <h2>NaCl module: <code id="statusField">Initializing</code>.</h2>
   <ul id="tests"></ul>


### PR DESCRIPTION
The header and the title in the HTML page of the NaCl test launcher were
misleading.