### PR TITLE
Fix incorrect setCertificate API calls

### DIFF
--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
@@ -526,6 +526,13 @@ function transformFunctionArguments(functionName, functionArguments) {
         functionArguments[0]["clientCertificates"],
         createClientCertificateInfo);
     transformedArguments[0] = {"clientCertificates": certificates};
+
+    if ("certificatesRequestId" in functionArguments[0])
+      transformedArguments[0]["certificatesRequestId"] =
+          functionArguments[0]["certificatesRequestId"];
+
+    if ("error" in functionArguments[0])
+      transformedArguments[0]["error"] = functionArguments[0]["error"];
   }
   return transformedArguments;
 }

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
@@ -32,6 +32,7 @@ goog.require('GoogleSmartCard.Requester');
 goog.require('goog.Disposable');
 goog.require('goog.array');
 goog.require('goog.log.Logger');
+goog.require('goog.object');
 
 goog.scope(function() {
 
@@ -522,17 +523,12 @@ function transformFunctionArguments(functionName, functionArguments) {
   if (functionName === 'setCertificates') {
     // The certificates need to be transformed in order to be recognized by the
     // API.
+    transformedArguments[0] =
+        goog.object.clone(/** @type {!Object<?,?>} */(functionArguments[0]));
     const certificates = goog.array.map(
         functionArguments[0]["clientCertificates"],
         createClientCertificateInfo);
-    transformedArguments[0] = {"clientCertificates": certificates};
-
-    if ("certificatesRequestId" in functionArguments[0])
-      transformedArguments[0]["certificatesRequestId"] =
-          functionArguments[0]["certificatesRequestId"];
-
-    if ("error" in functionArguments[0])
-      transformedArguments[0]["error"] = functionArguments[0]["error"];
+    transformedArguments[0]["clientCertificates"] = certificates;
   }
   return transformedArguments;
 }

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
@@ -246,6 +246,16 @@ Backend.prototype.handleRequest_ = function(payload) {
   const apiFunction = chrome.certificateProvider[
       remoteCallMessage.functionName];
   if (apiFunction) {
+    if (remoteCallMessage.functionName == 'setCertificates') {
+      // The arguments need to be transformed in order to be recognized by the
+      // API.
+      const certificates = goog.array.map(
+          remoteCallMessage.functionArguments[0]["clientCertificates"],
+          createClientCertificateInfo);
+      remoteCallMessage.functionArguments[0]["clientCertificates"] =
+          certificates;
+    }
+
     /** @preserveTry */
     try {
       remoteCallMessage.functionArguments.push(function() {

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
@@ -523,9 +523,9 @@ function transformFunctionArguments(functionName, functionArguments) {
     // The certificates need to be transformed in order to be recognized by the
     // API.
     const certificates = goog.array.map(
-        transformedArguments[0]["clientCertificates"],
+        functionArguments[0]["clientCertificates"],
         createClientCertificateInfo);
-    transformedArguments[0]["clientCertificates"] = certificates;
+    transformedArguments[0] = {"clientCertificates": certificates};
   }
   return transformedArguments;
 }

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.h
@@ -85,6 +85,11 @@ enum class PinRequestErrorType {
 //
 // For the corresponding original JavaScript definition, refer to:
 // <https://developer.chrome.com/extensions/certificateProvider#type-ClientCertificateInfo>.
+// Note that this does not perfectly match the JavaScript definition, but will
+// be transformed into the correct form by bridge-backend.js. The reason is that
+// on the JavaScript side, there are multiple similar but different forms,
+// and it depends on the Chrome version which one is required. The C++ side does
+// not need be concerned with those details and can always use this struct.
 struct ClientCertificateInfo {
   std::vector<uint8_t> certificate;
   std::vector<Algorithm> supported_algorithms;


### PR DESCRIPTION
Add example usage of setCertificates to the cpp example app.
Fix incorrect API calls that would previously happen when trying to use
ApiBridge::SetCertificates() by transforming the used parameters on the
JS side directly before the API call.