### PR TITLE
Omit '<"nacl_module.nmf">.NaCl' from logs

### DIFF
--- a/common/js/src/nacl-module/nacl-module-log-messages-receiver.js
+++ b/common/js/src/nacl-module/nacl-module-log-messages-receiver.js
@@ -39,9 +39,6 @@ var GSC = GoogleSmartCard;
 var SERVICE_NAME = 'log_message';
 
 /** @const */
-var LOGGER_TITLE = 'NaCl';
-
-/** @const */
 var LOG_LEVEL_MESSAGE_KEY = 'log_level';
 /** @const */
 var TEXT_MESSAGE_KEY = 'text';
@@ -52,13 +49,12 @@ var TEXT_MESSAGE_KEY = 'text';
  *
  * The NaCl module sends the emitted log messages as messages of some special
  * structure. This class handles these messages, extracts their fields and
- * transforms them into emitting log messages through a child logger of the
- * specified logger.
+ * transforms them into emitting log messages into the given logger.
  * @param {!goog.messaging.AbstractChannel} messageChannel
- * @param {!goog.log.Logger} parentLogger
+ * @param {!goog.log.Logger} logger
  * @constructor
  */
-GSC.NaclModuleLogMessagesReceiver = function(messageChannel, parentLogger) {
+GSC.NaclModuleLogMessagesReceiver = function(messageChannel, logger) {
   messageChannel.registerService(
       SERVICE_NAME, this.onMessageReceived_.bind(this), true);
 
@@ -66,7 +62,7 @@ GSC.NaclModuleLogMessagesReceiver = function(messageChannel, parentLogger) {
    * @type {!goog.log.Logger}
    * @const
    */
-  this.logger = GSC.Logging.getChildLogger(parentLogger, LOGGER_TITLE);
+  this.logger = logger;
 };
 
 /** @const */

--- a/common/js/src/nacl-module/nacl-module.js
+++ b/common/js/src/nacl-module/nacl-module.js
@@ -37,6 +37,8 @@ goog.scope(function() {
 /** @const */
 var GSC = GoogleSmartCard;
 
+const LOGGER_TITLE = 'Wrapper';
+
 /**
  * NaCl/PNaCl module element wrapper.
  *
@@ -50,18 +52,23 @@ var GSC = GoogleSmartCard;
  * @param {string} naclModulePath URL of the NaCl module manifest (.NMF file).
  * @param {!NaclModule.Type} type Type of the NaCl module (@code
  * {NaclModule.Type}).
+ * @param {boolean=} logModulePath Whether the logger scope should include the
+ * NaCl module path.
  * @constructor
  * @extends goog.Disposable
  */
-GSC.NaclModule = function(naclModulePath, type) {
+GSC.NaclModule = function(naclModulePath, type, logModulePath = false) {
   NaclModule.base(this, 'constructor');
 
+  const loggerScope = 'NaclModule' +
+                      (logModulePath ? `<"${naclModulePath}">` : '');
+  const messagesReceiverLogger = GSC.Logging.getScopedLogger(loggerScope);
   /**
    * @type {!goog.log.Logger}
    * @const
    */
-  this.logger = GSC.Logging.getScopedLogger(
-      'NaclModule<"' + naclModulePath + '">');
+  this.logger = GSC.Logging.getChildLogger(
+      messagesReceiverLogger, LOGGER_TITLE);
 
   /**
    * @type {string}
@@ -95,7 +102,7 @@ GSC.NaclModule = function(naclModulePath, type) {
 
   /** @type {!GSC.NaclModuleLogMessagesReceiver} */
   this.logMessagesReceiver = new GSC.NaclModuleLogMessagesReceiver(
-      this.messageChannel, this.logger);
+      this.messageChannel, messagesReceiverLogger);
 
   this.addStatusEventListeners_();
 };


### PR DESCRIPTION
Don't add the '<"nacl_module.nmf">.NaCl' suffix to the logger name
used for NaCl-related log messages. This information about the URL of
the NaCl module is redundant - we don't use multiple NaCl modules
currently.

Also drop the ".NaCl" suffix for messages forwarded from the NaCl
module, and instead add ".Wrapper" for all other messages logged
by the JS code of this class. This way, we move the log clutter from
typically long NaCl logs into usually less interesting JS logs.

Example before:
 [200930 04:21:34.51] [  7.244s] [NaclModule<"nacl_module.nmf">.NaCl] [syslog] 00000000 ../../src/src/ifdhandler.c:2008:init_driver() Driver version: 1.4.33 
Example after:
 [200930 04:21:34.51] [  7.244s] [NaclModule] [syslog] 00000000 ../../src/src/ifdhandler.c:2008:init_driver() Driver version: 1.4.33  

For the potential case when the detailed logging might be needed, a
boolean flag is kept in the code, allowing to revert to the old
behavior. Currently the flag is always set to false.

This change is part of the effort tracked by issue #146.