### PR TITLE
Add flag for disabling the reload-on-failure

### DIFF
--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -64,6 +64,13 @@ GSC.Logging.USE_SCOPED_LOGGERS =
     goog.define('GoogleSmartCard.Logging.USE_SCOPED_LOGGERS', true);
 
 /**
+ * @define {boolean} Whether to trigger the extension reload in case a fatal
+ * error occurs in Release mode.
+ */
+GSC.Logging.SELF_RELOAD_ON_FATAL_ERROR =
+    goog.define('GoogleSmartCard.Logging.SELF_RELOAD_ON_FATAL_ERROR', false);
+
+/**
  * Every logger created via this library is created as a child of this logger,
  * as long as the |USE_SCOPED_LOGGERS| constant is true. Ignored when that
  * constant is false.
@@ -226,8 +233,7 @@ GSC.Logging.checkWithLogger = function(
 GSC.Logging.fail = function(opt_message) {
   const message = opt_message ? opt_message : 'Failure';
   rootLogger.severe(message);
-  if (!goog.DEBUG)
-    scheduleAppReloadIfAllowed();
+  scheduleAppReloadIfAllowed();
   throw new Error(message);
 };
 
@@ -261,6 +267,8 @@ GSC.Logging.getLogBuffer = function() {
 };
 
 function scheduleAppReloadIfAllowed() {
+  if (goog.DEBUG || !GSC.Logging.SELF_RELOAD_ON_FATAL_ERROR)
+    return;
   GSC.Logging.CrashLoopDetection.handleImminentCrash().then(
       function(isInCrashLoop) {
         if (isInCrashLoop) {

--- a/example_cpp_smart_card_client_app/build/Makefile
+++ b/example_cpp_smart_card_client_app/build/Makefile
@@ -42,10 +42,13 @@ JS_COMPILER_INPUT_PATHS := \
 	$(PCSC_LITE_JS_CLIENT_COMPILER_INPUT_DIR_PATHS) \
 	$(SOURCES_PATH) \
 
-# Note: Change the USE_SCOPED_LOGGERS's value to "true" in case the JavaScript
+# Note: Change the SELF_RELOAD_ON_FATAL_ERROR's value to "false" in case you
+# need to suppress the automatic self-reload of the extension on fatal failures.
+# Change the USE_SCOPED_LOGGERS's value to "true" in case the JavaScript
 # code you added creates its own loggers whose names clash with the existing
 # ones.
 JS_COMPILER_FLAGS := \
+	--define='GoogleSmartCard.Logging.SELF_RELOAD_ON_FATAL_ERROR=true' \
 	--define='GoogleSmartCard.Logging.USE_SCOPED_LOGGERS=false' \
 
 $(eval $(call BUILD_JS_SCRIPT,background.js,$(JS_COMPILER_INPUT_PATHS),SmartCardClientApp.BackgroundMain,$(JS_COMPILER_FLAGS)))

--- a/example_js_smart_card_client_app/build/Makefile
+++ b/example_js_smart_card_client_app/build/Makefile
@@ -38,9 +38,14 @@ JS_COMPILER_INPUT_PATHS := \
 	$(PCSC_LITE_JS_DEMO_COMPILER_INPUTS) \
 	$(JS_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \
 
-$(eval $(call BUILD_JS_SCRIPT,background.js,$(JS_COMPILER_INPUT_PATHS),SmartCardClientApp.BackgroundMain))
+# Note: Change the SELF_RELOAD_ON_FATAL_ERROR's value to "false" in case you
+# need to suppress the automatic self-reload of the extension on fatal failures.
+JS_COMPILER_FLAGS := \
+	--define='GoogleSmartCard.Logging.SELF_RELOAD_ON_FATAL_ERROR=true' \
 
-$(eval $(call BUILD_JS_SCRIPT,pin-dialog.js,$(JS_COMPILER_INPUT_PATHS),SmartCardClientApp.PinDialog.Main))
+$(eval $(call BUILD_JS_SCRIPT,background.js,$(JS_COMPILER_INPUT_PATHS),SmartCardClientApp.BackgroundMain,$(JS_COMPILER_FLAGS)))
+
+$(eval $(call BUILD_JS_SCRIPT,pin-dialog.js,$(JS_COMPILER_INPUT_PATHS),SmartCardClientApp.PinDialog.Main,$(JS_COMPILER_FLAGS)))
 
 $(eval $(JS_COMMON_BACKGROUND_PAGE_UNLOAD_PREVENTING_IFRAME_RULE))
 

--- a/smart_card_connector_app/build/Makefile
+++ b/smart_card_connector_app/build/Makefile
@@ -58,6 +58,10 @@ include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/server_clients_management/inc
 SOURCES_PATH := ../src
 
 
+JS_COMPILER_FLAGS := \
+	--define='GoogleSmartCard.Logging.SELF_RELOAD_ON_FATAL_ERROR=true' \
+
+
 #
 # Constants and rules for compiling the background.js file.
 #
@@ -71,7 +75,7 @@ JS_COMPILER_BACKGROUND_INPUT_PATHS := \
 	$(PCSC_LITE_SERVER_JS_COMPILER_INPUT_DIR_PATHS) \
 	$(JS_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \
 
-$(eval $(call BUILD_JS_SCRIPT,background.js,$(JS_COMPILER_BACKGROUND_INPUT_PATHS),GoogleSmartCard.ConnectorApp.BackgroundMain))
+$(eval $(call BUILD_JS_SCRIPT,background.js,$(JS_COMPILER_BACKGROUND_INPUT_PATHS),GoogleSmartCard.ConnectorApp.BackgroundMain,$(JS_COMPILER_FLAGS)))
 
 
 #
@@ -86,7 +90,7 @@ JS_COMPILER_WINDOW_INPUT_PATHS := \
 	$(PCSC_LITE_SERVER_JS_COMPILER_INPUT_DIR_PATHS) \
 	$(JS_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \
 
-$(eval $(call BUILD_JS_SCRIPT,window.js,$(JS_COMPILER_WINDOW_INPUT_PATHS),GoogleSmartCard.ConnectorApp.Window.Main))
+$(eval $(call BUILD_JS_SCRIPT,window.js,$(JS_COMPILER_WINDOW_INPUT_PATHS),GoogleSmartCard.ConnectorApp.Window.Main,$(JS_COMPILER_FLAGS)))
 
 
 #

--- a/smart_card_connector_app/build/Makefile
+++ b/smart_card_connector_app/build/Makefile
@@ -57,7 +57,6 @@ include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/server_clients_management/inc
 
 SOURCES_PATH := ../src
 
-
 JS_COMPILER_FLAGS := \
 	--define='GoogleSmartCard.Logging.SELF_RELOAD_ON_FATAL_ERROR=true' \
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server_clients_management/build/Makefile
@@ -75,7 +75,10 @@ JS_COMPILER_INPUT_PATHS := \
 	$(JS_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \
 	$(PCSC_LITE_SERVER_CLIENTS_MANAGEMENT_JS_COMPILER_INPUT_DIR_PATHS) \
 
-$(eval $(call BUILD_JS_SCRIPT,pcsc_lite_server_clients_management/user-prompt-dialog.js,$(JS_COMPILER_INPUT_PATHS),GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.UserPromptDialog.Main))
+JS_COMPILER_FLAGS := \
+	--define='GoogleSmartCard.Logging.SELF_RELOAD_ON_FATAL_ERROR=true' \
+
+$(eval $(call BUILD_JS_SCRIPT,pcsc_lite_server_clients_management/user-prompt-dialog.js,$(JS_COMPILER_INPUT_PATHS),GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.UserPromptDialog.Main,$(JS_COMPILER_FLAGS)))
 
 
 INSTALLED_HEADERS_DIR_NAME := \


### PR DESCRIPTION
Add a build-time parameter that allows to enable/disable the
self-reloading of the extension/app in case a fatal error occurs. This
allows to easily disable this functionality in client applications that
don't want this behavior.

Note that this parameter also controls whether the "crash loop
detection" introduced in #156 is enabled.

Also leave this parameter in the "disabled" state for the
"example_js_standalone_smart_card_client_library", since this library is
used in a wide variety of different extensions/apps, and, most likely,
they don't want to be self-reloaded in case the smart card code fails.
It was an oversight that this functionality was enabled there, and now
with addition in #156 of chrome.storage manipulations it became more
apparent that we want to disable it there by default.