### PR TITLE
Fix type definition in cpp example app

### DIFF
--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.cc
@@ -28,6 +28,7 @@ using ErrorConverter = EnumConverter<ccp::Error, std::string>;
 using PinRequestTypeConverter = EnumConverter<ccp::PinRequestType, std::string>;
 using PinRequestErrorTypeConverter = EnumConverter<
     ccp::PinRequestErrorType, std::string>;
+using CertificateConverter = StructConverter<ccp::Certificate>;
 using ClientCertificateInfoConverter = StructConverter<
     ccp::ClientCertificateInfo>;
 using SetCertificatesDetailsConverter = StructConverter<
@@ -100,6 +101,20 @@ void PinRequestErrorTypeConverter::VisitCorrespondingPairs(Callback callback) {
 
 // static
 template <>
+constexpr const char* CertificateConverter::GetStructTypeName() {
+  return "chrome_certificate_provider::Certificate";
+}
+
+// static
+template <>
+template <typename Callback>
+void CertificateConverter::VisitFields(
+    const ccp::Certificate& value, Callback callback) {
+  callback(&value.certificate, "certificate");
+}
+
+// static
+template <>
 constexpr const char* ClientCertificateInfoConverter::GetStructTypeName() {
   return "chrome_certificate_provider::ClientCertificateInfo";
 }
@@ -109,7 +124,7 @@ template <>
 template <typename Callback>
 void ClientCertificateInfoConverter::VisitFields(
     const ccp::ClientCertificateInfo& value, Callback callback) {
-  callback(&value.certificate, "certificate");
+  callback(&value.certificate_chain, "certificateChain");
   callback(&value.supported_algorithms, "supportedAlgorithms");
 }
 
@@ -233,6 +248,16 @@ bool VarAs(const pp::Var& var, PinRequestErrorType* result,
 
 pp::Var MakeVar(PinRequestErrorType value) {
   return gsc::PinRequestErrorTypeConverter::ConvertToVar(value);
+}
+
+bool VarAs(const pp::Var& var, Certificate* result,
+           std::string* error_message) {
+  return gsc::CertificateConverter::ConvertFromVar(
+      var, result, error_message);
+}
+
+pp::Var MakeVar(const Certificate& value) {
+  return gsc::CertificateConverter::ConvertToVar(value);
 }
 
 bool VarAs(const pp::Var& var, ClientCertificateInfo* result,

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.h
@@ -81,12 +81,18 @@ enum class PinRequestErrorType {
   kUnknownError,
 };
 
+// Helper structure for ClientCertificateInfo.
+struct Certificate {
+  std::vector<uint8_t> certificate;
+};
+
 // Structure containing a certificate description.
 //
 // For the corresponding original JavaScript definition, refer to:
 // <https://developer.chrome.com/extensions/certificateProvider#type-ClientCertificateInfo>.
 struct ClientCertificateInfo {
-  std::vector<uint8_t> certificate;
+  // Note that certificate_chain must not contain more than one Certificate.
+  std::vector<Certificate> certificate_chain;
   std::vector<Algorithm> supported_algorithms;
 };
 

--- a/example_cpp_smart_card_client_app/src/pp_module.cc
+++ b/example_cpp_smart_card_client_app/src/pp_module.cc
@@ -200,8 +200,11 @@ class PpInstance final : public pp::Instance {
       // Note: the bytes "1, 2, 3" and the signature algorithms below are just
       // an example. In the real application, replace them with the bytes of the
       // DER encoding of a X.509 certificate and the supported algorithms.
+      ccp::Certificate certificate;
+      certificate.certificate.assign({1, 2, 3});
       ccp::ClientCertificateInfo certificate_info_1;
-      certificate_info_1.certificate.assign({1, 2, 3});
+      certificate_info_1.certificate_chain.push_back(
+          certificate);
       certificate_info_1.supported_algorithms.push_back(
           ccp::Algorithm::kRsassaPkcs1v15Sha1);
       ccp::ClientCertificateInfo certificate_info_2;


### PR DESCRIPTION
Fix definition of ClientCertificateInfo, which uses a vector of vectors
instead of a simple vector.
The inner vector is wrapped in a struct, since otherwise pepper fails to
extract the value.
Also add a note that the outer vector, right now, cannot contain
more than one element as per API definition.