### PR TITLE
Remove duplicate system time log

### DIFF
--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -52,12 +52,10 @@ const logBufferForwarderToNaclModule = new GSC.LogBufferForwarder(
     GSC.Logging.getLogBuffer(), JS_LOGS_HANDLER_MESSAGE_TYPE);
 
 const extensionManifest = chrome.runtime.getManifest();
-const formattedStartupTime = (new Date()).toLocaleString();
 logger.info(
     `The Smart Card Connector app (id "${chrome.runtime.id}", version ` +
     `${extensionManifest.version}) background script started. Browser ` +
-    `version: "${window.navigator.appVersion}". System time: ` +
-    `"${formattedStartupTime}"`);
+    `version: "${window.navigator.appVersion}".`);
 
 var naclModule = new GSC.NaclModule(
     'nacl_module.nmf', GSC.NaclModule.Type.PNACL);


### PR DESCRIPTION
There's no need to print the system time on the startup of the Smart
Card Connector app, since the system time is printed now with every log
message (since #108).