### PR TITLE
Add Help button

### DIFF
--- a/smart_card_connector_app/src/_locales/en/messages.json
+++ b/smart_card_connector_app/src/_locales/en/messages.json
@@ -69,7 +69,7 @@
   },
   "openHelp": {
     "message": "Help",
-    "description": "Title of the link that can be used to open the Help Article page"
+    "description": "Title of the link that can be used to open the Help Articley page"
   },
   "exportLogs": {
     "message": "Export logs",

--- a/smart_card_connector_app/src/_locales/en/messages.json
+++ b/smart_card_connector_app/src/_locales/en/messages.json
@@ -67,6 +67,10 @@
     "message": "About",
     "description": "Title of the link that can be used to open the App's About page"
   },
+  "openHelp": {
+    "message": "Help",
+    "description": "Title of the link that can be used to open the Help Article page"
+  },
   "exportLogs": {
     "message": "Export logs",
     "description": "Title of the link that can be used to copy the logs into the clipboard"

--- a/smart_card_connector_app/src/_locales/en/messages.json
+++ b/smart_card_connector_app/src/_locales/en/messages.json
@@ -69,7 +69,7 @@
   },
   "openHelp": {
     "message": "Help",
-    "description": "Title of the link that can be used to open the Help Articley page"
+    "description": "Title of the link that can be used to open the Help Article"
   },
   "exportLogs": {
     "message": "Export logs",

--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -24,6 +24,7 @@
     "alwaysOnTopWindows",
     "loginState",
     "usb",
+    "browser",
     {
       "usbDevices": [
 ${usb_devices}

--- a/smart_card_connector_app/src/window-help-showing.js
+++ b/smart_card_connector_app/src/window-help-showing.js
@@ -1,5 +1,5 @@
 /** @license
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2020 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,25 +26,18 @@ goog.require('goog.events.EventType');
 
 goog.scope(function() {
 
-/** @const */
-var HELP_WINDOW_URL = 'https://support.google.com/chrome/a/answer/7014689';
+const HELP_WINDOW_URL = 'https://support.google.com/chrome/a/answer/7014689';
 
-/** @const */
-var GSC = GoogleSmartCard;
+const GSC = GoogleSmartCard;
 
-/**
- * @type {!Element}
- * @const
- */
-var openHelpElement = /** @type {!Element} */ (goog.dom.getElement(
+const openHelpElement = /** @type {!Element} */ (goog.dom.getElement(
     'open-help'));
 
 /**
- * @param {!Event} e
+ * @param {!Event} event
  */
-function openHelpClickListener(e) {
-  e.preventDefault();
-  
+function openHelpClickListener(event) {
+  event.preventDefault();
   chrome.browser.openTab({url: HELP_WINDOW_URL});
 }
 
@@ -54,12 +47,3 @@ GSC.ConnectorApp.Window.HelpShowing.initialize = function() {
 };
 
 });  // goog.scope
-
-
-
-
-
-
-
-
-

--- a/smart_card_connector_app/src/window-help-showing.js
+++ b/smart_card_connector_app/src/window-help-showing.js
@@ -1,0 +1,65 @@
+/** @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview This script implements showing the Help Article in a browser 
+ * window.
+ */
+
+goog.provide('GoogleSmartCard.ConnectorApp.Window.HelpShowing');
+
+goog.require('goog.dom');
+goog.require('goog.events.EventType');
+
+goog.scope(function() {
+
+/** @const */
+var HELP_WINDOW_URL = 'https://support.google.com/chrome/a/answer/7014689';
+
+/** @const */
+var GSC = GoogleSmartCard;
+
+/**
+ * @type {!Element}
+ * @const
+ */
+var openHelpElement = /** @type {!Element} */ (goog.dom.getElement(
+    'open-help'));
+
+/**
+ * @param {!Event} e
+ */
+function openHelpClickListener(e) {
+  e.preventDefault();
+  
+  chrome.browser.openTab({url: HELP_WINDOW_URL});
+}
+
+GSC.ConnectorApp.Window.HelpShowing.initialize = function() {
+  goog.events.listen(
+      openHelpElement, goog.events.EventType.CLICK, openHelpClickListener);  
+};
+
+});  // goog.scope
+
+
+
+
+
+
+
+
+

--- a/smart_card_connector_app/src/window-main.js
+++ b/smart_card_connector_app/src/window-main.js
@@ -24,6 +24,7 @@ goog.require('GoogleSmartCard.ConnectorApp.Window.AboutShowing');
 goog.require('GoogleSmartCard.ConnectorApp.Window.AppsDisplaying');
 goog.require('GoogleSmartCard.ConnectorApp.Window.DevicesDisplaying');
 goog.require('GoogleSmartCard.ConnectorApp.Window.LogsExporting');
+goog.require('GoogleSmartCard.ConnectorApp.Window.HelpShowing');
 goog.require('GoogleSmartCard.I18n');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PopupWindow.Client');
@@ -55,6 +56,7 @@ GSC.ConnectorApp.Window.AboutShowing.initialize();
 GSC.ConnectorApp.Window.AppsDisplaying.initialize();
 GSC.ConnectorApp.Window.DevicesDisplaying.initialize();
 GSC.ConnectorApp.Window.LogsExporting.initialize();
+GSC.ConnectorApp.Window.HelpShowing.initialize();
 
 GSC.I18n.adjustElementsTranslation();
 

--- a/smart_card_connector_app/src/window.html
+++ b/smart_card_connector_app/src/window.html
@@ -41,6 +41,7 @@ limitations under the License.
   <div id="footer">
     <a id="open-about" href="#" class="footer-link" data-i18n="openAbout"></a>
     <a id="export-logs" href="#" class="footer-link" data-i18n="exportLogs"></a>
+    <a id="open-help" href="#" class="footer-link" data-i18n="openHelp"></a>
   </div>
 
   <script src="window.js"></script>


### PR DESCRIPTION
Add a help button that opens a browser tab with the Help Center Article.
Closes [#45](https://github.com/GoogleChromeLabs/chromeos_smart_card_connector/issues/45).