### PR TITLE
Unhandled promise fixes

### DIFF
--- a/common/js/src/nacl-module/nacl-module.js
+++ b/common/js/src/nacl-module/nacl-module.js
@@ -24,6 +24,7 @@ goog.provide('GoogleSmartCard.NaclModule');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.NaclModuleLogMessagesReceiver');
 goog.require('GoogleSmartCard.NaclModuleMessageChannel');
+goog.require('GoogleSmartCard.PromiseHelpers');
 goog.require('GoogleSmartCard.TypedMessage');
 goog.require('goog.Disposable');
 goog.require('goog.Promise');
@@ -76,6 +77,8 @@ GSC.NaclModule = function(naclModulePath, type) {
 
   /** @private */
   this.loadPromiseResolver_ = goog.Promise.withResolver();
+  GSC.PromiseHelpers.suppressUnhandledRejectionError(
+      this.loadPromiseResolver_.promise);
 
   /**
    * @type {!Element}

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -70,7 +70,7 @@ naclModule.getLoadPromise().then(() => {
   // Start forwarding all future log messages collected on the JS side, but also
   // immediately post the messages that have been accumulated so far.
   logBufferForwarderToNaclModule.startForwarding(naclModule.messageChannel);
-});
+}, () => {});
 
 var libusbChromeUsbBackend = new GSC.Libusb.ChromeUsbBackend(
     naclModule.messageChannel);


### PR DESCRIPTION
Fix a few places in the code that were legitimately creating promises
without handling their rejection. The standard promise behavior is that
when it's rejected and there's no rejection handler registered
(immediately or until the next tick) an error is raised. Since in these
pieces of code there's no meaningful error handling necessary, this
commit suppresses this behavior.

This change is intended to simplify investigation of crash reports as
per #156, since these spurious unhandled promise rejections could
distract attention from the actual underlying problem.

For posterity, these places of code were found by inspecting callsites
that create a new Promise (via constructor or via
goog.Promise.withResolver), temporarily inserting reject() calls and
verifying that the DevTools console doesn't contain errors about
unhandled promise rejections.