### PR TITLE
Call runtime.reload() before runtime.restart()

### DIFF
--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -279,11 +279,13 @@ function throwAssertionError(opt_message) {
 }
 
 function reloadApp() {
-  // This method works only in kiosk mode, and does nothing otherwise.
-  chrome.runtime.restart();
-
-  // This method works only in non-kiosk mode.
+  // This method works only in non-kiosk mode. Since this is a much more common
+  // case and as this function doesn't generate errors in any case, this method
+  // is called first.
   chrome.runtime.reload();
+
+  // This method works only in kiosk mode.
+  chrome.runtime.restart();
 }
 
 function setupConsoleLogging() {


### PR DESCRIPTION
Both functions achieve the same goal - reloading the extension - but
they are supported in different contexts: one only works in non-kiosk
sessions and another only in kiosk ones. We call both of them, in order
to simplify the code.

The commit swaps the order of these calls, so that reload() is called
first. This allows to remove the spurious error from restart() when run
in non-kiosk mode.

This is part of the crash-and-reload process improvement tracked by #156.