### PR TITLE
Fix minification issue in LogBufferForwarder

### DIFF
--- a/common/js/src/logging/log-buffer-forwarder.js
+++ b/common/js/src/logging/log-buffer-forwarder.js
@@ -143,7 +143,7 @@ LogBufferForwarder.prototype.sendLogRecord_ = function(formattedLogRecord) {
   this.logCapturingEnabled_ = false;
 
   GSC.Logging.check(this.messageChannel_);
-  const message = {formatted_log_message: formattedLogRecord};
+  const message = {'formatted_log_message': formattedLogRecord};
   this.messageChannel_.send(this.messageChannelServiceName_, message);
   GSC.Logging.check(!this.logCapturingEnabled_);
 


### PR DESCRIPTION
Fix a potential problem in LogBufferForwarder that the
"formatted_log_message" object key could be minified by the Closure
Compiler to something like "a", in case the aggressive optimization is
enabled.

For the background, the Closure Compiler in the aggressive compilation
mode renames all object properties to some minified names. This is
unwanted in this case, since the object constructed here is sent to the
NaCl module where it gets parsed (and the keys are expected to have
specific names). The way to suppress the Closure Compiler optimization
is to put the property name into quotes.

This was not a real bug at the moment, since we currently don't use the
aggressive compilation mode, but it's nice to fix it anyway.

This is a follow-up to #105 where this code was originally introduced.