### PR TITLE
Update extension names in known_client_apps.json

### DIFF
--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -1,5 +1,4 @@
 {
-"key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlc6hy5++uljMusXcpXspmA3UH5t9ppVHj3FfxvVMPOFX0RLrDvXtfH3f/TkdyPsAzk1QDDQ1++lDatRa3xc4rOGa2ynXljOR9y6rWoqB5wwMOjB42AWSVZWNwpccRsYkMhML5s7uur+B4SERWeMasXuJUhTPweS48Mz0mvp9wZMQB9+xPNm93iUeUZvVtB63ksibx5B3UJUCBz1wSUXLnEoTjy6TR9XsQ+boZlRsk/jY79A+iMQZw72QBBXvWSfJRaeDj266Dz+Jyp0h4lxZJjg/pnL0Rp5s0zlhlSNm6zyrQ6lWMzagjP/2G95LWMNvLTE95oKqhP4hNaxYrI/pUQIDAQAB",
   "manifest_version": 2,
   "name": "__MSG_appName__",
   "short_name": "__MSG_appShortName__",

--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -1,4 +1,5 @@
 {
+"key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlc6hy5++uljMusXcpXspmA3UH5t9ppVHj3FfxvVMPOFX0RLrDvXtfH3f/TkdyPsAzk1QDDQ1++lDatRa3xc4rOGa2ynXljOR9y6rWoqB5wwMOjB42AWSVZWNwpccRsYkMhML5s7uur+B4SERWeMasXuJUhTPweS48Mz0mvp9wZMQB9+xPNm93iUeUZvVtB63ksibx5B3UJUCBz1wSUXLnEoTjy6TR9XsQ+boZlRsk/jY79A+iMQZw72QBBXvWSfJRaeDj266Dz+Jyp0h4lxZJjg/pnL0Rp5s0zlhlSNm6zyrQ6lWMzagjP/2G95LWMNvLTE95oKqhP4hNaxYrI/pUQIDAQAB",
   "manifest_version": 2,
   "name": "__MSG_appName__",
   "short_name": "__MSG_appShortName__",

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/known_client_apps.json
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/known_client_apps.json
@@ -3,13 +3,13 @@
     "name": "Charismathics Smart Card Middleware"
   },
   "haeblkpifdemlfnkogkipmghfcbonief": {
-    "name": "Charismathics Smart Card Middleware"
+    "name": "CSSI Smart Card Middleware"
   },
   "omlchkeefdkmmdndbpbhaapnnemfkobc": {
     "name": "Charismathics Smart Card Middleware"
   },
   "haiffjcadagjlijoggckpgfnoeiflnem": {
-    "name": "Citrix Receiver"
+    "name": "Citrix Workspace"
   },
   "pckbpdplfajmgaipljfamclkinbjdnma": {
     "name": "VMware Horizon Client"
@@ -18,10 +18,10 @@
     "name": "CACKey"
   },
   "lbfgjakkeeccemhonnolnmglmfmccaag": {
-    "name": "Citrix Receiver - EAR"
+    "name": "Citrix Workspace - EAR"
   },
   "kdndmepchimlohdcdkokdddpbnniijoa": {
-    "name": "Citrix Receiver - Internal Build"
+    "name": "Citrix Workspace - Internal Build"
   },
   "djkkpfimmenglkapoanbonjbpgbkckag": {
     "name": "BAIMobile Sample Access PKCS11"
@@ -39,7 +39,7 @@
     "name": "VMware Horizon Client - Internal"
   },
   "fdlpibjfnlhnmeckjjhfiejfdghkmkdm": {
-    "name": "Xtralogic Remote Desktop Client"
+    "name": "Xtralogic RDP Client"
   },
   "hlbkkfgplamgidcmijjcglabmiekfech": {
     "name": "smart-pass"


### PR DESCRIPTION
Several apps and extensions were renamed since the time they were
originally added into known_client_apps.json, so updating these names.

Note that there are several unpublished extensions/apps, which aren't
served by WebStore anymore and therefore their old names are kept in
this config as-is.