### PR TITLE
Skip existing files&dirs in env/initialize.sh

### DIFF
--- a/env/initialize.sh
+++ b/env/initialize.sh
@@ -24,7 +24,7 @@
 
 set -eu
 
-is_forced=0
+force_reinitialization=0
 
 
 log_message() {
@@ -40,7 +40,7 @@ log_error_message() {
 }
 
 initialize_depot_tools() {
-  if [ -d ./depot_tools -a "${is_forced}" -eq "0" ]; then
+  if [ -d ./depot_tools -a "${force_reinitialization}" -eq "0" ]; then
     log_message "depot_tools already present, skipping."
     return
   fi
@@ -52,7 +52,7 @@ initialize_depot_tools() {
 }
 
 initialize_nacl_sdk() {
-  if [ -d ./nacl_sdk -a "${is_forced}" -eq "0" ]; then
+  if [ -d ./nacl_sdk -a "${force_reinitialization}" -eq "0" ]; then
     log_message "Native Client SDK already present, skipping."
     return
   fi
@@ -65,7 +65,7 @@ initialize_nacl_sdk() {
 }
 
 initialize_webports() {
-  if [ -d ./webports -a "${is_forced}" -eq "0" ]; then
+  if [ -d ./webports -a "${force_reinitialization}" -eq "0" ]; then
     log_message "webports already present, skipping."
     return
   fi
@@ -105,7 +105,7 @@ cd ${SCRIPTPATH}
 while getopts ":f" opt; do
   case $opt in
     f)
-      is_forced=1
+      force_reinitialization=1
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2

--- a/env/initialize.sh
+++ b/env/initialize.sh
@@ -14,8 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This scripts initializes the build environment, by downloading and setting up
+# all necessary tools and libraries.
+#
+# By default, existing directories and files are left intact (except the
+# "./activate" file), so it's safe to run this script multiple times. Add the
+# "-f" flag in order to enforce overwriting the existing state.
+
 
 set -eu
+
+is_forced=0
 
 
 log_message() {
@@ -31,6 +40,10 @@ log_error_message() {
 }
 
 initialize_depot_tools() {
+  if [ -d ./depot_tools -a "${is_forced}" -eq "0" ]; then
+    log_message "depot_tools already present, skipping."
+    return
+  fi
   log_message "Installing depot_tools..."
   rm -rf ./depot_tools
   git clone "${DEPOT_TOOLS_REPOSITORY_URL}" depot_tools
@@ -39,6 +52,10 @@ initialize_depot_tools() {
 }
 
 initialize_nacl_sdk() {
+  if [ -d ./nacl_sdk -a "${is_forced}" -eq "0" ]; then
+    log_message "Native Client SDK already present, skipping."
+    return
+  fi
   log_message "Installing Native Client SDK (version ${NACL_SDK_VERSION})..."
   rm -rf nacl_sdk
   cp -r ../third_party/nacl_sdk/nacl_sdk .
@@ -48,6 +65,10 @@ initialize_nacl_sdk() {
 }
 
 initialize_webports() {
+  if [ -d ./webports -a "${is_forced}" -eq "0" ]; then
+    log_message "webports already present, skipping."
+    return
+  fi
   log_message "Installing webports (with building the following libraries: ${WEBPORTS_TARGETS})..."
   rm -rf webports
   cp -r ../third_party/webports/src webports
@@ -80,6 +101,18 @@ SCRIPTPATH=$(dirname $(realpath ${0}))
 cd ${SCRIPTPATH}
 
 . ./constants.sh
+
+while getopts ":f" opt; do
+  case $opt in
+    f)
+      is_forced=1
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
 
 initialize_depot_tools
 initialize_nacl_sdk


### PR DESCRIPTION
Change the env/initialize.sh script to be idempotent by default, so that
already existing tools and libraries are left intact by it. Add the "-f"
option that allows to revert to the previous "destructive" behavior.

This is a preparation change for introducing the WebAssembly build tools
initialization in #177, since it'll make it possible for developers to
rerun "initialize.sh" in order to get WebAssembly tools without
destroying their existing Native Client related state.