### PR TITLE
Add conversion from NaCl's pp::Var into Value

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -53,6 +53,7 @@ SOURCES := \
 	$(SOURCES_PATH)/requesting/request_receiver.cc \
 	$(SOURCES_PATH)/requesting/request_result.cc \
 	$(SOURCES_PATH)/value.cc \
+	$(SOURCES_PATH)/value_nacl_pp_var_conversion.cc \
 
 TEST_SUPPORT_SOURCES := \
 	$(SOURCES_PATH)/integration_testing/integration_test_service.cc \

--- a/common/cpp/build/tests/Makefile
+++ b/common/cpp/build/tests/Makefile
@@ -48,6 +48,7 @@ TEST_SOURCES := \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/pp_var_utils/struct_converter_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/requesting/async_request_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/requesting/async_requests_storage_unittest.cc \
+	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_nacl_pp_var_conversion_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_unittest.cc \
 
 ADDITIONAL_TEST_CPPFLAGS := \

--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.cc
@@ -1,0 +1,105 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
+
+#include <stdint.h>
+
+#include <cstring>
+#include <limits>
+#include <string>
+#include <utility>
+
+#include <ppapi/cpp/var.h>
+#include <ppapi/cpp/var_array.h>
+#include <ppapi/cpp/var_array_buffer.h>
+#include <ppapi/cpp/var_dictionary.h>
+
+#include <google_smart_card_common/logging/logging.h>
+#include <google_smart_card_common/unique_ptr_utils.h>
+#include <google_smart_card_common/value.h>
+
+namespace google_smart_card {
+
+namespace {
+
+pp::Var CreateIntegerVar(int64_t integer_value) {
+  // `pp::Var` can only hold 32-bit integers. Larger numbers need to be
+  // represented via double.
+  if (integer_value >= std::numeric_limits<int32_t>::min() &&
+      integer_value <= std::numeric_limits<int32_t>::max())
+    return pp::Var(static_cast<int32_t>(integer_value));
+  return pp::Var(static_cast<double>(integer_value));
+}
+
+pp::VarArrayBuffer CreateVarArrayBuffer(
+    const Value::BinaryStorage& binary_storage) {
+  pp::VarArrayBuffer var_array_buffer(binary_storage.size());
+  if (!binary_storage.empty()) {
+    std::memcpy(var_array_buffer.Map(), &binary_storage.front(),
+                binary_storage.size());
+  }
+  var_array_buffer.Unmap();
+  return var_array_buffer;
+}
+
+pp::VarDictionary CreateVarDictionary(const Value& value) {
+  GOOGLE_SMART_CARD_CHECK(value.is_dictionary());
+  pp::VarDictionary var_dictionary;
+  for (auto& item: value.GetDictionary()) {
+    const std::string& item_key = item.first;
+    const std::unique_ptr<Value>& item_value = item.second;
+    var_dictionary.Set(item_key, ConvertValueToPpVar(*item_value));
+  }
+  return var_dictionary;
+}
+
+pp::VarArray CreateVarArray(const Value& value) {
+  GOOGLE_SMART_CARD_CHECK(value.is_array());
+  const Value::ArrayStorage& array_storage = value.GetArray();
+  pp::VarArray var_array;
+  var_array.SetLength(array_storage.size());
+  for (size_t index = 0; index < array_storage.size(); ++index) {
+    const std::unique_ptr<Value>& item = array_storage[index];
+    GOOGLE_SMART_CARD_CHECK(var_array.Set(
+        index, ConvertValueToPpVar(*item)));
+  }
+  return var_array;
+}
+
+}  // namespace
+
+pp::Var ConvertValueToPpVar(const Value& value) {
+  switch (value.type()) {
+    case Value::Type::kNull:
+      return pp::Var(pp::Var::Null());
+    case Value::Type::kBoolean:
+      return pp::Var(value.GetBoolean());
+    case Value::Type::kInteger:
+      return CreateIntegerVar(value.GetInteger());
+    case Value::Type::kFloat:
+      return pp::Var(value.GetFloat());
+    case Value::Type::kString:
+      return pp::Var(value.GetString());
+    case Value::Type::kBinary:
+      return CreateVarArrayBuffer(value.GetBinary());
+    case Value::Type::kDictionary:
+      return CreateVarDictionary(value);
+    case Value::Type::kArray:
+      return CreateVarArray(value);
+  }
+  GOOGLE_SMART_CARD_NOTREACHED;
+}
+
+}  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h
@@ -1,0 +1,32 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Provides helper functions for converting between the `Value` and the Native
+// Client's `pp::Var` classes.
+
+#ifndef GOOGLE_SMART_CARD_COMMON_VALUE_NACL_PP_VAR_CONVERSION_H_
+#define GOOGLE_SMART_CARD_COMMON_VALUE_NACL_PP_VAR_CONVERSION_H_
+
+#include <ppapi/cpp/var.h>
+
+#include <google_smart_card_common/value.h>
+
+namespace google_smart_card {
+
+// Converts the given `Value` into a `pp::Var`.
+pp::Var ConvertValueToPpVar(const Value& value);
+
+}  // namespace google_smart_card
+
+#endif  // GOOGLE_SMART_CARD_COMMON_VALUE_NACL_PP_VAR_CONVERSION_H_

--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion_unittest.cc
@@ -1,0 +1,142 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
+
+#include <stdint.h>
+
+#include <cstring>
+#include <limits>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <ppapi/cpp/var.h>
+#include <ppapi/cpp/var_array.h>
+#include <ppapi/cpp/var_array_buffer.h>
+#include <ppapi/cpp/var_dictionary.h>
+
+#include <google_smart_card_common/optional.h>
+#include <google_smart_card_common/unique_ptr_utils.h>
+#include <google_smart_card_common/value.h>
+
+namespace google_smart_card {
+
+TEST(ValueNaclPpVarConversion, NullValue) {
+  EXPECT_TRUE(ConvertValueToPpVar(Value()).is_null());
+}
+
+TEST(ValueNaclPpVarConversion, BooleanValue) {
+  const bool kBoolean = 123;
+  const pp::Var var = ConvertValueToPpVar(Value(kBoolean));
+  ASSERT_TRUE(var.is_bool());
+  EXPECT_EQ(var.AsBool(), kBoolean);
+}
+
+TEST(ValueNaclPpVarConversion, IntegerValue) {
+  const int kInteger = 123;
+  const pp::Var var = ConvertValueToPpVar(Value(kInteger));
+  ASSERT_TRUE(var.is_int());
+  EXPECT_EQ(var.AsInt(), kInteger);
+}
+
+TEST(ValueNaclPpVarConversion, Integer64BitMaxValue) {
+  const int64_t k64BitMax = std::numeric_limits<int64_t>::max();
+  const pp::Var var = ConvertValueToPpVar(Value(k64BitMax));
+  ASSERT_TRUE(var.is_double());
+  EXPECT_DOUBLE_EQ(var.AsDouble(), k64BitMax);
+}
+
+TEST(ValueNaclPpVarConversion, Integer64BitMinValue) {
+  const int64_t k64BitMin = std::numeric_limits<int64_t>::min();
+  const pp::Var var = ConvertValueToPpVar(Value(k64BitMin));
+  ASSERT_TRUE(var.is_double());
+  EXPECT_DOUBLE_EQ(var.AsDouble(), k64BitMin);
+}
+
+TEST(ValueNaclPpVarConversion, FloatValue) {
+  const double kFloat = 123.456;
+  const pp::Var var = ConvertValueToPpVar(Value(kFloat));
+  ASSERT_TRUE(var.is_double());
+  EXPECT_DOUBLE_EQ(var.AsDouble(), kFloat);
+}
+
+TEST(ValueNaclPpVarConversion, StringValue) {
+  const char kString[] = "foo";
+  const pp::Var var = ConvertValueToPpVar(Value(kString));
+  ASSERT_TRUE(var.is_string());
+  EXPECT_EQ(var.AsString(), kString);
+}
+
+TEST(ValueNaclPpVarConversion, BinaryValue) {
+  const std::vector<uint8_t> kBinary = {1, 2, 3};
+  const pp::Var var = ConvertValueToPpVar(Value(kBinary));
+  ASSERT_TRUE(var.is_array_buffer());
+  pp::VarArrayBuffer var_array_buffer(var);
+  EXPECT_EQ(var_array_buffer.ByteLength(), kBinary.size());
+  const void* const buffer_contents = var_array_buffer.Map();
+  EXPECT_EQ(std::memcmp(buffer_contents, &kBinary.front(), kBinary.size()), 0);
+}
+
+TEST(ValueNaclPpVarConversion, DictionaryValue) {
+  // The test data is: {"xyz": {"foo": null, "bar": 123}}.
+  std::map<std::string, std::unique_ptr<Value>> inner_items;
+  inner_items["foo"] = MakeUnique<Value>();
+  inner_items["bar"] = MakeUnique<Value>(123);
+  std::map<std::string, std::unique_ptr<Value>> items;
+  items["xyz"] = MakeUnique<Value>(std::move(inner_items));
+  const Value value(std::move(items));
+
+  const pp::Var var = ConvertValueToPpVar(value);
+  ASSERT_TRUE(var.is_dictionary());
+  const pp::VarDictionary var_dict(var);
+  EXPECT_EQ(var_dict.GetKeys().GetLength(), 1U);
+  const pp::Var item_xyz = var_dict.Get("xyz");
+  ASSERT_TRUE(item_xyz.is_dictionary());
+  const pp::VarDictionary inner_dict(item_xyz);
+  EXPECT_EQ(inner_dict.GetKeys().GetLength(), 2U);
+  const pp::Var inner_item_foo = inner_dict.Get("foo");
+  EXPECT_TRUE(inner_item_foo.is_null());
+  const pp::Var inner_item_bar = inner_dict.Get("bar");
+  ASSERT_TRUE(inner_item_bar.is_int());
+  EXPECT_EQ(inner_item_bar.AsInt(), 123);
+}
+
+TEST(ValueNaclPpVarConversion, ArrayValue) {
+  // The test data is: [[null, 123]].
+  std::vector<std::unique_ptr<Value>> inner_items;
+  inner_items.push_back(MakeUnique<Value>());
+  inner_items.push_back(MakeUnique<Value>(123));
+  std::vector<std::unique_ptr<Value>> items;
+  items.push_back(MakeUnique<Value>(std::move(inner_items)));
+  const Value value(std::move(items));
+
+  const pp::Var var = ConvertValueToPpVar(value);
+  ASSERT_TRUE(var.is_array());
+  const pp::VarArray var_array(var);
+  ASSERT_EQ(var_array.GetLength(), 1U);
+  const pp::Var item0 = var_array.Get(0);
+  ASSERT_TRUE(item0.is_array());
+  const pp::VarArray inner_array(item0);
+  ASSERT_EQ(inner_array.GetLength(), 2U);
+  const pp::Var inner_item0 = inner_array.Get(0);
+  EXPECT_TRUE(inner_item0.is_null());
+  const pp::Var inner_item1 = inner_array.Get(1);
+  ASSERT_TRUE(inner_item1.is_int());
+  EXPECT_EQ(inner_item1.AsInt(), 123);
+}
+
+}  // namespace google_smart_card


### PR DESCRIPTION
Implement helper function that transforms a Native Client SDK's pp::Var
object into a Value object.

This helper will be used in follow-ups in order to make most of the
//common/cpp library be toolchain-independent and work under both Native
Client and WebAssembly (as tracker by #185), since the Value class is
toolchain-independent.