### PR TITLE
Support new certificateProvider API in examples

### DIFF
--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
@@ -47,24 +47,28 @@ namespace chrome_certificate_provider {
 // Handler of the certificates listing request.
 //
 // For the related original JavaScript definition, refer to:
-// <https://developer.chrome.com/extensions/certificateProvider#event-onCertificatesRequested>
+// <https://developer.chrome.com/extensions/certificateProvider#event-onCertificatesUpdateRequested>
+// and
+// <https://developer.chrome.com/extensions/certificateProvider#event-onCertificatesRequested>.
 class CertificatesRequestHandler {
  public:
   virtual ~CertificatesRequestHandler() = default;
 
-  virtual bool HandleRequest(std::vector<CertificateInfo>* result) = 0;
+  virtual bool HandleRequest(std::vector<ClientCertificateInfo>* result) = 0;
 };
 
-// Handler of the digest signing request.
+// Handler of the signature request.
 //
 // For the related original JavaScript definition, refer to:
-// <https://developer.chrome.com/extensions/certificateProvider#event-onSignDigestRequested>
-class SignDigestRequestHandler {
+// <https://developer.chrome.com/extensions/certificateProvider#event-onSignatureRequested>
+// and
+// <https://developer.chrome.com/extensions/certificateProvider#event-onSignDigestRequested>.
+class SignatureRequestHandler {
  public:
-  virtual ~SignDigestRequestHandler() = default;
+  virtual ~SignatureRequestHandler() = default;
 
-  virtual bool HandleRequest(
-      const SignRequest& sign_request, std::vector<uint8_t>* result) = 0;
+  virtual bool HandleRequest(const SignatureRequest& signature_request,
+                             std::vector<uint8_t>* result) = 0;
 };
 
 // This class provides a C++ bridge to the chrome.certificateProvider JavaScript
@@ -102,9 +106,14 @@ class ApiBridge final : public google_smart_card::RequestHandler {
       std::weak_ptr<CertificatesRequestHandler> handler);
   void RemoveCertificatesRequestHandler();
 
-  void SetSignDigestRequestHandler(
-      std::weak_ptr<SignDigestRequestHandler> handler);
-  void RemoveSignDigestRequestHandler();
+  void SetSignatureRequestHandler(
+      std::weak_ptr<SignatureRequestHandler> handler);
+  void RemoveSignatureRequestHandler();
+
+  // Sends the current list of certificates in Chrome. The should be called
+  // after initialization and on every change in the set of currently available
+  // certificates.
+  void SetCertificates(const std::vector<ClientCertificateInfo>& certificates);
 
   // Sends a PIN request and waits for the response being received.
   //
@@ -136,7 +145,7 @@ class ApiBridge final : public google_smart_card::RequestHandler {
   void HandleCertificatesRequest(
       const pp::VarArray& arguments,
       google_smart_card::RequestReceiver::ResultCallback result_callback);
-  void HandleSignDigestRequest(
+  void HandleSignatureRequest(
       const pp::VarArray& arguments,
       google_smart_card::RequestReceiver::ResultCallback result_callback);
 
@@ -151,7 +160,7 @@ class ApiBridge final : public google_smart_card::RequestHandler {
 
   std::shared_ptr<google_smart_card::JsRequestReceiver> request_receiver_;
   std::weak_ptr<CertificatesRequestHandler> certificates_request_handler_;
-  std::weak_ptr<SignDigestRequestHandler> sign_digest_request_handler_;
+  std::weak_ptr<SignatureRequestHandler> signature_request_handler_;
 };
 
 }  // namespace chrome_certificate_provider

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
@@ -35,43 +35,40 @@ goog.require('goog.log.Logger');
 
 goog.scope(function() {
 
-/** @const */
-var NACL_INCOMING_REQUESTER_NAME = 'certificate_provider_nacl_incoming';
+const NACL_INCOMING_REQUESTER_NAME = 'certificate_provider_nacl_incoming';
 
-/** @const */
-var NACL_OUTGOING_REQUESTER_NAME = 'certificate_provider_nacl_outgoing';
+const NACL_OUTGOING_REQUESTER_NAME = 'certificate_provider_nacl_outgoing';
 
 /**
- * @const Function called in the NaCl module when handling
+ * Function called in the NaCl module when handling
  * onCertificatesUpdateRequested/onCertificatesRequested events.
  */
-var HANDLE_CERTIFICATES_REQUEST_FUNCTION_NAME = 'HandleCertificatesRequest';
+const HANDLE_CERTIFICATES_REQUEST_FUNCTION_NAME = 'HandleCertificatesRequest';
 
 /**
- * @const Function called in the NaCl module when handling
+ * Function called in the NaCl module when handling
  * onSignatureRequested/onSignDigestRequested events.
  */
-var HANDLE_SIGNATURE_REQUEST_FUNCTION_NAME = 'HandleSignatureRequest';
+const HANDLE_SIGNATURE_REQUEST_FUNCTION_NAME = 'HandleSignatureRequest';
 
-/** @const */
-var GSC = GoogleSmartCard;
+const GSC = GoogleSmartCard;
 
 /**
- * Mapping from the |Hash| enum values to the |Algorithm| ones.
- * @type {!Map<!chrome.certificateProvider.Hash,
- *             !chrome.certificateProvider.Algorithm>}
+ * Mapping from the |chrome.certificateProvider.Hash| enum values to the
+ * |chrome.certificateProvider.Algorithm| ones.
+ *
+ * Note: The actual string values are hardcoded below, instead of references to
+ * |chrome.certificateProvider|, since the latter will break when run with the
+ * API version that doesn't have these (on Chrome OS <=85 or on some future
+ * Chrome OS that has the legacy Hash enum deleted from the API).
+ * @type {!Map<string,string>}
  */
 const HASH_TO_ALGORITHM_MAPPING = new Map([
-  [chrome.certificateProvider.Hash.MD5_SHA1,
-      chrome.certificateProvider.Algorithm.RSASSA_PKCS1_v1_5_MD5_SHA1],
-  [chrome.certificateProvider.Hash.SHA1,
-      chrome.certificateProvider.Algorithm.RSASSA_PKCS1_v1_5_SHA1],
-  [chrome.certificateProvider.Hash.SHA256,
-      chrome.certificateProvider.Algorithm.RSASSA_PKCS1_v1_5_SHA256],
-  [chrome.certificateProvider.Hash.SHA384,
-      chrome.certificateProvider.Algorithm.RSASSA_PKCS1_v1_5_SHA384],
-  [chrome.certificateProvider.Hash.SHA512,
-      chrome.certificateProvider.Algorithm.RSASSA_PKCS1_v1_5_SHA512],
+  ['MD5_SHA1', 'RSASSA_PKCS1_v1_5_MD5_SHA1'],
+  ['SHA1', 'RSASSA_PKCS1_v1_5_SHA1'],
+  ['SHA256', 'RSASSA_PKCS1_v1_5_SHA256'],
+  ['SHA384', 'RSASSA_PKCS1_v1_5_SHA384'],
+  ['SHA512', 'RSASSA_PKCS1_v1_5_SHA512'],
 ]);
 
 /**
@@ -134,7 +131,7 @@ SmartCardClientApp.CertificateProviderBridge.Backend = function(naclModule) {
   this.certificatesUpdateRequestListener_ = null;
   /** @private {?function(!chrome.certificateProvider.SignatureRequest)} */
   this.signatureRequestListener_ = null;
-  /** @private {?function(function((!Array.<!chrome.certificateProvider.CertificateInfo>),function(!Array.<!chrome.certificateProvider.CertificateInfo>)))} */
+  /** @private {?function(function((!Array.<!chrome.certificateProvider.CertificateInfo>), function(!Array.<!chrome.certificateProvider.CertificateInfo>)))} */
   this.certificatesRequestListener_ = null;
   /** @private {?function(!chrome.certificateProvider.SignRequest, function(!ArrayBuffer=))} */
   this.signDigestRequestListener_ = null;
@@ -162,8 +159,7 @@ SmartCardClientApp.CertificateProviderBridge.Backend = function(naclModule) {
   this.logger.fine('Constructed');
 };
 
-/** @const */
-var Backend = SmartCardClientApp.CertificateProviderBridge.Backend;
+const Backend = SmartCardClientApp.CertificateProviderBridge.Backend;
 
 goog.inherits(Backend, goog.Disposable);
 
@@ -233,7 +229,7 @@ Backend.prototype.disposeInternal = function() {
  * @private
  */
 Backend.prototype.handleRequest_ = function(payload) {
-  var remoteCallMessage = GSC.RemoteCallMessage.parseRequestPayload(payload);
+  const remoteCallMessage = GSC.RemoteCallMessage.parseRequestPayload(payload);
   if (!remoteCallMessage) {
     GSC.Logging.failWithLogger(
         this.logger,
@@ -241,13 +237,14 @@ Backend.prototype.handleRequest_ = function(payload) {
         GSC.DebugDump.debugDump(payload));
   }
 
-  var debugRepresentation = 'chrome.certificateProvider.' +
-                            remoteCallMessage.getDebugRepresentation();
+  const debugRepresentation = 'chrome.certificateProvider.' +
+                              remoteCallMessage.getDebugRepresentation();
   this.logger.fine('Received a remote call request: ' + debugRepresentation);
 
-  var promiseResolver = goog.Promise.withResolver();
+  const promiseResolver = goog.Promise.withResolver();
 
-  var apiFunction = chrome.certificateProvider[remoteCallMessage.functionName];
+  const apiFunction = chrome.certificateProvider[
+      remoteCallMessage.functionName];
   if (apiFunction) {
     /** @preserveTry */
     try {
@@ -311,6 +308,9 @@ Backend.prototype.setupApiListeners_ = function() {
         this.signatureRequestListener_);
   } else {
     // TODO: Remove this branch after support of Chrome OS <=85 is dropped.
+    // (There's no specific timeline - a conservative approach would be to wait
+    // until all devices released with Chrome OS <=85 reach the auto-update
+    // expiration date, which will be roughly in year 2028.)
     this.logger.info(
         'Proactively notifying Chrome about certificate changes will not be ' +
         'possible: chrome.certificateProvider API version is too old.');
@@ -346,7 +346,7 @@ Backend.prototype.onSignatureRequested_ = function(request) {
 };
 
 /**
- * @param {function((!Array.<!chrome.certificateProvider.CertificateInfo>),function(!Array.<!chrome.certificateProvider.CertificateInfo>))} reportCallback
+ * @param {function((!Array.<!chrome.certificateProvider.CertificateInfo>), function(!Array.<!chrome.certificateProvider.CertificateInfo>))} reportCallback
  * @private
  */
 Backend.prototype.onCertificatesRequested_ = function(reportCallback) {
@@ -371,13 +371,13 @@ Backend.prototype.onSignDigestRequested_ = function(
  */
 Backend.prototype.processCertificatesUpdateRequest_ = function(request) {
   this.logger.info('Started handling certificates update request');
-  var remoteCallMessage = new GSC.RemoteCallMessage(
+  const remoteCallMessage = new GSC.RemoteCallMessage(
       HANDLE_CERTIFICATES_REQUEST_FUNCTION_NAME, []);
-  var promise = this.requester_.postRequest(
+  const promise = this.requester_.postRequest(
       remoteCallMessage.makeRequestPayload());
   promise.then(function(results) {
     GSC.Logging.checkWithLogger(this.logger, results.length == 1);
-    var certificates = goog.array.map(results[0], createClientCertificateInfo);
+    const certificates = goog.array.map(results[0], createClientCertificateInfo);
     this.logger.info(
         'Setting the certificate list with ' + certificates.length +
         ' certificates: ' + GSC.DebugDump.debugDump(certificates));
@@ -413,13 +413,13 @@ Backend.prototype.processSignatureRequest_ = function(request) {
     algorithm: request.algorithm,
     certificate: request.certificate,
   };
-  var remoteCallMessage = new GSC.RemoteCallMessage(
+  const remoteCallMessage = new GSC.RemoteCallMessage(
       HANDLE_SIGNATURE_REQUEST_FUNCTION_NAME, [naclRequest]);
-  var promise = this.requester_.postRequest(
+  const promise = this.requester_.postRequest(
       remoteCallMessage.makeRequestPayload());
   promise.then(function(results) {
     GSC.Logging.checkWithLogger(this.logger, results.length == 1);
-    var signature = normalizeSignature(results[0]);
+    const signature = normalizeSignature(results[0]);
     this.logger.info(
         'Responding to the signature request with the created signature: ' +
         GSC.DebugDump.debugDump(signature));
@@ -437,18 +437,18 @@ Backend.prototype.processSignatureRequest_ = function(request) {
 };
 
 /**
- * @param {function((!Array.<!chrome.certificateProvider.CertificateInfo>),function(!Array.<!chrome.certificateProvider.CertificateInfo>))} reportCallback
+ * @param {function((!Array.<!chrome.certificateProvider.CertificateInfo>), function(!Array.<!chrome.certificateProvider.CertificateInfo>))} reportCallback
  * @private
  */
 Backend.prototype.processCertificatesRequest_ = function(reportCallback) {
   this.logger.info('Started handling certificates request');
-  var remoteCallMessage = new GSC.RemoteCallMessage(
+  const remoteCallMessage = new GSC.RemoteCallMessage(
       HANDLE_CERTIFICATES_REQUEST_FUNCTION_NAME, []);
-  var promise = this.requester_.postRequest(
+  const promise = this.requester_.postRequest(
       remoteCallMessage.makeRequestPayload());
   promise.then(function(results) {
     GSC.Logging.checkWithLogger(this.logger, results.length == 1);
-    var certificates = goog.array.map(results[0], createCertificateInfo);
+    const certificates = goog.array.map(results[0], createCertificateInfo);
     this.logger.info(
         'Responding to the certificates request with ' + certificates.length +
         ' certificates: ' + GSC.DebugDump.debugDump(certificates));
@@ -479,13 +479,13 @@ Backend.prototype.processSignDigestRequest_ = function(
     algorithm: getAlgorithmFromHash(request.hash),
     certificate: request.certificate,
   };
-  var remoteCallMessage = new GSC.RemoteCallMessage(
+  const remoteCallMessage = new GSC.RemoteCallMessage(
       HANDLE_SIGNATURE_REQUEST_FUNCTION_NAME, [naclRequest]);
-  var promise = this.requester_.postRequest(
+  const promise = this.requester_.postRequest(
       remoteCallMessage.makeRequestPayload());
   promise.then(function(results) {
     GSC.Logging.checkWithLogger(this.logger, results.length == 1);
-    var signature = normalizeSignature(results[0]);
+    const signature = normalizeSignature(results[0]);
     this.logger.info(
         'Responding to the digest sign request with the created signature: ' +
         GSC.DebugDump.debugDump(signature));
@@ -539,8 +539,10 @@ function createCertificateInfo(naclCertificateInfo) {
  * @return {!chrome.certificateProvider.Algorithm}
  */
 function getAlgorithmFromHash(hash) {
-  if (HASH_TO_ALGORITHM_MAPPING.has(hash))
-    return HASH_TO_ALGORITHM_MAPPING.get(hash);
+  if (HASH_TO_ALGORITHM_MAPPING.has(hash)) {
+    return /** @type {!chrome.certificateProvider.Algorithm} */ (
+        HASH_TO_ALGORITHM_MAPPING.get(hash));
+  }
   GSC.Logging.fail(`Unknown hash ${hash}`);
   return chrome.certificateProvider.Algorithm.RSASSA_PKCS1_v1_5_SHA1;
 }
@@ -552,7 +554,7 @@ function getAlgorithmFromHash(hash) {
 function getHashFromAlgorithm(algorithm) {
   for (const hash of HASH_TO_ALGORITHM_MAPPING.keys()) {
     if (HASH_TO_ALGORITHM_MAPPING.get(hash) === algorithm)
-      return hash;
+      return /** @type {!chrome.certificateProvider.Hash} */ (hash);
   }
   GSC.Logging.fail(`Unknown algorithm ${algorithm}`);
   return chrome.certificateProvider.Hash.SHA1;

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.h
@@ -113,7 +113,7 @@ struct SetCertificatesDetails {
 struct SignatureRequest {
   int sign_request_id;
   std::vector<uint8_t> input;
-  std::vector<uint8_t> digest;
+  std::vector<uint8_t> digest;  // only used with the legacy API
   Algorithm algorithm;
   std::vector<uint8_t> certificate;
 };

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.h
@@ -42,13 +42,21 @@ namespace chrome_certificate_provider {
 // Enumerate that corresponds to different hash algorithms.
 //
 // For the corresponding original JavaScript definition, refer to:
-// <https://developer.chrome.com/extensions/certificateProvider#type-Hash>.
-enum class Hash {
-  kMd5Sha1,
-  kSha1,
-  kSha256,
-  kSha384,
-  kSha512,
+// <https://developer.chrome.com/extensions/certificateProvider#type-Algorithm>.
+enum class Algorithm {
+  kRsassaPkcs1v15Md5Sha1,
+  kRsassaPkcs1v15Sha1,
+  kRsassaPkcs1v15Sha384,
+  kRsassaPkcs1v15Sha256,
+  kRsassaPkcs1v15Sha512,
+};
+
+// Enumerate that corresponds to types of errors that the extension can report.
+//
+// For the corresponding original JavaScript definition, refer to:
+// <https://developer.chrome.com/extensions/certificateProvider#type-Error>.
+enum class Error {
+  kGeneral,
 };
 
 // Enumerate that corresponds to the type of the PIN dialog.
@@ -76,20 +84,37 @@ enum class PinRequestErrorType {
 // Structure containing a certificate description.
 //
 // For the corresponding original JavaScript definition, refer to:
-// <https://developer.chrome.com/extensions/certificateProvider#type-CertificateInfo>.
-struct CertificateInfo {
+// <https://developer.chrome.com/extensions/certificateProvider#type-ClientCertificateInfo>.
+struct ClientCertificateInfo {
   std::vector<uint8_t> certificate;
-  std::vector<Hash> supported_hashes;
+  std::vector<Algorithm> supported_algorithms;
 };
 
-// Structure containing the data of the digest signing request.
+// Structure containing the parameters for the
+// chrome.certificateProvider.setCertificates() function.
 //
 // For the corresponding original JavaScript definition, refer to:
-// <https://developer.chrome.com/extensions/certificateProvider#type-SignRequest>.
-struct SignRequest {
+// <https://developer.chrome.com/extensions/certificateProvider#method-setCertificates>.
+struct SetCertificatesDetails {
+  google_smart_card::optional<int> certificates_request_id;
+  google_smart_card::optional<Error> error;
+  std::vector<ClientCertificateInfo> client_certificates;
+};
+
+// Structure containing the data of the signature request.
+//
+// Note that either |input| or |digest| will be set (but not both
+// simultaneously).
+//
+// For the corresponding original JavaScript definition, refer to:
+// <https://developer.chrome.com/extensions/certificateProvider#event-onSignatureRequested>
+// and
+// <https://developer.chrome.com/extensions/certificateProvider#event-onSignDigestRequested>.
+struct SignatureRequest {
   int sign_request_id;
+  std::vector<uint8_t> input;
   std::vector<uint8_t> digest;
-  Hash hash;
+  Algorithm algorithm;
   std::vector<uint8_t> certificate;
 };
 
@@ -124,8 +149,11 @@ struct StopPinRequestOptions {
   google_smart_card::optional<PinRequestErrorType> error_type;
 };
 
-bool VarAs(const pp::Var& var, Hash* result, std::string* error_message);
-pp::Var MakeVar(Hash value);
+bool VarAs(const pp::Var& var, Algorithm* result, std::string* error_message);
+pp::Var MakeVar(Algorithm value);
+
+bool VarAs(const pp::Var& var, Error* result, std::string* error_message);
+pp::Var MakeVar(Error value);
 
 bool VarAs(const pp::Var& var, PinRequestType* result,
            std::string* error_message);
@@ -135,12 +163,17 @@ bool VarAs(const pp::Var& var, PinRequestErrorType* result,
            std::string* error_message);
 pp::Var MakeVar(PinRequestErrorType value);
 
-bool VarAs(
-    const pp::Var& var, CertificateInfo* result, std::string* error_message);
-pp::Var MakeVar(const CertificateInfo& value);
+bool VarAs(const pp::Var& var, ClientCertificateInfo* result,
+           std::string* error_message);
+pp::Var MakeVar(const ClientCertificateInfo& value);
 
-bool VarAs(const pp::Var& var, SignRequest* result, std::string* error_message);
-pp::Var MakeVar(const SignRequest& value);
+bool VarAs(const pp::Var& var, SetCertificatesDetails* result,
+           std::string* error_message);
+pp::Var MakeVar(const SetCertificatesDetails& value);
+
+bool VarAs(const pp::Var& var, SignatureRequest* result,
+           std::string* error_message);
+pp::Var MakeVar(const SignatureRequest& value);
 
 bool VarAs(const pp::Var& var, RequestPinOptions* result,
            std::string* error_message);

--- a/third_party/closure-compiler/src_additional/chrome_extensions.js
+++ b/third_party/closure-compiler/src_additional/chrome_extensions.js
@@ -33,33 +33,122 @@ chrome.certificateProvider = {};
 
 
 /**
- * @typedef {string}
+ * @enum {string}
  */
-chrome.certificateProvider.Hash;
+chrome.certificateProvider.Algorithm = {
+  RSASSA_PKCS1_v1_5_MD5_SHA1: 'RSASSA_PKCS1_v1_5_MD5_SHA1',
+  RSASSA_PKCS1_v1_5_SHA1: 'RSASSA_PKCS1_v1_5_SHA1',
+  RSASSA_PKCS1_v1_5_SHA256: 'RSASSA_PKCS1_v1_5_SHA256',
+  RSASSA_PKCS1_v1_5_SHA384: 'RSASSA_PKCS1_v1_5_SHA384',
+  RSASSA_PKCS1_v1_5_SHA512: 'RSASSA_PKCS1_v1_5_SHA512',
+};
+
+
+/**
+ * @enum {string}
+ */
+chrome.certificateProvider.Error = {
+  GENERAL_ERROR: 'GENERAL_ERROR',
+};
+
+
+/**
+ * @enum {string}
+ */
+chrome.certificateProvider.Hash = {
+  MD5_SHA1: 'MD5_SHA1',
+  SHA1: 'SHA1',
+  SHA256: 'SHA256',
+  SHA384: 'SHA384',
+  SHA512: 'SHA512',
+};
+
+
+/**
+ * @typedef {{
+ *   certificateChain: !Array<!ArrayBuffer>,
+ *   supportedAlgorithms: !Array<!chrome.certificateProvider.Algorithm>
+ * }}
+ */
+chrome.certificateProvider.ClientCertificateInfo;
+
+
+/**
+ * @typedef {{
+ *   certificatesRequestId: number,
+ *   error: (!chrome.certificateProvider.Error|undefined),
+ *   clientCertificates: !Array<!chrome.certificateProvider.ClientCertificateInfo>
+ * }}
+ */
+chrome.certificateProvider.SetCertificatesDetails;
 
 
 /**
  * @constructor
  */
-chrome.certificateProvider.CertificateInfo = function() {};
+chrome.certificateProvider.CertificatesUpdateRequest = function() {};
 
+/**
+ * @type {number}
+ */
+chrome.certificateProvider.CertificatesUpdateRequest.prototype.certificatesRequestId;
+
+
+/**
+ * @constructor
+ */
+chrome.certificateProvider.SignatureRequest = function() {};
+
+/**
+ * @type {number}
+ */
+chrome.certificateProvider.SignatureRequest.prototype.signRequestId;
 
 /**
  * @type {!ArrayBuffer}
  */
-chrome.certificateProvider.CertificateInfo.prototype.certificate;
+chrome.certificateProvider.SignatureRequest.prototype.input;
+
+/**
+ * @type {!chrome.certificateProvider.Algorithm}
+ */
+chrome.certificateProvider.SignatureRequest.prototype.algorithm;
+
+/**
+ * @type {!ArrayBuffer}
+ */
+chrome.certificateProvider.SignatureRequest.prototype.certificate;
 
 
 /**
- * @type {!Array.<chrome.certificateProvider.Hash>}
+ * @typedef {{
+ *   signRequestId: number,
+ *   error: (!chrome.certificateProvider.Error|undefined),
+ *   signature: (!ArrayBuffer|undefined)
+ * }}
  */
-chrome.certificateProvider.CertificateInfo.prototype.supportedHashes;
+chrome.certificateProvider.ReportSignatureDetails;
+
+
+/**
+ * @typedef {{
+ *   certificate: !ArrayBuffer,
+ *   supportedHashes: !Array.<chrome.certificateProvider.Hash>
+ * }}
+ */
+chrome.certificateProvider.CertificateInfo;
 
 
 /**
  * @constructor
  */
 chrome.certificateProvider.SignRequest = function() {};
+
+
+/**
+ * @type {number}
+ */
+chrome.certificateProvider.SignRequest.prototype.signRequestId;
 
 
 /**
@@ -78,6 +167,48 @@ chrome.certificateProvider.SignRequest.prototype.hash;
  * @type {!ArrayBuffer}
  */
 chrome.certificateProvider.SignRequest.prototype.certificate;
+
+
+/**
+ * @constructor
+ */
+chrome.certificateProvider.CertificatesUpdateRequestEvent = function() {};
+
+/**
+ * @param {function(!chrome.certificateProvider.CertificatesUpdateRequest)} callback
+ */
+chrome.certificateProvider.CertificatesUpdateRequestEvent.prototype.addListener = function(callback) {};
+
+/**
+ * @param {function(!chrome.certificateProvider.CertificatesUpdateRequest)} callback
+ */
+chrome.certificateProvider.CertificatesUpdateRequestEvent.prototype.removeListener = function(callback) {};
+
+/**
+ * @type {!chrome.certificateProvider.CertificatesUpdateRequestEvent}
+ */
+chrome.certificateProvider.onCertificatesUpdateRequested;
+
+
+/**
+ * @constructor
+ */
+chrome.certificateProvider.SignatureRequestEvent = function() {};
+
+/**
+ * @param {function(!chrome.certificateProvider.SignatureRequest)} callback
+ */
+chrome.certificateProvider.SignatureRequestEvent.prototype.addListener = function(callback) {};
+
+/**
+ * @param {function(!chrome.certificateProvider.SignatureRequest)} callback
+ */
+chrome.certificateProvider.SignatureRequestEvent.prototype.removeListener = function(callback) {};
+
+/**
+ * @type {!chrome.certificateProvider.SignatureRequestEvent}
+ */
+chrome.certificateProvider.onSignatureRequested;
 
 
 /**
@@ -126,6 +257,19 @@ chrome.certificateProvider.SignDigestRequestEvent.prototype.removeListener = fun
  * @type {!chrome.certificateProvider.SignDigestRequestEvent}
  */
 chrome.certificateProvider.onSignDigestRequested;
+
+/**
+ * @param {!chrome.certificateProvider.SetCertificatesDetails} details
+ * @param {function()=} callback
+ */
+chrome.certificateProvider.setCertificates = function(details, callback) {};
+
+/**
+ * @param {!chrome.certificateProvider.ReportSignatureDetails} details
+ * @param {function()=} callback
+ */
+chrome.certificateProvider.reportSignature = function(details, callback) {};
+
 
 /**
  * @const

--- a/third_party/closure-compiler/src_additional/chrome_extensions.js
+++ b/third_party/closure-compiler/src_additional/chrome_extensions.js
@@ -75,7 +75,7 @@ chrome.certificateProvider.ClientCertificateInfo;
 
 /**
  * @typedef {{
- *   certificatesRequestId: number,
+ *   certificatesRequestId: (number|undefined),
  *   error: (!chrome.certificateProvider.Error|undefined),
  *   clientCertificates: !Array<!chrome.certificateProvider.ClientCertificateInfo>
  * }}


### PR DESCRIPTION
Implement the support of the new chrome.certificateProvider API
functionality in the Example C++ Client App, namely:

* Using new events
  "onCertificatesUpdateRequested"+"onSignatureRequested" instead of the
  deprecated ones "onCertificatesRequested"+"onSignDigestRequested"
  (with a graceful fallback to the deprecated ones when there's no
  choice);
* Using the new type "Algorithm" instead of the deprecated "Hash";
* Plumbing for the "setCertificates" function, that allows to
  proactively notify Chrome about changes.