### PR TITLE
Change text on Add Reader button depending on list being empty or not

### DIFF
--- a/common/js/src/i18n.js
+++ b/common/js/src/i18n.js
@@ -75,52 +75,55 @@ function transformAllElements(attribute, transformFunction) {
   }
 }
 
-function transformFunctionI18nDataAttribute(element, translatedText) {
+/**
+ * @param {!Element} element 
+ * @param {string} translatedText 
+ */
+function applyTranslation(element, translatedText) {
   logger.fine('Translating element.textContent [' + element.outerHTML +
               '] to "' + translatedText + '"');
   element.textContent = translatedText;
 }
 
-function transformFunctionI18nDataAriaLabelAttribute(element, translatedText) {
+/**
+ * @param {!Element} element 
+ * @param {string} translatedText 
+ */
+function applyAriaLabelTranslation(element, translatedText) {
   logger.fine('Translating element.aria-label [' + element.outerHTML +
               '] to "' + translatedText + '"');
   element.setAttribute('aria-label', translatedText);
 }
 
 /** 
- * Takes the single element passed, replacing element.textContent with translation
- * if it conatins I18N_DATA_ATTRIBUTE, and setting aria-label to translation
- * if it contains I18N_DATA_ARIA_LABEL_ATTRIBUTE.
-*/
+ * Takes the element passed, replacing element.textContent with 
+ * translation if it contains I18N_DATA_ATTRIBUTE, and setting aria-label to 
+ * translation if it contains I18N_DATA_ARIA_LABEL_ATTRIBUTE.
+ * @param {!Element} element
+ */
 GSC.I18n.adjustElementTranslation = function(element) {
-  if (goog.dom.dataset.has(element, 'i18n')) {
+  if (element.hasAttribute(I18N_DATA_ATTRIBUTE)) {
     transformElement(
-      element, I18N_DATA_ATTRIBUTE, 
-      transformFunctionI18nDataAttribute);
+        element, I18N_DATA_ATTRIBUTE, applyTranslation);
   }
 
-  if(goog.dom.dataset.has(element, 'i18nAriaLabel')) {
+  if (element.hasAttribute(I18N_DATA_ARIA_LABEL_ATTRIBUTE)) {
     transformElement(
-      element, I18N_DATA_ARIA_LABEL_ATTRIBUTE, 
-      transformFunctionI18nDataAriaLabelAttribute);
+        element, I18N_DATA_ARIA_LABEL_ATTRIBUTE, applyAriaLabelTranslation);
   }
 };
 
 /**
- * Goes through all the HTML elements in the current window, replacing
- * element.textContent with translation for elements containing attribute
- * I18N_DATA_ATTRIBUTE, and setting attribute aria-label to translation for
- * elements containing attribute I18N_DATA_ARIA_LABEL_ATTRIBUTE. Used for
- * translation that plays nice with Chromevox (accessibility tool).
+ * Applies adjustElementTranslation() to all HTML elements in the current 
+ * document. Used for translation that plays nice with Chromevox (accessibility
+ * tool).
  */
 GSC.I18n.adjustAllElementsTranslation = function() {
   transformAllElements(
-      I18N_DATA_ATTRIBUTE,
-      transformFunctionI18nDataAttribute);
+      I18N_DATA_ATTRIBUTE, applyTranslation);
 
   transformAllElements(
-      I18N_DATA_ARIA_LABEL_ATTRIBUTE,
-      transformFunctionI18nDataAriaLabelAttribute);
+      I18N_DATA_ARIA_LABEL_ATTRIBUTE, applyAriaLabelTranslation);
 };
 
 });  // goog.scope

--- a/common/js/src/i18n.js
+++ b/common/js/src/i18n.js
@@ -22,7 +22,6 @@
 goog.provide('GoogleSmartCard.I18n');
 
 goog.require('GoogleSmartCard.Logging');
-goog.require('goog.dom');
 goog.require('goog.log.Logger');
 
 goog.scope(function() {

--- a/common/js/src/i18n.js
+++ b/common/js/src/i18n.js
@@ -22,6 +22,7 @@
 goog.provide('GoogleSmartCard.I18n');
 
 goog.require('GoogleSmartCard.Logging');
+goog.require('goog.dom');
 goog.require('goog.log.Logger');
 
 goog.scope(function() {
@@ -74,6 +75,37 @@ function transformAllElements(attribute, transformFunction) {
   }
 }
 
+function transformFunctionI18nDataAttribute(element, translatedText) {
+  logger.fine('Translating element.textContent [' + element.outerHTML +
+              '] to "' + translatedText + '"');
+  element.textContent = translatedText;
+}
+
+function transformFunctionI18nDataAriaLabelAttribute(element, translatedText) {
+  logger.fine('Translating element.aria-label [' + element.outerHTML +
+              '] to "' + translatedText + '"');
+  element.setAttribute('aria-label', translatedText);
+}
+
+/** 
+ * Takes the single element passed, replacing element.textContent with translation
+ * if it conatins I18N_DATA_ATTRIBUTE, and setting aria-label to translation
+ * if it contains I18N_DATA_ARIA_LABEL_ATTRIBUTE.
+*/
+GSC.I18n.adjustElementTranslation = function(element) {
+  if (goog.dom.dataset.has(element, 'i18n')) {
+    transformElement(
+      element, I18N_DATA_ATTRIBUTE, 
+      transformFunctionI18nDataAttribute);
+  }
+
+  if(goog.dom.dataset.has(element, 'i18nAriaLabel')) {
+    transformElement(
+      element, I18N_DATA_ARIA_LABEL_ATTRIBUTE, 
+      transformFunctionI18nDataAriaLabelAttribute);
+  }
+};
+
 /**
  * Goes through all the HTML elements in the current window, replacing
  * element.textContent with translation for elements containing attribute
@@ -81,20 +113,14 @@ function transformAllElements(attribute, transformFunction) {
  * elements containing attribute I18N_DATA_ARIA_LABEL_ATTRIBUTE. Used for
  * translation that plays nice with Chromevox (accessibility tool).
  */
-GSC.I18n.adjustElementsTranslation = function() {
+GSC.I18n.adjustAllElementsTranslation = function() {
   transformAllElements(
-      I18N_DATA_ATTRIBUTE, function(element, translatedText) {
-    logger.fine('Translating element.textContent [' + element.outerHTML +
-                '] to "' + translatedText + '"');
-    element.textContent = translatedText;
-  });
+      I18N_DATA_ATTRIBUTE,
+      transformFunctionI18nDataAttribute);
 
   transformAllElements(
-      I18N_DATA_ARIA_LABEL_ATTRIBUTE, function(element, translatedText) {
-    logger.fine('Translating element.aria-label [' + element.outerHTML +
-                '] to "' + translatedText + '"');
-    element.setAttribute('aria-label', translatedText);
-  });
+      I18N_DATA_ARIA_LABEL_ATTRIBUTE,
+      transformFunctionI18nDataAriaLabelAttribute);
 };
 
 });  // goog.scope

--- a/example_cpp_smart_card_client_app/src/window.js
+++ b/example_cpp_smart_card_client_app/src/window.js
@@ -48,7 +48,7 @@ const naclModuleMessageChannel =
          GSC.PopupWindow.Client.getData(), 'naclModuleMessageChannel'));
 
 // Load the localized strings into the HTML elements.
-GSC.I18n.adjustElementsTranslation();
+GSC.I18n.adjustAllElementsTranslation();
 
 // Called when the "close" button is clicked. Closes the window.
 function onCloseWindowClicked(e) {

--- a/smart_card_connector_app/src/_locales/en/messages.json
+++ b/smart_card_connector_app/src/_locales/en/messages.json
@@ -35,6 +35,10 @@
     "message": "ADD READER",
     "description": "Title of the button that can be used to open a dialog for adding a new Smart Card reader"
   },
+  "addAnotherDevice": {
+    "message": "ADD ANOTHER READER",
+    "description": "Title of the button that can be used to open a dialog for adding another Smart Card reader"
+  },
   "appListHeader": {
     "message": "Connected Apps",
     "description": "The header displayed in front of the application list"

--- a/smart_card_connector_app/src/_locales/en/messages.json
+++ b/smart_card_connector_app/src/_locales/en/messages.json
@@ -33,11 +33,11 @@
   },
   "addDevice": {
     "message": "ADD READER",
-    "description": "Title of the button that can be used to open a dialog for adding a new Smart Card reader"
+    "description": "Title of the button that can be used to open a dialog for adding a new Smart Card reader when the list is still empty"
   },
   "addAnotherDevice": {
     "message": "ADD ANOTHER READER",
-    "description": "Title of the button that can be used to open a dialog for adding another Smart Card reader"
+    "description": "Title of the button that can be used to open a dialog for adding another Smart Card reader when the list has one or more readers already connected"
   },
   "appListHeader": {
     "message": "Connected Apps",

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -181,7 +181,7 @@ function externalMessageListener(message, sender) {
 }
 
 /**
- * Returns an single message based channel instance that talks to the specified
+ * Returns a single message based channel instance that talks to the specified
  * extension - either returns an existing instance if there's one, or creates a
  * new one otherwise. May return null if the channel becomes immediately
  * disposed of due to some error.

--- a/smart_card_connector_app/src/window-devices-displaying.js
+++ b/smart_card_connector_app/src/window-devices-displaying.js
@@ -74,6 +74,9 @@ var readersListElement = /** @type {!Element} */ (goog.dom.getElement(
 var addDeviceElement = /** @type {!Element} */ (goog.dom.getElement(
     'add-device'));
 
+/**
+ * @param {!Array.<!GSC.PcscLiteServer.ReaderInfo>} readers 
+ */
 function onReadersChanged(readers) {
   displayReaderList(readers);
   updateAddDeviceButtonText(readers.length);
@@ -92,7 +95,7 @@ function displayReaderList(readers) {
     goog.asserts.assert(readersListElement);
 
     var indicatorClasses = 'reader-state-indicator reader-state-indicator-' +
-                            reader['status'];
+                           reader['status'];
     if (reader['status'] == GSC.PcscLiteServer.ReaderStatus.SUCCESS &&
         reader['isCardPresent']) {
       indicatorClasses = 'reader-card-present-indicator';
@@ -100,13 +103,13 @@ function displayReaderList(readers) {
     var indicator = goog.dom.createDom('span', indicatorClasses);
 
     var indicatorContainer = goog.dom.createDom(
-      'span', 'reader-indicator-container', indicator);
+        'span', 'reader-indicator-container', indicator);
 
     var text = makeReaderNameForDisplaying(reader['name']) +
-      (reader['error'] ? ' (Error ' + reader['error'] + ')' : '');
+        (reader['error'] ? ' (Error ' + reader['error'] + ')' : '');
 
     var element = goog.dom.createDom('li', undefined, indicatorContainer, text);
-      goog.dom.append(readersListElement, element);
+    goog.dom.append(readersListElement, element);
   }
 }
 
@@ -123,7 +126,10 @@ function makeReaderNameForDisplaying(readerName) {
   return readerName;
 }
 
-function updateAddDeviceButtonText(readersCount){
+/**
+ * @param {number} readersCount 
+ */
+function updateAddDeviceButtonText(readersCount) {
   if (readersCount == 0) {
     addDeviceElement.dataset.i18n = 'addDevice';
   } else {

--- a/smart_card_connector_app/src/window-devices-displaying.js
+++ b/smart_card_connector_app/src/window-devices-displaying.js
@@ -22,11 +22,13 @@
 goog.provide('GoogleSmartCard.ConnectorApp.Window.DevicesDisplaying');
 
 goog.require('GoogleSmartCard.DebugDump');
+goog.require('GoogleSmartCard.I18n');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.ObjectHelpers');
 goog.require('GoogleSmartCard.PcscLiteServer.ReaderTracker');
 goog.require('goog.asserts');
 goog.require('goog.dom');
+goog.require('goog.dom.dataset');
 goog.require('goog.events.EventType');
 goog.require('goog.log.Logger');
 goog.scope(function() {
@@ -83,24 +85,25 @@ function displayReaderList(readers) {
   for (let reader of readers) {
     GSC.Logging.checkWithLogger(logger, readersListElement !== null);
     goog.asserts.assert(readersListElement);
-
+    
     var indicatorClasses = 'reader-state-indicator reader-state-indicator-' +
-                           reader['status'];
+    reader['status'];
     if (reader['status'] == GSC.PcscLiteServer.ReaderStatus.SUCCESS &&
-        reader['isCardPresent']) {
+    reader['isCardPresent']) {
       indicatorClasses = 'reader-card-present-indicator';
     }
     var indicator = goog.dom.createDom('span', indicatorClasses);
-
+    
     var indicatorContainer = goog.dom.createDom(
-        'span', 'reader-indicator-container', indicator);
-
-    var text = makeReaderNameForDisplaying(reader['name']) +
-        (reader['error'] ? ' (Error ' + reader['error'] + ')' : '');
-
-    var element = goog.dom.createDom('li', undefined, indicatorContainer, text);
-    goog.dom.append(readersListElement, element);
-  }
+      'span', 'reader-indicator-container', indicator);
+      
+      var text = makeReaderNameForDisplaying(reader['name']) +
+      (reader['error'] ? ' (Error ' + reader['error'] + ')' : '');
+      
+      var element = goog.dom.createDom('li', undefined, indicatorContainer, text);
+      goog.dom.append(readersListElement, element);
+    }
+    updateAddDeviceButtonText(readers.length);
 }
 
 function makeReaderNameForDisplaying(readerName) {
@@ -116,6 +119,15 @@ function makeReaderNameForDisplaying(readerName) {
   return readerName;
 }
 
+function updateAddDeviceButtonText(readersCount){
+  if(readersCount == 0){
+    addDeviceElement.dataset.i18n = 'addDevice';
+  }
+  else{
+    addDeviceElement.dataset.i18n = 'addAnotherDevice';
+  }
+  GSC.I18n.adjustElementsTranslation();
+}
 /**
  * @param {!Event} e
  */

--- a/smart_card_connector_app/src/window-devices-displaying.js
+++ b/smart_card_connector_app/src/window-devices-displaying.js
@@ -74,6 +74,11 @@ var readersListElement = /** @type {!Element} */ (goog.dom.getElement(
 var addDeviceElement = /** @type {!Element} */ (goog.dom.getElement(
     'add-device'));
 
+function onReadersChanged(readers) {
+  displayReaderList(readers);
+  updateAddDeviceButtonText(readers.length);
+}
+
 /**
  * @param {!Array.<!GSC.PcscLiteServer.ReaderInfo>} readers
  */
@@ -85,25 +90,24 @@ function displayReaderList(readers) {
   for (let reader of readers) {
     GSC.Logging.checkWithLogger(logger, readersListElement !== null);
     goog.asserts.assert(readersListElement);
-    
+
     var indicatorClasses = 'reader-state-indicator reader-state-indicator-' +
-    reader['status'];
+                            reader['status'];
     if (reader['status'] == GSC.PcscLiteServer.ReaderStatus.SUCCESS &&
-    reader['isCardPresent']) {
+        reader['isCardPresent']) {
       indicatorClasses = 'reader-card-present-indicator';
     }
     var indicator = goog.dom.createDom('span', indicatorClasses);
-    
+
     var indicatorContainer = goog.dom.createDom(
       'span', 'reader-indicator-container', indicator);
-      
-      var text = makeReaderNameForDisplaying(reader['name']) +
+
+    var text = makeReaderNameForDisplaying(reader['name']) +
       (reader['error'] ? ' (Error ' + reader['error'] + ')' : '');
-      
-      var element = goog.dom.createDom('li', undefined, indicatorContainer, text);
+
+    var element = goog.dom.createDom('li', undefined, indicatorContainer, text);
       goog.dom.append(readersListElement, element);
-    }
-    updateAddDeviceButtonText(readers.length);
+  }
 }
 
 function makeReaderNameForDisplaying(readerName) {
@@ -120,14 +124,14 @@ function makeReaderNameForDisplaying(readerName) {
 }
 
 function updateAddDeviceButtonText(readersCount){
-  if(readersCount == 0){
+  if (readersCount == 0) {
     addDeviceElement.dataset.i18n = 'addDevice';
-  }
-  else{
+  } else {
     addDeviceElement.dataset.i18n = 'addAnotherDevice';
   }
-  GSC.I18n.adjustElementsTranslation();
+  GSC.I18n.adjustElementTranslation(addDeviceElement);
 }
+
 /**
  * @param {!Event} e
  */
@@ -158,7 +162,7 @@ GSC.ConnectorApp.Window.DevicesDisplaying.initialize = function() {
       (GSC.ObjectHelpers.extractKey(
            GSC.PopupWindow.Client.getData(), 'readerTrackerSubscriber'));
   // Start tracking the current list of readers.
-  readerTrackerSubscriber(displayReaderList);
+  readerTrackerSubscriber(onReadersChanged);
 
   /**
    * Points to the "removeOnUpdateListener" method of the ReaderTracker instance
@@ -170,7 +174,7 @@ GSC.ConnectorApp.Window.DevicesDisplaying.initialize = function() {
            GSC.PopupWindow.Client.getData(), 'readerTrackerUnsubscriber'));
   // Stop tracking the current list of readers when our window gets closed.
   chrome.app.window.current().onClosed.addListener(function() {
-    readerTrackerUnsubscriber(displayReaderList);
+    readerTrackerUnsubscriber(onReadersChanged);
   });
 
   goog.events.listen(

--- a/smart_card_connector_app/src/window-main.js
+++ b/smart_card_connector_app/src/window-main.js
@@ -58,7 +58,7 @@ GSC.ConnectorApp.Window.DevicesDisplaying.initialize();
 GSC.ConnectorApp.Window.HelpShowing.initialize();
 GSC.ConnectorApp.Window.LogsExporting.initialize();
 
-GSC.I18n.adjustElementsTranslation();
+GSC.I18n.adjustAllElementsTranslation();
 
 GSC.PopupWindow.Client.showWindow();
 


### PR DESCRIPTION
Gives the add-device button text value of "Add Reader" when no readers are in the list, and gives it the value "Add Another Reader" when 1 or more readers are in the list.
This is to prevent confusion as mentioned in issue #104.