### PR TITLE
Download Emscripten in env/initialize.sh

### DIFF
--- a/env/.gitignore
+++ b/env/.gitignore
@@ -1,4 +1,5 @@
 /activate
 /depot_tools/
+/emsdk/
 /nacl_sdk/
 /webports/

--- a/env/constants.sh
+++ b/env/constants.sh
@@ -18,9 +18,8 @@
 DEPOT_TOOLS_REPOSITORY_URL="https://chromium.googlesource.com/chromium/tools/depot_tools.git"
 
 EMSCRIPTEN_SDK_REPOSITORY_URL="https://github.com/emscripten-core/emsdk.git"
+EMSCRIPTEN_VERSION="2.0.6"
 
 NACL_SDK_VERSION="47"
 
 WEBPORTS_TARGETS="glibc-compat openssl"
-
-EMSCRIPTEN_VERSION="2.0.6"

--- a/env/constants.sh
+++ b/env/constants.sh
@@ -17,6 +17,10 @@
 
 DEPOT_TOOLS_REPOSITORY_URL="https://chromium.googlesource.com/chromium/tools/depot_tools.git"
 
+EMSCRIPTEN_SDK_REPOSITORY_URL="https://github.com/emscripten-core/emsdk.git"
+
 NACL_SDK_VERSION="47"
 
 WEBPORTS_TARGETS="glibc-compat openssl"
+
+EMSCRIPTEN_VERSION="2.0.6"

--- a/env/initialize.sh
+++ b/env/initialize.sh
@@ -47,7 +47,6 @@ initialize_emscripten() {
   log_message "Installing Emscripten..."
   rm -rf ./emsdk
   git clone "${EMSCRIPTEN_SDK_REPOSITORY_URL}" emsdk
-  PATH="${SCRIPTPATH}/emsdk:${PATH}"
   ./emsdk/emsdk install "${EMSCRIPTEN_VERSION}"
   ./emsdk/emsdk activate "${EMSCRIPTEN_VERSION}"
   log_message "Emscripten was installed successfully."
@@ -130,8 +129,13 @@ while getopts ":f" opt; do
   esac
 done
 
-initialize_emscripten
 initialize_depot_tools
+
+initialize_emscripten
+
+# Depends on depot_tools.
 initialize_nacl_sdk
+# Depends on nacl_sdk.
 initialize_webports
+
 create_activate_script

--- a/env/initialize.sh
+++ b/env/initialize.sh
@@ -39,6 +39,20 @@ log_error_message() {
   echo -e "\033[33;31m${message}\033[0m"
 }
 
+initialize_emscripten() {
+  if [ -d ./emsdk -a "${force_reinitialization}" -eq "0" ]; then
+    log_message "Emscripten already present, skipping."
+    return
+  fi
+  log_message "Installing Emscripten..."
+  rm -rf ./emsdk
+  git clone "${EMSCRIPTEN_SDK_REPOSITORY_URL}" emsdk
+  PATH="${SCRIPTPATH}/emsdk:${PATH}"
+  ./emsdk/emsdk install "${EMSCRIPTEN_VERSION}"
+  ./emsdk/emsdk activate "${EMSCRIPTEN_VERSION}"
+  log_message "Emscripten was installed successfully."
+}
+
 initialize_depot_tools() {
   if [ -d ./depot_tools -a "${force_reinitialization}" -eq "0" ]; then
     log_message "depot_tools already present, skipping."
@@ -92,7 +106,9 @@ initialize_webports() {
 
 create_activate_script() {
   log_message "Creating \"activate\" script..."
-  echo "export NACL_SDK_ROOT=${NACL_SDK_ROOT}" > activate
+  echo > activate
+  echo "export NACL_SDK_ROOT=${NACL_SDK_ROOT}" >> activate
+  echo "source ${SCRIPTPATH}/emsdk/emsdk_env.sh" >> activate
   log_message "\"activate\" script was created successfully. Run \"source $(dirname ${0})/activate\" in order to trigger all necessary environment definitions."
 }
 
@@ -114,6 +130,7 @@ while getopts ":f" opt; do
   esac
 done
 
+initialize_emscripten
 initialize_depot_tools
 initialize_nacl_sdk
 initialize_webports


### PR DESCRIPTION
Add download and installation of Emscripten into the env/initialize.sh
script. This will be used in the future for building the WebAssembly
ports of the C/C++ code in the Smart Card Connector app and related
projects (instead of the currently used Native Client) - see #177.

The version of Emscripten is pinned, so that all developers get
consistent results and avoid any potential breakages related to uprevs.