### PR TITLE
Drop var_args from logging.js methods

### DIFF
--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -202,7 +202,7 @@ GSC.Logging.checkWithLogger = function(
 
 /**
  * Fails with the specified message.
-  *
+ *
  * In the debug mode, this function effectively throws an instance of
  * goog.asserts.AssertionError.
  *

--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -179,11 +179,10 @@ GSC.Logging.setLoggerVerbosityAtMost = function(logger, boundaryLevel) {
  * @template T
  * @param {T} condition The condition to check.
  * @param {string=} opt_message Error message in case of failure.
- * @param {...*} var_args The items to substitute into the failure message.
  */
-GSC.Logging.check = function(condition, opt_message, var_args) {
+GSC.Logging.check = function(condition, opt_message) {
   if (!condition)
-    GSC.Logging.fail(opt_message, Array.prototype.slice.call(arguments, 2));
+    GSC.Logging.fail(opt_message);
 };
 
 /**
@@ -194,31 +193,28 @@ GSC.Logging.check = function(condition, opt_message, var_args) {
  * to the error message.
  * @param {T} condition The condition to check.
  * @param {string=} opt_message Error message in case of failure.
- * @param {...*} var_args The items to substitute into the failure message.
  */
 GSC.Logging.checkWithLogger = function(
-    logger, condition, opt_message, var_args) {
+    logger, condition, opt_message) {
   if (!condition)
-    GSC.Logging.failWithLogger(logger, opt_message, var_args);
+    GSC.Logging.failWithLogger(logger, opt_message);
 };
 
 /**
  * Fails with the specified message.
- *
+  *
  * In the debug mode, this function effectively throws an instance of
  * goog.asserts.AssertionError.
  *
  * In the release mode, this function emits severe log message and initiates the
  * App reload.
  * @param {string=} opt_message Error message in case of failure.
- * @param {...*} var_args The items to substitute into the failure message.
  */
-GSC.Logging.fail = function(opt_message, var_args) {
+GSC.Logging.fail = function(opt_message) {
   if (goog.DEBUG) {
-    throwAssertionError(opt_message, var_args);
+    throwAssertionError(opt_message);
   } else {
-    var messageAndArgs = Array.prototype.slice.call(arguments);
-    rootLogger.severe.apply(rootLogger, messageAndArgs);
+    rootLogger.severe(opt_message ? opt_message : 'Failure');
     rootLogger.info('Reloading the App due to the fatal error...');
     reloadApp();
   }
@@ -229,15 +225,12 @@ GSC.Logging.fail = function(opt_message, var_args) {
  * @param {!goog.log.Logger} logger The logger which name is to be prepended
  * to the error message.
  * @param {string=} opt_message Error message in case of failure.
- * @param {...*} var_args The items to substitute into the failure message.
  */
-GSC.Logging.failWithLogger = function(logger, opt_message, var_args) {
+GSC.Logging.failWithLogger = function(logger, opt_message) {
   var messagePrefix = 'Failure in ' + logger.getName();
   if (opt_message !== undefined) {
     var transformedMessage = messagePrefix + ': ' + opt_message;
-    var args = Array.prototype.slice.call(arguments, 2);
-    GSC.Logging.fail.apply(
-        GSC.Logging, goog.array.concat(transformedMessage, args));
+    GSC.Logging.fail(transformedMessage);
   } else {
     GSC.Logging.fail(messagePrefix);
   }
@@ -258,12 +251,10 @@ GSC.Logging.getLogBuffer = function() {
 
 /**
  * @param {string=} opt_message Error message in case of failure.
- * @param {...*} var_args The items to substitute into the failure message.
  */
-function throwAssertionError(opt_message, var_args) {
+function throwAssertionError(opt_message) {
   if (goog.asserts.ENABLE_ASSERTS) {
-    var messageAndArgs = Array.prototype.slice.call(arguments);
-    goog.asserts.fail.apply(null, messageAndArgs);
+    goog.asserts.fail(opt_message);
   } else {
     // This branch is the last resort, and should generally never happen
     // (unless the goog.asserts.ENABLE_ASSERTS constant was changed from its

--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -48,17 +48,14 @@ goog.require('goog.log.Logger');
 
 goog.scope(function() {
 
-/** @const */
-var LOGGER_SCOPE = 'GoogleSmartCard';
+const LOGGER_SCOPE = 'GoogleSmartCard';
 
 /**
  * The logging level that will be applied to the root logger (and therefore
  * would be effective for all loggers unless the ones that have an explicitly
  * set level).
- * @type {!goog.log.Level}
- * @const
  */
-var ROOT_LOGGER_LEVEL = goog.DEBUG ? goog.log.Level.FINE : goog.log.Level.INFO;
+const ROOT_LOGGER_LEVEL = goog.DEBUG ? goog.log.Level.FINE : goog.log.Level.INFO;
 
 /**
  * The capacity of the buffer that stores the emitted log messages.
@@ -66,28 +63,24 @@ var ROOT_LOGGER_LEVEL = goog.DEBUG ? goog.log.Level.FINE : goog.log.Level.INFO;
  * When the number of log messages exceeds this capacity, the messages from the
  * middle will be removed (so only some first and some last messages will be
  * kept at any given moment of time).
- * @const
  */
-var LOG_BUFFER_CAPACITY = goog.DEBUG ? 10 * 1000 : 1000;
+const LOG_BUFFER_CAPACITY = goog.DEBUG ? 10 * 1000 : 1000;
 
-/** @const */
-var GSC = GoogleSmartCard;
+const GSC = GoogleSmartCard;
 
 /**
  * @type {!goog.log.Logger}
- * @const
  */
-var rootLogger = goog.asserts.assert(goog.log.getLogger(
+const rootLogger = goog.asserts.assert(goog.log.getLogger(
     goog.log.ROOT_LOGGER_NAME));
 
 /**
  * @type {!goog.log.Logger}
- * @const
  */
-var logger = goog.asserts.assert(goog.log.getLogger(LOGGER_SCOPE));
+const logger = goog.asserts.assert(goog.log.getLogger(LOGGER_SCOPE));
 
 /** @type {boolean} */
-var wasLoggingSetUp = false;
+let wasLoggingSetUp = false;
 
 /**
  * This constant specifies the name of the special window attribute, that should
@@ -127,7 +120,7 @@ GSC.Logging.setupLogging = function() {
  * @return {!goog.log.Logger}
  */
 GSC.Logging.getLogger = function(name, opt_level) {
-  var logger = goog.log.getLogger(name, opt_level);
+  const logger = goog.log.getLogger(name, opt_level);
   GSC.Logging.check(logger);
   goog.asserts.assert(logger);
   return logger;
@@ -140,7 +133,7 @@ GSC.Logging.getLogger = function(name, opt_level) {
  * @return {!goog.log.Logger}
  */
 GSC.Logging.getScopedLogger = function(name, opt_level) {
-  var fullName = LOGGER_SCOPE;
+  let fullName = LOGGER_SCOPE;
   if (name)
     fullName += '.' + name;
   return GSC.Logging.getLogger(fullName, opt_level);
@@ -166,7 +159,7 @@ GSC.Logging.getChildLogger = function(
  * @param {!goog.log.Level} boundaryLevel
  */
 GSC.Logging.setLoggerVerbosityAtMost = function(logger, boundaryLevel) {
-  var effectiveLevel = logger.getEffectiveLevel();
+  const effectiveLevel = logger.getEffectiveLevel();
   if (!effectiveLevel || effectiveLevel.value < boundaryLevel.value)
     logger.setLevel(boundaryLevel);
 };
@@ -227,9 +220,9 @@ GSC.Logging.fail = function(opt_message) {
  * @param {string=} opt_message Error message in case of failure.
  */
 GSC.Logging.failWithLogger = function(logger, opt_message) {
-  var messagePrefix = 'Failure in ' + logger.getName();
+  const messagePrefix = 'Failure in ' + logger.getName();
   if (opt_message !== undefined) {
-    var transformedMessage = messagePrefix + ': ' + opt_message;
+    const transformedMessage = messagePrefix + ': ' + opt_message;
     GSC.Logging.fail(transformedMessage);
   } else {
     GSC.Logging.fail(messagePrefix);
@@ -272,7 +265,7 @@ function reloadApp() {
 }
 
 function setupConsoleLogging() {
-  var console = new goog.debug.Console;
+  const console = new goog.debug.Console;
   console.getFormatter().showAbsoluteTime = true;
   console.setCapturing(true);
 }
@@ -283,7 +276,7 @@ function setupRootLoggerLevel() {
 
 function setupLogBuffer() {
   /** @type {!GSC.LogBuffer} */
-  var logBuffer;
+  let logBuffer;
   if (goog.object.containsKey(
           window, GSC.Logging.GLOBAL_LOG_BUFFER_VARIABLE_NAME)) {
     logBuffer = window[GSC.Logging.GLOBAL_LOG_BUFFER_VARIABLE_NAME];

--- a/docs/updating-pcsc-lite.md
+++ b/docs/updating-pcsc-lite.md
@@ -47,8 +47,6 @@ somewhat outdated version of the PC/SC-Lite daemon.
    * `//third_party/pcsc-lite/naclport/common/build/`
    * `//third_party/pcsc-lite/naclport/cpp_client/build/`
    * `//third_party/pcsc-lite/naclport/cpp_demo/build/`
-   * `//third_party/pcsc-lite/naclport/js_client/build/`
-   * `//third_party/pcsc-lite/naclport/js_demo/build/`
    * `//third_party/pcsc-lite/naclport/server/build/`
    * `//third_party/pcsc-lite/naclport/server_clients_management/build/`
 


### PR DESCRIPTION
These optional formatting arguments are not used anywhere, and will
complicate the upcoming implementation of crash loop detection (tracked
by #156).

Therefore this CL deletes this unused functionality.