### PR TITLE
Fix JS Requester post-after-dispose bug

### DIFF
--- a/common/js/src/requesting/requester-unittest.js
+++ b/common/js/src/requesting/requester-unittest.js
@@ -153,4 +153,25 @@ goog.exportSymbol('testRequester', function() {
   return request0CompletionPromise;
 });
 
+goog.exportSymbol('testRequester_disposed', function() {
+  const REQUESTER_NAME = 'test-requester';
+
+  const mockControl = new goog.testing.MockControl;
+  const mockMessageChannel = new goog.testing.messaging.MockMessageChannel(
+      mockControl);
+  /** @type {?} */ mockMessageChannel.send;
+
+  const requester = new GSC.Requester(REQUESTER_NAME, mockMessageChannel);
+  requester.dispose();
+
+  const requestPromise = requester.postRequest({});
+  // No message should be sent.
+  mockMessageChannel.send.$verify();
+
+  return requestPromise.then(() => {
+    fail('Unexpected success');
+  }, () => {
+  });
+});
+
 });  // goog.scope

--- a/common/js/src/requesting/requester.js
+++ b/common/js/src/requesting/requester.js
@@ -119,7 +119,7 @@ Requester.prototype.postRequest = function(payload) {
   if (this.isDisposed()) {
     // FIXME(emaxx): Probably add the disposal reason information into the
     // message?
-    this.rejectRequest_(requestId, 'The requester is already disposed');
+    promiseResolver.reject(new Error('The requester is already disposed'));
     return promiseResolver.promise;
   }
 


### PR DESCRIPTION
Fix a bug that could lead to JavaScript exception in a corner case when
the Requester's postRequest() method is called after the object is
already disposed of. The error was:

  TypeError: Cannot read property 'get' of null
  at GoogleSmartCard.Requester.popRequestPromiseResolver_

Also add a regression unit test against this bug.