### PR TITLE
Introduce variant Value type

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -52,6 +52,7 @@ SOURCES := \
 	$(SOURCES_PATH)/requesting/requester_message.cc \
 	$(SOURCES_PATH)/requesting/request_receiver.cc \
 	$(SOURCES_PATH)/requesting/request_result.cc \
+	$(SOURCES_PATH)/value.cc \
 
 TEST_SUPPORT_SOURCES := \
 	$(SOURCES_PATH)/integration_testing/integration_test_service.cc \
@@ -105,6 +106,7 @@ INSTALLING_HEADERS := \
 	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):thread_safe_unique_ptr.h \
 	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):tuple_unpacking.h \
 	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):unique_ptr_utils.h \
+	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):value.h \
 
 $(eval $(call NACL_LIBRARY_HEADERS_INSTALLATION_RULE,$(INSTALLING_HEADERS)))
 

--- a/common/cpp/build/tests/Makefile
+++ b/common/cpp/build/tests/Makefile
@@ -48,6 +48,7 @@ TEST_SOURCES := \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/pp_var_utils/struct_converter_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/requesting/async_request_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/requesting/async_requests_storage_unittest.cc \
+	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_unittest.cc \
 
 ADDITIONAL_TEST_CPPFLAGS := \
 	-I$(TEST_SOURCES_PATH) \

--- a/common/cpp/src/google_smart_card_common/value.cc
+++ b/common/cpp/src/google_smart_card_common/value.cc
@@ -69,7 +69,7 @@ Value::Value(double float_value)
     : type_(Type::kFloat), float_value_(float_value) {}
 
 Value::Value(const char* string_value)
-    : type_(Type::kString), string_value_(string_value) {}
+    : Value(std::string(string_value)) {}
 
 Value::Value(std::string string_value)
     : type_(Type::kString), string_value_(std::move(string_value)) {}
@@ -121,12 +121,12 @@ const Value::BinaryStorage& Value::GetBinary() const {
   return binary_value_;
 }
 
-const Value::DictionaryStorage& Value::GetDictionaryItems() const {
+const Value::DictionaryStorage& Value::GetDictionary() const {
   GOOGLE_SMART_CARD_CHECK(is_dictionary());
   return dictionary_value_;
 }
 
-const Value::ArrayStorage& Value::GetArrayItems() const {
+const Value::ArrayStorage& Value::GetArray() const {
   GOOGLE_SMART_CARD_CHECK(is_array());
   return array_value_;
 }

--- a/common/cpp/src/google_smart_card_common/value.h
+++ b/common/cpp/src/google_smart_card_common/value.h
@@ -25,7 +25,7 @@
 
 namespace google_smart_card {
 
-// A variadic data type that approximately corresponds to JSONifiable types.
+// A variant data type that approximately corresponds to JSONifiable types.
 //
 // Is intended to be used in generic interfaces related to message exchanging
 // with remote callers/receivers, for instance, for sending/receiving messages
@@ -82,9 +82,10 @@ class Value final {
   double GetFloat() const;
   const std::string& GetString() const;
   const BinaryStorage& GetBinary() const;
-  const DictionaryStorage& GetDictionaryItems() const;
-  const ArrayStorage& GetArrayItems() const;
+  const DictionaryStorage& GetDictionary() const;
+  const ArrayStorage& GetArray() const;
 
+  // Returns null when the key isn't present.
   const Value* GetDictionaryItem(const std::string& key) const;
 
   void SetDictionaryItem(std::string key, Value value);

--- a/common/cpp/src/google_smart_card_common/value.h
+++ b/common/cpp/src/google_smart_card_common/value.h
@@ -1,0 +1,137 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_SMART_CARD_COMMON_VALUE_H_
+#define GOOGLE_SMART_CARD_COMMON_VALUE_H_
+
+#include <stdint.h>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace google_smart_card {
+
+// A variadic data type that approximately corresponds to JSONifiable types.
+//
+// Is intended to be used in generic interfaces related to message exchanging
+// with remote callers/receivers, for instance, for sending/receiving messages
+// to/from JavaScript code.
+//
+// Inspired by Chromium's base::Value, Pepper's pp::Var classes and JavaScript
+// type system.
+class Value final {
+ public:
+  enum class Type {
+    kNull,
+    kBoolean,
+    kInteger,
+    kFloat,
+    kString,
+    kBinary,
+    kDictionary,
+    kArray,
+  };
+
+  using BinaryStorage = std::vector<uint8_t>;
+  using DictionaryStorage = std::map<std::string, std::unique_ptr<Value>>;
+  using ArrayStorage = std::vector<std::unique_ptr<Value>>;
+
+  Value();
+  explicit Value(Type type);
+  explicit Value(bool boolean_value);
+  explicit Value(int integer_value);
+  explicit Value(int64_t integer_value);
+  explicit Value(double float_value);
+  explicit Value(const char* string_value);
+  explicit Value(std::string string_value);
+  explicit Value(BinaryStorage binary_value);
+  explicit Value(DictionaryStorage dictionary_value);
+  explicit Value(ArrayStorage array_value);
+  Value(Value&& other);
+  Value& operator=(Value&& other);
+  Value(const Value&) = delete;
+  Value& operator=(const Value&) = delete;
+  ~Value();
+
+  Type type() const { return type_; }
+  bool is_null() const { return type_ == Type::kNull; }
+  bool is_boolean() const { return type_ == Type::kBoolean; }
+  bool is_integer() const { return type_ == Type::kInteger; }
+  bool is_float() const { return type_ == Type::kFloat; }
+  bool is_string() const { return type_ == Type::kString; }
+  bool is_binary() const { return type_ == Type::kBinary; }
+  bool is_dictionary() const { return type_ == Type::kDictionary; }
+  bool is_array() const { return type_ == Type::kArray; }
+
+  bool GetBoolean() const;
+  int64_t GetInteger() const;
+  double GetFloat() const;
+  const std::string& GetString() const;
+  const BinaryStorage& GetBinary() const;
+  const DictionaryStorage& GetDictionaryItems() const;
+  const ArrayStorage& GetArrayItems() const;
+
+  const Value* GetDictionaryItem(const std::string& key) const;
+
+  void SetDictionaryItem(std::string key, Value value);
+  void SetDictionaryItem(std::string key, bool boolean_value) {
+    SetDictionaryItem(std::move(key), Value(boolean_value));
+  }
+  void SetDictionaryItem(std::string key, int integer_value) {
+    SetDictionaryItem(std::move(key), Value(integer_value));
+  }
+  void SetDictionaryItem(std::string key, int64_t integer_value) {
+    SetDictionaryItem(std::move(key), Value(integer_value));
+  }
+  void SetDictionaryItem(std::string key, double float_value) {
+    SetDictionaryItem(std::move(key), Value(float_value));
+  }
+  void SetDictionaryItem(std::string key, const char* string_value) {
+    SetDictionaryItem(std::move(key), Value(string_value));
+  }
+  void SetDictionaryItem(std::string key, std::string string_value) {
+    SetDictionaryItem(std::move(key), Value(std::move(string_value)));
+  }
+  void SetDictionaryItem(std::string key, BinaryStorage binary_value) {
+    SetDictionaryItem(std::move(key), Value(std::move(binary_value)));
+  }
+  void SetDictionaryItem(std::string key, DictionaryStorage dictionary_value) {
+    SetDictionaryItem(std::move(key), Value(std::move(dictionary_value)));
+  }
+  void SetDictionaryItem(std::string key, ArrayStorage array_value) {
+    SetDictionaryItem(std::move(key), Value(std::move(array_value)));
+  }
+
+ private:
+  void MoveConstructFrom(Value&& other);
+  void Destroy();
+
+  Type type_ = Type::kNull;
+  union {
+    bool boolean_value_;
+    int64_t integer_value_;
+    double float_value_;
+    std::string string_value_;
+    BinaryStorage binary_value_;
+    DictionaryStorage dictionary_value_;
+    ArrayStorage array_value_;
+  };
+};
+
+}  // namespace google_smart_card
+
+#endif  // GOOGLE_SMART_CARD_COMMON_VALUE_H_

--- a/common/cpp/src/google_smart_card_common/value_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_unittest.cc
@@ -1,0 +1,339 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google_smart_card_common/value.h>
+
+#include <stdint.h>
+
+#include <map>
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <google_smart_card_common/unique_ptr_utils.h>
+
+namespace google_smart_card {
+
+TEST(ValueTest, DefaultConstructed) {
+  const Value value;
+  EXPECT_EQ(value.type(), Value::Type::kNull);
+  EXPECT_TRUE(value.is_null());
+  EXPECT_FALSE(value.is_integer());
+  EXPECT_FALSE(value.is_float());
+  EXPECT_FALSE(value.is_string());
+  EXPECT_FALSE(value.is_binary());
+  EXPECT_FALSE(value.is_dictionary());
+  EXPECT_FALSE(value.is_array());
+}
+
+TEST(ValueTest, Null) {
+  const Value value(Value::Type::kNull);
+  EXPECT_EQ(value.type(), Value::Type::kNull);
+  EXPECT_TRUE(value.is_null());
+  EXPECT_FALSE(value.is_integer());
+  EXPECT_FALSE(value.is_float());
+  EXPECT_FALSE(value.is_string());
+  EXPECT_FALSE(value.is_binary());
+  EXPECT_FALSE(value.is_dictionary());
+  EXPECT_FALSE(value.is_array());
+}
+
+TEST(ValueTest, Integer) {
+  const Value value(123);
+  EXPECT_EQ(value.type(), Value::Type::kInteger);
+  EXPECT_FALSE(value.is_null());
+  EXPECT_TRUE(value.is_integer());
+  EXPECT_FALSE(value.is_float());
+  EXPECT_FALSE(value.is_string());
+  EXPECT_FALSE(value.is_binary());
+  EXPECT_FALSE(value.is_dictionary());
+  EXPECT_FALSE(value.is_array());
+  EXPECT_EQ(value.GetInteger(), 123);
+  EXPECT_DOUBLE_EQ(value.GetFloat(), 123);
+}
+
+TEST(ValueTest, IntegerDefault) {
+  const Value value(Value::Type::kInteger);
+  EXPECT_EQ(value.type(), Value::Type::kInteger);
+  EXPECT_FALSE(value.is_null());
+  EXPECT_TRUE(value.is_integer());
+  EXPECT_FALSE(value.is_float());
+  EXPECT_FALSE(value.is_string());
+  EXPECT_FALSE(value.is_binary());
+  EXPECT_FALSE(value.is_dictionary());
+  EXPECT_FALSE(value.is_array());
+  EXPECT_EQ(value.GetInteger(), 0);
+  EXPECT_DOUBLE_EQ(value.GetFloat(), 0);
+}
+
+TEST(ValueTest, Float) {
+  const Value value(123.456);
+  EXPECT_EQ(value.type(), Value::Type::kFloat);
+  EXPECT_FALSE(value.is_null());
+  EXPECT_FALSE(value.is_integer());
+  EXPECT_TRUE(value.is_float());
+  EXPECT_FALSE(value.is_string());
+  EXPECT_FALSE(value.is_binary());
+  EXPECT_FALSE(value.is_dictionary());
+  EXPECT_FALSE(value.is_array());
+  EXPECT_DOUBLE_EQ(value.GetFloat(), 123.456);
+}
+
+TEST(ValueTest, FloatDefault) {
+  const Value value(Value::Type::kFloat);
+  EXPECT_EQ(value.type(), Value::Type::kFloat);
+  EXPECT_FALSE(value.is_null());
+  EXPECT_FALSE(value.is_integer());
+  EXPECT_TRUE(value.is_float());
+  EXPECT_FALSE(value.is_string());
+  EXPECT_FALSE(value.is_binary());
+  EXPECT_FALSE(value.is_dictionary());
+  EXPECT_FALSE(value.is_array());
+  EXPECT_DOUBLE_EQ(value.GetFloat(), 0);
+}
+
+TEST(ValueTest, String) {
+  const Value value("foo");
+  EXPECT_EQ(value.type(), Value::Type::kString);
+  EXPECT_FALSE(value.is_null());
+  EXPECT_FALSE(value.is_integer());
+  EXPECT_FALSE(value.is_float());
+  EXPECT_TRUE(value.is_string());
+  EXPECT_FALSE(value.is_binary());
+  EXPECT_FALSE(value.is_dictionary());
+  EXPECT_FALSE(value.is_array());
+  EXPECT_EQ(value.GetString(), "foo");
+}
+
+TEST(ValueTest, StringDefault) {
+  const Value value(Value::Type::kString);
+  EXPECT_EQ(value.type(), Value::Type::kString);
+  EXPECT_FALSE(value.is_null());
+  EXPECT_FALSE(value.is_integer());
+  EXPECT_FALSE(value.is_float());
+  EXPECT_TRUE(value.is_string());
+  EXPECT_FALSE(value.is_binary());
+  EXPECT_FALSE(value.is_dictionary());
+  EXPECT_FALSE(value.is_array());
+  EXPECT_EQ(value.GetString(), "");
+}
+
+TEST(ValueTest, Binary) {
+  const std::vector<uint8_t> bytes = {1, 2, 3};
+  const Value value(bytes);
+  EXPECT_EQ(value.type(), Value::Type::kBinary);
+  EXPECT_FALSE(value.is_null());
+  EXPECT_FALSE(value.is_integer());
+  EXPECT_FALSE(value.is_float());
+  EXPECT_FALSE(value.is_string());
+  EXPECT_TRUE(value.is_binary());
+  EXPECT_FALSE(value.is_dictionary());
+  EXPECT_FALSE(value.is_array());
+  EXPECT_EQ(value.GetBinary(), bytes);
+}
+
+TEST(ValueTest, BinaryDefault) {
+  const std::vector<uint8_t> bytes;
+  const Value value(bytes);
+  EXPECT_EQ(value.type(), Value::Type::kBinary);
+  EXPECT_FALSE(value.is_null());
+  EXPECT_FALSE(value.is_integer());
+  EXPECT_FALSE(value.is_float());
+  EXPECT_FALSE(value.is_string());
+  EXPECT_TRUE(value.is_binary());
+  EXPECT_FALSE(value.is_dictionary());
+  EXPECT_FALSE(value.is_array());
+  EXPECT_EQ(value.GetBinary(), bytes);
+}
+
+TEST(ValueTest, Dictionary) {
+  std::map<std::string, std::unique_ptr<Value>> items;
+  items["foo"] = MakeUnique<Value>();
+  items["bar"] = MakeUnique<Value>(123);
+  const Value value(std::move(items));
+  EXPECT_EQ(value.type(), Value::Type::kDictionary);
+  EXPECT_FALSE(value.is_null());
+  EXPECT_FALSE(value.is_integer());
+  EXPECT_FALSE(value.is_float());
+  EXPECT_FALSE(value.is_string());
+  EXPECT_FALSE(value.is_binary());
+  EXPECT_TRUE(value.is_dictionary());
+  EXPECT_FALSE(value.is_array());
+  EXPECT_EQ(value.GetDictionaryItems().size(), 2U);
+  const Value* const item_foo = value.GetDictionaryItem("foo");
+  ASSERT_TRUE(item_foo);
+  EXPECT_TRUE(item_foo->is_null());
+  const Value* const item_bar = value.GetDictionaryItem("bar");
+  ASSERT_TRUE(item_bar);
+  ASSERT_TRUE(item_bar->is_integer());
+  EXPECT_EQ(item_bar->GetInteger(), 123);
+  const Value* const item_baz = value.GetDictionaryItem("baz");
+  EXPECT_FALSE(item_baz);
+}
+
+TEST(ValueTest, DictionaryDefault) {
+  const Value value(Value::Type::kDictionary);
+  EXPECT_EQ(value.type(), Value::Type::kDictionary);
+  EXPECT_FALSE(value.is_null());
+  EXPECT_FALSE(value.is_integer());
+  EXPECT_FALSE(value.is_float());
+  EXPECT_FALSE(value.is_string());
+  EXPECT_FALSE(value.is_binary());
+  EXPECT_TRUE(value.is_dictionary());
+  EXPECT_FALSE(value.is_array());
+  EXPECT_TRUE(value.GetDictionaryItems().empty());
+  const Value* const item_foo = value.GetDictionaryItem("foo");
+  EXPECT_FALSE(item_foo);
+}
+
+TEST(ValueTest, Array) {
+  std::vector<std::unique_ptr<Value>> items;
+  items.push_back(MakeUnique<Value>());
+  items.push_back(MakeUnique<Value>(123));
+  const Value value(std::move(items));
+  EXPECT_EQ(value.type(), Value::Type::kArray);
+  EXPECT_FALSE(value.is_null());
+  EXPECT_FALSE(value.is_integer());
+  EXPECT_FALSE(value.is_float());
+  EXPECT_FALSE(value.is_string());
+  EXPECT_FALSE(value.is_binary());
+  EXPECT_FALSE(value.is_dictionary());
+  EXPECT_TRUE(value.is_array());
+  ASSERT_EQ(value.GetArrayItems().size(), 2U);
+  const Value* item0 = value.GetArrayItems()[0].get();
+  ASSERT_TRUE(item0);
+  EXPECT_TRUE(item0->is_null());
+  const Value* item1 = value.GetArrayItems()[1].get();
+  ASSERT_TRUE(item1);
+  ASSERT_TRUE(item1->is_integer());
+  EXPECT_EQ(item1->GetInteger(), 123);
+}
+
+TEST(ValueTest, ArrayDefault) {
+  const Value value(Value::Type::kArray);
+  EXPECT_EQ(value.type(), Value::Type::kArray);
+  EXPECT_FALSE(value.is_null());
+  EXPECT_FALSE(value.is_integer());
+  EXPECT_FALSE(value.is_float());
+  EXPECT_FALSE(value.is_string());
+  EXPECT_FALSE(value.is_binary());
+  EXPECT_FALSE(value.is_dictionary());
+  EXPECT_TRUE(value.is_array());
+  EXPECT_TRUE(value.GetArrayItems().empty());
+}
+
+TEST(ValueTest, MoveConstruction) {
+  {
+    Value value1;
+    Value value2 = std::move(value1);
+    EXPECT_TRUE(value2.is_null());
+  }
+
+  {
+    Value value1(123);
+    Value value2 = std::move(value1);
+    ASSERT_TRUE(value2.is_integer());
+    EXPECT_EQ(value2.GetInteger(), 123);
+  }
+
+  {
+    Value value1("foo");
+    Value value2 = std::move(value1);
+    ASSERT_TRUE(value2.is_string());
+    EXPECT_EQ(value2.GetString(), "foo");
+  }
+}
+
+TEST(ValueTest, MoveAssignment) {
+  {
+    Value value1("foo");
+    Value value2;
+    value2 = std::move(value1);
+    ASSERT_TRUE(value2.is_string());
+    EXPECT_EQ(value2.GetString(), "foo");
+  }
+
+  {
+    Value value1("foo");
+    Value value2(123);
+    value2 = std::move(value1);
+    ASSERT_TRUE(value2.is_string());
+    EXPECT_EQ(value2.GetString(), "foo");
+  }
+
+  {
+    Value value1("foo");
+    Value value2("bar");
+    value2 = std::move(value1);
+    ASSERT_TRUE(value2.is_string());
+    EXPECT_EQ(value2.GetString(), "foo");
+  }
+
+  {
+    std::vector<std::unique_ptr<Value>> items;
+    items.push_back(MakeUnique<Value>("foo"));
+    Value value1(std::move(items));
+    Value value2("bar");
+    value2 = std::move(value1);
+    ASSERT_TRUE(value2.is_array());
+    EXPECT_EQ(value2.GetArrayItems().size(), 1U);
+  }
+}
+
+TEST(ValueTest, MoveAssignmentToItself) {
+  Value value("foo");
+  value = std::move(value);
+  ASSERT_TRUE(value.is_string());
+  EXPECT_EQ(value.GetString(), "foo");
+}
+
+TEST(ValueTest, DictionaryModification) {
+  Value value(Value::Type::kDictionary);
+
+  value.SetDictionaryItem("foo", 123);
+  EXPECT_EQ(value.GetDictionaryItems().size(), 1U);
+  {
+    const Value* const item_foo = value.GetDictionaryItem("foo");
+    ASSERT_TRUE(item_foo);
+    ASSERT_TRUE(item_foo->is_integer());
+    EXPECT_EQ(item_foo->GetInteger(), 123);
+  }
+
+  value.SetDictionaryItem("bar", Value());
+  EXPECT_EQ(value.GetDictionaryItems().size(), 2U);
+  {
+    const Value* const item_foo = value.GetDictionaryItem("foo");
+    ASSERT_TRUE(item_foo);
+    ASSERT_TRUE(item_foo->is_integer());
+    EXPECT_EQ(item_foo->GetInteger(), 123);
+    const Value* const item_bar = value.GetDictionaryItem("bar");
+    ASSERT_TRUE(item_bar);
+    ASSERT_TRUE(item_bar->is_null());
+  }
+
+  value.SetDictionaryItem("foo", "text");
+  EXPECT_EQ(value.GetDictionaryItems().size(), 2U);
+  {
+    const Value* const item_foo = value.GetDictionaryItem("foo");
+    ASSERT_TRUE(item_foo);
+    ASSERT_TRUE(item_foo->is_string());
+    EXPECT_EQ(item_foo->GetString(), "text");
+    const Value* const item_bar = value.GetDictionaryItem("bar");
+    ASSERT_TRUE(item_bar);
+    ASSERT_TRUE(item_bar->is_null());
+  }
+}
+
+}  // namespace google_smart_card


### PR DESCRIPTION
Initial implementation of the "Value" class that, approximately, can
hold any JSONifiable object.

This class will be used in follow-ups to replace the widespread usage of
the Native Client / Pepper specific "pp::Var" class, so that all
depending code can be reused in WebAssembly builds (that effort is
tracked by #185).

The class is additionally inspired by the Chromium's "base::Value", but
we're having a much simpler custom implementation here, because
Chromium's implementation brings a bunch of dependencies and is not
trivial to compile.