### PR TITLE
Omit "<background page>." from logs

### DIFF
--- a/common/js/src/logging/log-formatting.js
+++ b/common/js/src/logging/log-formatting.js
@@ -43,16 +43,16 @@ textFormatter.showSeverityLevel = true;
  */
 function getFormattedDocumentLocation(documentLocation, isCompact) {
   if (!isCompact)
-    return documentLocation;
+    return `<${documentLocation}>`;
   let uri;
   try {
     uri = goog.Uri.parse(documentLocation);
   } catch (URIError) {
-    return documentLocation;
+    return `<${documentLocation}>`;
   }
   if (uri.getPath() == '/_generated_background_page.html')
-    return 'background page';
-  return uri.getPath();
+    return '';
+  return `<${uri.getPath()}>`;
 }
 
 /**
@@ -62,10 +62,11 @@ function getFormattedDocumentLocation(documentLocation, isCompact) {
  * @return {!goog.log.LogRecord}
  */
 function prefixLogRecord(documentLocation, logRecord, isCompact) {
+  var loggerNameParts = [];
   const formattedDocumentLocation = getFormattedDocumentLocation(
       documentLocation, isCompact);
-  var loggerNameParts = [];
-  loggerNameParts.push('<' + formattedDocumentLocation + '>');
+  if (formattedDocumentLocation)
+    loggerNameParts.push(formattedDocumentLocation);
   if (logRecord.getLoggerName())
     loggerNameParts.push(logRecord.getLoggerName());
   var prefixedLoggerName = loggerNameParts.join('.');
@@ -95,7 +96,7 @@ GSC.LogFormatting.formatLogRecord = function(documentLocation, logRecord) {
  * given document.
  *
  * The compact representation omits detailed context information, e.g. the
- * extension ID.
+ * extension ID or the background page label.
  * @param {string} documentLocation
  * @param {!goog.log.LogRecord} logRecord
  * @return {string}

--- a/common/js/src/logging/log-formatting.js
+++ b/common/js/src/logging/log-formatting.js
@@ -62,14 +62,14 @@ function getFormattedDocumentLocation(documentLocation, isCompact) {
  * @return {!goog.log.LogRecord}
  */
 function prefixLogRecord(documentLocation, logRecord, isCompact) {
-  var loggerNameParts = [];
+  const loggerNameParts = [];
   const formattedDocumentLocation = getFormattedDocumentLocation(
       documentLocation, isCompact);
   if (formattedDocumentLocation)
     loggerNameParts.push(formattedDocumentLocation);
   if (logRecord.getLoggerName())
     loggerNameParts.push(logRecord.getLoggerName());
-  var prefixedLoggerName = loggerNameParts.join('.');
+  const prefixedLoggerName = loggerNameParts.join('.');
 
   return new goog.log.LogRecord(
       logRecord.getLevel(),
@@ -96,7 +96,7 @@ GSC.LogFormatting.formatLogRecord = function(documentLocation, logRecord) {
  * given document.
  *
  * The compact representation omits detailed context information, e.g. the
- * extension ID or the background page label.
+ * extension ID and the background page label.
  * @param {string} documentLocation
  * @param {!goog.log.LogRecord} logRecord
  * @return {string}


### PR DESCRIPTION
Don't mention the background page in the JavaScript/NaCl log messages -
this information can be inferred from the absence of the HTML page URL.
Given that the majority of log messages come from the background page,
it makes sense to reduce the log clutter (and the RAM usage) by omitting
this part.

This change is part of the effort tracked by issue #146.