### PR TITLE
Cherry-pick Sunrex HP USB Business Slim Smartcard CCID Keyboard suppo…

### DIFF
--- a/smart_card_connector_app/build/human_readable_supported_readers.txt
+++ b/smart_card_connector_app/build/human_readable_supported_readers.txt
@@ -373,6 +373,7 @@ SpringCard SpringCore
 Spyrus Inc PocketVault P-3X
 Spyrus Inc Rosetta USB
 Spyrus Inc WorkSafe Pro
+Sunrex HP USB Business Slim Smartcard CCID Keyboard
 Swissbit Secure USB PU-50n SE/PE
 SYNNIX STD200
 Sysking MII136C

--- a/third_party/ccid/patches/0003-Add-Sunrex-HP-USB-Business-Slim-Smartcard-CCID-Keybo.patch
+++ b/third_party/ccid/patches/0003-Add-Sunrex-HP-USB-Business-Slim-Smartcard-CCID-Keybo.patch
@@ -1,0 +1,100 @@
+From 48680b3af325d63f58516b5737e8df8985b53bc7 Mon Sep 17 00:00:00 2001
+From: Ludovic Rousseau <ludovic.rousseau@free.fr>
+Date: Sat, 29 Aug 2020 11:45:10 +0200
+Subject: [PATCH] Add Sunrex HP USB Business Slim Smartcard CCID Keyboard
+
+---
+ ..._Business_Slim_Smartcard_CCID_Keyboard.txt | 58 +++++++++++++++++++
+ readers/supported_readers.txt                 |  5 +-
+ 2 files changed, 62 insertions(+), 1 deletion(-)
+ create mode 100644 readers/Sunrex_HP_USB_Business_Slim_Smartcard_CCID_Keyboard.txt
+
+diff --git a/readers/Sunrex_HP_USB_Business_Slim_Smartcard_CCID_Keyboard.txt b/readers/Sunrex_HP_USB_Business_Slim_Smartcard_CCID_Keyboard.txt
+new file mode 100644
+index 0000000..d5a2e14
+--- /dev/null
++++ b/readers/Sunrex_HP_USB_Business_Slim_Smartcard_CCID_Keyboard.txt
+@@ -0,0 +1,58 @@
++ idVendor: 0x05AF
++  iManufacturer: Sunrex
++ idProduct: 0x605A
++  iProduct: HP USB Business Slim Smartcard CCID Keyboard
++ bcdDevice: 2.11 (firmware release?)
++ bLength: 9
++ bDescriptorType: 4
++ bInterfaceNumber: 1
++ bAlternateSetting: 0
++ bNumEndpoints: 3
++  bulk-IN, bulk-OUT and Interrupt-IN
++ bInterfaceClass: 0x0B [Chip Card Interface Device Class (CCID)]
++ bInterfaceSubClass: 0
++ bInterfaceProtocol: 0
++  bulk transfer, optional interrupt-IN (CCID)
++ iInterface: HP Skylab Smartcard Reader
++ CCID Class Descriptor
++  bLength: 0x36
++  bDescriptorType: 0x21
++  bcdCCID: 1.10
++  bMaxSlotIndex: 0x00
++  bVoltageSupport: 0x07
++   5.0V
++   3.0V
++   1.8V
++  dwProtocols: 0x0000 0x0003
++   T=0
++   T=1
++  dwDefaultClock: 4.800 MHz
++  dwMaximumClock: 12.000 MHz
++  bNumClockSupported: 0 (will use whatever is returned)
++   IFD does not support GET CLOCK FREQUENCIES request: LIBUSB_ERROR_PIPE
++  dwDataRate: 12903 bps
++  dwMaxDataRate: 412903 bps
++  bNumDataRatesSupported: 0 (will use whatever is returned)
++   IFD does not support GET_DATA_RATES request: LIBUSB_ERROR_PIPE
++  dwMaxIFSD: 254
++  dwSynchProtocols: 0x00000000
++  dwMechanical: 0x00000000
++   No special characteristics
++  dwFeatures: 0x000104BA
++   ....02 Automatic parameter configuration based on ATR data
++   ....08 Automatic ICC voltage selection
++   ....10 Automatic ICC clock frequency change according to parameters
++   ....20 Automatic baud rate change according to frequency and Fi, Di params
++   ....80 Automatic PPS made by the CCID
++   ..04.. Automatic IFSD exchange as first exchange (T=1)
++   01.... TPDU level exchange
++  dwMaxCCIDMessageLength: 271 bytes
++  bClassGetResponse: 0xFF
++   echoes the APDU class
++  bClassEnvelope: 0xFF
++   echoes the APDU class
++  wLcdLayout: 0x0000
++  bPINSupport: 0x03
++   PIN Verification supported
++   PIN Modification supported
++  bMaxCCIDBusySlots: 1
+diff --git a/readers/supported_readers.txt b/readers/supported_readers.txt
+index 1fcb100..444ac14 100644
+--- a/readers/supported_readers.txt
++++ b/readers/supported_readers.txt
+@@ -1,6 +1,6 @@
+ #
+ # List of readers supported by the CCID driver
+-# Generated: 2020-08-26
++# Generated: 2020-08-29
+ #
+ # DO NOT EDIT BY HAND
+ 
+@@ -725,6 +725,9 @@
+ 0x08DF:0x3117:Spyrus Inc WorkSafe Pro
+ 0x08DF:0x3201:Spyrus Inc PocketVault P-3X
+ 
++# Sunrex
++0x05AF:0x605A:Sunrex HP USB Business Slim Smartcard CCID Keyboard
++
+ # Swissbit
+ 0x1370:0x0901:Swissbit Secure USB PU-50n SE/PE
+ 
+-- 
+2.28.0.681.g6f77f65b4e-goog
+

--- a/third_party/ccid/src/readers/Sunrex_HP_USB_Business_Slim_Smartcard_CCID_Keyboard.txt
+++ b/third_party/ccid/src/readers/Sunrex_HP_USB_Business_Slim_Smartcard_CCID_Keyboard.txt
@@ -1,0 +1,58 @@
+ idVendor: 0x05AF
+  iManufacturer: Sunrex
+ idProduct: 0x605A
+  iProduct: HP USB Business Slim Smartcard CCID Keyboard
+ bcdDevice: 2.11 (firmware release?)
+ bLength: 9
+ bDescriptorType: 4
+ bInterfaceNumber: 1
+ bAlternateSetting: 0
+ bNumEndpoints: 3
+  bulk-IN, bulk-OUT and Interrupt-IN
+ bInterfaceClass: 0x0B [Chip Card Interface Device Class (CCID)]
+ bInterfaceSubClass: 0
+ bInterfaceProtocol: 0
+  bulk transfer, optional interrupt-IN (CCID)
+ iInterface: HP Skylab Smartcard Reader
+ CCID Class Descriptor
+  bLength: 0x36
+  bDescriptorType: 0x21
+  bcdCCID: 1.10
+  bMaxSlotIndex: 0x00
+  bVoltageSupport: 0x07
+   5.0V
+   3.0V
+   1.8V
+  dwProtocols: 0x0000 0x0003
+   T=0
+   T=1
+  dwDefaultClock: 4.800 MHz
+  dwMaximumClock: 12.000 MHz
+  bNumClockSupported: 0 (will use whatever is returned)
+   IFD does not support GET CLOCK FREQUENCIES request: LIBUSB_ERROR_PIPE
+  dwDataRate: 12903 bps
+  dwMaxDataRate: 412903 bps
+  bNumDataRatesSupported: 0 (will use whatever is returned)
+   IFD does not support GET_DATA_RATES request: LIBUSB_ERROR_PIPE
+  dwMaxIFSD: 254
+  dwSynchProtocols: 0x00000000
+  dwMechanical: 0x00000000
+   No special characteristics
+  dwFeatures: 0x000104BA
+   ....02 Automatic parameter configuration based on ATR data
+   ....08 Automatic ICC voltage selection
+   ....10 Automatic ICC clock frequency change according to parameters
+   ....20 Automatic baud rate change according to frequency and Fi, Di params
+   ....80 Automatic PPS made by the CCID
+   ..04.. Automatic IFSD exchange as first exchange (T=1)
+   01.... TPDU level exchange
+  dwMaxCCIDMessageLength: 271 bytes
+  bClassGetResponse: 0xFF
+   echoes the APDU class
+  bClassEnvelope: 0xFF
+   echoes the APDU class
+  wLcdLayout: 0x0000
+  bPINSupport: 0x03
+   PIN Verification supported
+   PIN Modification supported
+  bMaxCCIDBusySlots: 1

--- a/third_party/ccid/src/readers/supported_readers.txt
+++ b/third_party/ccid/src/readers/supported_readers.txt
@@ -1,6 +1,6 @@
 #
 # List of readers supported by the CCID driver
-# Generated: 2020-06-25
+# Generated: 2020-08-29
 #
 # DO NOT EDIT BY HAND
 
@@ -714,6 +714,9 @@
 0x08DF:0x3115:Spyrus Inc WorkSafe Pro
 0x08DF:0x3117:Spyrus Inc WorkSafe Pro
 0x08DF:0x3201:Spyrus Inc PocketVault P-3X
+
+# Sunrex
+0x05AF:0x605A:Sunrex HP USB Business Slim Smartcard CCID Keyboard
 
 # Swissbit
 0x1370:0x0901:Swissbit Secure USB PU-50n SE/PE


### PR DESCRIPTION
…rt into CCID

Apply a patch from the upstream Free CCID library that enables the
support of the Sunrex HP USB Business Slim Smartcard CCID Keyboard:

LudovicRousseau/CCID@48680b3

This local patch can be removed in the future once the upstream CCID
library releases a new version which includes this change.