### PR TITLE
Framework for JS-and-C++ integration tests

### DIFF
--- a/common/integration_testing/build/.gitignore
+++ b/common/integration_testing/build/.gitignore
@@ -1,0 +1,2 @@
+/headers_installed.stamp
+/pnacl/

--- a/common/integration_testing/build/Makefile
+++ b/common/integration_testing/build/Makefile
@@ -1,0 +1,45 @@
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TARGET := google_smart_card_integration_testing
+
+include ../../make/common.mk
+
+include $(COMMON_DIR_PATH)/make/nacl_module_building_common.mk
+
+include ../include.mk
+
+
+ROOT_SOURCES_PATH := ../src
+ROOT_SOURCES_SUBDIR := google_smart_card_integration_testing
+SOURCES_PATH := $(ROOT_SOURCES_PATH)/$(ROOT_SOURCES_SUBDIR)
+
+SOURCES := \
+	$(SOURCES_PATH)/integration_test_pp_module.cc \
+	$(SOURCES_PATH)/integration_test_service.cc \
+
+CXXFLAGS := \
+	-I$(SOURCES_PATH) \
+	-Wextra \
+	-std=gnu++11 \
+
+$(foreach src,$(SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
+
+$(eval $(call NACL_LIBRARY_BUILD_RULE,$(SOURCES)))
+
+INSTALLING_HEADERS := \
+	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):integration_test_helper.h \
+	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):integration_test_service.h \
+
+$(eval $(call NACL_LIBRARY_HEADERS_INSTALLATION_RULE,$(INSTALLING_HEADERS)))

--- a/common/integration_testing/dependency.mk
+++ b/common/integration_testing/dependency.mk
@@ -1,0 +1,25 @@
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#
+# Including of this file creates a NaCl module building dependency on this
+# library.
+#
+# /common/make/common.mk, /common/make/nacl_module_building_common.mk and
+# include.mk must be included before including this file.
+#
+
+
+$(eval $(call DEPEND_RULE,$(INTEGRATION_TESTING_LIB),$(INTEGRATION_TESTING_DIR_PATH)/build))

--- a/common/integration_testing/include.mk
+++ b/common/integration_testing/include.mk
@@ -1,0 +1,40 @@
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#
+# This file contains helper definitions for using this library.
+#
+# /common/make/common.mk and /common/make/nacl_module_building_common.mk must be
+# included before including this file.
+#
+
+
+INTEGRATION_TESTING_LIB := google_smart_card_integration_testing
+
+INTEGRATION_TESTING_DIR_PATH := $(COMMON_DIR_PATH)/integration_testing
+
+# This constant contains the list of input paths for the Closure Compiler for
+# compiling the code using this library.
+INTEGRATION_TESTING_JS_COMPILER_INPUT_DIR_PATHS := \
+	$(INTEGRATION_TESTING_DIR_PATH) \
+
+
+#
+# Helper target that installs the library headers.
+#
+# This target can be used in dependant libraries.
+#
+
+$(eval $(call DEFINE_NACL_LIBRARY_HEADERS_INSTALLATION_TARGET,INTEGRATION_TESTING_HEADERS_INSTALLATION_STAMP_FILE,$(INTEGRATION_TESTING_DIR_PATH)/build))

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration-test-controller.js
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration-test-controller.js
@@ -1,0 +1,110 @@
+/** @license
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.provide('GoogleSmartCard.IntegrationTestController');
+
+goog.require('GoogleSmartCard.NaclModule');
+goog.require('GoogleSmartCard.RemoteCallMessage');
+goog.require('GoogleSmartCard.Requester');
+goog.require('goog.testing.PropertyReplacer');
+
+goog.setTestOnly();
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+const NACL_MODULE_PATH = 'integration_tests.nmf';
+const INTEGRATION_TEST_NACL_MODULE_REQUESTER_NAME = 'integration_test';
+
+/**
+ * Class that encapsulates setup/teardown/communication steps of a
+ * JavaScript-and-C++ integration test.
+ * @constructor
+ */
+GSC.IntegrationTestController = function() {
+  /** @type {!goog.testing.PropertyReplacer} */
+  this.propertyReplacer = new goog.testing.PropertyReplacer;
+  /** @type {!GSC.NaclModule} */
+  this.naclModule = new GSC.NaclModule(
+      NACL_MODULE_PATH, GSC.NaclModule.Type.PNACL);
+  /** @type {!GSC.Requester} @private */
+  this.naclModuleRequester_ = new GSC.Requester(
+      INTEGRATION_TEST_NACL_MODULE_REQUESTER_NAME,
+      this.naclModule.messageChannel);
+};
+
+/**
+ * @return {!goog.Promise<void>}
+ */
+GSC.IntegrationTestController.prototype.initAsync = function() {
+  this.naclModule.startLoading();
+  return this.naclModule.getLoadPromise();
+};
+
+/**
+ * @return {!goog.Promise<void>}
+ */
+GSC.IntegrationTestController.prototype.disposeAsync = function() {
+  return this.callCpp_('TearDownAll', /*functionArguments=*/[]).thenAlways(
+      () => {
+        this.naclModuleRequester_.dispose();
+        this.naclModule.dispose();
+        this.propertyReplacer.reset();
+      });
+};
+
+/**
+ * Tells the C++ side to initialize the given helper; reports the result of the
+ * setup via the returned promise.
+ * @param {string} helperName
+ * @param {!Object} helperArgument
+ * @return {!goog.Promise<void>}
+ */
+GSC.IntegrationTestController.prototype.setUpCppHelper = function(
+    helperName, helperArgument) {
+  return this.callCpp_(
+      'SetUp', /*functionArguments=*/[helperName, helperArgument]);
+};
+
+/**
+ * Sends a message to the given C++ helper; reports the result via a promise.
+ * @param {string} helperName
+ * @param {*} messageForHelper
+ * @return {!goog.Promise<void>}
+ */
+GSC.IntegrationTestController.prototype.sendMessageToCppHelper = function(
+    helperName, messageForHelper) {
+  return this.callCpp_(
+      'HandleMessage', /*functionArguments=*/[helperName, messageForHelper]);
+};
+
+/**
+ * Sends a remote call request to the NaCl module and returns its response via a
+ * promise.
+ * @param {string} functionName
+ * @param {!Array.<*>} functionArguments
+ * @return {!goog.Promise}
+ */
+GSC.IntegrationTestController.prototype.callCpp_ = function(
+    functionName, functionArguments) {
+  const remoteCallMessage = new GSC.RemoteCallMessage(
+      functionName, functionArguments);
+  return this.naclModuleRequester_.postRequest(
+      remoteCallMessage.makeRequestPayload());
+};
+
+});

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h
@@ -1,0 +1,64 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_SMART_CARD_INTEGRATION_TESTING_INTEGRATION_TEST_HELPER_H_
+#define GOOGLE_SMART_CARD_INTEGRATION_TESTING_INTEGRATION_TEST_HELPER_H_
+
+#include <string>
+
+#include <ppapi/cpp/core.h>
+#include <ppapi/cpp/instance.h>
+#include <ppapi/cpp/var.h>
+
+#include <google_smart_card_common/messaging/typed_message_router.h>
+#include <google_smart_card_common/requesting/request_receiver.h>
+
+namespace google_smart_card {
+
+// Abstract interface of a C/C++ helper used for a JavaScript-and-C++
+// integration test.
+//
+// Intended usage scenario:
+// 1. Write the main test scenario in a JavaScript file.
+// 2. The test's needed C/C++ counterpart is implemented as a subclass of this
+//    interface.
+// 3. In the helper's .cc file, a global object is created that constructs and
+//    registers an instance of this helper:
+//
+//      const auto g_foo_helper = IntegrationTestService::RegisterHelper(
+//          MakeUnique<FooHelper>());
+//
+// Note: We're explicitly violating the Google C++ Style Guide by using global
+// objects with nontrivial constructors; we're doing it because it allows to
+// avoid maintaining a source file that would enumerate all helpers. A similar
+// trick is actually used by Googletest internally.
+class IntegrationTestHelper {
+ public:
+  virtual ~IntegrationTestHelper() = default;
+
+  virtual std::string GetName() const = 0;
+  virtual void SetUp(
+      pp::Instance* /*pp_instance*/,
+      pp::Core* /*pp_core*/,
+      TypedMessageRouter* /*typed_message_router*/,
+      const pp::Var& /*data*/) {}
+  virtual void TearDown() {}
+  virtual void OnMessageFromJs(
+      const pp::Var& data,
+      RequestReceiver::ResultCallback result_callback) = 0;
+};
+
+}  // namespace google_smart_card
+
+#endif  // GOOGLE_SMART_CARD_INTEGRATION_TESTING_INTEGRATION_TEST_HELPER_H_

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_pp_module.cc
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_pp_module.cc
@@ -1,0 +1,74 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+
+#include <ppapi/c/ppb_instance.h>
+#include <ppapi/cpp/core.h>
+#include <ppapi/cpp/instance.h>
+#include <ppapi/cpp/module.h>
+#include <ppapi/cpp/var.h>
+
+#include <google_smart_card_common/logging/logging.h>
+#include <google_smart_card_common/messaging/typed_message_router.h>
+#include <google_smart_card_common/pp_var_utils/debug_dump.h>
+#include <google_smart_card_integration_testing/integration_test_service.h>
+
+namespace google_smart_card {
+
+namespace {
+
+// The NaCl module implementation that hosts Javascript-and-C++ integration test
+// service and helpers.
+class IntegrationTestPpInstance final : public pp::Instance {
+ public:
+  explicit IntegrationTestPpInstance(PP_Instance instance)
+      : pp::Instance(instance) {
+    IntegrationTestService::GetInstance()->Activate(
+        this, pp::Module::Get()->core(), &typed_message_router_);
+  }
+
+  ~IntegrationTestPpInstance() override {
+    IntegrationTestService::GetInstance()->Deactivate();
+  }
+
+  void HandleMessage(const pp::Var& message) override {
+    if (!typed_message_router_.OnMessageReceived(message)) {
+      GOOGLE_SMART_CARD_LOG_FATAL << "Unexpected message received: " <<
+          DumpVar(message);
+    }
+  }
+
+ private:
+  TypedMessageRouter typed_message_router_;
+};
+
+class IntegrationTestPpModule final : public pp::Module {
+ public:
+  pp::Instance* CreateInstance(PP_Instance instance) override {
+    return new IntegrationTestPpInstance(instance);
+  }
+};
+
+}  // namespace
+
+}  // namespace google_smart_card
+
+namespace pp {
+
+Module* CreateModule() {
+  return new google_smart_card::IntegrationTestPpModule;
+}
+
+}  // namespace pp

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.cc
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.cc
@@ -1,0 +1,163 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google_smart_card_integration_testing/integration_test_service.h>
+
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <ppapi/cpp/instance.h>
+#include <ppapi/cpp/var.h>
+#include <ppapi/cpp/var_array.h>
+
+#include <google_smart_card_common/logging/logging.h>
+#include <google_smart_card_common/messaging/typed_message_router.h>
+#include <google_smart_card_common/pp_var_utils/debug_dump.h>
+#include <google_smart_card_common/pp_var_utils/extraction.h>
+#include <google_smart_card_common/requesting/js_request_receiver.h>
+#include <google_smart_card_common/requesting/remote_call_message.h>
+#include <google_smart_card_common/requesting/request_result.h>
+#include <google_smart_card_common/unique_ptr_utils.h>
+#include <google_smart_card_integration_testing/integration_test_helper.h>
+
+namespace google_smart_card {
+
+namespace {
+
+constexpr char kIntegrationTestServiceRequesterName[] = "integration_test";
+
+}  // namespace
+
+// static
+IntegrationTestService* IntegrationTestService::GetInstance() {
+  static IntegrationTestService instance;
+  return &instance;
+}
+
+// static
+IntegrationTestHelper* IntegrationTestService::RegisterHelper(
+    std::unique_ptr<IntegrationTestHelper> helper) {
+  IntegrationTestHelper* const helper_ptr = helper.get();
+  GetInstance()->helpers_.push_back(std::move(helper));
+  return helper_ptr;
+}
+
+void IntegrationTestService::Activate(
+    pp::Instance* pp_instance,
+    pp::Core* pp_core,
+    TypedMessageRouter* typed_message_router) {
+  GOOGLE_SMART_CARD_CHECK(pp_instance);
+  GOOGLE_SMART_CARD_CHECK(pp_core);
+  GOOGLE_SMART_CARD_CHECK(typed_message_router);
+  GOOGLE_SMART_CARD_CHECK(!pp_instance_);
+  GOOGLE_SMART_CARD_CHECK(!pp_core_);
+  GOOGLE_SMART_CARD_CHECK(!typed_message_router_);
+  GOOGLE_SMART_CARD_CHECK(!js_request_receiver_);
+  pp_instance_ = pp_instance;
+  pp_core_ = pp_core;
+  typed_message_router_ = typed_message_router;
+  js_request_receiver_ = std::make_shared<JsRequestReceiver>(
+      kIntegrationTestServiceRequesterName,
+      /*request_handler=*/this,
+      typed_message_router_,
+      MakeUnique<JsRequestReceiver::PpDelegateImpl>(pp_instance_));
+}
+
+void IntegrationTestService::Deactivate() {
+  GOOGLE_SMART_CARD_CHECK(js_request_receiver_);
+  TearDownAllHelpers();
+  js_request_receiver_.reset();
+  typed_message_router_ = nullptr;
+  pp_core_ = nullptr;
+  pp_instance_ = nullptr;
+}
+
+void IntegrationTestService::HandleRequest(
+    const pp::Var& payload,
+    RequestReceiver::ResultCallback result_callback) {
+  std::string method_name;
+  pp::VarArray method_arguments;
+  if (!ParseRemoteCallRequestPayload(
+           payload, &method_name, &method_arguments)) {
+    GOOGLE_SMART_CARD_LOG_FATAL << "Cannot parse call parameters from " <<
+        DumpVar(payload);
+  }
+  if (method_name == "SetUp") {
+    std::string helper_name;
+    pp::Var data_for_helper;
+    GetVarArrayItems(method_arguments, &helper_name, &data_for_helper);
+    SetUpHelper(helper_name, data_for_helper);
+    result_callback(GenericRequestResult::CreateSuccessful(pp::Var()));
+    return;
+  }
+  if (method_name == "TearDownAll") {
+    GOOGLE_SMART_CARD_CHECK(method_arguments.GetLength() == 0);
+    TearDownAllHelpers();
+    result_callback(GenericRequestResult::CreateSuccessful(pp::Var()));
+    return;
+  }
+  if (method_name == "HandleMessage") {
+    std::string helper_name;
+    pp::Var message_for_helper;
+    GetVarArrayItems(method_arguments, &helper_name, &message_for_helper);
+    SendMessageToHelper(helper_name, message_for_helper, result_callback);
+    return;
+  }
+  GOOGLE_SMART_CARD_LOG_FATAL << "Unexpected method " << method_name;
+}
+
+IntegrationTestService::IntegrationTestService() = default;
+
+IntegrationTestService::~IntegrationTestService() = default;
+
+IntegrationTestHelper* IntegrationTestService::FindHelperByName(
+    const std::string& name) {
+  for (const auto& helper : helpers_) {
+    if (helper->GetName() == name)
+      return helper.get();
+  }
+  return nullptr;
+}
+
+void IntegrationTestService::SetUpHelper(
+    const std::string& helper_name, const pp::Var& data_for_helper) {
+  IntegrationTestHelper* helper = FindHelperByName(helper_name);
+  if (!helper)
+    GOOGLE_SMART_CARD_LOG_FATAL << "Unknown helper " << helper_name;
+  GOOGLE_SMART_CARD_CHECK(!set_up_helpers_.count(helper));
+  set_up_helpers_.insert(helper);
+  helper->SetUp(pp_instance_, pp_core_, typed_message_router_, data_for_helper);
+}
+
+void IntegrationTestService::TearDownAllHelpers() {
+  for (auto* helper : set_up_helpers_)
+    helper->TearDown();
+  set_up_helpers_.clear();
+}
+
+void IntegrationTestService::SendMessageToHelper(
+    const std::string& helper_name,
+    const pp::Var& message_for_helper,
+    RequestReceiver::ResultCallback result_callback) {
+  IntegrationTestHelper* helper = FindHelperByName(helper_name);
+  if (!helper)
+    GOOGLE_SMART_CARD_LOG_FATAL << "Unknown helper " << helper_name;
+  GOOGLE_SMART_CARD_CHECK(set_up_helpers_.count(helper));
+  helper->OnMessageFromJs(message_for_helper, result_callback);
+}
+
+}  // namespace google_smart_card

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
@@ -1,0 +1,84 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_SMART_CARD_INTEGRATION_TESTING_INTEGRATION_TEST_SERVICE_H_
+#define GOOGLE_SMART_CARD_INTEGRATION_TESTING_INTEGRATION_TEST_SERVICE_H_
+
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <ppapi/cpp/core.h>
+#include <ppapi/cpp/instance.h>
+#include <ppapi/cpp/var.h>
+
+#include <google_smart_card_common/messaging/typed_message_listener.h>
+#include <google_smart_card_common/requesting/js_request_receiver.h>
+#include <google_smart_card_integration_testing/integration_test_helper.h>
+
+namespace google_smart_card {
+
+// Singleton service class for handling JavaScript-and-C++ integration test
+// scenarios.
+class IntegrationTestService final : public RequestHandler {
+ public:
+  IntegrationTestService(const IntegrationTestService&) = delete;
+  IntegrationTestService& operator=(const IntegrationTestService&) = delete;
+
+  static IntegrationTestService* GetInstance();
+  // Registers the given helper in the singleton instance, allowing JavaScript
+  // test code to make calls to it once the singleton is activated.
+  static IntegrationTestHelper* RegisterHelper(
+      std::unique_ptr<IntegrationTestHelper> helper);
+
+  // Starts listening for incoming requests and translating them into commands
+  // for test helpers.
+  void Activate(
+      pp::Instance* pp_instance,
+      pp::Core* pp_core,
+      TypedMessageRouter* typed_message_router);
+  // Tears down all previously set up helpers and stops listening for incoming
+  // requests.
+  void Deactivate();
+
+  // RequestHandler:
+  void HandleRequest(
+      const pp::Var& payload,
+      RequestReceiver::ResultCallback result_callback) override;
+
+ private:
+  IntegrationTestService();
+  ~IntegrationTestService();
+
+  IntegrationTestHelper* FindHelperByName(const std::string& name);
+  void SetUpHelper(
+      const std::string& helper_name, const pp::Var& data_for_helper);
+  void TearDownAllHelpers();
+  void SendMessageToHelper(
+      const std::string& helper_name,
+      const pp::Var& message_for_helper,
+      RequestReceiver::ResultCallback result_callback);
+
+  pp::Instance* pp_instance_ = nullptr;
+  pp::Core* pp_core_ = nullptr;
+  TypedMessageRouter* typed_message_router_ = nullptr;
+  std::shared_ptr<JsRequestReceiver> js_request_receiver_;
+  std::vector<std::unique_ptr<IntegrationTestHelper>> helpers_;
+  std::set<IntegrationTestHelper*> set_up_helpers_;
+};
+
+}  // namespace google_smart_card
+
+#endif  // GOOGLE_SMART_CARD_INTEGRATION_TESTING_INTEGRATION_TEST_SERVICE_H_

--- a/common/js/src/requesting/requester.js
+++ b/common/js/src/requesting/requester.js
@@ -119,7 +119,7 @@ Requester.prototype.postRequest = function(payload) {
   if (this.isDisposed()) {
     // FIXME(emaxx): Probably add the disposal reason information into the
     // message?
-    this.rejectRequest_(requestId, 'The requester is already disposed');
+    promiseResolver.reject(new Error('The requester is already disposed'));
     return promiseResolver.promise;
   }
 

--- a/common/js/src/requesting/requester.js
+++ b/common/js/src/requesting/requester.js
@@ -119,7 +119,7 @@ Requester.prototype.postRequest = function(payload) {
   if (this.isDisposed()) {
     // FIXME(emaxx): Probably add the disposal reason information into the
     // message?
-    promiseResolver.reject(new Error('The requester is already disposed'));
+    this.rejectRequest_(requestId, 'The requester is already disposed');
     return promiseResolver.promise;
   }
 

--- a/example_cpp_smart_card_client_app/build/Makefile
+++ b/example_cpp_smart_card_client_app/build/Makefile
@@ -70,3 +70,14 @@ $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/window.html))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/window.css))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/built_in_pin_dialog/built-in-pin-dialog.css))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/built_in_pin_dialog/built-in-pin-dialog.html))
+
+
+# Rules for building and running tests and for cleaning test build files.
+
+test::
+	+$(MAKE) --directory integration_tests run
+
+tests_clean::
+	+$(MAKE) --directory integration_tests clean
+
+clean: tests_clean

--- a/example_cpp_smart_card_client_app/build/integration_tests/.gitignore
+++ b/example_cpp_smart_card_client_app/build/integration_tests/.gitignore
@@ -1,0 +1,3 @@
+/js_build/
+/out/
+/pnacl/

--- a/example_cpp_smart_card_client_app/build/integration_tests/Makefile
+++ b/example_cpp_smart_card_client_app/build/integration_tests/Makefile
@@ -1,0 +1,86 @@
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#
+# Makefile for JavaScript-and-C++ integration tests.
+#
+
+TARGET := integration_tests
+
+include ../../../common/make/common.mk
+
+PAGE := $(OUT_DIR_PATH)/index.html
+
+include $(COMMON_DIR_PATH)/make/js_building_common.mk
+include $(COMMON_DIR_PATH)/make/nacl_module_building_common.mk
+include $(COMMON_DIR_PATH)/cpp/include.mk
+include $(COMMON_DIR_PATH)/cpp/dependency.mk
+include $(COMMON_DIR_PATH)/js/include.mk
+include $(COMMON_DIR_PATH)/integration_testing/include.mk
+include $(COMMON_DIR_PATH)/integration_testing/dependency.mk
+
+
+SOURCE_DIR := ../../src/
+
+CPP_SOURCES := \
+	$(SOURCE_DIR)/chrome_certificate_provider/api_bridge.cc \
+	$(SOURCE_DIR)/chrome_certificate_provider/types.cc \
+
+JS_COMPILER_INPUT_PATHS := \
+	$(INTEGRATION_TESTING_JS_COMPILER_INPUT_DIR_PATHS) \
+	$(JS_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \
+	$(SOURCE_DIR) \
+
+# Note: INTEGRATION_TESTING_LIB has to come before CPP_COMMON_LIB, since the
+# former uses symbols from the latter. And DEFAULT_NACL_LIBS is specified twice,
+# because there's a circular dependency between it and INTEGRATION_TESTING_LIB.
+LIBS := \
+	$(DEFAULT_NACL_LIBS) \
+	$(INTEGRATION_TESTING_LIB) \
+	$(CPP_COMMON_LIB) \
+	$(DEFAULT_NACL_LIBS) \
+
+DEPS := \
+	$(CPP_COMMON_LIB) \
+	$(INTEGRATION_TESTING_LIB) \
+
+CPPFLAGS := \
+	-I$(SOURCE_DIR) \
+	-pedantic \
+	-std=gnu++11 \
+	-Wextra \
+	-Wno-zero-length-array \
+
+$(foreach src,$(CPP_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CPPFLAGS))))
+$(eval $(call NACL_MODULE_BUILD_RULE,$(CPP_SOURCES),$(LIBS),$(DEPS)))
+
+$(foreach src,$(CPP_SOURCES),$(eval $(call DEPEND_COMPILE_ON_NACL_LIBRARY_HEADERS,$(src),$(CPP_COMMON_HEADERS_INSTALLATION_STAMP_FILE))))
+$(foreach src,$(CPP_SOURCES),$(eval $(call DEPEND_COMPILE_ON_NACL_LIBRARY_HEADERS,$(src),$(INTEGRATION_TESTING_HEADERS_INSTALLATION_STAMP_FILE))))
+
+$(eval $(call BUILD_TESTING_JS_SCRIPT,tests.js,$(JS_COMPILER_INPUT_PATHS)))
+
+$(OUT_DIR_PATH)/index.html: $(OUT_DIR_PATH)
+	@echo "<script src='tests.js'></script>" > $(OUT_DIR_PATH)/index.html
+
+
+#
+# Hack: change CURDIR to the out directory, so that the "run" target starts
+# Chrome with the correct working directory, and re-adjust path to the loaded
+# page accordingly.
+#
+
+CURDIR := $(OUT_DIR_PATH)
+
+PAGE := index.html


### PR DESCRIPTION
Implement a mini-framework that allows to implement hybrid tests that
exercise both JavaScript and C++ code. In such tests, the main test
script will be written in JavaScript, meanwhile the C++ counterpart is
structured as a set of "helpers" that can be called from the JS code.
The implemented framework abstracts away some boilerplate related to
JS-and-C++ communication and code compilation.

This commit paves the way for fixing the missing test coverage for the
parts that cross the language boundary. Up to this point, we only had
unit test coverage for pieces within single language (only within
JavaScript or only within C/C++), which has been insufficient.