### PR TITLE
Apply clang-format and fix minor style issues

### DIFF
--- a/common/cpp/src/google_smart_card_common/external_logs_printer.cc
+++ b/common/cpp/src/google_smart_card_common/external_logs_printer.cc
@@ -55,7 +55,7 @@ void StructConverter<ExternalLogMessageData>::VisitFields(
 
 ExternalLogsPrinter::ExternalLogsPrinter(
     const std::string& listened_message_type)
-  : listened_message_type_(listened_message_type) {}
+    : listened_message_type_(listened_message_type) {}
 
 ExternalLogsPrinter::~ExternalLogsPrinter() = default;
 
@@ -67,9 +67,9 @@ bool ExternalLogsPrinter::OnTypedMessageReceived(const pp::Var& data) {
   ExternalLogMessageData message_data;
   std::string error_message;
   if (!StructConverter<ExternalLogMessageData>::ConvertFromVar(
-           data, &message_data, &error_message)) {
-    GOOGLE_SMART_CARD_LOG_FATAL << "Failed to parse external log message: " <<
-        error_message;
+          data, &message_data, &error_message)) {
+    GOOGLE_SMART_CARD_LOG_FATAL << "Failed to parse external log message: "
+                                << error_message;
   }
   PrintExternalLogMessage(message_data);
   return true;

--- a/common/cpp/src/google_smart_card_common/external_logs_printer.h
+++ b/common/cpp/src/google_smart_card_common/external_logs_printer.h
@@ -26,7 +26,7 @@ namespace google_smart_card {
 
 class ExternalLogsPrinter final : public TypedMessageListener {
  public:
-  ExternalLogsPrinter(const std::string& listened_message_type);
+  explicit ExternalLogsPrinter(const std::string& listened_message_type);
   ExternalLogsPrinter(const ExternalLogsPrinter&) = delete;
   ExternalLogsPrinter& operator=(const ExternalLogsPrinter&) = delete;
   ~ExternalLogsPrinter() override;

--- a/common/cpp/src/google_smart_card_common/formatting.cc
+++ b/common/cpp/src/google_smart_card_common/formatting.cc
@@ -17,9 +17,13 @@
 #include <cstdio>
 #include <vector>
 
-const size_t kInitialPrintfBufferSize = 100;
-
 namespace google_smart_card {
+
+namespace {
+
+constexpr size_t kInitialPrintfBufferSize = 100;
+
+}  // namespace
 
 std::string FormatPrintfTemplate(const char* format, ...) {
   va_list var_args;
@@ -34,8 +38,8 @@ std::string FormatPrintfTemplate(const char* format, va_list var_args) {
   for (;;) {
     va_list var_args_copy;
     va_copy(var_args_copy, var_args);
-    const int result = std::vsnprintf(
-        &buffer[0], buffer.size(), format, var_args_copy);
+    const int result =
+        std::vsnprintf(&buffer[0], buffer.size(), format, var_args_copy);
     va_end(var_args_copy);
     if (0 <= result && result < static_cast<int>(buffer.size()))
       return std::string(buffer.begin(), buffer.begin() + result);

--- a/common/cpp/src/google_smart_card_common/formatting.h
+++ b/common/cpp/src/google_smart_card_common/formatting.h
@@ -20,12 +20,10 @@
 #include <cstdarg>
 #include <string>
 
-#include <google_smart_card_common/logging/logging.h>
-
 namespace google_smart_card {
 
 std::string FormatPrintfTemplate(const char* format, ...)
-  __attribute__((format(__printf__, 1, 2)));
+    __attribute__((format(__printf__, 1, 2)));
 
 std::string FormatPrintfTemplate(const char* format, va_list var_args);
 

--- a/common/cpp/src/google_smart_card_common/logging/function_call_tracer.cc
+++ b/common/cpp/src/google_smart_card_common/logging/function_call_tracer.cc
@@ -16,63 +16,59 @@
 
 namespace google_smart_card {
 
-const LogSeverity kDefaultLogSeverity = LogSeverity::kDebug;
-
-FunctionCallTracer::FunctionCallTracer(
-    const std::string& function_name,
-    const std::string& logging_prefix,
-    LogSeverity log_severity)
+FunctionCallTracer::FunctionCallTracer(const std::string& function_name,
+                                       const std::string& logging_prefix,
+                                       LogSeverity log_severity)
     : function_name_(function_name),
       logging_prefix_(logging_prefix),
       log_severity_(log_severity) {}
 
-void FunctionCallTracer::AddPassedArg(
-    const std::string& name, const std::string& dumped_value) {
+FunctionCallTracer::~FunctionCallTracer() = default;
+
+void FunctionCallTracer::AddPassedArg(const std::string& name,
+                                      const std::string& dumped_value) {
   passed_args_.emplace_back(name, dumped_value);
 }
 
-void FunctionCallTracer::AddReturnValue(
-    const std::string& dumped_value) {
+void FunctionCallTracer::AddReturnValue(const std::string& dumped_value) {
   GOOGLE_SMART_CARD_CHECK(!dumped_return_value_);
   dumped_return_value_ = dumped_value;
 }
 
-void FunctionCallTracer::AddReturnedArg(
-    const std::string& name, const std::string& dumped_value) {
+void FunctionCallTracer::AddReturnedArg(const std::string& name,
+                                        const std::string& dumped_value) {
   returned_args_.emplace_back(name, dumped_value);
 }
 
 void FunctionCallTracer::LogEntrance() const {
-  GOOGLE_SMART_CARD_LOG(log_severity_) << logging_prefix_ << function_name_ <<
-      "(" << DumpArgs(passed_args_) << "): called...";
+  GOOGLE_SMART_CARD_LOG(log_severity_)
+      << logging_prefix_ << function_name_ << "(" << DumpArgs(passed_args_)
+      << "): called...";
 }
 
 void FunctionCallTracer::LogExit() const {
   std::string results_part;
-  if (dumped_return_value_)
-    results_part = *dumped_return_value_;
+  if (dumped_return_value_) results_part = *dumped_return_value_;
   if (!returned_args_.empty()) {
-    if (!results_part.empty())
-      results_part += ", ";
+    if (!results_part.empty()) results_part += ", ";
     results_part += DumpArgs(returned_args_);
   }
 
-  GOOGLE_SMART_CARD_LOG(log_severity_) << logging_prefix_ << function_name_ <<
-      ": returning" << (results_part.empty() ? "" : " ") << results_part;
+  GOOGLE_SMART_CARD_LOG(log_severity_)
+      << logging_prefix_ << function_name_ << ": returning"
+      << (results_part.empty() ? "" : " ") << results_part;
 }
 
 FunctionCallTracer::ArgNameWithValue::ArgNameWithValue(
     const std::string& name, const std::string& dumped_value)
-    : name(name),
-      dumped_value(dumped_value) {}
+    : name(name), dumped_value(dumped_value) {}
 
 // static
 std::string FunctionCallTracer::DumpArgs(
     const std::vector<ArgNameWithValue>& args) {
   std::string result;
   for (const auto& arg : args) {
-    if (!result.empty())
-      result += ", ";
+    if (!result.empty()) result += ", ";
     result += arg.name;
     result += "=";
     result += arg.dumped_value;

--- a/common/cpp/src/google_smart_card_common/logging/function_call_tracer.h
+++ b/common/cpp/src/google_smart_card_common/logging/function_call_tracer.h
@@ -31,19 +31,18 @@ namespace google_smart_card {
 // methods are called in a valid order and valid number of times).
 class FunctionCallTracer final {
  public:
-  explicit FunctionCallTracer(
-      const std::string& function_name,
-      const std::string& logging_prefix = "",
-      LogSeverity log_severity = LogSeverity::kDebug);
+  explicit FunctionCallTracer(const std::string& function_name,
+                              const std::string& logging_prefix = "",
+                              LogSeverity log_severity = LogSeverity::kDebug);
   FunctionCallTracer(const FunctionCallTracer&) = delete;
+  FunctionCallTracer& operator=(const FunctionCallTracer&) = delete;
+  ~FunctionCallTracer();
 
-  void AddPassedArg(
-      const std::string& name, const std::string& dumped_value);
+  void AddPassedArg(const std::string& name, const std::string& dumped_value);
 
   void AddReturnValue(const std::string& dumped_value);
 
-  void AddReturnedArg(
-      const std::string& name, const std::string& dumped_value);
+  void AddReturnedArg(const std::string& name, const std::string& dumped_value);
 
   void LogEntrance() const;
   void LogEntrance(const std::string& logging_prefix) const;

--- a/common/cpp/src/google_smart_card_common/logging/hex_dumping.cc
+++ b/common/cpp/src/google_smart_card_common/logging/hex_dumping.cc
@@ -20,11 +20,11 @@
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/numeric_conversions.h>
 
-const int kBitsPerHexDigit = 4;
-
 namespace google_smart_card {
 
 namespace {
+
+constexpr int kBitsPerHexDigit = 4;
 
 template <typename T>
 std::string HexDumpIntegerWithExactBitLength(T value, int bit_length) {
@@ -37,8 +37,7 @@ std::string HexDumpIntegerWithExactBitLength(T value, int bit_length) {
   // representation), and then the adjustment of the negative numbers is made
   // when necessary (if the original bit length was smaller than 64).
   uint64_t value_to_dump = static_cast<uint64_t>(value);
-  if (value < 0 && bit_length < 64)
-    value_to_dump += 1ULL << bit_length;
+  if (value < 0 && bit_length < 64) value_to_dump += 1ULL << bit_length;
 
   std::ostringstream stream;
   stream.setf(std::ios::uppercase);
@@ -97,37 +96,31 @@ std::string HexDumpOctlet(uint64_t value) {
 }
 
 std::string HexDumpPointer(const void* value) {
-  if (!value)
-    return "NULL";
+  if (!value) return "NULL";
   return HexDumpInteger(reinterpret_cast<uintptr_t>(value));
 }
 
 std::string HexDumpUnknownSizeInteger(int64_t value) {
-  return HexDumpIntegerWithExactBitLength(
-      value, GuessIntegerBitLength(value));
+  return HexDumpIntegerWithExactBitLength(value, GuessIntegerBitLength(value));
 }
 
 std::string HexDumpUnknownSizeInteger(uint64_t value) {
-  return HexDumpIntegerWithExactBitLength(
-      value, GuessIntegerBitLength(value));
+  return HexDumpIntegerWithExactBitLength(value, GuessIntegerBitLength(value));
 }
 
 std::string HexDumpBytes(const void* begin, int64_t size) {
-  if (size)
-    GOOGLE_SMART_CARD_CHECK(begin);
+  if (size) GOOGLE_SMART_CARD_CHECK(begin);
   const uint8_t* const begin_casted = static_cast<const uint8_t*>(begin);
   std::string result;
   for (int64_t index = 0; index < size; ++index) {
-    if (index)
-      result += ' ';
+    if (index) result += ' ';
     result += HexDumpByte(begin_casted[index]);
   }
   return result;
 }
 
 std::string HexDumpBytes(const std::vector<uint8_t>& bytes) {
-  if (bytes.empty())
-    return "";
+  if (bytes.empty()) return "";
   return HexDumpBytes(&bytes[0], bytes.size());
 }
 

--- a/common/cpp/src/google_smart_card_common/logging/hex_dumping.h
+++ b/common/cpp/src/google_smart_card_common/logging/hex_dumping.h
@@ -76,57 +76,54 @@ HexDumpInteger(T value) {
 }
 
 template <typename T>
-inline typename std::enable_if<
-    sizeof(T) == sizeof(uint8_t) && std::is_unsigned<T>::value,
-    std::string>::type
+inline typename std::enable_if<sizeof(T) == sizeof(uint8_t) &&
+                                   std::is_unsigned<T>::value,
+                               std::string>::type
 HexDumpInteger(T value) {
   return HexDumpByte(static_cast<uint8_t>(value));
 }
 
 template <typename T>
 inline typename std::enable_if<
-    sizeof(T) == sizeof(int16_t) && std::is_signed<T>::value,
-    std::string>::type
+    sizeof(T) == sizeof(int16_t) && std::is_signed<T>::value, std::string>::type
 HexDumpInteger(T value) {
   return HexDumpDoublet(static_cast<int16_t>(value));
 }
 
 template <typename T>
-inline typename std::enable_if<
-    sizeof(T) == sizeof(uint16_t) && std::is_unsigned<T>::value,
-    std::string>::type
+inline typename std::enable_if<sizeof(T) == sizeof(uint16_t) &&
+                                   std::is_unsigned<T>::value,
+                               std::string>::type
 HexDumpInteger(T value) {
   return HexDumpDoublet(static_cast<uint16_t>(value));
 }
 
 template <typename T>
 inline typename std::enable_if<
-    sizeof(T) == sizeof(int32_t) && std::is_signed<T>::value,
-    std::string>::type
+    sizeof(T) == sizeof(int32_t) && std::is_signed<T>::value, std::string>::type
 HexDumpInteger(T value) {
   return HexDumpQuadlet(static_cast<int32_t>(value));
 }
 
 template <typename T>
-inline typename std::enable_if<
-    sizeof(T) == sizeof(uint32_t) && std::is_unsigned<T>::value,
-    std::string>::type
+inline typename std::enable_if<sizeof(T) == sizeof(uint32_t) &&
+                                   std::is_unsigned<T>::value,
+                               std::string>::type
 HexDumpInteger(T value) {
   return HexDumpQuadlet(static_cast<uint32_t>(value));
 }
 
 template <typename T>
 inline typename std::enable_if<
-    sizeof(T) == sizeof(int64_t) && std::is_signed<T>::value,
-    std::string>::type
+    sizeof(T) == sizeof(int64_t) && std::is_signed<T>::value, std::string>::type
 HexDumpInteger(T value) {
   return HexDumpOctlet(static_cast<int64_t>(value));
 }
 
 template <typename T>
-inline typename std::enable_if<
-    sizeof(T) == sizeof(uint64_t) && std::is_unsigned<T>::value,
-    std::string>::type
+inline typename std::enable_if<sizeof(T) == sizeof(uint64_t) &&
+                                   std::is_unsigned<T>::value,
+                               std::string>::type
 HexDumpInteger(T value) {
   return HexDumpOctlet(static_cast<uint64_t>(value));
 }

--- a/common/cpp/src/google_smart_card_common/logging/logging.cc
+++ b/common/cpp/src/google_smart_card_common/logging/logging.cc
@@ -22,21 +22,21 @@
 #include <utility>
 
 #ifdef __native_client__
-#include <ppapi/cpp/var.h>
-#include <ppapi/cpp/var_dictionary.h>
 #include <ppapi/cpp/instance.h>
 #include <ppapi/cpp/module.h>
+#include <ppapi/cpp/var.h>
+#include <ppapi/cpp/var_dictionary.h>
 #endif  // __native_client__
-
-const char kTypeMessageKey[] = "type";
-const char kMessageType[] = "log_message";
-const char kDataMessageKey[] = "data";
-const char kDataLogLevelMessageKey[] = "log_level";
-const char kDataTextMessageKey[] = "text";
 
 namespace google_smart_card {
 
 namespace {
+
+constexpr char kTypeMessageKey[] = "type";
+constexpr char kMessageType[] = "log_message";
+constexpr char kDataMessageKey[] = "data";
+constexpr char kDataLogLevelMessageKey[] = "log_level";
+constexpr char kDataTextMessageKey[] = "text";
 
 bool ShouldLogWithSeverity(LogSeverity severity) {
 #ifdef NDEBUG
@@ -66,13 +66,13 @@ std::string StringifyLogSeverity(LogSeverity severity) {
   }
 }
 
-void EmitLogMessageToStderr(
-    LogSeverity severity, const std::string& message_text) {
+void EmitLogMessageToStderr(LogSeverity severity,
+                            const std::string& message_text) {
   // Prepare the whole message in advance, so that we don't mess with other
   // threads writing to std::cerr too.
   std::ostringstream stream;
-  stream << "[NaCl module " << StringifyLogSeverity(severity) << "] " <<
-      message_text << std::endl;
+  stream << "[NaCl module " << StringifyLogSeverity(severity) << "] "
+         << message_text << std::endl;
 
   std::cerr << stream.str();
   std::cerr.flush();
@@ -106,22 +106,19 @@ std::string CleanupLogMessageTextForVar(const std::string& message_text) {
   const char kPlaceholder = '_';
   std::string result = message_text;
   std::replace_if(
-      result.begin(),
-      result.end(),
-      [](char c) {
-        return !std::isprint(static_cast<unsigned char>(c));
-      },
+      result.begin(), result.end(),
+      [](char c) { return !std::isprint(static_cast<unsigned char>(c)); },
       kPlaceholder);
   return result;
 }
 
-void EmitLogMessageToJavaScript(
-    LogSeverity severity, const std::string& message_text) {
+void EmitLogMessageToJavaScript(LogSeverity severity,
+                                const std::string& message_text) {
   pp::VarDictionary message_data;
-  message_data.Set(
-      kDataLogLevelMessageKey, GetGoogLogLevelByLogSeverity(severity));
-  message_data.Set(
-      kDataTextMessageKey, CleanupLogMessageTextForVar(message_text));
+  message_data.Set(kDataLogLevelMessageKey,
+                   GetGoogLogLevelByLogSeverity(severity));
+  message_data.Set(kDataTextMessageKey,
+                   CleanupLogMessageTextForVar(message_text));
   pp::VarDictionary message;
   message.Set(kTypeMessageKey, kMessageType);
   message.Set(kDataMessageKey, message_data);
@@ -133,8 +130,7 @@ void EmitLogMessageToJavaScript(
     for (const std::pair<PP_Instance, pp::Instance*>& instance_map_item :
          pp_instance_map) {
       pp::Instance* const instance = instance_map_item.second;
-      if (instance)
-        instance->PostMessage(message);
+      if (instance) instance->PostMessage(message);
     }
   }
 }
@@ -152,8 +148,7 @@ void EmitLogMessage(LogSeverity severity, const std::string& message_text) {
 
 namespace internal {
 
-LogMessage::LogMessage(LogSeverity severity)
-    : severity_(severity) {}
+LogMessage::LogMessage(LogSeverity severity) : severity_(severity) {}
 
 LogMessage::~LogMessage() {
   if (ShouldLogWithSeverity(severity_)) {
@@ -169,26 +164,22 @@ LogMessage::~LogMessage() {
   }
 }
 
-std::ostringstream& LogMessage::stream() {
-  return stream_;
-}
+std::ostringstream& LogMessage::stream() { return stream_; }
 
-std::string MakeCheckFailedMessage(
-    const std::string& stringified_condition,
-    const std::string& file,
-    int line,
-    const std::string& function) {
+std::string MakeCheckFailedMessage(const std::string& stringified_condition,
+                                   const std::string& file, int line,
+                                   const std::string& function) {
   std::ostringstream stream;
-  stream << "Check \"" << stringified_condition << "\" failed. File \"" <<
-      file << "\", line " << line << ", function \"" << function << "\"";
+  stream << "Check \"" << stringified_condition << "\" failed. File \"" << file
+         << "\", line " << line << ", function \"" << function << "\"";
   return stream.str();
 }
 
-std::string MakeNotreachedHitMessage(
-    const std::string& file, int line, const std::string& function) {
+std::string MakeNotreachedHitMessage(const std::string& file, int line,
+                                     const std::string& function) {
   std::ostringstream stream;
-  stream << "NOTREACHED hit at file \"" << file << "\", line " << line <<
-      ", function \"" << function << "\"";
+  stream << "NOTREACHED hit at file \"" << file << "\", line " << line
+         << ", function \"" << function << "\"";
   return stream.str();
 }
 

--- a/common/cpp/src/google_smart_card_common/logging/logging.h
+++ b/common/cpp/src/google_smart_card_common/logging/logging.h
@@ -34,13 +34,7 @@ namespace google_smart_card {
 // This enumerate contains all supported logging severity levels.
 //
 // The levels are listed in the increasing order of severity.
-enum class LogSeverity {
-  kDebug,
-  kInfo,
-  kWarning,
-  kError,
-  kFatal
-};
+enum class LogSeverity { kDebug, kInfo, kWarning, kError, kFatal };
 
 namespace internal {
 
@@ -48,6 +42,7 @@ class LogMessage final {
  public:
   explicit LogMessage(LogSeverity severity);
   LogMessage(const LogMessage&) = delete;
+  LogMessage& operator=(const LogMessage&) = delete;
   ~LogMessage();
 
   std::ostringstream& stream();
@@ -57,20 +52,17 @@ class LogMessage final {
   std::ostringstream stream_;
 };
 
-std::string MakeCheckFailedMessage(
-    const std::string& stringified_condition,
-    const std::string& file,
-    int line,
-    const std::string& function);
+std::string MakeCheckFailedMessage(const std::string& stringified_condition,
+                                   const std::string& file, int line,
+                                   const std::string& function);
 
-std::string MakeNotreachedHitMessage(
-    const std::string& file, int line, const std::string& function);
+std::string MakeNotreachedHitMessage(const std::string& file, int line,
+                                     const std::string& function);
 
 #define GOOGLE_SMART_CARD_INTERNAL_LOGGING_WITH_SEVERITY(severity) \
-    ::google_smart_card::internal::LogMessage(severity).stream()
+  ::google_smart_card::internal::LogMessage(severity).stream()
 
-#define GOOGLE_SMART_CARD_INTERNAL_LOG_DISABLING \
-    while (false)
+#define GOOGLE_SMART_CARD_INTERNAL_LOG_DISABLING while (false)
 
 }  // namespace internal
 
@@ -82,7 +74,7 @@ std::string MakeNotreachedHitMessage(
 //
 // Logging a message at the FATAL severity level causes the program termination.
 #define GOOGLE_SMART_CARD_LOG(severity) \
-    GOOGLE_SMART_CARD_INTERNAL_LOGGING_WITH_SEVERITY(severity)
+  GOOGLE_SMART_CARD_INTERNAL_LOGGING_WITH_SEVERITY(severity)
 
 //
 // Series of the definitions for printing log messages with different severity
@@ -105,46 +97,46 @@ std::string MakeNotreachedHitMessage(
 //
 
 #ifdef NDEBUG
-#define GOOGLE_SMART_CARD_LOG_DEBUG \
-    GOOGLE_SMART_CARD_INTERNAL_LOG_DISABLING \
-    GOOGLE_SMART_CARD_INTERNAL_LOGGING_WITH_SEVERITY( \
-        ::google_smart_card::LogSeverity::kDebug)
+#define GOOGLE_SMART_CARD_LOG_DEBUG                 \
+  GOOGLE_SMART_CARD_INTERNAL_LOG_DISABLING          \
+  GOOGLE_SMART_CARD_INTERNAL_LOGGING_WITH_SEVERITY( \
+      ::google_smart_card::LogSeverity::kDebug)
 #else
-#define GOOGLE_SMART_CARD_LOG_DEBUG \
-    GOOGLE_SMART_CARD_INTERNAL_LOGGING_WITH_SEVERITY( \
-        ::google_smart_card::LogSeverity::kDebug)
+#define GOOGLE_SMART_CARD_LOG_DEBUG                 \
+  GOOGLE_SMART_CARD_INTERNAL_LOGGING_WITH_SEVERITY( \
+      ::google_smart_card::LogSeverity::kDebug)
 #endif
 
-#define GOOGLE_SMART_CARD_LOG_INFO \
-    GOOGLE_SMART_CARD_INTERNAL_LOGGING_WITH_SEVERITY( \
-        ::google_smart_card::LogSeverity::kInfo)
+#define GOOGLE_SMART_CARD_LOG_INFO                  \
+  GOOGLE_SMART_CARD_INTERNAL_LOGGING_WITH_SEVERITY( \
+      ::google_smart_card::LogSeverity::kInfo)
 
-#define GOOGLE_SMART_CARD_LOG_WARNING \
-    GOOGLE_SMART_CARD_INTERNAL_LOGGING_WITH_SEVERITY( \
-        ::google_smart_card::LogSeverity::kWarning)
+#define GOOGLE_SMART_CARD_LOG_WARNING               \
+  GOOGLE_SMART_CARD_INTERNAL_LOGGING_WITH_SEVERITY( \
+      ::google_smart_card::LogSeverity::kWarning)
 
-#define GOOGLE_SMART_CARD_LOG_ERROR \
-    GOOGLE_SMART_CARD_INTERNAL_LOGGING_WITH_SEVERITY( \
-        ::google_smart_card::LogSeverity::kError)
+#define GOOGLE_SMART_CARD_LOG_ERROR                 \
+  GOOGLE_SMART_CARD_INTERNAL_LOGGING_WITH_SEVERITY( \
+      ::google_smart_card::LogSeverity::kError)
 
-#define GOOGLE_SMART_CARD_LOG_FATAL \
-    GOOGLE_SMART_CARD_INTERNAL_LOGGING_WITH_SEVERITY( \
-        ::google_smart_card::LogSeverity::kFatal)
+#define GOOGLE_SMART_CARD_LOG_FATAL                 \
+  GOOGLE_SMART_CARD_INTERNAL_LOGGING_WITH_SEVERITY( \
+      ::google_smart_card::LogSeverity::kFatal)
 
 // Evaluates the specified condition and, if it has a falsy value, then emits a
 // FATAL message (containing the stringified condition).
 //
 // Usage example:
 //    GOOGLE_SMART_CARD_CHECK(number >= 0);
-#define GOOGLE_SMART_CARD_CHECK(condition) \
-    do { \
-      if (!(condition)) { \
-        GOOGLE_SMART_CARD_LOG_FATAL << \
-            ::google_smart_card::internal::MakeCheckFailedMessage( \
-                #condition, __FILE__, __LINE__, __func__); \
-        std::abort(); \
-      } \
-    } while (false)
+#define GOOGLE_SMART_CARD_CHECK(condition)                          \
+  do {                                                              \
+    if (!(condition)) {                                             \
+      GOOGLE_SMART_CARD_LOG_FATAL                                   \
+          << ::google_smart_card::internal::MakeCheckFailedMessage( \
+                 #condition, __FILE__, __LINE__, __func__);         \
+      std::abort();                                                 \
+    }                                                               \
+  } while (false)
 
 // Emits a FATAL message with the special message.
 //
@@ -158,13 +150,13 @@ std::string MakeNotreachedHitMessage(
 //    if (number % 2 == 1)
 //      return 1;
 //    GOOGLE_SMART_CARD_NOTREACHED;
-#define GOOGLE_SMART_CARD_NOTREACHED \
-    do { \
-      GOOGLE_SMART_CARD_LOG_FATAL << \
-          ::google_smart_card::internal::MakeNotreachedHitMessage( \
-              __FILE__, __LINE__, __func__); \
-      std::abort(); \
-    } while (false)
+#define GOOGLE_SMART_CARD_NOTREACHED                                \
+  do {                                                              \
+    GOOGLE_SMART_CARD_LOG_FATAL                                     \
+        << ::google_smart_card::internal::MakeNotreachedHitMessage( \
+               __FILE__, __LINE__, __func__);                       \
+    std::abort();                                                   \
+  } while (false)
 
 }  // namespace google_smart_card
 

--- a/common/cpp/src/google_smart_card_common/logging/mask_dumping.h
+++ b/common/cpp/src/google_smart_card_common/logging/mask_dumping.h
@@ -27,32 +27,27 @@ namespace google_smart_card {
 template <typename T>
 struct MaskOptionValueWithName {
   MaskOptionValueWithName(T value, const std::string& name)
-      : value(value),
-        name(name) {}
+      : value(value), name(name) {}
 
   T value;
   std::string name;
 };
 
-template <typename T, typename ... Args>
+template <typename T, typename... Args>
 inline std::string DumpMask(
     T value, const std::vector<MaskOptionValueWithName<T>>& options) {
   std::string result;
   for (const auto& option : options) {
-    if (!(value & option.value))
-      continue;
-    if (!result.empty())
-      result += '|';
+    if (!(value & option.value)) continue;
+    if (!result.empty()) result += '|';
     result += option.name;
     value &= ~option.value;
   }
   if (value) {
-    if (!result.empty())
-      result += '|';
+    if (!result.empty()) result += '|';
     result += HexDumpInteger(value);
   }
-  if (result.empty())
-    return "0";
+  if (result.empty()) return "0";
   return result;
 }
 

--- a/common/cpp/src/google_smart_card_common/logging/syslog/syslog.cc
+++ b/common/cpp/src/google_smart_card_common/logging/syslog/syslog.cc
@@ -36,7 +36,11 @@
 #include <google_smart_card_common/formatting.h>
 #include <google_smart_card_common/logging/logging.h>
 
-const char kLoggingPrefix[] = "[syslog] ";
+namespace {
+
+constexpr char kLoggingPrefix[] = "[syslog] ";
+
+}  // namespace
 
 void syslog(int priority, const char* format, ...) {
   va_list var_args;

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message.cc
@@ -19,17 +19,20 @@
 #include <google_smart_card_common/pp_var_utils/construction.h>
 #include <google_smart_card_common/pp_var_utils/extraction.h>
 
-const char kTypeMessageKey[] = "type";
-const char kDataMessageKey[] = "data";
-
 namespace google_smart_card {
 
-bool ParseTypedMessage(
-    const pp::Var& message, std::string* type, pp::Var* data) {
+namespace {
+
+constexpr char kTypeMessageKey[] = "type";
+constexpr char kDataMessageKey[] = "data";
+
+}  // namespace
+
+bool ParseTypedMessage(const pp::Var& message, std::string* type,
+                       pp::Var* data) {
   std::string error_message;
   pp::VarDictionary message_dict;
-  if (!VarAs(message, &message_dict, &error_message))
-    return false;
+  if (!VarAs(message, &message_dict, &error_message)) return false;
   return VarDictValuesExtractor(message_dict)
       .Extract(kTypeMessageKey, type)
       .Extract(kDataMessageKey, data)
@@ -38,7 +41,9 @@ bool ParseTypedMessage(
 
 pp::Var MakeTypedMessage(const std::string& type, const pp::Var& data) {
   return VarDictBuilder()
-      .Add(kTypeMessageKey, type).Add(kDataMessageKey, data).Result();
+      .Add(kTypeMessageKey, type)
+      .Add(kDataMessageKey, data)
+      .Result();
 }
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message.h
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message.h
@@ -33,8 +33,8 @@ namespace google_smart_card {
 
 // Parses the typed message, splitting it into two components: the message type
 // and the message data.
-bool ParseTypedMessage(
-    const pp::Var& message, std::string* type, pp::Var* data);
+bool ParseTypedMessage(const pp::Var& message, std::string* type,
+                       pp::Var* data);
 
 // Creates a typed message having the specified message type and message data.
 pp::Var MakeTypedMessage(const std::string& type, const pp::Var& data);

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_router.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_router.cc
@@ -21,19 +21,23 @@
 
 namespace google_smart_card {
 
+TypedMessageRouter::TypedMessageRouter() = default;
+
+TypedMessageRouter::~TypedMessageRouter() = default;
+
 void TypedMessageRouter::AddRoute(TypedMessageListener* listener) {
   const std::unique_lock<std::mutex> lock(mutex_);
 
-  const bool is_new_route_added = route_map_.emplace(
-      listener->GetListenedMessageType(), listener).second;
+  const bool is_new_route_added =
+      route_map_.emplace(listener->GetListenedMessageType(), listener).second;
   GOOGLE_SMART_CARD_CHECK(is_new_route_added);
 }
 
 void TypedMessageRouter::RemoveRoute(TypedMessageListener* listener) {
   const std::unique_lock<std::mutex> lock(mutex_);
 
-  const auto route_map_iter = route_map_.find(
-      listener->GetListenedMessageType());
+  const auto route_map_iter =
+      route_map_.find(listener->GetListenedMessageType());
   GOOGLE_SMART_CARD_CHECK(route_map_iter != route_map_.end());
   GOOGLE_SMART_CARD_CHECK(route_map_iter->second == listener);
   route_map_.erase(route_map_iter);
@@ -42,12 +46,10 @@ void TypedMessageRouter::RemoveRoute(TypedMessageListener* listener) {
 bool TypedMessageRouter::OnMessageReceived(const pp::Var& message) {
   std::string type;
   pp::Var data;
-  if (!ParseTypedMessage(message, &type, &data))
-    return false;
+  if (!ParseTypedMessage(message, &type, &data)) return false;
 
   TypedMessageListener* const listener = FindListenerByType(type);
-  if (!listener)
-    return false;
+  if (!listener) return false;
 
   return listener->OnTypedMessageReceived(data);
 }
@@ -57,8 +59,7 @@ TypedMessageListener* TypedMessageRouter::FindListenerByType(
   const std::unique_lock<std::mutex> lock(mutex_);
 
   const auto route_map_iter = route_map_.find(message_type);
-  if (route_map_iter == route_map_.end())
-    return nullptr;
+  if (route_map_iter == route_map_.end()) return nullptr;
   return route_map_iter->second;
 }
 

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_router.h
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_router.h
@@ -43,8 +43,10 @@ namespace google_smart_card {
 // called).
 class TypedMessageRouter final : public MessageListener {
  public:
-  TypedMessageRouter() = default;
+  TypedMessageRouter();
   TypedMessageRouter(const TypedMessageRouter&) = delete;
+  TypedMessageRouter& operator=(const TypedMessageRouter&) = delete;
+  ~TypedMessageRouter();
 
   // Adds a new listener, which will handle all messages having the type equal
   // to the GetListenedMessageType return value.

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_router_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_router_unittest.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <google_smart_card_common/messaging/typed_message_router.h>
+
 #include <string>
 #include <thread>
 
@@ -22,15 +24,11 @@
 #include <google_smart_card_common/formatting.h>
 #include <google_smart_card_common/messaging/typed_message.h>
 #include <google_smart_card_common/messaging/typed_message_listener.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
 #include <google_smart_card_common/pp_var_utils/extraction.h>
 
 // Google Mock doesn't provide the C++11 "override" specifier for the mock
 // method definitions
 #pragma GCC diagnostic ignored "-Winconsistent-missing-override"
-
-const char kSampleType1[] = "sample type 1";
-const char kSampleType2[] = "sample type 2";
 
 using testing::_;
 using testing::Eq;
@@ -41,14 +39,15 @@ namespace google_smart_card {
 
 namespace {
 
+constexpr char kSampleType1[] = "sample type 1";
+constexpr char kSampleType2[] = "sample type 2";
+
 class MockTypedMessageListener final : public TypedMessageListener {
  public:
   explicit MockTypedMessageListener(const std::string& message_type)
       : message_type_(message_type) {}
 
-  std::string GetListenedMessageType() const override {
-    return message_type_;
-  }
+  std::string GetListenedMessageType() const override { return message_type_; }
 
   MOCK_METHOD1(OnTypedMessageReceived, bool(const pp::Var&));
 
@@ -72,48 +71,42 @@ TEST(MessagingTypedMessageRouterTest, Basic) {
   MockTypedMessageListener listener_2(kSampleType2);
 
   // Initially, the router contains no route, so no listeners are invoked
-  EXPECT_FALSE(router.OnMessageReceived(MakeTypedMessage(
-      kSampleType1, MakeSampleData(1))));
-  EXPECT_FALSE(router.OnMessageReceived(MakeTypedMessage(
-      kSampleType2, MakeSampleData(2))));
+  EXPECT_FALSE(router.OnMessageReceived(
+      MakeTypedMessage(kSampleType1, MakeSampleData(1))));
+  EXPECT_FALSE(router.OnMessageReceived(
+      MakeTypedMessage(kSampleType2, MakeSampleData(2))));
 
   // After the first listener is registered, it is invoked by the router on the
   // corresponding message receival
   router.AddRoute(&listener_1);
-  EXPECT_CALL(
-      listener_1,
-      OnTypedMessageReceived(
-          ResultOf(GetMessageDataString, Eq(MakeSampleData(3)))))
+  EXPECT_CALL(listener_1, OnTypedMessageReceived(ResultOf(
+                              GetMessageDataString, Eq(MakeSampleData(3)))))
       .WillOnce(Return(true));
-  EXPECT_TRUE(router.OnMessageReceived(MakeTypedMessage(
-      kSampleType1, MakeSampleData(3))));
-  EXPECT_FALSE(router.OnMessageReceived(MakeTypedMessage(
-      kSampleType2, MakeSampleData(4))));
+  EXPECT_TRUE(router.OnMessageReceived(
+      MakeTypedMessage(kSampleType1, MakeSampleData(3))));
+  EXPECT_FALSE(router.OnMessageReceived(
+      MakeTypedMessage(kSampleType2, MakeSampleData(4))));
 
   // When the listener returns false, the router returns false too
-  EXPECT_CALL(
-      listener_1,
-      OnTypedMessageReceived(
-          ResultOf(GetMessageDataString, Eq(MakeSampleData(5)))))
+  EXPECT_CALL(listener_1, OnTypedMessageReceived(ResultOf(
+                              GetMessageDataString, Eq(MakeSampleData(5)))))
       .WillOnce(Return(false));
-  EXPECT_FALSE(router.OnMessageReceived(MakeTypedMessage(
-      kSampleType1, MakeSampleData(5))));
+  EXPECT_FALSE(router.OnMessageReceived(
+      MakeTypedMessage(kSampleType1, MakeSampleData(5))));
 
   // After the second listener is registered, it is invoked by the router on the
   // corresponding message receival
   router.AddRoute(&listener_2);
-  EXPECT_CALL(
-      listener_2,
-      OnTypedMessageReceived(
-          ResultOf(GetMessageDataString, Eq(MakeSampleData(6)))))
+  EXPECT_CALL(listener_2, OnTypedMessageReceived(ResultOf(
+                              GetMessageDataString, Eq(MakeSampleData(6)))))
       .WillOnce(Return(true));
-  EXPECT_TRUE(router.OnMessageReceived(MakeTypedMessage(
-      kSampleType2, MakeSampleData(6))));
+  EXPECT_TRUE(router.OnMessageReceived(
+      MakeTypedMessage(kSampleType2, MakeSampleData(6))));
 
   // After the first listener is removed, it is no more invoked by the router
   router.RemoveRoute(&listener_1);
-  EXPECT_FALSE(router.OnMessageReceived(MakeTypedMessage(
-      kSampleType1, MakeSampleData(7))));
+  EXPECT_FALSE(router.OnMessageReceived(
+      MakeTypedMessage(kSampleType1, MakeSampleData(7))));
 }
 
 TEST(MessagingTypedMessageRouterTest, MultiThreading) {
@@ -122,11 +115,11 @@ TEST(MessagingTypedMessageRouterTest, MultiThreading) {
   TypedMessageRouter router;
 
   MockTypedMessageListener listener_1(kSampleType1);
-  EXPECT_CALL(listener_1, OnTypedMessageReceived(_)).WillRepeatedly(
-      Return(true));
+  EXPECT_CALL(listener_1, OnTypedMessageReceived(_))
+      .WillRepeatedly(Return(true));
   MockTypedMessageListener listener_2(kSampleType2);
-  EXPECT_CALL(listener_2, OnTypedMessageReceived(_)).WillRepeatedly(
-      Return(true));
+  EXPECT_CALL(listener_2, OnTypedMessageReceived(_))
+      .WillRepeatedly(Return(true));
 
   std::thread route_1_operating_thread([&router, &listener_1] {
     for (int iteration = 0; iteration < kIterationCount; ++iteration) {

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_unittest.cc
@@ -12,28 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <google_smart_card_common/messaging/typed_message.h>
+
 #include <string>
 
 #include <gtest/gtest.h>
 #include <ppapi/cpp/var.h>
 #include <ppapi/cpp/var_dictionary.h>
 
-#include <google_smart_card_common/messaging/typed_message.h>
 #include <google_smart_card_common/pp_var_utils/construction.h>
 #include <google_smart_card_common/pp_var_utils/extraction.h>
 
-const char kTypeMessageKey[] = "type";
-const char kDataMessageKey[] = "data";
-const char kSampleType[] = "sample type";
-const char kSampleData[] = "sample value";
-
 namespace google_smart_card {
+
+namespace {
+
+constexpr char kTypeMessageKey[] = "type";
+constexpr char kDataMessageKey[] = "data";
+constexpr char kSampleType[] = "sample type";
+constexpr char kSampleData[] = "sample value";
+
+}  // namespace
 
 TEST(MessagingTypedMessageTest, CorrectTypedMessageParsing) {
   const pp::VarDictionary var = VarDictBuilder()
-      .Add(kTypeMessageKey, kSampleType)
-      .Add(kDataMessageKey, kSampleData)
-      .Result();
+                                    .Add(kTypeMessageKey, kSampleType)
+                                    .Add(kDataMessageKey, kSampleData)
+                                    .Result();
 
   std::string type;
   pp::Var data;
@@ -48,19 +53,16 @@ TEST(MessagingTypedMessageTest, BadTypedMessageParsing) {
   EXPECT_FALSE(ParseTypedMessage(pp::Var(), &type, &data));
   EXPECT_FALSE(ParseTypedMessage(pp::VarDictionary(), &type, &data));
   EXPECT_FALSE(ParseTypedMessage(
-      VarDictBuilder().Add(kTypeMessageKey, kSampleType).Result(),
-      &type,
+      VarDictBuilder().Add(kTypeMessageKey, kSampleType).Result(), &type,
       &data));
   EXPECT_FALSE(ParseTypedMessage(
-      VarDictBuilder().Add(kDataMessageKey, kSampleData).Result(),
-      &type,
+      VarDictBuilder().Add(kDataMessageKey, kSampleData).Result(), &type,
       &data));
-  EXPECT_FALSE(ParseTypedMessage(
-      VarDictBuilder()
-          .Add(kTypeMessageKey, 123)
-          .Add(kDataMessageKey, kSampleData)
-          .Result(),
-      &type, &data));
+  EXPECT_FALSE(ParseTypedMessage(VarDictBuilder()
+                                     .Add(kTypeMessageKey, 123)
+                                     .Add(kDataMessageKey, kSampleData)
+                                     .Result(),
+                                 &type, &data));
 }
 
 TEST(MessagingTypedMessageTest, TypedMessageMaking) {

--- a/common/cpp/src/google_smart_card_common/multi_string.cc
+++ b/common/cpp/src/google_smart_card_common/multi_string.cc
@@ -35,8 +35,7 @@ std::vector<std::string> ExtractMultiStringElements(
 
 }  // namespace
 
-std::string CreateMultiString(
-    const std::vector<std::string>& elements) {
+std::string CreateMultiString(const std::vector<std::string>& elements) {
   std::string result;
   for (const auto& element : elements) {
     GOOGLE_SMART_CARD_CHECK(element.find('\0') == std::string::npos);
@@ -52,15 +51,14 @@ std::vector<std::string> ExtractMultiStringElements(
   GOOGLE_SMART_CARD_CHECK(multi_string.length());
   GOOGLE_SMART_CARD_CHECK(multi_string.back() == '\0');
   const char* multi_string_end;
-  const std::vector<std::string> result = ExtractMultiStringElements(
-      multi_string.c_str(), &multi_string_end);
-  GOOGLE_SMART_CARD_CHECK(
-      multi_string_end == multi_string.c_str() + multi_string.length());
+  const std::vector<std::string> result =
+      ExtractMultiStringElements(multi_string.c_str(), &multi_string_end);
+  GOOGLE_SMART_CARD_CHECK(multi_string_end ==
+                          multi_string.c_str() + multi_string.length());
   return result;
 }
 
-std::vector<std::string> ExtractMultiStringElements(
-    const char* multi_string) {
+std::vector<std::string> ExtractMultiStringElements(const char* multi_string) {
   const char* multi_string_end;
   return ExtractMultiStringElements(multi_string, &multi_string_end);
 }

--- a/common/cpp/src/google_smart_card_common/multi_string.h
+++ b/common/cpp/src/google_smart_card_common/multi_string.h
@@ -30,8 +30,7 @@ std::string CreateMultiString(const std::vector<std::string>& elements);
 std::vector<std::string> ExtractMultiStringElements(
     const std::string& multi_string);
 
-std::vector<std::string> ExtractMultiStringElements(
-    const char* multi_string);
+std::vector<std::string> ExtractMultiStringElements(const char* multi_string);
 
 }  // namespace google_smart_card
 

--- a/common/cpp/src/google_smart_card_common/nacl_io_utils.cc
+++ b/common/cpp/src/google_smart_card_common/nacl_io_utils.cc
@@ -32,15 +32,16 @@ void InitializeNaclIo(const pp::Instance& pp_instance) {
 
   GOOGLE_SMART_CARD_CHECK(!pp_module->core()->IsMainThread());
 
-  GOOGLE_SMART_CARD_CHECK(::nacl_io_init_ppapi(
-      pp_instance.pp_instance(), pp_module->get_browser_interface()) == 0);
+  GOOGLE_SMART_CARD_CHECK(
+      ::nacl_io_init_ppapi(pp_instance.pp_instance(),
+                           pp_module->get_browser_interface()) == 0);
 
   GOOGLE_SMART_CARD_CHECK(::umount("/") == 0);
 
   GOOGLE_SMART_CARD_CHECK(::mount("", "/tmp", "memfs", 0, "") == 0);
 
-  GOOGLE_SMART_CARD_CHECK(::mount(
-      "/", "/crx", "httpfs", 0, "manifest=/nacl_io_manifest.txt") == 0);
+  GOOGLE_SMART_CARD_CHECK(
+      ::mount("/", "/crx", "httpfs", 0, "manifest=/nacl_io_manifest.txt") == 0);
 
   GOOGLE_SMART_CARD_LOG_DEBUG << "[nacl_io] successfully initialized";
 }

--- a/common/cpp/src/google_smart_card_common/numeric_conversions.cc
+++ b/common/cpp/src/google_smart_card_common/numeric_conversions.cc
@@ -21,22 +21,21 @@ namespace google_smart_card {
 namespace internal {
 
 // Definitions of the constants declared in the header file
-const int64_t kDoubleExactRangeMax = 1LL << std::numeric_limits<double>::digits;
-const int64_t kDoubleExactRangeMin = -(1LL <<
-    std::numeric_limits<double>::digits);
+constexpr int64_t kDoubleExactRangeMax =
+    1LL << std::numeric_limits<double>::digits;
+constexpr int64_t kDoubleExactRangeMin =
+    -(1LL << std::numeric_limits<double>::digits);
 
 }  // namespace internal
 
-bool CastDoubleToInt64(
-    double value, int64_t* result, std::string* error_message) {
+bool CastDoubleToInt64(double value, int64_t* result,
+                       std::string* error_message) {
   if (!(internal::kDoubleExactRangeMin <= value &&
         value <= internal::kDoubleExactRangeMax)) {
     *error_message = FormatPrintfTemplate(
         "The real value is outside the exact integer representation range: %f "
         "not in [%" PRId64 "; %" PRId64 "]",
-        value,
-        internal::kDoubleExactRangeMin,
-        internal::kDoubleExactRangeMax);
+        value, internal::kDoubleExactRangeMin, internal::kDoubleExactRangeMax);
     return false;
   }
   *result = static_cast<int64_t>(value);

--- a/common/cpp/src/google_smart_card_common/numeric_conversions.h
+++ b/common/cpp/src/google_smart_card_common/numeric_conversions.h
@@ -44,15 +44,14 @@ extern const int64_t kDoubleExactRangeMin;
 // Performs safe cast of double value into a 64-bit integer value (fails if the
 // value is outside the range of integers that can be represented by the double
 // type exactly).
-bool CastDoubleToInt64(
-    double value, int64_t* result, std::string* error_message);
+bool CastDoubleToInt64(double value, int64_t* result,
+                       std::string* error_message);
 
 namespace internal {
 
 template <typename T>
 inline int GetIntegerSign(T value) {
-  if (!value)
-    return 0;
+  if (!value) return 0;
   return value > 0 ? +1 : -1;
 }
 
@@ -69,13 +68,11 @@ inline int CompareIntegers(T1 value_1, T2 value_2) {
   // numbers.
   const int sign_1 = internal::GetIntegerSign(value_1);
   const int sign_2 = internal::GetIntegerSign(value_2);
-  if (sign_1 != sign_2)
-    return sign_1 < sign_2 ? -1 : +1;
+  if (sign_1 != sign_2) return sign_1 < sign_2 ? -1 : +1;
   using CommonType = typename std::common_type<T1, T2>::type;
   const CommonType promoted_value_1 = static_cast<CommonType>(value_1);
   const CommonType promoted_value_2 = static_cast<CommonType>(value_2);
-  if (promoted_value_1 == promoted_value_2)
-    return 0;
+  if (promoted_value_1 == promoted_value_2) return 0;
   return promoted_value_1 < promoted_value_2 ? -1 : +1;
 }
 
@@ -83,21 +80,18 @@ inline int CompareIntegers(T1 value_1, T2 value_2) {
 // possibly of different type (fails if the value is outside the target type
 // range).
 template <typename T>
-inline bool CastInt64ToInteger(
-    int64_t value,
-    const std::string& type_name,
-    T* result,
-    std::string* error_message) {
+inline bool CastInt64ToInteger(int64_t value, const std::string& type_name,
+                               T* result, std::string* error_message) {
   if (CompareIntegers(std::numeric_limits<T>::min(), value) <= 0 &&
       CompareIntegers(std::numeric_limits<T>::max(), value) >= 0) {
     *result = static_cast<T>(value);
     return true;
   }
   *error_message = FormatPrintfTemplate(
-      "The integer value is outside the range of type \"%s\": %" PRId64 " not "
+      "The integer value is outside the range of type \"%s\": %" PRId64
+      " not "
       "in [%" PRIdMAX "; %" PRIuMAX "] range",
-      type_name.c_str(),
-      value,
+      type_name.c_str(), value,
       static_cast<intmax_t>(std::numeric_limits<T>::min()),
       static_cast<uintmax_t>(std::numeric_limits<T>::max()));
   return false;
@@ -107,8 +101,8 @@ inline bool CastInt64ToInteger(
 // is outside the range of integers that can be represented by the double type
 // exactly).
 template <typename T>
-inline bool CastIntegerToDouble(
-    T value, double* result, std::string* error_message) {
+inline bool CastIntegerToDouble(T value, double* result,
+                                std::string* error_message) {
   if (CompareIntegers(internal::kDoubleExactRangeMin, value) <= 0 &&
       CompareIntegers(internal::kDoubleExactRangeMax, value) >= 0) {
     *result = static_cast<double>(value);
@@ -116,18 +110,17 @@ inline bool CastIntegerToDouble(
   }
   std::string formatted_value;
   if (value >= 0) {
-    formatted_value = FormatPrintfTemplate(
-        "%" PRIuMAX, static_cast<uintmax_t>(value));
+    formatted_value =
+        FormatPrintfTemplate("%" PRIuMAX, static_cast<uintmax_t>(value));
   } else {
-    formatted_value = FormatPrintfTemplate(
-        "%" PRIdMAX, static_cast<intmax_t>(value));
+    formatted_value =
+        FormatPrintfTemplate("%" PRIdMAX, static_cast<intmax_t>(value));
   }
   *error_message = FormatPrintfTemplate(
       "The integer %s cannot be converted into a floating-point double value "
       "without loss of precision: it is outside [%" PRId64 "; %" PRId64
       "] range",
-      formatted_value.c_str(),
-      internal::kDoubleExactRangeMin,
+      formatted_value.c_str(), internal::kDoubleExactRangeMin,
       internal::kDoubleExactRangeMax);
   return false;
 }

--- a/common/cpp/src/google_smart_card_common/numeric_conversions_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/numeric_conversions_unittest.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <google_smart_card_common/numeric_conversions.h>
+
 #include <stdint.h>
 
 #include <limits>
@@ -19,8 +21,6 @@
 #include <vector>
 
 #include <gtest/gtest.h>
-
-#include <google_smart_card_common/numeric_conversions.h>
 
 namespace google_smart_card {
 
@@ -34,16 +34,16 @@ class NumericConversionsDoubleCastingTest : public ::testing::Test {
     std::string error_message;
 
     double double_value = 0;
-    ASSERT_TRUE(CastIntegerToDouble(value, &double_value, &error_message)) <<
-        "Failed to convert integer value " << value << " into double: " <<
-        error_message;
+    ASSERT_TRUE(CastIntegerToDouble(value, &double_value, &error_message))
+        << "Failed to convert integer value " << value
+        << " into double: " << error_message;
     ASSERT_EQ(value, static_cast<NumericType>(double_value));
 
     int64_t int64_value = 0;
-    ASSERT_TRUE(CastDoubleToInt64(
-        double_value, &int64_value, &error_message)) << "Failed to convert " <<
-        "double value " << double_value << " into 64-bit integer: " <<
-        error_message;
+    ASSERT_TRUE(CastDoubleToInt64(double_value, &int64_value, &error_message))
+        << "Failed to convert "
+        << "double value " << double_value
+        << " into 64-bit integer: " << error_message;
     EXPECT_EQ(static_cast<int64_t>(value), int64_value);
   }
 
@@ -52,16 +52,16 @@ class NumericConversionsDoubleCastingTest : public ::testing::Test {
     std::string error_message;
 
     double double_value = 0;
-    EXPECT_FALSE(CastIntegerToDouble(value, &double_value, &error_message)) <<
-        "Unexpectedly successful conversion from integer " << value <<
-        " into double";
+    EXPECT_FALSE(CastIntegerToDouble(value, &double_value, &error_message))
+        << "Unexpectedly successful conversion from integer " << value
+        << " into double";
 
     double_value = static_cast<double>(value);
     int64_t int64_value = 0;
-    EXPECT_FALSE(CastDoubleToInt64(
-        double_value, &int64_value, &error_message)) << "Unexpectedly " <<
-        "successful conversion from double value " << double_value << " into" <<
-        " 64-bit integer";
+    EXPECT_FALSE(CastDoubleToInt64(double_value, &int64_value, &error_message))
+        << "Unexpectedly "
+        << "successful conversion from double value " << double_value << " into"
+        << " 64-bit integer";
   }
 };
 
@@ -93,18 +93,16 @@ TEST_F(NumericConversionsDoubleCastingTest, ValuesOutsideDoubleExactRange) {
 class NumericConversionsInt64ToIntegerCastingTest : public ::testing::Test {
  protected:
   template <typename TargetIntegerType>
-  void TestCasting(
-      int64_t value,
-      const std::string& type_name,
-      bool expected_success) const {
+  void TestCasting(int64_t value, const std::string& type_name,
+                   bool expected_success) const {
     TargetIntegerType result_value;
     std::string error_message;
     ASSERT_EQ(
         expected_success,
-        CastInt64ToInteger(value, type_name, &result_value, &error_message)) <<
-        "Conversion of " << value << " into " << type_name << " type " <<
-        "finished unexpectedly: expected " <<
-        (expected_success ? "successful" : "unsuccessful") << " conversion";
+        CastInt64ToInteger(value, type_name, &result_value, &error_message))
+        << "Conversion of " << value << " into " << type_name << " type "
+        << "finished unexpectedly: expected "
+        << (expected_success ? "successful" : "unsuccessful") << " conversion";
   }
 };
 

--- a/common/cpp/src/google_smart_card_common/optional.h
+++ b/common/cpp/src/google_smart_card_common/optional.h
@@ -52,9 +52,7 @@ class optional final {
   optional(T&& value)  // NOLINT
       : storage_(new T(std::move(value))) {}
 
-  optional& operator=(const optional& other) {
-    return *this = optional(other);
-  }
+  optional& operator=(const optional& other) { return *this = optional(other); }
 
   optional& operator=(optional&& other) = default;
 
@@ -68,47 +66,29 @@ class optional final {
     return storage_.get();
   }
 
-  const T& operator*() const& {
-    return *(operator->());
-  }
+  const T& operator*() const& { return *(operator->()); }
 
-  T& operator*() & {
-    return *(operator->());
-  }
+  T& operator*() & { return *(operator->()); }
 
-  T&& operator*() && {
-    return std::move(operator*());
-  }
+  T&& operator*() && { return std::move(operator*()); }
 
-  explicit operator bool() const {
-    return !!storage_;
-  }
+  explicit operator bool() const { return !!storage_; }
 
-  T& value() & {
-    return operator*();
-  }
+  T& value() & { return operator*(); }
 
-  const T& value() const& {
-    return operator*();
-  }
+  const T& value() const& { return operator*(); }
 
-  T&& value() && {
-    return operator*();
-  }
+  T&& value() && { return operator*(); }
 
   bool operator<(const optional& other) const {
-    if (!*this || !other)
-      return !*this && other;
+    if (!*this || !other) return !*this && other;
     return value() < other.value();
   }
 
-  bool operator>(const optional& other) const {
-    return other < *this;
-  }
+  bool operator>(const optional& other) const { return other < *this; }
 
   bool operator==(const optional& other) const {
-    if (!*this || !other)
-      return !*this == !other;
+    if (!*this || !other) return !*this == !other;
     return value() == other.value();
   }
 

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/construction.cc
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/construction.cc
@@ -51,25 +51,15 @@ bool IsStringValidForVar(const std::string& string) {
 
 }  // namespace
 
-pp::Var MakeVar(unsigned value) {
-  return MakeVarFromInteger(value);
-}
+pp::Var MakeVar(unsigned value) { return MakeVarFromInteger(value); }
 
-pp::Var MakeVar(long value) {
-  return MakeVarFromInteger(value);
-}
+pp::Var MakeVar(long value) { return MakeVarFromInteger(value); }
 
-pp::Var MakeVar(unsigned long value) {
-  return MakeVarFromInteger(value);
-}
+pp::Var MakeVar(unsigned long value) { return MakeVarFromInteger(value); }
 
-pp::Var MakeVar(int64_t value) {
-  return MakeVarFromInteger(value);
-}
+pp::Var MakeVar(int64_t value) { return MakeVarFromInteger(value); }
 
-pp::Var MakeVar(uint64_t value) {
-  return MakeVarFromInteger(value);
-}
+pp::Var MakeVar(uint64_t value) { return MakeVarFromInteger(value); }
 
 pp::Var MakeVar(const std::string& value) {
   GOOGLE_SMART_CARD_CHECK(IsStringValidForVar(value));
@@ -79,17 +69,13 @@ pp::Var MakeVar(const std::string& value) {
 std::string CleanupStringForVar(const std::string& string) {
   const char kPlaceholder = '_';
   std::string result = string;
-  std::replace_if(
-      result.begin(),
-      result.end(),
-      std::not1(std::ptr_fun(IsCharValidForVar)),
-      kPlaceholder);
+  std::replace_if(result.begin(), result.end(),
+                  std::not1(std::ptr_fun(IsCharValidForVar)), kPlaceholder);
   return result;
 }
 
 pp::VarArrayBuffer MakeVarArrayBuffer(const std::vector<uint8_t>& data) {
-  if (data.empty())
-    return pp::VarArrayBuffer();
+  if (data.empty()) return pp::VarArrayBuffer();
   return MakeVarArrayBuffer(&data[0], data.size());
 }
 
@@ -99,5 +85,9 @@ pp::VarArrayBuffer MakeVarArrayBuffer(const void* data, size_t size) {
   result.Unmap();
   return result;
 }
+
+VarDictBuilder::VarDictBuilder() = default;
+
+VarDictBuilder::~VarDictBuilder() = default;
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/construction.h
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/construction.h
@@ -68,8 +68,7 @@ pp::Var MakeVar(const std::string& value);
 
 template <typename T>
 inline pp::Var MakeVar(const optional<T>& value) {
-  if (!value)
-    return pp::Var();
+  if (!value) return pp::Var();
   return MakeVar(*value);
 }
 
@@ -96,15 +95,12 @@ pp::VarArrayBuffer MakeVarArrayBuffer(const void* data, size_t size);
 
 namespace internal {
 
-inline void FillVarArray(
-    pp::VarArray* /*var*/, uint32_t /*current_item_index*/) {}
+inline void FillVarArray(pp::VarArray* /*var*/,
+                         uint32_t /*current_item_index*/) {}
 
-template <typename Arg, typename ... Args>
-inline void FillVarArray(
-    pp::VarArray* var,
-    uint32_t current_item_index,
-    const Arg& arg,
-    const Args& ... args) {
+template <typename Arg, typename... Args>
+inline void FillVarArray(pp::VarArray* var, uint32_t current_item_index,
+                         const Arg& arg, const Args&... args) {
   GOOGLE_SMART_CARD_CHECK(var->Set(current_item_index, MakeVar(arg)));
   FillVarArray(var, current_item_index + 1, args...);
 }
@@ -112,8 +108,8 @@ inline void FillVarArray(
 }  // namespace internal
 
 // Constructs a Pepper array from the list of values of any supported type.
-template <typename ... Args>
-inline pp::VarArray MakeVarArray(const Args& ... args) {
+template <typename... Args>
+inline pp::VarArray MakeVarArray(const Args&... args) {
   pp::VarArray result;
   internal::FillVarArray(&result, 0, args...);
   return result;
@@ -128,8 +124,10 @@ inline pp::VarArray MakeVarArray(const Args& ... args) {
 //        .Result();
 class VarDictBuilder final {
  public:
-  VarDictBuilder() = default;
+  VarDictBuilder();
   VarDictBuilder(const VarDictBuilder&) = delete;
+  VarDictBuilder& operator=(const VarDictBuilder&) = delete;
+  ~VarDictBuilder();
 
   template <typename T>
   VarDictBuilder& Add(const std::string& key, const T& value) {
@@ -138,9 +136,7 @@ class VarDictBuilder final {
     return *this;
   }
 
-  pp::VarDictionary Result() const {
-    return dict_;
-  }
+  pp::VarDictionary Result() const { return dict_; }
 
  private:
   pp::VarDictionary dict_;

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/construction_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/construction_unittest.cc
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <google_smart_card_common/pp_var_utils/construction.h>
+
 #include <string>
 
 #include <gtest/gtest.h>
-
 #include <ppapi/cpp/var.h>
-
-#include <google_smart_card_common/pp_var_utils/construction.h>
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/copying.cc
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/copying.cc
@@ -44,7 +44,8 @@ pp::VarArrayBuffer CopyVarArrayBuffer(pp::VarArrayBuffer var) {
   return result;
 }
 
-pp::VarDictionary CopyVarDictUpToDepth(const pp::VarDictionary& var, int depth) {
+pp::VarDictionary CopyVarDictUpToDepth(const pp::VarDictionary& var,
+                                       int depth) {
   GOOGLE_SMART_CARD_CHECK(depth > 0);
   const pp::VarArray keys = var.GetKeys();
   pp::VarDictionary result;
@@ -58,38 +59,27 @@ pp::VarDictionary CopyVarDictUpToDepth(const pp::VarDictionary& var, int depth) 
 
 pp::Var CopyVarUpToDepth(const pp::Var& var, int depth) {
   GOOGLE_SMART_CARD_CHECK(depth >= 0);
-  if (!depth)
-    return var;
-  if (var.is_undefined())
-    return pp::Var();
-  if (var.is_null())
-    return pp::Var::Null();
-  if (var.is_bool())
-    return var.AsBool();
-  if (var.is_string())
-    return var.AsString();
+  if (!depth) return var;
+  if (var.is_undefined()) return pp::Var();
+  if (var.is_null()) return pp::Var::Null();
+  if (var.is_bool()) return var.AsBool();
+  if (var.is_string()) return var.AsString();
   if (var.is_object())
     GOOGLE_SMART_CARD_LOG_FATAL << "Cannot copy object Pepper value";
-  if (var.is_array())
-    return CopyVarArrayUpToDepth(pp::VarArray(var), depth);
+  if (var.is_array()) return CopyVarArrayUpToDepth(pp::VarArray(var), depth);
   if (var.is_dictionary())
     return CopyVarDictUpToDepth(pp::VarDictionary(var), depth);
   if (var.is_resource())
     GOOGLE_SMART_CARD_LOG_FATAL << "Cannot copy resource Pepper value";
-  if (var.is_int())
-    return var.AsInt();
-  if (var.is_double())
-    return var.AsDouble();
-  if (var.is_array_buffer())
-    return CopyVarArrayBuffer(pp::VarArrayBuffer(var));
+  if (var.is_int()) return var.AsInt();
+  if (var.is_double()) return var.AsDouble();
+  if (var.is_array_buffer()) return CopyVarArrayBuffer(pp::VarArrayBuffer(var));
   GOOGLE_SMART_CARD_NOTREACHED;
 }
 
 }  // namespace
 
-pp::Var ShallowCopyVar(const pp::Var& var) {
-  return CopyVarUpToDepth(var, 1);
-}
+pp::Var ShallowCopyVar(const pp::Var& var) { return CopyVarUpToDepth(var, 1); }
 
 pp::VarArray ShallowCopyVar(const pp::VarArray& var) {
   return CopyVarArrayUpToDepth(var, 1);

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/debug_dump.cc
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/debug_dump.cc
@@ -39,36 +39,23 @@ const char kRealJsTypeTitle[] = "Real";
 const char kArrayBufferJsTypeTitle[] = "ArrayBuffer";
 
 std::string GetVarTypeTitle(const pp::Var& var) {
-  if (var.is_undefined())
-    return kUndefinedJsTypeTitle;
-  if (var.is_null())
-    return kNullJsTypeTitle;
-  if (var.is_bool())
-    return kBooleanJsTypeTitle;
-  if (var.is_string())
-    return kStringJsTypeTitle;
-  if (var.is_object())
-    return kObjectJsTypeTitle;
-  if (var.is_array())
-    return kArrayJsTypeTitle;
-  if (var.is_dictionary())
-    return kDictionaryJsTypeTitle;
-  if (var.is_resource())
-    return kResourceJsTypeTitle;
-  if (var.is_int())
-    return kIntegerJsTypeTitle;
-  if (var.is_double())
-    return kRealJsTypeTitle;
-  if (var.is_array_buffer())
-    return kArrayBufferJsTypeTitle;
+  if (var.is_undefined()) return kUndefinedJsTypeTitle;
+  if (var.is_null()) return kNullJsTypeTitle;
+  if (var.is_bool()) return kBooleanJsTypeTitle;
+  if (var.is_string()) return kStringJsTypeTitle;
+  if (var.is_object()) return kObjectJsTypeTitle;
+  if (var.is_array()) return kArrayJsTypeTitle;
+  if (var.is_dictionary()) return kDictionaryJsTypeTitle;
+  if (var.is_resource()) return kResourceJsTypeTitle;
+  if (var.is_int()) return kIntegerJsTypeTitle;
+  if (var.is_double()) return kRealJsTypeTitle;
+  if (var.is_array_buffer()) return kArrayBufferJsTypeTitle;
   GOOGLE_SMART_CARD_NOTREACHED;
 }
 
 namespace {
 
-std::string DumpBoolValue(bool value) {
-  return value ? "true" : "false";
-}
+std::string DumpBoolValue(bool value) { return value ? "true" : "false"; }
 
 std::string DumpStringValue(const std::string& value) {
   return '"' + value + '"';
@@ -77,8 +64,7 @@ std::string DumpStringValue(const std::string& value) {
 std::string DumpVarArrayValue(const pp::VarArray& var) {
   std::string result = "[";
   for (uint32_t index = 0; index < var.GetLength(); ++index) {
-    if (index > 0)
-      result += ", ";
+    if (index > 0) result += ", ";
     result += DumpVar(var.Get(index));
   }
   result += "]";
@@ -89,8 +75,7 @@ std::string DumpVarDictValue(const pp::VarDictionary& var) {
   std::string result = "{";
   const pp::VarArray keys = var.GetKeys();
   for (uint32_t index = 0; index < keys.GetLength(); ++index) {
-    if (index > 0)
-      result += ", ";
+    if (index > 0) result += ", ";
     const pp::Var key = keys.Get(index);
     GOOGLE_SMART_CARD_CHECK(key.is_string());
     result += DumpStringValue(key.AsString()) + ": " + DumpVar(var.Get(key));
@@ -103,8 +88,7 @@ std::string DumpVarArrayBufferValue(pp::VarArrayBuffer var) {
   const uint8_t* const data = static_cast<const uint8_t*>(var.Map());
   std::string result = std::string(kArrayBufferJsTypeTitle) + "[";
   for (uint32_t offset = 0; offset < var.ByteLength(); ++offset) {
-    if (offset > 0)
-      result += ", ";
+    if (offset > 0) result += ", ";
     result += HexDumpByte(data[offset]);
   }
   result += "]";
@@ -123,26 +107,17 @@ std::string DebugDumpVar(const pp::Var& var) {
 }
 
 std::string DumpVar(const pp::Var& var) {
-  if (var.is_undefined())
-    return kUndefinedJsTypeTitle;
-  if (var.is_null())
-    return kNullJsTypeTitle;
-  if (var.is_bool())
-    return DumpBoolValue(var.AsBool());
-  if (var.is_string())
-    return DumpStringValue(var.AsString());
-  if (var.is_object())
-    return std::string(kObjectJsTypeTitle) + "<...>";
-  if (var.is_array())
-    return DumpVarArrayValue(pp::VarArray(var));
-  if (var.is_dictionary())
-    return DumpVarDictValue(pp::VarDictionary(var));
-  if (var.is_resource())
-    return std::string(kResourceJsTypeTitle) + "<...>";
+  if (var.is_undefined()) return kUndefinedJsTypeTitle;
+  if (var.is_null()) return kNullJsTypeTitle;
+  if (var.is_bool()) return DumpBoolValue(var.AsBool());
+  if (var.is_string()) return DumpStringValue(var.AsString());
+  if (var.is_object()) return std::string(kObjectJsTypeTitle) + "<...>";
+  if (var.is_array()) return DumpVarArrayValue(pp::VarArray(var));
+  if (var.is_dictionary()) return DumpVarDictValue(pp::VarDictionary(var));
+  if (var.is_resource()) return std::string(kResourceJsTypeTitle) + "<...>";
   if (var.is_int())
     return HexDumpUnknownSizeInteger(static_cast<int64_t>(var.AsInt()));
-  if (var.is_double())
-    return std::to_string(var.AsDouble());
+  if (var.is_double()) return std::to_string(var.AsDouble());
   if (var.is_array_buffer())
     return DumpVarArrayBufferValue(pp::VarArrayBuffer(var));
   GOOGLE_SMART_CARD_NOTREACHED;

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/enum_converter_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/enum_converter_unittest.cc
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <google_smart_card_common/pp_var_utils/enum_converter.h>
+
 #include <string>
 
 #include <gtest/gtest.h>
-
 #include <ppapi/cpp/var.h>
 
-#include <google_smart_card_common/pp_var_utils/enum_converter.h>
 #include <google_smart_card_common/pp_var_utils/extraction.h>
 
 namespace google_smart_card {
@@ -49,14 +49,12 @@ void TestEnumStringConverter::VisitCorrespondingPairs(Callback callback) {
 }
 
 TEST(PpVarUtilsEnumConverterTest, EnumToStringConversion) {
-  EXPECT_EQ(
-      "test_value_1",
-      VarAs<std::string>(TestEnumStringConverter::ConvertToVar(
-          TestEnum::kTestValue1)));
-  EXPECT_EQ(
-      "test_value_2",
-      VarAs<std::string>(TestEnumStringConverter::ConvertToVar(
-          TestEnum::kTestValue2)));
+  EXPECT_EQ("test_value_1",
+            VarAs<std::string>(
+                TestEnumStringConverter::ConvertToVar(TestEnum::kTestValue1)));
+  EXPECT_EQ("test_value_2",
+            VarAs<std::string>(
+                TestEnumStringConverter::ConvertToVar(TestEnum::kTestValue2)));
 }
 
 TEST(PpVarUtilsEnumConverterTest, EnumFromStringConversion) {

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/extraction.cc
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/extraction.cc
@@ -18,19 +18,16 @@
 
 #include <google_smart_card_common/numeric_conversions.h>
 
-const char kErrorWrongType[] =
-    "Expected a value of type \"%s\", instead got: %s";
-
 namespace google_smart_card {
 
 namespace {
 
+constexpr char kErrorWrongType[] =
+    "Expected a value of type \"%s\", instead got: %s";
+
 template <typename T>
-bool VarAsInteger(
-    const pp::Var& var,
-    const std::string& type_name,
-    T* result,
-    std::string* error_message) {
+bool VarAsInteger(const pp::Var& var, const std::string& type_name, T* result,
+                  std::string* error_message) {
   int64_t integer;
   if (var.is_int()) {
     integer = var.AsInt();
@@ -38,8 +35,8 @@ bool VarAsInteger(
     if (!CastDoubleToInt64(var.AsDouble(), &integer, error_message))
       return false;
   } else {
-    *error_message = FormatPrintfTemplate(
-        kErrorWrongType, kIntegerJsTypeTitle, DebugDumpVar(var).c_str());
+    *error_message = FormatPrintfTemplate(kErrorWrongType, kIntegerJsTypeTitle,
+                                          DebugDumpVar(var).c_str());
     return false;
   }
   return CastInt64ToInteger(integer, type_name, result, error_message);
@@ -83,23 +80,22 @@ bool VarAs(const pp::Var& var, long* result, std::string* error_message) {
   return VarAsInteger(var, "long", result, error_message);
 }
 
-bool VarAs(
-    const pp::Var& var, unsigned long* result, std::string* error_message) {
+bool VarAs(const pp::Var& var, unsigned long* result,
+           std::string* error_message) {
   return VarAsInteger(var, "unsigned long", result, error_message);
 }
 
 bool VarAs(const pp::Var& var, float* result, std::string* error_message) {
   double double_value;
-  if (!VarAs(var, &double_value, error_message))
-    return false;
+  if (!VarAs(var, &double_value, error_message)) return false;
   *result = static_cast<float>(double_value);
   return true;
 }
 
 bool VarAs(const pp::Var& var, double* result, std::string* error_message) {
   if (!var.is_number()) {
-    *error_message = FormatPrintfTemplate(
-        kErrorWrongType, kIntegerJsTypeTitle, DebugDumpVar(var).c_str());
+    *error_message = FormatPrintfTemplate(kErrorWrongType, kIntegerJsTypeTitle,
+                                          DebugDumpVar(var).c_str());
     return false;
   }
   *result = var.AsDouble();
@@ -108,46 +104,44 @@ bool VarAs(const pp::Var& var, double* result, std::string* error_message) {
 
 bool VarAs(const pp::Var& var, bool* result, std::string* error_message) {
   if (!var.is_bool()) {
-    *error_message = FormatPrintfTemplate(
-        kErrorWrongType, kBooleanJsTypeTitle, DebugDumpVar(var).c_str());
+    *error_message = FormatPrintfTemplate(kErrorWrongType, kBooleanJsTypeTitle,
+                                          DebugDumpVar(var).c_str());
     return false;
   }
   *result = var.AsBool();
   return true;
 }
 
-bool VarAs(
-    const pp::Var& var, std::string* result, std::string* error_message) {
+bool VarAs(const pp::Var& var, std::string* result,
+           std::string* error_message) {
   if (!var.is_string()) {
-    *error_message = FormatPrintfTemplate(
-        kErrorWrongType, kStringJsTypeTitle, DebugDumpVar(var).c_str());
+    *error_message = FormatPrintfTemplate(kErrorWrongType, kStringJsTypeTitle,
+                                          DebugDumpVar(var).c_str());
     return false;
   }
   *result = var.AsString();
   return true;
 }
 
-bool VarAs(
-    const pp::Var& var, pp::Var* result, std::string* /*error_message*/) {
+bool VarAs(const pp::Var& var, pp::Var* result,
+           std::string* /*error_message*/) {
   *result = var;
   return true;
 }
 
-bool VarAs(
-    const pp::Var& var, pp::VarArray* result, std::string* error_message) {
+bool VarAs(const pp::Var& var, pp::VarArray* result,
+           std::string* error_message) {
   if (!var.is_array()) {
-    *error_message = FormatPrintfTemplate(
-        kErrorWrongType, kArrayJsTypeTitle, DebugDumpVar(var).c_str());
+    *error_message = FormatPrintfTemplate(kErrorWrongType, kArrayJsTypeTitle,
+                                          DebugDumpVar(var).c_str());
     return false;
   }
   *result = pp::VarArray(var);
   return true;
 }
 
-bool VarAs(
-    const pp::Var& var,
-    pp::VarArrayBuffer* result,
-    std::string* error_message) {
+bool VarAs(const pp::Var& var, pp::VarArrayBuffer* result,
+           std::string* error_message) {
   if (!var.is_array_buffer()) {
     *error_message = FormatPrintfTemplate(
         kErrorWrongType, kArrayBufferJsTypeTitle, DebugDumpVar(var).c_str());
@@ -157,8 +151,8 @@ bool VarAs(
   return true;
 }
 
-bool VarAs(
-    const pp::Var& var, pp::VarDictionary* result, std::string* error_message) {
+bool VarAs(const pp::Var& var, pp::VarDictionary* result,
+           std::string* error_message) {
   if (!var.is_dictionary()) {
     *error_message = FormatPrintfTemplate(
         kErrorWrongType, kDictionaryJsTypeTitle, DebugDumpVar(var).c_str());
@@ -168,11 +162,11 @@ bool VarAs(
   return true;
 }
 
-bool VarAs(
-    const pp::Var& var, pp::Var::Null* /*result*/, std::string* error_message) {
+bool VarAs(const pp::Var& var, pp::Var::Null* /*result*/,
+           std::string* error_message) {
   if (!var.is_null()) {
-    *error_message = FormatPrintfTemplate(
-        kErrorWrongType, kNullJsTypeTitle, DebugDumpVar(var).c_str());
+    *error_message = FormatPrintfTemplate(kErrorWrongType, kNullJsTypeTitle,
+                                          DebugDumpVar(var).c_str());
     return false;
   }
   return true;
@@ -199,14 +193,11 @@ int GetVarArraySize(const pp::VarArray& var) {
   return static_cast<int>(var.GetLength());
 }
 
-bool GetVarDictValue(
-    const pp::VarDictionary& var,
-    const std::string& key,
-    pp::Var* result,
-    std::string* error_message) {
+bool GetVarDictValue(const pp::VarDictionary& var, const std::string& key,
+                     pp::Var* result, std::string* error_message) {
   if (!var.HasKey(key)) {
-    *error_message = FormatPrintfTemplate(
-        "The dictionary has no key \"%s\"", key.c_str());
+    *error_message =
+        FormatPrintfTemplate("The dictionary has no key \"%s\"", key.c_str());
     return false;
   }
   *result = var.Get(key);
@@ -222,10 +213,9 @@ pp::Var GetVarDictValue(const pp::VarDictionary& var, const std::string& key) {
 }
 
 VarDictValuesExtractor::VarDictValuesExtractor(const pp::VarDictionary& var)
-    : var_(var),
-      failed_(false) {
-  const std::vector<std::string> keys = VarAs<std::vector<std::string>>(
-      var_.GetKeys());
+    : var_(var) {
+  const std::vector<std::string> keys =
+      VarAs<std::vector<std::string>>(var_.GetKeys());
   not_requested_keys_.insert(keys.begin(), keys.end());
 }
 
@@ -239,18 +229,16 @@ bool VarDictValuesExtractor::GetSuccess(std::string* error_message) const {
 
 bool VarDictValuesExtractor::GetSuccessWithNoExtraKeysAllowed(
     std::string* error_message) const {
-  if (!GetSuccess(error_message))
-    return false;
+  if (!GetSuccess(error_message)) return false;
   if (!not_requested_keys_.empty()) {
     std::string unexpected_keys_dump;
     for (const std::string& key : not_requested_keys_) {
-      if (!unexpected_keys_dump.empty())
-        unexpected_keys_dump += ", ";
+      if (!unexpected_keys_dump.empty()) unexpected_keys_dump += ", ";
       unexpected_keys_dump += '"' + key + '"';
     }
-    *error_message = FormatPrintfTemplate(
-        "The dictionary contains unexpected keys: %s",
-        unexpected_keys_dump.c_str());
+    *error_message =
+        FormatPrintfTemplate("The dictionary contains unexpected keys: %s",
+                             unexpected_keys_dump.c_str());
     return false;
   }
   return true;
@@ -258,8 +246,7 @@ bool VarDictValuesExtractor::GetSuccessWithNoExtraKeysAllowed(
 
 void VarDictValuesExtractor::CheckSuccess() const {
   std::string error_message;
-  if (!GetSuccess(&error_message))
-    GOOGLE_SMART_CARD_LOG_FATAL << error_message;
+  if (!GetSuccess(&error_message)) GOOGLE_SMART_CARD_LOG_FATAL << error_message;
 }
 
 void VarDictValuesExtractor::CheckSuccessWithNoExtraKeysAllowed() const {
@@ -280,8 +267,7 @@ void VarDictValuesExtractor::ProcessFailedExtraction(
     return;
   }
   error_message_ = FormatPrintfTemplate(
-      "Failed to extract the dictionary value with key \"%s\": %s",
-      key.c_str(),
+      "Failed to extract the dictionary value with key \"%s\": %s", key.c_str(),
       extraction_error_message.c_str());
   failed_ = true;
 }

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/extraction.h
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/extraction.h
@@ -24,6 +24,7 @@
 
 #include <inttypes.h>
 #include <stdint.h>
+
 #include <set>
 #include <string>
 #include <vector>
@@ -75,8 +76,8 @@ bool VarAs(const pp::Var& var, uint64_t* result, std::string* error_message);
 
 bool VarAs(const pp::Var& var, long* result, std::string* error_message);
 
-bool VarAs(
-    const pp::Var& var, unsigned long* result, std::string* error_message);
+bool VarAs(const pp::Var& var, unsigned long* result,
+           std::string* error_message);
 
 bool VarAs(const pp::Var& var, float* result, std::string* error_message);
 
@@ -88,28 +89,27 @@ bool VarAs(const pp::Var& var, std::string* result, std::string* error_message);
 
 bool VarAs(const pp::Var& var, pp::Var* result, std::string* error_message);
 
-bool VarAs(
-    const pp::Var& var, pp::VarArray* result, std::string* error_message);
+bool VarAs(const pp::Var& var, pp::VarArray* result,
+           std::string* error_message);
 
-bool VarAs(
-    const pp::Var& var, pp::VarArrayBuffer* result, std::string* error_message);
+bool VarAs(const pp::Var& var, pp::VarArrayBuffer* result,
+           std::string* error_message);
 
-bool VarAs(
-    const pp::Var& var, pp::VarDictionary* result, std::string* error_message);
+bool VarAs(const pp::Var& var, pp::VarDictionary* result,
+           std::string* error_message);
 
-bool VarAs(
-    const pp::Var& var, pp::Var::Null* result, std::string* error_message);
+bool VarAs(const pp::Var& var, pp::Var::Null* result,
+           std::string* error_message);
 
 template <typename T>
-inline bool VarAs(
-    const pp::Var& var, optional<T>* result, std::string* error_message) {
+inline bool VarAs(const pp::Var& var, optional<T>* result,
+                  std::string* error_message) {
   if (var.is_undefined() || var.is_null()) {
     *result = optional<T>();
     return true;
   }
   T result_value;
-  if (!VarAs(var, &result_value, error_message))
-    return false;
+  if (!VarAs(var, &result_value, error_message)) return false;
   *result = result_value;
   return true;
 }
@@ -117,16 +117,14 @@ inline bool VarAs(
 namespace internal {
 
 template <typename T>
-inline bool GetVarArrayItemsVector(
-    const pp::VarArray& var,
-    std::vector<T>* result,
-    std::string* error_message) {
+inline bool GetVarArrayItemsVector(const pp::VarArray& var,
+                                   std::vector<T>* result,
+                                   std::string* error_message) {
   result->resize(var.GetLength());
   for (uint32_t index = 0; index < var.GetLength(); ++index) {
     if (!VarAs(var.Get(index), &(*result)[index], error_message)) {
       *error_message = FormatPrintfTemplate(
-          "Failed to extract the array item with index %" PRIu32 ": %s",
-          index,
+          "Failed to extract the array item with index %" PRIu32 ": %s", index,
           error_message->c_str());
       return false;
     }
@@ -135,20 +133,18 @@ inline bool GetVarArrayItemsVector(
 }
 
 template <typename T>
-inline bool VarAsVarArrayAsVector(
-    const pp::Var& var, std::vector<T>* result, std::string* error_message) {
+inline bool VarAsVarArrayAsVector(const pp::Var& var, std::vector<T>* result,
+                                  std::string* error_message) {
   pp::VarArray var_array;
-  if (!VarAs(var, &var_array, error_message))
-    return false;
+  if (!VarAs(var, &var_array, error_message)) return false;
   return GetVarArrayItemsVector(var_array, result, error_message);
 }
 
 std::vector<uint8_t> GetVarArrayBufferData(pp::VarArrayBuffer var);
 
-inline bool VarAsVarArrayBufferAsUint8Vector(
-    const pp::Var& var,
-    std::vector<uint8_t>* result,
-    std::string* error_message) {
+inline bool VarAsVarArrayBufferAsUint8Vector(const pp::Var& var,
+                                             std::vector<uint8_t>* result,
+                                             std::string* error_message) {
   pp::VarArrayBuffer var_array_buffer;
   if (!VarAs(var, &var_array_buffer, error_message)) {
     *error_message = FormatPrintfTemplate(
@@ -163,16 +159,14 @@ inline bool VarAsVarArrayBufferAsUint8Vector(
 }  // namespace internal
 
 template <typename T>
-inline bool VarAs(
-    const pp::Var& var, std::vector<T>* result, std::string* error_message) {
+inline bool VarAs(const pp::Var& var, std::vector<T>* result,
+                  std::string* error_message) {
   return internal::VarAsVarArrayAsVector(var, result, error_message);
 }
 
 template <>
-inline bool VarAs(
-    const pp::Var& var,
-    std::vector<uint8_t>* result,
-    std::string* error_message) {
+inline bool VarAs(const pp::Var& var, std::vector<uint8_t>* result,
+                  std::string* error_message) {
   return internal::VarAsVarArrayAsVector(var, result, error_message) ||
          internal::VarAsVarArrayBufferAsUint8Vector(var, result, error_message);
 }
@@ -199,11 +193,8 @@ int GetVarArraySize(const pp::VarArray& var);
 // Extracts the value from the Pepper dictionary by the given key.
 //
 // Returns false (and sets error_message) if the requested key is not present.
-bool GetVarDictValue(
-    const pp::VarDictionary& var,
-    const std::string& key,
-    pp::Var* result,
-    std::string* error_message);
+bool GetVarDictValue(const pp::VarDictionary& var, const std::string& key,
+                     pp::Var* result, std::string* error_message);
 
 // Extracts the value from the dictionary by the given key.
 //
@@ -218,11 +209,9 @@ pp::Var GetVarDictValue(const pp::VarDictionary& var, const std::string& key);
 // Returns false (and sets error_message) if the requested key is not present or
 // if the value conversion didn't succeed.
 template <typename T>
-inline bool GetVarDictValueAs(
-    const pp::VarDictionary& var,
-    const std::string& key,
-    T* result,
-    std::string* error_message) {
+inline bool GetVarDictValueAs(const pp::VarDictionary& var,
+                              const std::string& key, T* result,
+                              std::string* error_message) {
   pp::Var value_var;
   if (!GetVarDictValue(var, key, &value_var, error_message)) {
     *error_message = FormatPrintfTemplate(
@@ -241,8 +230,8 @@ inline bool GetVarDictValueAs(
 // Asserts that the request key is present and that the value conversion
 // succeeded.
 template <typename T>
-inline T GetVarDictValueAs(
-    const pp::VarDictionary& var, const std::string& key) {
+inline T GetVarDictValueAs(const pp::VarDictionary& var,
+                           const std::string& key) {
   T result;
   std::string error_message;
   if (!GetVarDictValueAs(var, key, &result, &error_message))
@@ -252,14 +241,11 @@ inline T GetVarDictValueAs(
 
 namespace internal {
 
-inline bool IsVarArraySizeValid(
-    const pp::VarArray& var,
-    size_t expected_size,
-    std::string* error_message) {
+inline bool IsVarArraySizeValid(const pp::VarArray& var, size_t expected_size,
+                                std::string* error_message) {
   if (var.GetLength() != expected_size) {
     *error_message = FormatPrintfTemplate(
-        "Expected an array of size %zu, instead got: %" PRIu32,
-        expected_size,
+        "Expected an array of size %zu, instead got: %" PRIu32, expected_size,
         var.GetLength());
     return false;
   }
@@ -268,38 +254,34 @@ inline bool IsVarArraySizeValid(
 
 }  // namespace internal
 
-inline bool TryGetVarArrayItemsInternal(
-    const pp::VarArray& /*var*/,
-    uint32_t /*current_item_index*/,
-    std::string* /*error_message*/) {
+inline bool TryGetVarArrayItemsInternal(const pp::VarArray& /*var*/,
+                                        uint32_t /*current_item_index*/,
+                                        std::string* /*error_message*/) {
   return true;
 }
 
-template <typename Arg, typename ... Args>
-inline bool TryGetVarArrayItemsInternal(
-    const pp::VarArray& var,
-    uint32_t current_item_index,
-    std::string* error_message,
-    Arg* arg,
-    Args* ... args) {
+template <typename Arg, typename... Args>
+inline bool TryGetVarArrayItemsInternal(const pp::VarArray& var,
+                                        uint32_t current_item_index,
+                                        std::string* error_message, Arg* arg,
+                                        Args*... args) {
   if (!VarAs(var.Get(current_item_index), arg, error_message)) {
     *error_message = FormatPrintfTemplate(
         "Failed to extract the array item with index %" PRIu32 ": %s",
-        current_item_index,
-        error_message->c_str());
+        current_item_index, error_message->c_str());
     return false;
   }
-  return TryGetVarArrayItemsInternal(
-      var, current_item_index + 1, error_message, args...);
+  return TryGetVarArrayItemsInternal(var, current_item_index + 1, error_message,
+                                     args...);
 }
 
 // Extracts the items of the Pepper array into the passed value sequence.
 //
 // Returns false (and sets error_message) if the array has a different length or
 // if some value conversion didn't succeed.
-template <typename ... Args>
-inline bool TryGetVarArrayItems(
-    const pp::VarArray& var, std::string* error_message, Args* ... args) {
+template <typename... Args>
+inline bool TryGetVarArrayItems(const pp::VarArray& var,
+                                std::string* error_message, Args*... args) {
   return internal::IsVarArraySizeValid(var, sizeof...(Args), error_message) &&
          TryGetVarArrayItemsInternal(var, 0, error_message, args...);
 }
@@ -308,8 +290,8 @@ inline bool TryGetVarArrayItems(
 //
 // Asserts that the array has the desired length and that all values conversion
 // succeeded.
-template <typename ... Args>
-inline void GetVarArrayItems(const pp::VarArray& var, Args* ... args) {
+template <typename... Args>
+inline void GetVarArrayItems(const pp::VarArray& var, Args*... args) {
   std::string error_message;
   if (!TryGetVarArrayItems(var, &error_message, args...))
     GOOGLE_SMART_CARD_LOG_FATAL << error_message;
@@ -353,8 +335,8 @@ class VarDictValuesExtractor final {
   //
   // Returns *this to simplify coding by allowing chaining of multiple calls.
   template <typename T>
-  VarDictValuesExtractor& TryExtractOptional(
-      const std::string& key, optional<T>* result) {
+  VarDictValuesExtractor& TryExtractOptional(const std::string& key,
+                                             optional<T>* result) {
     std::string extraction_error_message;
     pp::Var var_value;
     if (!GetVarDictValue(var_, key, &var_value, &extraction_error_message)) {
@@ -384,12 +366,12 @@ class VarDictValuesExtractor final {
  private:
   void AddRequestedKey(const std::string& key);
 
-  void ProcessFailedExtraction(
-      const std::string& key, const std::string& extraction_error_message);
+  void ProcessFailedExtraction(const std::string& key,
+                               const std::string& extraction_error_message);
 
   const pp::VarDictionary var_;
   std::set<std::string> not_requested_keys_;
-  bool failed_;
+  bool failed_ = false;
   std::string error_message_;
 };
 

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/operations.cc
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/operations.cc
@@ -16,8 +16,8 @@
 
 namespace google_smart_card {
 
-pp::VarArray SliceVarArray(
-    const pp::VarArray& var, uint32_t begin_index, uint32_t count) {
+pp::VarArray SliceVarArray(const pp::VarArray& var, uint32_t begin_index,
+                           uint32_t count) {
   GOOGLE_SMART_CARD_CHECK(begin_index + count <= var.GetLength());
   pp::VarArray result;
   result.SetLength(count);

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/operations.h
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/operations.h
@@ -43,8 +43,8 @@ inline void SetVarArrayItem(pp::VarArray* var, size_t index, const T& value) {
 // Returns a sub-array of the given Pepper array.
 //
 // Asserts the validity of the specified indices.
-pp::VarArray SliceVarArray(
-  const pp::VarArray& var, uint32_t begin_index, uint32_t count);
+pp::VarArray SliceVarArray(const pp::VarArray& var, uint32_t begin_index,
+                           uint32_t count);
 
 // Adds or updates the Pepper dictionary item.
 //
@@ -52,8 +52,8 @@ pp::VarArray SliceVarArray(
 // conversion of the passed value into the Pepper value (using the MakeVar
 // function in construction.h file).
 template <typename T>
-inline void SetVarDictValue(
-    pp::VarDictionary* var, const std::string& key, const T& value) {
+inline void SetVarDictValue(pp::VarDictionary* var, const std::string& key,
+                            const T& value) {
   GOOGLE_SMART_CARD_CHECK(var->Set(key, MakeVar(value)));
 }
 
@@ -64,8 +64,8 @@ inline void SetVarDictValue(
 // conversion of the passed value into the Pepper value (using the MakeVar
 // function in construction.h file).
 template <typename T>
-inline void AddVarDictValue(
-    pp::VarDictionary* var, const std::string& key, const T& value) {
+inline void AddVarDictValue(pp::VarDictionary* var, const std::string& key,
+                            const T& value) {
   GOOGLE_SMART_CARD_CHECK(!var->HasKey(key));
   SetVarDictValue(var, key, value);
 }

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/struct_converter.h
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/struct_converter.h
@@ -59,13 +59,12 @@ class StructConverter final {
   // Fails if the Pepper value is not a dictionary, or if it contains some
   // unexpected extra keys, or if at least one key corresponding to a
   // non-optional field is missing.
-  static bool ConvertFromVar(
-      const pp::Var& var, StructType* result, std::string* error_message) {
+  static bool ConvertFromVar(const pp::Var& var, StructType* result,
+                             std::string* error_message) {
     GOOGLE_SMART_CARD_CHECK(result);
     GOOGLE_SMART_CARD_CHECK(error_message);
     pp::VarDictionary var_dict;
-    if (!VarAs(var, &var_dict, error_message))
-      return false;
+    if (!VarAs(var, &var_dict, error_message)) return false;
     VarDictValuesExtractor extractor(var_dict);
     VisitFields(*result, FromVarConversionCallback(&extractor));
     return extractor.GetSuccessWithNoExtraKeysAllowed(error_message);
@@ -99,6 +98,11 @@ class StructConverter final {
         : target_var_(target_var) {
       GOOGLE_SMART_CARD_CHECK(target_var_);
     }
+    ToVarConversionCallback(const ToVarConversionCallback&) = delete;
+    ToVarConversionCallback& operator=(const ToVarConversionCallback&) = delete;
+    ToVarConversionCallback(ToVarConversionCallback&&) = default;
+    ToVarConversionCallback& operator=(ToVarConversionCallback&&) = default;
+    ~ToVarConversionCallback() = default;
 
     template <typename FieldType>
     void operator()(const FieldType* field, const std::string& field_name) {
@@ -107,15 +111,14 @@ class StructConverter final {
     }
 
     template <typename FieldType>
-    void operator()(
-        const optional<FieldType>* field, const std::string& field_name) {
+    void operator()(const optional<FieldType>* field,
+                    const std::string& field_name) {
       GOOGLE_SMART_CARD_CHECK(field);
-      if (*field)
-        SetVarDictValue(target_var_, field_name, **field);
+      if (*field) SetVarDictValue(target_var_, field_name, **field);
     }
 
    private:
-    pp::VarDictionary* target_var_;
+    pp::VarDictionary* const target_var_;
   };
 
   // The functor that is passed to the VisitFields method when the conversion
@@ -124,6 +127,12 @@ class StructConverter final {
    public:
     explicit FromVarConversionCallback(VarDictValuesExtractor* extractor)
         : extractor_(extractor) {}
+    FromVarConversionCallback(const FromVarConversionCallback&) = delete;
+    FromVarConversionCallback& operator=(const FromVarConversionCallback&) =
+        delete;
+    FromVarConversionCallback(FromVarConversionCallback&&) = default;
+    FromVarConversionCallback& operator=(FromVarConversionCallback&&) = default;
+    ~FromVarConversionCallback() = default;
 
     template <typename FieldType>
     void operator()(const FieldType* field, const std::string& field_name) {
@@ -141,8 +150,8 @@ class StructConverter final {
     }
 
     template <typename FieldType>
-    void ProcessField(
-        optional<FieldType>* field, const std::string& field_name) {
+    void ProcessField(optional<FieldType>* field,
+                      const std::string& field_name) {
       extractor_->TryExtractOptional(field_name, field);
     }
 

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/struct_converter_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/struct_converter_unittest.cc
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <google_smart_card_common/pp_var_utils/struct_converter.h>
+
 #include <string>
 
 #include <gtest/gtest.h>
-
 #include <ppapi/cpp/var.h>
 #include <ppapi/cpp/var_dictionary.h>
 
-#include <google_smart_card_common/pp_var_utils/struct_converter.h>
 #include <google_smart_card_common/pp_var_utils/extraction.h>
 
 namespace google_smart_card {
@@ -46,8 +46,8 @@ constexpr const char* TestStructConverter::GetStructTypeName() {
 // static
 template <>
 template <typename Callback>
-void TestStructConverter::VisitFields(
-    const TestStruct& value, Callback callback) {
+void TestStructConverter::VisitFields(const TestStruct& value,
+                                      Callback callback) {
   callback(&value.int_field, "int_field");
   callback(&value.string_field, "string_field");
   callback(&value.optional_field_1, "optional_field_1");
@@ -66,25 +66,22 @@ TEST(PpVarUtilsStructConverterTest, SampleStructConversion) {
   pp::VarDictionary var_dict;
   ASSERT_TRUE(VarAs(var, &var_dict, &error_message));
   int converted_int_field;
-  ASSERT_TRUE(GetVarDictValueAs(
-      var_dict, "int_field", &converted_int_field, &error_message));
+  ASSERT_TRUE(GetVarDictValueAs(var_dict, "int_field", &converted_int_field,
+                                &error_message));
   EXPECT_EQ(123, converted_int_field);
   std::string converted_string_field;
-  ASSERT_TRUE(GetVarDictValueAs(
-      var_dict, "string_field", &converted_string_field, &error_message));
+  ASSERT_TRUE(GetVarDictValueAs(var_dict, "string_field",
+                                &converted_string_field, &error_message));
   EXPECT_EQ("foo", converted_string_field);
   int converted_optional_field_1;
-  ASSERT_TRUE(GetVarDictValueAs(
-      var_dict,
-      "optional_field_1",
-      &converted_optional_field_1,
-      &error_message));
+  ASSERT_TRUE(GetVarDictValueAs(var_dict, "optional_field_1",
+                                &converted_optional_field_1, &error_message));
   EXPECT_EQ(456, converted_optional_field_1);
   EXPECT_EQ(3, GetVarDictSize(var_dict));
 
   TestStruct back_converted_value;
-  ASSERT_TRUE(TestStructConverter::ConvertFromVar(
-      var, &back_converted_value, &error_message));
+  ASSERT_TRUE(TestStructConverter::ConvertFromVar(var, &back_converted_value,
+                                                  &error_message));
   EXPECT_EQ(value.int_field, back_converted_value.int_field);
   EXPECT_EQ(value.string_field, back_converted_value.string_field);
   EXPECT_TRUE(back_converted_value.optional_field_1);

--- a/common/cpp/src/google_smart_card_common/requesting/async_request.h
+++ b/common/cpp/src/google_smart_card_common/requesting/async_request.h
@@ -37,8 +37,8 @@ namespace google_smart_card {
 //
 
 template <typename PayloadType>
-using AsyncRequestCallback = std::function<
-    void(RequestResult<PayloadType> request_result)>;
+using AsyncRequestCallback =
+    std::function<void(RequestResult<PayloadType> request_result)>;
 
 using GenericAsyncRequestCallback = AsyncRequestCallback<pp::Var>;
 
@@ -54,6 +54,8 @@ class AsyncRequestState final {
     GOOGLE_SMART_CARD_CHECK(callback_);
   }
   AsyncRequestState(const AsyncRequestState&) = delete;
+  AsyncRequestState& operator=(const AsyncRequestState&) = delete;
+  ~AsyncRequestState() = default;
 
   // Sets the result of the request, unless it was already set before.
   //
@@ -89,6 +91,7 @@ class AsyncRequest final {
  public:
   AsyncRequest() = default;
   AsyncRequest(const AsyncRequest&) = default;
+  ~AsyncRequest() = default;
 
   explicit AsyncRequest(std::shared_ptr<AsyncRequestState<PayloadType>> state)
       : state_(state) {

--- a/common/cpp/src/google_smart_card_common/requesting/async_request_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/async_request_unittest.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <google_smart_card_common/requesting/async_request.h>
+
 #include <chrono>
 #include <functional>
 #include <thread>
@@ -21,7 +23,6 @@
 #include <gtest/gtest.h>
 
 #include <google_smart_card_common/pp_var_utils/extraction.h>
-#include <google_smart_card_common/requesting/async_request.h>
 #include <google_smart_card_common/requesting/request_result.h>
 
 namespace google_smart_card {
@@ -35,13 +36,9 @@ class TestAsyncRequestCallback {
     ++call_count_;
   }
 
-  int call_count() const {
-    return call_count_;
-  }
+  int call_count() const { return call_count_; }
 
-  const GenericRequestResult& request_result() const {
-    return request_result_;
-  }
+  const GenericRequestResult& request_result() const { return request_result_; }
 
  private:
   int call_count_ = 0;
@@ -60,8 +57,8 @@ TEST(RequestingAsyncRequestTest, AsyncRequestStateBasic) {
 
   // The first set of the request result is successful and triggers the callback
   const int kValue = 123;
-  ASSERT_TRUE(request_state.SetResult(GenericRequestResult::CreateSuccessful(
-      kValue)));
+  ASSERT_TRUE(
+      request_state.SetResult(GenericRequestResult::CreateSuccessful(kValue)));
   ASSERT_EQ(1, callback.call_count());
   EXPECT_EQ(kValue, VarAs<int>(callback.request_result().payload()));
 
@@ -82,8 +79,8 @@ TEST(RequestingAsyncRequestTest, AsyncRequestStateMultiThreading) {
     std::vector<TestAsyncRequestCallback> callbacks(kStateCount);
     std::vector<std::unique_ptr<GenericAsyncRequestState>> states;
     for (int index = 0; index < kStateCount; ++index) {
-      states.emplace_back(new GenericAsyncRequestState(std::ref(
-          callbacks[index])));
+      states.emplace_back(
+          new GenericAsyncRequestState(std::ref(callbacks[index])));
     }
 
     std::vector<std::thread> threads;
@@ -108,8 +105,8 @@ TEST(RequestingAsyncRequestTest, AsyncRequestBasic) {
   TestAsyncRequestCallback callback;
 
   // Initially the request is constructed with an empty request state
-  const auto request_state = std::make_shared<GenericAsyncRequestState>(
-      std::ref(callback));
+  const auto request_state =
+      std::make_shared<GenericAsyncRequestState>(std::ref(callback));
   GenericAsyncRequest request(request_state);
   ASSERT_EQ(0, callback.call_count());
 
@@ -126,8 +123,8 @@ TEST(RequestingAsyncRequestTest, AsyncRequestCancellation) {
   TestAsyncRequestCallback callback;
 
   // Initially the request is constructed with an empty request state
-  const auto request_state = std::make_shared<GenericAsyncRequestState>(
-      std::ref(callback));
+  const auto request_state =
+      std::make_shared<GenericAsyncRequestState>(std::ref(callback));
   GenericAsyncRequest request(request_state);
   ASSERT_EQ(0, callback.call_count());
 

--- a/common/cpp/src/google_smart_card_common/requesting/async_requests_storage.h
+++ b/common/cpp/src/google_smart_card_common/requesting/async_requests_storage.h
@@ -35,10 +35,12 @@ namespace google_smart_card {
 template <typename PayloadType>
 class AsyncRequestsStorage final {
  public:
-  AsyncRequestsStorage()
-      : next_free_request_id_(0) {}
+  AsyncRequestsStorage() = default;
 
   AsyncRequestsStorage(const AsyncRequestsStorage&) = delete;
+  AsyncRequestsStorage& operator=(const AsyncRequestsStorage&) = delete;
+
+  ~AsyncRequestsStorage() = default;
 
   // Adds a new asynchronous request state under a unique identifier and returns
   // this identifier.
@@ -49,8 +51,8 @@ class AsyncRequestsStorage final {
     const RequestId request_id = next_free_request_id_;
     ++next_free_request_id_;
 
-    const bool is_new_state_added = state_map_.emplace(
-        request_id, async_request_state).second;
+    const bool is_new_state_added =
+        state_map_.emplace(request_id, async_request_state).second;
     GOOGLE_SMART_CARD_CHECK(is_new_state_added);
 
     return request_id;
@@ -64,8 +66,7 @@ class AsyncRequestsStorage final {
     const std::unique_lock<std::mutex> lock(mutex_);
 
     const auto state_map_iter = state_map_.find(request_id);
-    if (state_map_iter == state_map_.end())
-      return nullptr;
+    if (state_map_iter == state_map_.end()) return nullptr;
     const std::shared_ptr<AsyncRequestState<PayloadType>> result =
         state_map_iter->second;
     state_map_.erase(state_map_iter);
@@ -87,10 +88,10 @@ class AsyncRequestsStorage final {
 
  private:
   std::mutex mutex_;
-  RequestId next_free_request_id_;
-  std::unordered_map<
-      RequestId, const std::shared_ptr<AsyncRequestState<PayloadType>>>
-  state_map_;
+  RequestId next_free_request_id_ = 0;
+  std::unordered_map<RequestId,
+                     const std::shared_ptr<AsyncRequestState<PayloadType>>>
+      state_map_;
 };
 
 using GenericAsyncRequestsStorage = AsyncRequestsStorage<pp::Var>;

--- a/common/cpp/src/google_smart_card_common/requesting/async_requests_storage_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/async_requests_storage_unittest.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <google_smart_card_common/requesting/async_requests_storage.h>
+
 #include <memory>
 #include <thread>
 #include <vector>
@@ -19,7 +21,6 @@
 #include <gtest/gtest.h>
 
 #include <google_smart_card_common/requesting/async_request.h>
-#include <google_smart_card_common/requesting/async_requests_storage.h>
 #include <google_smart_card_common/requesting/request_id.h>
 #include <google_smart_card_common/requesting/request_result.h>
 
@@ -76,9 +77,9 @@ TEST(RequestingAsyncRequestsStorageTest, Basic) {
   const std::vector<std::shared_ptr<GenericAsyncRequestState>> requests =
       storage.PopAll();
   ASSERT_EQ(static_cast<size_t>(2), requests.size());
-  EXPECT_TRUE(
-      requests[0] == request_3_state && requests[1] == request_4_state ||
-      requests[0] == request_4_state && requests[1] == request_3_state);
+  EXPECT_TRUE(requests[0] == request_3_state &&
+                  requests[1] == request_4_state ||
+              requests[0] == request_4_state && requests[1] == request_3_state);
   EXPECT_TRUE(storage.PopAll().empty());
   EXPECT_FALSE(storage.Pop(request_3_id));
   EXPECT_FALSE(storage.Pop(request_4_id));
@@ -95,13 +96,12 @@ TEST(RequestingAsyncRequestsStorageTest, MultiThreading) {
     threads.emplace_back([&storage, thread_index] {
       std::vector<RequestId> request_ids;
       for (int iteration = 0; iteration < kIterationCount; ++iteration) {
-        request_ids.push_back(storage.Push(
-            std::make_shared<GenericAsyncRequestState>(
+        request_ids.push_back(
+            storage.Push(std::make_shared<GenericAsyncRequestState>(
                 TestAsyncRequestCallback())));
       }
       if (thread_index % 2 == 0) {
-        for (auto request_id : request_ids)
-          storage.Pop(request_id);
+        for (auto request_id : request_ids) storage.Pop(request_id);
       } else {
         storage.PopAll();
       }

--- a/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.h
+++ b/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.h
@@ -61,6 +61,9 @@ class JsRequestReceiver final : public RequestReceiver,
   class PpDelegateImpl final : public PpDelegate {
    public:
     explicit PpDelegateImpl(pp::Instance* pp_instance);
+    PpDelegateImpl(const PpDelegateImpl&) = delete;
+    PpDelegateImpl& operator=(const PpDelegateImpl&) = delete;
+    ~PpDelegateImpl();
 
     // PpDelegate:
     void PostMessage(const pp::Var& message) override;
@@ -73,13 +76,12 @@ class JsRequestReceiver final : public RequestReceiver,
   //
   // Adds a new route into the passed TypedMessageRouter for receiving the
   // requests messages.
-  JsRequestReceiver(
-      const std::string& name,
-      RequestHandler* request_handler,
-      TypedMessageRouter* typed_message_router,
-      std::unique_ptr<PpDelegate> pp_delegate);
+  JsRequestReceiver(const std::string& name, RequestHandler* request_handler,
+                    TypedMessageRouter* typed_message_router,
+                    std::unique_ptr<PpDelegate> pp_delegate);
 
   JsRequestReceiver(const JsRequestReceiver&) = delete;
+  JsRequestReceiver& operator=(const JsRequestReceiver&) = delete;
 
   ~JsRequestReceiver() override;
 
@@ -92,8 +94,8 @@ class JsRequestReceiver final : public RequestReceiver,
 
  private:
   // RequestReceiver:
-  void PostResult(
-      RequestId request_id, GenericRequestResult request_result) override;
+  void PostResult(RequestId request_id,
+                  GenericRequestResult request_result) override;
 
   // TypedMessageListener:
   std::string GetListenedMessageType() const override;

--- a/common/cpp/src/google_smart_card_common/requesting/js_requester.h
+++ b/common/cpp/src/google_smart_card_common/requesting/js_requester.h
@@ -60,6 +60,9 @@ class JsRequester final : public Requester, public TypedMessageListener {
   class PpDelegateImpl final : public PpDelegate {
    public:
     PpDelegateImpl(pp::Instance* pp_instance, pp::Core* pp_core);
+    PpDelegateImpl(const PpDelegateImpl&) = delete;
+    PpDelegateImpl& operator=(const PpDelegateImpl&) = delete;
+    ~PpDelegateImpl();
 
     void PostMessage(const pp::Var& message) override;
     bool IsMainThread() override;
@@ -77,21 +80,19 @@ class JsRequester final : public Requester, public TypedMessageListener {
   // Note that the passed TypedMessageRouter is allowed to be destroyed earlier
   // than the JsRequester object - but the Detach() method must be called before
   // destroying it.
-  JsRequester(
-      const std::string& name,
-      TypedMessageRouter* typed_message_router,
-      std::unique_ptr<PpDelegate> pp_delegate);
+  JsRequester(const std::string& name, TypedMessageRouter* typed_message_router,
+              std::unique_ptr<PpDelegate> pp_delegate);
 
   JsRequester(const JsRequester&) = delete;
+  JsRequester& operator=(const JsRequester&) = delete;
 
   ~JsRequester() override;
 
   // Requester implementation
   void Detach() override;
-  void StartAsyncRequest(
-      const pp::Var& payload,
-      GenericAsyncRequestCallback callback,
-      GenericAsyncRequest* async_request) override;
+  void StartAsyncRequest(const pp::Var& payload,
+                         GenericAsyncRequestCallback callback,
+                         GenericAsyncRequest* async_request) override;
   // Requester implementation override
   //
   // Note that it is asserted that this method is called not from the main

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.cc
@@ -27,15 +27,16 @@ RemoteCallAdaptor::RemoteCallAdaptor(Requester* requester)
   GOOGLE_SMART_CARD_CHECK(requester_);
 }
 
+RemoteCallAdaptor::~RemoteCallAdaptor() = default;
+
 GenericRequestResult RemoteCallAdaptor::PerformSyncRequest(
     const std::string& function_name, const pp::VarArray& converted_arguments) {
-  return requester_->PerformSyncRequest(MakeRemoteCallRequestPayload(
-      function_name, converted_arguments));
+  return requester_->PerformSyncRequest(
+      MakeRemoteCallRequestPayload(function_name, converted_arguments));
 }
 
 GenericAsyncRequest RemoteCallAdaptor::StartAsyncRequest(
-    const std::string& function_name,
-    const pp::VarArray& converted_arguments,
+    const std::string& function_name, const pp::VarArray& converted_arguments,
     GenericAsyncRequestCallback callback) {
   return requester_->StartAsyncRequest(
       MakeRemoteCallRequestPayload(function_name, converted_arguments),
@@ -43,14 +44,11 @@ GenericAsyncRequest RemoteCallAdaptor::StartAsyncRequest(
 }
 
 void RemoteCallAdaptor::StartAsyncRequest(
-    const std::string& function_name,
-    const pp::VarArray& converted_arguments,
-    GenericAsyncRequestCallback callback,
-    GenericAsyncRequest* async_request) {
+    const std::string& function_name, const pp::VarArray& converted_arguments,
+    GenericAsyncRequestCallback callback, GenericAsyncRequest* async_request) {
   requester_->StartAsyncRequest(
       MakeRemoteCallRequestPayload(function_name, converted_arguments),
-      callback,
-      async_request);
+      callback, async_request);
 }
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.h
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.h
@@ -39,40 +39,35 @@ class RemoteCallAdaptor final {
  public:
   explicit RemoteCallAdaptor(Requester* requester);
   RemoteCallAdaptor(const RemoteCallAdaptor&) = delete;
+  RemoteCallAdaptor& operator=(const RemoteCallAdaptor&) = delete;
+  ~RemoteCallAdaptor();
 
-  template <typename ... Args>
-  GenericRequestResult SyncCall(
-      const std::string& function_name, const Args& ... args) {
+  template <typename... Args>
+  GenericRequestResult SyncCall(const std::string& function_name,
+                                const Args&... args) {
     return PerformSyncRequest(function_name, ConvertRequestArguments(args...));
   }
 
-  template <typename ... Args>
-  GenericAsyncRequest AsyncCall(
-      GenericAsyncRequestCallback callback,
-      const std::string& function_name,
-      const Args& ... args) {
-    return StartAsyncRequest(
-        function_name, ConvertRequestArguments(args...), callback);
+  template <typename... Args>
+  GenericAsyncRequest AsyncCall(GenericAsyncRequestCallback callback,
+                                const std::string& function_name,
+                                const Args&... args) {
+    return StartAsyncRequest(function_name, ConvertRequestArguments(args...),
+                             callback);
   }
 
-  template <typename ... Args>
-  void AsyncCall(
-      GenericAsyncRequest* async_request,
-      GenericAsyncRequestCallback callback,
-      const std::string& function_name,
-      const Args& ... args) {
-    StartAsyncRequest(
-        function_name,
-        ConvertRequestArguments(args...),
-        callback,
-        async_request);
+  template <typename... Args>
+  void AsyncCall(GenericAsyncRequest* async_request,
+                 GenericAsyncRequestCallback callback,
+                 const std::string& function_name, const Args&... args) {
+    StartAsyncRequest(function_name, ConvertRequestArguments(args...), callback,
+                      async_request);
   }
 
-  template <typename ... PayloadFields>
+  template <typename... PayloadFields>
   static bool ExtractResultPayload(
       const GenericRequestResult& generic_request_result,
-      std::string* error_message,
-      PayloadFields* ... payload_fields) {
+      std::string* error_message, PayloadFields*... payload_fields) {
     // TODO(emaxx): Probably add details about the function call into the error
     // messages?
     if (!generic_request_result.is_successful()) {
@@ -81,24 +76,24 @@ class RemoteCallAdaptor final {
     }
     pp::VarArray var_array;
     if (!VarAs(generic_request_result.payload(), &var_array, error_message)) {
-      GOOGLE_SMART_CARD_LOG_FATAL << "Failed to extract the response " <<
-          "payload items: " << *error_message;
+      GOOGLE_SMART_CARD_LOG_FATAL << "Failed to extract the response "
+                                  << "payload items: " << *error_message;
     }
     if (!TryGetVarArrayItems(var_array, error_message, payload_fields...)) {
-      GOOGLE_SMART_CARD_LOG_FATAL << "Failed to extract the response " <<
-          "payload items: " << *error_message;
+      GOOGLE_SMART_CARD_LOG_FATAL << "Failed to extract the response "
+                                  << "payload items: " << *error_message;
     }
     return true;
   }
 
-  template <typename PayloadType, typename ... PayloadFields>
+  template <typename PayloadType, typename... PayloadFields>
   static RequestResult<PayloadType> ConvertResultPayload(
       const GenericRequestResult& generic_request_result,
       PayloadType* payload_in_case_of_success,
-      PayloadFields* ... payload_fields) {
+      PayloadFields*... payload_fields) {
     std::string error_message;
-    if (!ExtractResultPayload(
-             generic_request_result, &error_message, payload_fields...)) {
+    if (!ExtractResultPayload(generic_request_result, &error_message,
+                              payload_fields...)) {
       return RequestResult<PayloadType>::CreateFailed(error_message);
     }
     return RequestResult<PayloadType>::CreateSuccessful(
@@ -106,8 +101,8 @@ class RemoteCallAdaptor final {
   }
 
  private:
-  template <typename ... Args>
-  static pp::VarArray ConvertRequestArguments(const Args& ... args) {
+  template <typename... Args>
+  static pp::VarArray ConvertRequestArguments(const Args&... args) {
     return MakeVarArray(args...);
   }
 
@@ -115,16 +110,14 @@ class RemoteCallAdaptor final {
       const std::string& function_name,
       const pp::VarArray& converted_arguments);
 
-  GenericAsyncRequest StartAsyncRequest(
-      const std::string& function_name,
-      const pp::VarArray& converted_arguments,
-      GenericAsyncRequestCallback callback);
+  GenericAsyncRequest StartAsyncRequest(const std::string& function_name,
+                                        const pp::VarArray& converted_arguments,
+                                        GenericAsyncRequestCallback callback);
 
-  void StartAsyncRequest(
-      const std::string& function_name,
-      const pp::VarArray& converted_arguments,
-      GenericAsyncRequestCallback callback,
-      GenericAsyncRequest* async_request);
+  void StartAsyncRequest(const std::string& function_name,
+                         const pp::VarArray& converted_arguments,
+                         GenericAsyncRequestCallback callback,
+                         GenericAsyncRequest* async_request);
 
   Requester* const requester_;
 };

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_message.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_message.cc
@@ -21,23 +21,26 @@
 #include <google_smart_card_common/pp_var_utils/debug_dump.h>
 #include <google_smart_card_common/pp_var_utils/extraction.h>
 
-const char kFunctionNameMessageField[] = "function_name";
-const char kFunctionArgumentsMessageField[] = "arguments";
-
 namespace google_smart_card {
 
-pp::Var MakeRemoteCallRequestPayload(
-    const std::string& function_name, const pp::VarArray& arguments) {
+namespace {
+
+constexpr char kFunctionNameMessageField[] = "function_name";
+constexpr char kFunctionArgumentsMessageField[] = "arguments";
+
+}  // namespace
+
+pp::Var MakeRemoteCallRequestPayload(const std::string& function_name,
+                                     const pp::VarArray& arguments) {
   return VarDictBuilder()
       .Add(kFunctionNameMessageField, function_name)
       .Add(kFunctionArgumentsMessageField, arguments)
       .Result();
 }
 
-bool ParseRemoteCallRequestPayload(
-    const pp::Var& request_payload,
-    std::string* function_name,
-    pp::VarArray* arguments) {
+bool ParseRemoteCallRequestPayload(const pp::Var& request_payload,
+                                   std::string* function_name,
+                                   pp::VarArray* arguments) {
   std::string error_message;
   pp::VarDictionary request_payload_dict;
   if (!VarAs(request_payload, &request_payload_dict, &error_message))
@@ -48,8 +51,8 @@ bool ParseRemoteCallRequestPayload(
       .GetSuccessWithNoExtraKeysAllowed(&error_message);
 }
 
-std::string DebugDumpRemoteCallRequest(
-    const std::string& function_name, const pp::VarArray& arguments) {
+std::string DebugDumpRemoteCallRequest(const std::string& function_name,
+                                       const pp::VarArray& arguments) {
   std::string dumped_arguments = DebugDumpVar(arguments);
   GOOGLE_SMART_CARD_CHECK(!dumped_arguments.empty());
   GOOGLE_SMART_CARD_CHECK(dumped_arguments.front() == '[');

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_message.h
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_message.h
@@ -24,19 +24,18 @@ namespace google_smart_card {
 
 // Constructs the message data payload of the remote call request, containing
 // the specified function name and the array of the function arguments.
-pp::Var MakeRemoteCallRequestPayload(
-    const std::string& function_name, const pp::VarArray& arguments);
+pp::Var MakeRemoteCallRequestPayload(const std::string& function_name,
+                                     const pp::VarArray& arguments);
 
 // Parses the message data payload of the remote call request, extracting the
 // function name and the array of the function arguments.
-bool ParseRemoteCallRequestPayload(
-    const pp::Var& request_payload,
-    std::string* function_name,
-    pp::VarArray* arguments);
+bool ParseRemoteCallRequestPayload(const pp::Var& request_payload,
+                                   std::string* function_name,
+                                   pp::VarArray* arguments);
 
 // Generates a human-readable debug dump of the remote call request.
-std::string DebugDumpRemoteCallRequest(
-    const std::string& function_name, const pp::VarArray& arguments);
+std::string DebugDumpRemoteCallRequest(const std::string& function_name,
+                                       const pp::VarArray& arguments);
 
 }  // namespace google_smart_card
 

--- a/common/cpp/src/google_smart_card_common/requesting/request_receiver.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/request_receiver.cc
@@ -21,26 +21,26 @@
 
 namespace google_smart_card {
 
-RequestReceiver::RequestReceiver(
-    const std::string& name, RequestHandler* handler)
-    : name_(name),
-      handler_(handler) {
+RequestReceiver::RequestReceiver(const std::string& name,
+                                 RequestHandler* handler)
+    : name_(name), handler_(handler) {
   GOOGLE_SMART_CARD_CHECK(handler_);
 }
 
-std::string RequestReceiver::name() const {
-  return name_;
-}
+RequestReceiver::~RequestReceiver() = default;
 
-void RequestReceiver::HandleRequest(
-    RequestId request_id, const pp::Var& payload) {
+std::string RequestReceiver::name() const { return name_; }
+
+void RequestReceiver::HandleRequest(RequestId request_id,
+                                    const pp::Var& payload) {
   handler_->HandleRequest(payload, MakeResultCallback(request_id));
 }
 
 RequestReceiver::ResultCallbackImpl::ResultCallbackImpl(
     RequestId request_id, std::weak_ptr<RequestReceiver> request_receiver)
-    : request_id_(request_id),
-      request_receiver_(request_receiver) {}
+    : request_id_(request_id), request_receiver_(request_receiver) {}
+
+RequestReceiver::ResultCallbackImpl::~ResultCallbackImpl() = default;
 
 void RequestReceiver::ResultCallbackImpl::operator()(
     GenericRequestResult request_result) {
@@ -52,8 +52,8 @@ void RequestReceiver::ResultCallbackImpl::operator()(
 
 RequestReceiver::ResultCallback RequestReceiver::MakeResultCallback(
     RequestId request_id) {
-  return ResultCallbackImpl(
-      request_id, std::weak_ptr<RequestReceiver>(shared_from_this()));
+  return ResultCallbackImpl(request_id,
+                            std::weak_ptr<RequestReceiver>(shared_from_this()));
 }
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/requesting/request_receiver.h
+++ b/common/cpp/src/google_smart_card_common/requesting/request_receiver.h
@@ -64,8 +64,9 @@ class RequestReceiver : public std::enable_shared_from_this<RequestReceiver> {
   RequestReceiver(const std::string& name, RequestHandler* handler);
 
   RequestReceiver(const RequestReceiver&) = delete;
+  RequestReceiver& operator=(const RequestReceiver&) = delete;
 
-  virtual ~RequestReceiver() = default;
+  virtual ~RequestReceiver();
 
   std::string name() const;
 
@@ -73,8 +74,8 @@ class RequestReceiver : public std::enable_shared_from_this<RequestReceiver> {
   // Posts the request result back to the request sender.
   //
   // The implementation must be thread-safe.
-  virtual void PostResult(
-      RequestId request_id, GenericRequestResult request_result) = 0;
+  virtual void PostResult(RequestId request_id,
+                          GenericRequestResult request_result) = 0;
 
   // Runs the associated request handler with the specified request and with
   // created ResultCallback functor.
@@ -83,8 +84,11 @@ class RequestReceiver : public std::enable_shared_from_this<RequestReceiver> {
  private:
   class ResultCallbackImpl final {
    public:
-    ResultCallbackImpl(
-        RequestId request_id, std::weak_ptr<RequestReceiver> request_receiver);
+    ResultCallbackImpl(RequestId request_id,
+                       std::weak_ptr<RequestReceiver> request_receiver);
+    ResultCallbackImpl(const ResultCallbackImpl&) = default;
+    ResultCallbackImpl& operator=(const ResultCallbackImpl&) = delete;
+    ~ResultCallbackImpl();
 
     void operator()(GenericRequestResult request_result);
 

--- a/common/cpp/src/google_smart_card_common/requesting/request_result.h
+++ b/common/cpp/src/google_smart_card_common/requesting/request_result.h
@@ -54,13 +54,9 @@ template <typename PayloadType>
 class RequestResult final {
  public:
   RequestResult() = default;
-
-  RequestResult& operator=(const RequestResult& other) {
-    status_ = other.status_;
-    error_message_ = other.error_message_;
-    payload_ = other.payload_;
-    return *this;
-  }
+  RequestResult(const RequestResult&) = default;
+  RequestResult& operator=(const RequestResult&) = default;
+  ~RequestResult() = default;
 
   static RequestResult CreateSuccessful(PayloadType payload) {
     return RequestResult(PayloadType(std::move(payload)));
@@ -71,12 +67,12 @@ class RequestResult final {
   }
 
   static RequestResult CreateCanceled() {
-    return CreateUnsuccessful(
-        RequestResultStatus::kCanceled, internal::kRequestCanceledErrorMessage);
+    return CreateUnsuccessful(RequestResultStatus::kCanceled,
+                              internal::kRequestCanceledErrorMessage);
   }
 
-  static RequestResult CreateUnsuccessful(
-      RequestResultStatus status, const std::string& error_message) {
+  static RequestResult CreateUnsuccessful(RequestResultStatus status,
+                                          const std::string& error_message) {
     return RequestResult(status, error_message);
   }
 
@@ -107,19 +103,17 @@ class RequestResult final {
 
  private:
   explicit RequestResult(PayloadType payload)
-      : status_(RequestResultStatus::kSucceeded),
-        payload_(payload) {}
+      : status_(RequestResultStatus::kSucceeded), payload_(payload) {}
 
   RequestResult(RequestResultStatus status, const std::string& error_message)
-      : status_(status),
-        error_message_(error_message) {
+      : status_(status), error_message_(error_message) {
     GOOGLE_SMART_CARD_CHECK(status != RequestResultStatus::kSucceeded);
   }
 
   void CheckInitialized() const {
     if (!status_) {
-      GOOGLE_SMART_CARD_LOG_FATAL << "Trying to access an uninitialized " <<
-          "request result";
+      GOOGLE_SMART_CARD_LOG_FATAL << "Trying to access an uninitialized "
+                                  << "request result";
     }
   }
 

--- a/common/cpp/src/google_smart_card_common/requesting/requester.h
+++ b/common/cpp/src/google_smart_card_common/requesting/requester.h
@@ -50,9 +50,7 @@ class Requester {
   // immediately.
   virtual ~Requester();
 
-  std::string name() const {
-    return name_;
-  }
+  std::string name() const { return name_; }
 
   // Detaches the requester, which may prevent it from sending new requests (new
   // requests may immediately finish with the RequestResultStatus::kFailed
@@ -71,8 +69,8 @@ class Requester {
   // Note: It's also possible that the callback is executed synchronously during
   // this method call (e.g. when a fatal error occurred that prevents the
   // implementation from starting the asynchronous request).
-  GenericAsyncRequest StartAsyncRequest(
-      const pp::Var& payload, GenericAsyncRequestCallback callback);
+  GenericAsyncRequest StartAsyncRequest(const pp::Var& payload,
+                                        GenericAsyncRequestCallback callback);
 
   // Starts an asynchronous request with the given payload and the given
   // callback, which will be executed once the request finishes (either
@@ -89,10 +87,9 @@ class Requester {
   // Note: It's also possible that the callback is executed synchronously during
   // this method call (e.g. when a fatal error occurred that prevents the
   // implementation from starting the asynchronous request).
-  virtual void StartAsyncRequest(
-      const pp::Var& payload,
-      GenericAsyncRequestCallback callback,
-      GenericAsyncRequest* async_request) = 0;
+  virtual void StartAsyncRequest(const pp::Var& payload,
+                                 GenericAsyncRequestCallback callback,
+                                 GenericAsyncRequest* async_request) = 0;
 
   // Performs a synchronous request, blocking current thread until the result is
   // received.
@@ -105,10 +102,9 @@ class Requester {
   // Creates and stores internally a new asynchronous request state, returning
   // its public proxy object (GenericAsyncRequest object) and its generated
   // request identifier.
-  GenericAsyncRequest CreateAsyncRequest(
-      const pp::Var& payload,
-      GenericAsyncRequestCallback callback,
-      RequestId* request_id);
+  GenericAsyncRequest CreateAsyncRequest(const pp::Var& payload,
+                                         GenericAsyncRequestCallback callback,
+                                         RequestId* request_id);
 
   // Finds the request state by the specified request identifier and sets its
   // result (which, in turn, runs the callback if it has not been executed yet).
@@ -117,8 +113,8 @@ class Requester {
   // requester anymore.
   //
   // Returns whether the request with the specified identifier was found.
-  bool SetAsyncRequestResult(
-      RequestId request_id, GenericRequestResult request_result);
+  bool SetAsyncRequestResult(RequestId request_id,
+                             GenericRequestResult request_result);
 
  private:
   const std::string name_;

--- a/common/cpp/src/google_smart_card_common/requesting/requester_message.h
+++ b/common/cpp/src/google_smart_card_common/requesting/requester_message.h
@@ -49,23 +49,22 @@ pp::Var MakeRequestMessageData(RequestId request_id, const pp::Var& payload);
 //
 // Note that the if the response has the RequestResultStatus::kCanceled state,
 // then for simplicity reasons it will be serialized as a failed response.
-pp::Var MakeResponseMessageData(
-    RequestId request_id, const GenericRequestResult& request_result);
+pp::Var MakeResponseMessageData(RequestId request_id,
+                                const GenericRequestResult& request_result);
 
 // Parses the request message data, extracting the request identifier and the
 // request data from it.
-bool ParseRequestMessageData(
-    const pp::Var& message_data, RequestId* request_id, pp::Var* payload);
+bool ParseRequestMessageData(const pp::Var& message_data, RequestId* request_id,
+                             pp::Var* payload);
 
 // Parses the request response message data, extracting the request identifier
 // and the request result information from it.
 //
 // Note that the only possible result states returned are
 // RequestResultStatus::kSucceeded and RequestResultStatus::kFailed.
-bool ParseResponseMessageData(
-    const pp::Var& message_data,
-    RequestId* request_id,
-    GenericRequestResult* request_result);
+bool ParseResponseMessageData(const pp::Var& message_data,
+                              RequestId* request_id,
+                              GenericRequestResult* request_result);
 
 }  // namespace google_smart_card
 

--- a/common/cpp/src/google_smart_card_common/thread_safe_unique_ptr.h
+++ b/common/cpp/src/google_smart_card_common/thread_safe_unique_ptr.h
@@ -77,16 +77,13 @@ class ThreadSafeUniquePtr final {
       return object_;
     }
 
-    explicit operator bool() const {
-      return object_;
-    }
+    explicit operator bool() const { return object_; }
 
    private:
     friend class ThreadSafeUniquePtr;
 
     Locked(T* object, std::unique_lock<std::mutex> lock)
-        : object_(object),
-          lock_(std::move(lock)) {
+        : object_(object), lock_(std::move(lock)) {
       GOOGLE_SMART_CARD_CHECK(lock_);
     }
 
@@ -96,9 +93,12 @@ class ThreadSafeUniquePtr final {
 
   ThreadSafeUniquePtr() = default;
   ThreadSafeUniquePtr(const ThreadSafeUniquePtr&) = delete;
+  ThreadSafeUniquePtr& operator=(const ThreadSafeUniquePtr&) = delete;
 
   explicit ThreadSafeUniquePtr(std::unique_ptr<T> value)
       : object_(std::move(value)) {}
+
+  ~ThreadSafeUniquePtr() = default;
 
   void Reset() {
     const std::unique_lock<std::mutex> lock(mutex_);

--- a/common/cpp/src/google_smart_card_common/tuple_unpacking.h
+++ b/common/cpp/src/google_smart_card_common/tuple_unpacking.h
@@ -19,16 +19,16 @@ namespace google_smart_card {
 
 // Helper template class that holds a compile-time integer sequence as its
 // template parameter pack.
-template <size_t ... Sequence>
+template <size_t... Sequence>
 struct ArgIndexes {};
 
 namespace internal {
 
-template <size_t ArgCounter, size_t ... Sequence>
+template <size_t ArgCounter, size_t... Sequence>
 struct ArgIndexesGenerator
     : ArgIndexesGenerator<ArgCounter - 1, ArgCounter - 1, Sequence...> {};
 
-template <size_t ... Sequence>
+template <size_t... Sequence>
 struct ArgIndexesGenerator<0, Sequence...> {
   using result = ArgIndexes<Sequence...>;
 };

--- a/common/cpp/src/google_smart_card_common/unique_ptr_utils.h
+++ b/common/cpp/src/google_smart_card_common/unique_ptr_utils.h
@@ -21,8 +21,8 @@
 namespace google_smart_card {
 
 // Replacement of std::make_unique, which will be introduced only in C++14.
-template <typename T, typename ... Args>
-inline std::unique_ptr<T> MakeUnique(Args&& ... args) {
+template <typename T, typename... Args>
+inline std::unique_ptr<T> MakeUnique(Args&&... args) {
   return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 

--- a/common/cpp/src/google_smart_card_common/value.cc
+++ b/common/cpp/src/google_smart_card_common/value.cc
@@ -68,8 +68,7 @@ Value::Value(int64_t integer_value)
 Value::Value(double float_value)
     : type_(Type::kFloat), float_value_(float_value) {}
 
-Value::Value(const char* string_value)
-    : Value(std::string(string_value)) {}
+Value::Value(const char* string_value) : Value(std::string(string_value)) {}
 
 Value::Value(std::string string_value)
     : type_(Type::kString), string_value_(std::move(string_value)) {}

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.cc
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.cc
@@ -16,18 +16,18 @@
 
 #include <ppapi/cpp/var_dictionary.h>
 
-#include <google_smart_card_common/requesting/request_result.h>
 #include <google_smart_card_common/pp_var_utils/extraction.h>
+#include <google_smart_card_common/requesting/request_result.h>
 #include <google_smart_card_common/unique_ptr_utils.h>
-
-// Note: These parameters should stay in sync with the JS side
-// (pin-dialog-backend.js).
-const char kRequesterName[] = "built_in_pin_dialog";
-const char kPinMessageKey[] = "pin";
 
 namespace smart_card_client {
 
 namespace {
+
+// Note: These parameters should stay in sync with the JS side
+// (pin-dialog-backend.js).
+constexpr char kRequesterName[] = "built_in_pin_dialog";
+constexpr char kPinMessageKey[] = "pin";
 
 void ExtractPinRequestResult(
     const google_smart_card::GenericRequestResult& request_result,
@@ -44,24 +44,20 @@ void ExtractPinRequestResult(
 
 BuiltInPinDialogServer::BuiltInPinDialogServer(
     google_smart_card::TypedMessageRouter* typed_message_router,
-    pp::Instance* pp_instance,
-    pp::Core* pp_core)
-    : js_requester_(
-          kRequesterName,
-          typed_message_router,
-          google_smart_card::MakeUnique<
-              google_smart_card::JsRequester::PpDelegateImpl>(
-                  pp_instance, pp_core)) {}
+    pp::Instance* pp_instance, pp::Core* pp_core)
+    : js_requester_(kRequesterName, typed_message_router,
+                    google_smart_card::MakeUnique<
+                        google_smart_card::JsRequester::PpDelegateImpl>(
+                        pp_instance, pp_core)) {}
 
-void BuiltInPinDialogServer::Detach() {
-  js_requester_.Detach();
-}
+BuiltInPinDialogServer::~BuiltInPinDialogServer() = default;
+
+void BuiltInPinDialogServer::Detach() { js_requester_.Detach(); }
 
 bool BuiltInPinDialogServer::RequestPin(std::string* pin) {
   const google_smart_card::GenericRequestResult request_result =
       js_requester_.PerformSyncRequest(pp::VarDictionary());
-  if (!request_result.is_successful())
-    return false;
+  if (!request_result.is_successful()) return false;
   ExtractPinRequestResult(request_result, pin);
   return true;
 }

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.h
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.h
@@ -45,10 +45,12 @@ class BuiltInPinDialogServer final {
   // into the specified TypedMessageRouter for receiving the request responses.
   BuiltInPinDialogServer(
       google_smart_card::TypedMessageRouter* typed_message_router,
-      pp::Instance* pp_instance,
-      pp::Core* pp_core);
+      pp::Instance* pp_instance, pp::Core* pp_core);
 
   BuiltInPinDialogServer(const BuiltInPinDialogServer&) = delete;
+  BuiltInPinDialogServer& operator=(const BuiltInPinDialogServer&) = delete;
+
+  ~BuiltInPinDialogServer();
 
   // Detaches from the Pepper module and the typed message router, which
   // prevents any further requests and waiting for the request responses.

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
@@ -92,13 +92,14 @@ class ApiBridge final : public google_smart_card::RequestHandler {
   // The |request_handling_mutex| parameter, when non-null, allows to avoid
   // simultaneous execution of multiple requests: each next request will be
   // executed only once the previous one finishes.
-  ApiBridge(
-      google_smart_card::TypedMessageRouter* typed_message_router,
-      pp::Instance* pp_instance,
-      pp::Core* pp_core,
-      std::shared_ptr<std::mutex> request_handling_mutex);
+  ApiBridge(google_smart_card::TypedMessageRouter* typed_message_router,
+            pp::Instance* pp_instance, pp::Core* pp_core,
+            std::shared_ptr<std::mutex> request_handling_mutex);
 
   ApiBridge(const ApiBridge&) = delete;
+  ApiBridge& operator=(const ApiBridge&) = delete;
+
+  ~ApiBridge();
 
   void Detach();
 
@@ -137,10 +138,9 @@ class ApiBridge final : public google_smart_card::RequestHandler {
 
  private:
   // google_smart_card::RequestHandler:
-  void HandleRequest(
-      const pp::Var& payload,
-      google_smart_card::RequestReceiver::ResultCallback result_callback)
-  override;
+  void HandleRequest(const pp::Var& payload,
+                     google_smart_card::RequestReceiver::ResultCallback
+                         result_callback) override;
 
   void HandleCertificatesRequest(
       const pp::VarArray& arguments,

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
@@ -46,23 +46,22 @@ namespace {
 constexpr uint8_t kFakeCert1Der[] = {1, 2, 3};
 constexpr Algorithm kFakeCert1Algorithms[] = {Algorithm::kRsassaPkcs1v15Sha256};
 constexpr uint8_t kFakeCert2Der[] = {4};
-constexpr Algorithm kFakeCert2Algorithms[] = {
-  Algorithm::kRsassaPkcs1v15Sha512, Algorithm::kRsassaPkcs1v15Sha1
-};
+constexpr Algorithm kFakeCert2Algorithms[] = {Algorithm::kRsassaPkcs1v15Sha512,
+                                              Algorithm::kRsassaPkcs1v15Sha1};
 
 ClientCertificateInfo GetFakeCert1() {
   ClientCertificateInfo info;
   info.certificate.assign(std::begin(kFakeCert1Der), std::end(kFakeCert1Der));
-  info.supported_algorithms.assign(
-      std::begin(kFakeCert1Algorithms), std::end(kFakeCert1Algorithms));
+  info.supported_algorithms.assign(std::begin(kFakeCert1Algorithms),
+                                   std::end(kFakeCert1Algorithms));
   return info;
 }
 
 ClientCertificateInfo GetFakeCert2() {
   ClientCertificateInfo info;
   info.certificate.assign(std::begin(kFakeCert2Der), std::end(kFakeCert2Der));
-  info.supported_algorithms.assign(
-      std::begin(kFakeCert2Algorithms), std::end(kFakeCert2Algorithms));
+  info.supported_algorithms.assign(std::begin(kFakeCert2Algorithms),
+                                   std::end(kFakeCert2Algorithms));
   return info;
 }
 
@@ -83,11 +82,9 @@ class ApiBridgeIntegrationTestHelper final : public gsc::IntegrationTestHelper {
  public:
   // IntegrationTestHelper:
   std::string GetName() const override;
-  void SetUp(
-      pp::Instance* pp_instance,
-      pp::Core* pp_core,
-      gsc::TypedMessageRouter* typed_message_router,
-      const pp::Var& data) override;
+  void SetUp(pp::Instance* pp_instance, pp::Core* pp_core,
+             gsc::TypedMessageRouter* typed_message_router,
+             const pp::Var& data) override;
   void TearDown() override;
   void OnMessageFromJs(
       const pp::Var& data,
@@ -110,15 +107,11 @@ std::string ApiBridgeIntegrationTestHelper::GetName() const {
 }
 
 void ApiBridgeIntegrationTestHelper::SetUp(
-    pp::Instance* pp_instance,
-    pp::Core* pp_core,
-    gsc::TypedMessageRouter* typed_message_router,
-    const pp::Var& /*data*/) {
-  api_bridge_ = std::make_shared<ApiBridge>(
-      typed_message_router,
-      pp_instance,
-      pp_core,
-      /*request_handling_mutex=*/nullptr);
+    pp::Instance* pp_instance, pp::Core* pp_core,
+    gsc::TypedMessageRouter* typed_message_router, const pp::Var& /*data*/) {
+  api_bridge_ =
+      std::make_shared<ApiBridge>(typed_message_router, pp_instance, pp_core,
+                                  /*request_handling_mutex=*/nullptr);
 }
 
 void ApiBridgeIntegrationTestHelper::TearDown() {
@@ -127,8 +120,7 @@ void ApiBridgeIntegrationTestHelper::TearDown() {
 }
 
 void ApiBridgeIntegrationTestHelper::OnMessageFromJs(
-    const pp::Var& data,
-    gsc::RequestReceiver::ResultCallback result_callback) {
+    const pp::Var& data, gsc::RequestReceiver::ResultCallback result_callback) {
   std::string command;
   std::string error_message;
   if (!gsc::VarAs(data, &command, &error_message))
@@ -136,8 +128,8 @@ void ApiBridgeIntegrationTestHelper::OnMessageFromJs(
   if (command == "setCertificates_empty") {
     ScheduleSetCertificatesCall(/*certificates=*/{}, result_callback);
   } else if (command == "setCertificates_fakeCerts") {
-    ScheduleSetCertificatesCall(
-        {GetFakeCert1(), GetFakeCert2()}, result_callback);
+    ScheduleSetCertificatesCall({GetFakeCert1(), GetFakeCert2()},
+                                result_callback);
   } else {
     GOOGLE_SMART_CARD_LOG_FATAL << "Unknown command " << command;
   }
@@ -148,11 +140,9 @@ void ApiBridgeIntegrationTestHelper::ScheduleSetCertificatesCall(
     gsc::RequestReceiver::ResultCallback result_callback) {
   // Post to a background thread, since the main thread isn't allowed to perform
   // blocking calls, which SetCertificates() is.
-  std::thread(
-      &SetCertificatesOnBackgroundThread,
-      api_bridge_,
-      certificates,
-      result_callback).detach();
+  std::thread(&SetCertificatesOnBackgroundThread, api_bridge_, certificates,
+              result_callback)
+      .detach();
 }
 
 }  // namespace chrome_certificate_provider

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.cc
@@ -26,16 +26,17 @@ namespace google_smart_card {
 using AlgorithmConverter = EnumConverter<ccp::Algorithm, std::string>;
 using ErrorConverter = EnumConverter<ccp::Error, std::string>;
 using PinRequestTypeConverter = EnumConverter<ccp::PinRequestType, std::string>;
-using PinRequestErrorTypeConverter = EnumConverter<
-    ccp::PinRequestErrorType, std::string>;
-using ClientCertificateInfoConverter = StructConverter<
-    ccp::ClientCertificateInfo>;
-using SetCertificatesDetailsConverter = StructConverter<
-    ccp::SetCertificatesDetails>;
+using PinRequestErrorTypeConverter =
+    EnumConverter<ccp::PinRequestErrorType, std::string>;
+using ClientCertificateInfoConverter =
+    StructConverter<ccp::ClientCertificateInfo>;
+using SetCertificatesDetailsConverter =
+    StructConverter<ccp::SetCertificatesDetails>;
 using SignatureRequestConverter = StructConverter<ccp::SignatureRequest>;
 using RequestPinOptionsConverter = StructConverter<ccp::RequestPinOptions>;
 using RequestPinResultsConverter = StructConverter<ccp::RequestPinResults>;
-using StopPinRequestOptionsConverter = StructConverter<ccp::StopPinRequestOptions>;
+using StopPinRequestOptionsConverter =
+    StructConverter<ccp::StopPinRequestOptions>;
 
 // static
 template <>
@@ -94,7 +95,8 @@ template <typename Callback>
 void PinRequestErrorTypeConverter::VisitCorrespondingPairs(Callback callback) {
   callback(ccp::PinRequestErrorType::kInvalidPin, "INVALID_PIN");
   callback(ccp::PinRequestErrorType::kInvalidPuk, "INVALID_PUK");
-  callback(ccp::PinRequestErrorType::kMaxAttemptsExceeded, "MAX_ATTEMPTS_EXCEEDED");
+  callback(ccp::PinRequestErrorType::kMaxAttemptsExceeded,
+           "MAX_ATTEMPTS_EXCEEDED");
   callback(ccp::PinRequestErrorType::kUnknownError, "UNKNOWN_ERROR");
 }
 
@@ -138,8 +140,8 @@ constexpr const char* SignatureRequestConverter::GetStructTypeName() {
 // static
 template <>
 template <typename Callback>
-void SignatureRequestConverter::VisitFields(
-    const ccp::SignatureRequest& value, Callback callback) {
+void SignatureRequestConverter::VisitFields(const ccp::SignatureRequest& value,
+                                            Callback callback) {
   callback(&value.sign_request_id, "signRequestId");
   callback(&value.input, "input");
   callback(&value.digest, "digest");
@@ -217,8 +219,8 @@ pp::Var MakeVar(Error value) {
 
 bool VarAs(const pp::Var& var, PinRequestType* result,
            std::string* error_message) {
-  return gsc::PinRequestTypeConverter::ConvertFromVar(
-      var, result, error_message);
+  return gsc::PinRequestTypeConverter::ConvertFromVar(var, result,
+                                                      error_message);
 }
 
 pp::Var MakeVar(PinRequestType value) {
@@ -227,8 +229,8 @@ pp::Var MakeVar(PinRequestType value) {
 
 bool VarAs(const pp::Var& var, PinRequestErrorType* result,
            std::string* error_message) {
-  return gsc::PinRequestErrorTypeConverter::ConvertFromVar(
-      var, result, error_message);
+  return gsc::PinRequestErrorTypeConverter::ConvertFromVar(var, result,
+                                                           error_message);
 }
 
 pp::Var MakeVar(PinRequestErrorType value) {
@@ -237,8 +239,8 @@ pp::Var MakeVar(PinRequestErrorType value) {
 
 bool VarAs(const pp::Var& var, ClientCertificateInfo* result,
            std::string* error_message) {
-  return gsc::ClientCertificateInfoConverter::ConvertFromVar(
-      var, result, error_message);
+  return gsc::ClientCertificateInfoConverter::ConvertFromVar(var, result,
+                                                             error_message);
 }
 
 pp::Var MakeVar(const ClientCertificateInfo& value) {
@@ -247,8 +249,8 @@ pp::Var MakeVar(const ClientCertificateInfo& value) {
 
 bool VarAs(const pp::Var& var, SetCertificatesDetails* result,
            std::string* error_message) {
-  return gsc::SetCertificatesDetailsConverter::ConvertFromVar(
-      var, result, error_message);
+  return gsc::SetCertificatesDetailsConverter::ConvertFromVar(var, result,
+                                                              error_message);
 }
 
 pp::Var MakeVar(const SetCertificatesDetails& value) {
@@ -257,8 +259,8 @@ pp::Var MakeVar(const SetCertificatesDetails& value) {
 
 bool VarAs(const pp::Var& var, SignatureRequest* result,
            std::string* error_message) {
-  return gsc::SignatureRequestConverter::ConvertFromVar(
-      var, result, error_message);
+  return gsc::SignatureRequestConverter::ConvertFromVar(var, result,
+                                                        error_message);
 }
 
 pp::Var MakeVar(const SignatureRequest& value) {
@@ -267,8 +269,8 @@ pp::Var MakeVar(const SignatureRequest& value) {
 
 bool VarAs(const pp::Var& var, RequestPinOptions* result,
            std::string* error_message) {
-  return gsc::RequestPinOptionsConverter::ConvertFromVar(
-      var, result, error_message);
+  return gsc::RequestPinOptionsConverter::ConvertFromVar(var, result,
+                                                         error_message);
 }
 
 pp::Var MakeVar(const RequestPinOptions& value) {
@@ -277,8 +279,8 @@ pp::Var MakeVar(const RequestPinOptions& value) {
 
 bool VarAs(const pp::Var& var, RequestPinResults* result,
            std::string* error_message) {
-  return gsc::RequestPinResultsConverter::ConvertFromVar(
-      var, result, error_message);
+  return gsc::RequestPinResultsConverter::ConvertFromVar(var, result,
+                                                         error_message);
 }
 
 pp::Var MakeVar(const RequestPinResults& value) {
@@ -287,8 +289,8 @@ pp::Var MakeVar(const RequestPinResults& value) {
 
 bool VarAs(const pp::Var& var, StopPinRequestOptions* result,
            std::string* error_message) {
-  return gsc::StopPinRequestOptionsConverter::ConvertFromVar(
-      var, result, error_message);
+  return gsc::StopPinRequestOptionsConverter::ConvertFromVar(var, result,
+                                                             error_message);
 }
 
 pp::Var MakeVar(const StopPinRequestOptions& value) {

--- a/example_cpp_smart_card_client_app/src/ui_bridge.h
+++ b/example_cpp_smart_card_client_app/src/ui_bridge.h
@@ -47,10 +47,9 @@ class UiBridge final : public google_smart_card::TypedMessageListener {
   // The |request_handling_mutex| parameter, when non-null, allows to avoid
   // simultaneous execution of multiple requests: each next request will be
   // executed only once the previous one finishes.
-  UiBridge(
-      google_smart_card::TypedMessageRouter* typed_message_router,
-      pp::Instance* pp_instance,
-      std::shared_ptr<std::mutex> request_handling_mutex);
+  UiBridge(google_smart_card::TypedMessageRouter* typed_message_router,
+           pp::Instance* pp_instance,
+           std::shared_ptr<std::mutex> request_handling_mutex);
 
   UiBridge(const UiBridge&) = delete;
   UiBridge& operator=(const UiBridge&) = delete;
@@ -75,8 +74,8 @@ class UiBridge final : public google_smart_card::TypedMessageListener {
   struct AttachedState {
     AttachedState(pp::Instance* pp_instance,
                   google_smart_card::TypedMessageRouter* typed_message_router)
-      : pp_instance(pp_instance),
-        typed_message_router(typed_message_router) {}
+        : pp_instance(pp_instance),
+          typed_message_router(typed_message_router) {}
 
     pp::Instance* const pp_instance;
     google_smart_card::TypedMessageRouter* const typed_message_router;

--- a/smart_card_connector_app/src/pp_module.cc
+++ b/smart_card_connector_app/src/pp_module.cc
@@ -68,8 +68,8 @@ class PpInstance final : public pp::Instance {
 
   void HandleMessage(const pp::Var& message) override {
     if (!typed_message_router_.OnMessageReceived(message)) {
-      GOOGLE_SMART_CARD_LOG_FATAL << "Unexpected message received: " <<
-          DebugDumpVar(message);
+      GOOGLE_SMART_CARD_LOG_FATAL << "Unexpected message received: "
+                                  << DebugDumpVar(message);
     }
   }
 
@@ -85,14 +85,13 @@ class PpInstance final : public pp::Instance {
     pcsc_lite_server_global_->InitializeAndRunDaemonThread();
 
     pcsc_lite_server_clients_management_backend_.reset(
-        new PcscLiteServerClientsManagementBackend(
-            this, &typed_message_router_));
+        new PcscLiteServerClientsManagementBackend(this,
+                                                   &typed_message_router_));
 
-    GOOGLE_SMART_CARD_LOG_DEBUG << "All services are successfully " <<
-        "initialized, posting ready message...";
-    PostMessage(MakeTypedMessage(
-        GetPcscLiteServerReadyMessageType(),
-        MakePcscLiteServerReadyMessageData()));
+    GOOGLE_SMART_CARD_LOG_DEBUG << "All services are successfully "
+                                << "initialized, posting ready message...";
+    PostMessage(MakeTypedMessage(GetPcscLiteServerReadyMessageType(),
+                                 MakePcscLiteServerReadyMessageData()));
   }
 
   TypedMessageRouter typed_message_router_;
@@ -116,8 +115,6 @@ class PpModule final : public pp::Module {
 
 namespace pp {
 
-Module* CreateModule() {
-  return new google_smart_card::PpModule;
-}
+Module* CreateModule() { return new google_smart_card::PpModule; }
 
 }  // namespace pp

--- a/third_party/libusb/naclport/src/chrome_usb/api_bridge.cc
+++ b/third_party/libusb/naclport/src/chrome_usb/api_bridge.cc
@@ -26,22 +26,21 @@ namespace google_smart_card {
 namespace chrome_usb {
 
 ApiBridge::ApiBridge(std::unique_ptr<Requester> requester)
-    : requester_(std::move(requester)),
-      remote_call_adaptor_(requester_.get()) {
+    : requester_(std::move(requester)), remote_call_adaptor_(requester_.get()) {
   GOOGLE_SMART_CARD_CHECK(requester_);
 }
 
-void ApiBridge::Detach() {
-  requester_->Detach();
-}
+ApiBridge::~ApiBridge() = default;
+
+void ApiBridge::Detach() { requester_->Detach(); }
 
 RequestResult<GetDevicesResult> ApiBridge::GetDevices(
     const GetDevicesOptions& options) {
   const GenericRequestResult generic_request_result =
       remote_call_adaptor_.SyncCall("getDevices", options);
   GetDevicesResult result;
-  return RemoteCallAdaptor::ConvertResultPayload(
-      generic_request_result, &result, &result.devices);
+  return RemoteCallAdaptor::ConvertResultPayload(generic_request_result,
+                                                 &result, &result.devices);
 }
 
 RequestResult<GetUserSelectedDevicesResult> ApiBridge::GetUserSelectedDevices(
@@ -49,8 +48,8 @@ RequestResult<GetUserSelectedDevicesResult> ApiBridge::GetUserSelectedDevices(
   const GenericRequestResult generic_request_result =
       remote_call_adaptor_.SyncCall("getUserSelectedDevices", options);
   GetUserSelectedDevicesResult result;
-  return RemoteCallAdaptor::ConvertResultPayload(
-      generic_request_result, &result, &result.devices);
+  return RemoteCallAdaptor::ConvertResultPayload(generic_request_result,
+                                                 &result, &result.devices);
 }
 
 RequestResult<GetConfigurationsResult> ApiBridge::GetConfigurations(
@@ -75,18 +74,18 @@ RequestResult<CloseDeviceResult> ApiBridge::CloseDevice(
   const GenericRequestResult generic_request_result =
       remote_call_adaptor_.SyncCall("closeDevice", connection_handle);
   CloseDeviceResult result;
-  return RemoteCallAdaptor::ConvertResultPayload(
-      generic_request_result, &result);
+  return RemoteCallAdaptor::ConvertResultPayload(generic_request_result,
+                                                 &result);
 }
 
 RequestResult<SetConfigurationResult> ApiBridge::SetConfiguration(
     const ConnectionHandle& connection_handle, int64_t configuration_value) {
   const GenericRequestResult generic_request_result =
-      remote_call_adaptor_.SyncCall(
-          "setConfiguration", connection_handle, configuration_value);
+      remote_call_adaptor_.SyncCall("setConfiguration", connection_handle,
+                                    configuration_value);
   SetConfigurationResult result;
-  return RemoteCallAdaptor::ConvertResultPayload(
-      generic_request_result, &result);
+  return RemoteCallAdaptor::ConvertResultPayload(generic_request_result,
+                                                 &result);
 }
 
 RequestResult<GetConfigurationResult> ApiBridge::GetConfiguration(
@@ -103,33 +102,34 @@ RequestResult<ListInterfacesResult> ApiBridge::ListInterfaces(
   const GenericRequestResult generic_request_result =
       remote_call_adaptor_.SyncCall("listInterfaces", connection_handle);
   ListInterfacesResult result;
-  return RemoteCallAdaptor::ConvertResultPayload(
-      generic_request_result, &result, &result.descriptors);
+  return RemoteCallAdaptor::ConvertResultPayload(generic_request_result,
+                                                 &result, &result.descriptors);
 }
 
 RequestResult<ClaimInterfaceResult> ApiBridge::ClaimInterface(
     const ConnectionHandle& connection_handle, int64_t interface_number) {
   const GenericRequestResult generic_request_result =
-      remote_call_adaptor_.SyncCall(
-          "claimInterface", connection_handle, interface_number);
+      remote_call_adaptor_.SyncCall("claimInterface", connection_handle,
+                                    interface_number);
   ClaimInterfaceResult result;
-  return RemoteCallAdaptor::ConvertResultPayload(
-      generic_request_result, &result);
+  return RemoteCallAdaptor::ConvertResultPayload(generic_request_result,
+                                                 &result);
 }
 
 RequestResult<ReleaseInterfaceResult> ApiBridge::ReleaseInterface(
     const ConnectionHandle& connection_handle, int64_t interface_number) {
   const GenericRequestResult generic_request_result =
-      remote_call_adaptor_.SyncCall(
-          "releaseInterface", connection_handle, interface_number);
+      remote_call_adaptor_.SyncCall("releaseInterface", connection_handle,
+                                    interface_number);
   ReleaseInterfaceResult result;
-  return RemoteCallAdaptor::ConvertResultPayload(
-      generic_request_result, &result);
+  return RemoteCallAdaptor::ConvertResultPayload(generic_request_result,
+                                                 &result);
 }
 
 namespace {
 
-GenericAsyncRequestCallback WrapAsyncTransferCallback(AsyncTransferCallback callback) {
+GenericAsyncRequestCallback WrapAsyncTransferCallback(
+    AsyncTransferCallback callback) {
   return [callback](GenericRequestResult generic_request_result) {
     TransferResult result;
     return callback(RemoteCallAdaptor::ConvertResultPayload(
@@ -139,37 +139,28 @@ GenericAsyncRequestCallback WrapAsyncTransferCallback(AsyncTransferCallback call
 
 }  // namespace
 
-void ApiBridge::AsyncControlTransfer(
-    const ConnectionHandle& connection_handle,
-    const ControlTransferInfo& transfer_info,
-    AsyncTransferCallback callback) {
-  remote_call_adaptor_.AsyncCall(
-      WrapAsyncTransferCallback(callback),
-      "controlTransfer",
-      connection_handle,
-      transfer_info);
+void ApiBridge::AsyncControlTransfer(const ConnectionHandle& connection_handle,
+                                     const ControlTransferInfo& transfer_info,
+                                     AsyncTransferCallback callback) {
+  remote_call_adaptor_.AsyncCall(WrapAsyncTransferCallback(callback),
+                                 "controlTransfer", connection_handle,
+                                 transfer_info);
 }
 
-void ApiBridge::AsyncBulkTransfer(
-    const ConnectionHandle& connection_handle,
-    const GenericTransferInfo& transfer_info,
-    AsyncTransferCallback callback) {
-  remote_call_adaptor_.AsyncCall(
-      WrapAsyncTransferCallback(callback),
-      "bulkTransfer",
-      connection_handle,
-      transfer_info);
+void ApiBridge::AsyncBulkTransfer(const ConnectionHandle& connection_handle,
+                                  const GenericTransferInfo& transfer_info,
+                                  AsyncTransferCallback callback) {
+  remote_call_adaptor_.AsyncCall(WrapAsyncTransferCallback(callback),
+                                 "bulkTransfer", connection_handle,
+                                 transfer_info);
 }
 
 void ApiBridge::AsyncInterruptTransfer(
     const ConnectionHandle& connection_handle,
-    const GenericTransferInfo& transfer_info,
-    AsyncTransferCallback callback) {
-  remote_call_adaptor_.AsyncCall(
-      WrapAsyncTransferCallback(callback),
-      "interruptTransfer",
-      connection_handle,
-      transfer_info);
+    const GenericTransferInfo& transfer_info, AsyncTransferCallback callback) {
+  remote_call_adaptor_.AsyncCall(WrapAsyncTransferCallback(callback),
+                                 "interruptTransfer", connection_handle,
+                                 transfer_info);
 }
 
 RequestResult<ResetDeviceResult> ApiBridge::ResetDevice(

--- a/third_party/libusb/naclport/src/chrome_usb/api_bridge.h
+++ b/third_party/libusb/naclport/src/chrome_usb/api_bridge.h
@@ -22,8 +22,8 @@
 #include <memory>
 
 #include <google_smart_card_common/requesting/remote_call_adaptor.h>
-#include <google_smart_card_common/requesting/requester.h>
 #include <google_smart_card_common/requesting/request_result.h>
+#include <google_smart_card_common/requesting/requester.h>
 
 #include "chrome_usb/api_bridge_interface.h"
 #include "chrome_usb/types.h"
@@ -45,6 +45,8 @@ class ApiBridge final : public ApiBridgeInterface {
  public:
   explicit ApiBridge(std::unique_ptr<Requester> requester);
   ApiBridge(const ApiBridge&) = delete;
+  ApiBridge& operator=(const ApiBridge&) = delete;
+  ~ApiBridge();
 
   void Detach();
 
@@ -71,18 +73,15 @@ class ApiBridge final : public ApiBridgeInterface {
   RequestResult<ReleaseInterfaceResult> ReleaseInterface(
       const ConnectionHandle& connection_handle,
       int64_t interface_number) override;
-  void AsyncControlTransfer(
-      const ConnectionHandle& connection_handle,
-      const ControlTransferInfo& transfer_info,
-      AsyncTransferCallback callback) override;
-  void AsyncBulkTransfer(
-      const ConnectionHandle& connection_handle,
-      const GenericTransferInfo& transfer_info,
-      AsyncTransferCallback callback) override;
-  void AsyncInterruptTransfer(
-      const ConnectionHandle& connection_handle,
-      const GenericTransferInfo& transfer_info,
-      AsyncTransferCallback callback) override;
+  void AsyncControlTransfer(const ConnectionHandle& connection_handle,
+                            const ControlTransferInfo& transfer_info,
+                            AsyncTransferCallback callback) override;
+  void AsyncBulkTransfer(const ConnectionHandle& connection_handle,
+                         const GenericTransferInfo& transfer_info,
+                         AsyncTransferCallback callback) override;
+  void AsyncInterruptTransfer(const ConnectionHandle& connection_handle,
+                              const GenericTransferInfo& transfer_info,
+                              AsyncTransferCallback callback) override;
   RequestResult<ResetDeviceResult> ResetDevice(
       const ConnectionHandle& connection_handle) override;
 

--- a/third_party/libusb/naclport/src/chrome_usb/api_bridge_interface.h
+++ b/third_party/libusb/naclport/src/chrome_usb/api_bridge_interface.h
@@ -63,20 +63,17 @@ class ApiBridgeInterface {
   virtual RequestResult<ReleaseInterfaceResult> ReleaseInterface(
       const ConnectionHandle& connection_handle, int64_t interface_number) = 0;
 
-  virtual void AsyncControlTransfer(
-      const ConnectionHandle& connection_handle,
-      const ControlTransferInfo& transfer_info,
-      AsyncTransferCallback callback) = 0;
+  virtual void AsyncControlTransfer(const ConnectionHandle& connection_handle,
+                                    const ControlTransferInfo& transfer_info,
+                                    AsyncTransferCallback callback) = 0;
 
-  virtual void AsyncBulkTransfer(
-      const ConnectionHandle& connection_handle,
-      const GenericTransferInfo& transfer_info,
-      AsyncTransferCallback callback) = 0;
+  virtual void AsyncBulkTransfer(const ConnectionHandle& connection_handle,
+                                 const GenericTransferInfo& transfer_info,
+                                 AsyncTransferCallback callback) = 0;
 
-  virtual void AsyncInterruptTransfer(
-      const ConnectionHandle& connection_handle,
-      const GenericTransferInfo& transfer_info,
-      AsyncTransferCallback callback) = 0;
+  virtual void AsyncInterruptTransfer(const ConnectionHandle& connection_handle,
+                                      const GenericTransferInfo& transfer_info,
+                                      AsyncTransferCallback callback) = 0;
 
   virtual RequestResult<ResetDeviceResult> ResetDevice(
       const ConnectionHandle& connection_handle) = 0;

--- a/third_party/libusb/naclport/src/chrome_usb/types.cc
+++ b/third_party/libusb/naclport/src/chrome_usb/types.cc
@@ -21,23 +21,23 @@
 
 namespace google_smart_card {
 
-using chrome_usb::Direction;
-using chrome_usb::Device;
-using chrome_usb::ConnectionHandle;
-using chrome_usb::EndpointDescriptorType;
-using chrome_usb::EndpointDescriptorSynchronization;
-using chrome_usb::EndpointDescriptorUsage;
-using chrome_usb::EndpointDescriptor;
-using chrome_usb::InterfaceDescriptor;
 using chrome_usb::ConfigDescriptor;
-using chrome_usb::GenericTransferInfo;
+using chrome_usb::ConnectionHandle;
+using chrome_usb::ControlTransferInfo;
 using chrome_usb::ControlTransferInfoRecipient;
 using chrome_usb::ControlTransferInfoRequestType;
-using chrome_usb::ControlTransferInfo;
-using chrome_usb::TransferResultInfo;
+using chrome_usb::Device;
 using chrome_usb::DeviceFilter;
+using chrome_usb::Direction;
+using chrome_usb::EndpointDescriptor;
+using chrome_usb::EndpointDescriptorSynchronization;
+using chrome_usb::EndpointDescriptorType;
+using chrome_usb::EndpointDescriptorUsage;
+using chrome_usb::GenericTransferInfo;
 using chrome_usb::GetDevicesOptions;
 using chrome_usb::GetUserSelectedDevicesOptions;
+using chrome_usb::InterfaceDescriptor;
+using chrome_usb::TransferResultInfo;
 
 using DirectionConverter = EnumConverter<Direction, std::string>;
 
@@ -45,14 +45,14 @@ using DeviceConverter = StructConverter<Device>;
 
 using ConnectionHandleConverter = StructConverter<ConnectionHandle>;
 
-using EndpointDescriptorTypeConverter = EnumConverter<
-    EndpointDescriptorType, std::string>;
+using EndpointDescriptorTypeConverter =
+    EnumConverter<EndpointDescriptorType, std::string>;
 
-using EndpointDescriptorSynchronizationConverter = EnumConverter<
-    EndpointDescriptorSynchronization, std::string>;
+using EndpointDescriptorSynchronizationConverter =
+    EnumConverter<EndpointDescriptorSynchronization, std::string>;
 
-using EndpointDescriptorUsageConverter = EnumConverter<
-    EndpointDescriptorUsage, std::string>;
+using EndpointDescriptorUsageConverter =
+    EnumConverter<EndpointDescriptorUsage, std::string>;
 
 using EndpointDescriptorConverter = StructConverter<EndpointDescriptor>;
 
@@ -62,11 +62,11 @@ using ConfigDescriptorConverter = StructConverter<ConfigDescriptor>;
 
 using GenericTransferInfoConverter = StructConverter<GenericTransferInfo>;
 
-using ControlTransferInfoRecipientConverter = EnumConverter<
-    ControlTransferInfoRecipient, std::string>;
+using ControlTransferInfoRecipientConverter =
+    EnumConverter<ControlTransferInfoRecipient, std::string>;
 
-using ControlTransferInfoRequestTypeConverter = EnumConverter<
-    ControlTransferInfoRequestType, std::string>;
+using ControlTransferInfoRequestTypeConverter =
+    EnumConverter<ControlTransferInfoRequestType, std::string>;
 
 using ControlTransferInfoConverter = StructConverter<ControlTransferInfo>;
 
@@ -81,39 +81,31 @@ using GetUserSelectedDevicesOptionsConverter =
 
 namespace {
 
-bool IsSameOptionalArrayBuffer(
-    const optional<pp::VarArrayBuffer>& lhs,
-    const optional<pp::VarArrayBuffer>& rhs) {
-  if (!lhs || !rhs)
-    return lhs == rhs;
+bool IsSameOptionalArrayBuffer(const optional<pp::VarArrayBuffer>& lhs,
+                               const optional<pp::VarArrayBuffer>& rhs) {
+  if (!lhs || !rhs) return lhs == rhs;
   return VarAs<std::vector<uint8_t>>(*lhs) == VarAs<std::vector<uint8_t>>(*rhs);
 }
 
 }  // namespace
 
 bool Device::operator==(const Device& other) const {
-  return device == other.device &&
-         vendor_id == other.vendor_id &&
-         product_id == other.product_id &&
-         version == other.version &&
+  return device == other.device && vendor_id == other.vendor_id &&
+         product_id == other.product_id && version == other.version &&
          product_name == other.product_name &&
          manufacturer_name == other.manufacturer_name &&
          serial_number == other.serial_number;
 }
 
 bool ConnectionHandle::operator==(const ConnectionHandle& other) const {
-  return handle == other.handle &&
-         vendor_id == other.vendor_id &&
+  return handle == other.handle && vendor_id == other.vendor_id &&
          product_id == other.product_id;
 }
 
 bool ControlTransferInfo::operator==(const ControlTransferInfo& other) const {
-  return direction == other.direction &&
-         recipient == other.recipient &&
-         request_type == other.request_type &&
-         request == other.request &&
-         value == other.value &&
-         index == other.index &&
+  return direction == other.direction && recipient == other.recipient &&
+         request_type == other.request_type && request == other.request &&
+         value == other.value && index == other.index &&
          length == other.length &&
          IsSameOptionalArrayBuffer(data, other.data) &&
          timeout == other.timeout;
@@ -161,8 +153,8 @@ constexpr const char* ConnectionHandleConverter::GetStructTypeName() {
 // static
 template <>
 template <typename Callback>
-void ConnectionHandleConverter::VisitFields(
-    const ConnectionHandle& value, Callback callback) {
+void ConnectionHandleConverter::VisitFields(const ConnectionHandle& value,
+                                            Callback callback) {
   callback(&value.handle, "handle");
   callback(&value.vendor_id, "vendorId");
   callback(&value.product_id, "productId");
@@ -229,8 +221,8 @@ constexpr const char* EndpointDescriptorConverter::GetStructTypeName() {
 // static
 template <>
 template <typename Callback>
-void EndpointDescriptorConverter::VisitFields(
-    const EndpointDescriptor& value, Callback callback) {
+void EndpointDescriptorConverter::VisitFields(const EndpointDescriptor& value,
+                                              Callback callback) {
   callback(&value.address, "address");
   callback(&value.type, "type");
   callback(&value.direction, "direction");
@@ -250,8 +242,8 @@ constexpr const char* InterfaceDescriptorConverter::GetStructTypeName() {
 // static
 template <>
 template <typename Callback>
-void InterfaceDescriptorConverter::VisitFields(
-    const InterfaceDescriptor& value, Callback callback) {
+void InterfaceDescriptorConverter::VisitFields(const InterfaceDescriptor& value,
+                                               Callback callback) {
   callback(&value.interface_number, "interfaceNumber");
   callback(&value.alternate_setting, "alternateSetting");
   callback(&value.interface_class, "interfaceClass");
@@ -271,8 +263,8 @@ constexpr const char* ConfigDescriptorConverter::GetStructTypeName() {
 // static
 template <>
 template <typename Callback>
-void ConfigDescriptorConverter::VisitFields(
-    const ConfigDescriptor& value, Callback callback) {
+void ConfigDescriptorConverter::VisitFields(const ConfigDescriptor& value,
+                                            Callback callback) {
   callback(&value.active, "active");
   callback(&value.configuration_value, "configurationValue");
   callback(&value.description, "description");
@@ -292,8 +284,8 @@ constexpr const char* GenericTransferInfoConverter::GetStructTypeName() {
 // static
 template <>
 template <typename Callback>
-void GenericTransferInfoConverter::VisitFields(
-    const GenericTransferInfo& value, Callback callback) {
+void GenericTransferInfoConverter::VisitFields(const GenericTransferInfo& value,
+                                               Callback callback) {
   callback(&value.direction, "direction");
   callback(&value.endpoint, "endpoint");
   callback(&value.length, "length");
@@ -345,8 +337,8 @@ constexpr const char* ControlTransferInfoConverter::GetStructTypeName() {
 // static
 template <>
 template <typename Callback>
-void ControlTransferInfoConverter::VisitFields(
-    const ControlTransferInfo& value, Callback callback) {
+void ControlTransferInfoConverter::VisitFields(const ControlTransferInfo& value,
+                                               Callback callback) {
   callback(&value.direction, "direction");
   callback(&value.recipient, "recipient");
   callback(&value.request_type, "requestType");
@@ -367,8 +359,8 @@ constexpr const char* TransferResultInfoConverter::GetStructTypeName() {
 // static
 template <>
 template <typename Callback>
-void TransferResultInfoConverter::VisitFields(
-    const TransferResultInfo& value, Callback callback) {
+void TransferResultInfoConverter::VisitFields(const TransferResultInfo& value,
+                                              Callback callback) {
   callback(&value.result_code, "resultCode");
   callback(&value.data, "data");
 }
@@ -382,8 +374,8 @@ constexpr const char* DeviceFilterConverter::GetStructTypeName() {
 // static
 template <>
 template <typename Callback>
-void DeviceFilterConverter::VisitFields(
-    const DeviceFilter& value, Callback callback) {
+void DeviceFilterConverter::VisitFields(const DeviceFilter& value,
+                                        Callback callback) {
   callback(&value.vendor_id, "vendorId");
   callback(&value.product_id, "productId");
   callback(&value.interface_class, "interfaceClass");
@@ -400,8 +392,8 @@ constexpr const char* GetDevicesOptionsConverter::GetStructTypeName() {
 // static
 template <>
 template <typename Callback>
-void GetDevicesOptionsConverter::VisitFields(
-    const GetDevicesOptions& value, Callback callback) {
+void GetDevicesOptionsConverter::VisitFields(const GetDevicesOptions& value,
+                                             Callback callback) {
   callback(&value.filters, "filters");
 }
 
@@ -438,8 +430,8 @@ pp::Var MakeVar(const Device& value) {
   return DeviceConverter::ConvertToVar(value);
 }
 
-bool VarAs(
-    const pp::Var& var, ConnectionHandle* result, std::string* error_message) {
+bool VarAs(const pp::Var& var, ConnectionHandle* result,
+           std::string* error_message) {
   return ConnectionHandleConverter::ConvertFromVar(var, result, error_message);
 }
 
@@ -447,22 +439,18 @@ pp::Var MakeVar(const ConnectionHandle& value) {
   return ConnectionHandleConverter::ConvertToVar(value);
 }
 
-bool VarAs(
-    const pp::Var& var,
-    EndpointDescriptorType* result,
-    std::string* error_message) {
-  return EndpointDescriptorTypeConverter::ConvertFromVar(
-      var, result, error_message);
+bool VarAs(const pp::Var& var, EndpointDescriptorType* result,
+           std::string* error_message) {
+  return EndpointDescriptorTypeConverter::ConvertFromVar(var, result,
+                                                         error_message);
 }
 
 pp::Var MakeVar(EndpointDescriptorType value) {
   return EndpointDescriptorTypeConverter::ConvertToVar(value);
 }
 
-bool VarAs(
-    const pp::Var& var,
-    EndpointDescriptorSynchronization* result,
-    std::string* error_message) {
+bool VarAs(const pp::Var& var, EndpointDescriptorSynchronization* result,
+           std::string* error_message) {
   return EndpointDescriptorSynchronizationConverter::ConvertFromVar(
       var, result, error_message);
 }
@@ -471,38 +459,30 @@ pp::Var MakeVar(EndpointDescriptorSynchronization value) {
   return EndpointDescriptorSynchronizationConverter::ConvertToVar(value);
 }
 
-bool VarAs(
-    const pp::Var& var,
-    EndpointDescriptorUsage* result,
-    std::string* error_message) {
-  return EndpointDescriptorUsageConverter::ConvertFromVar(
-      var, result, error_message);
+bool VarAs(const pp::Var& var, EndpointDescriptorUsage* result,
+           std::string* error_message) {
+  return EndpointDescriptorUsageConverter::ConvertFromVar(var, result,
+                                                          error_message);
 }
 
 pp::Var MakeVar(EndpointDescriptorUsage value) {
   return EndpointDescriptorUsageConverter::ConvertToVar(value);
 }
 
-bool VarAs(
-    const pp::Var& var,
-    EndpointDescriptor* result,
-    std::string* error_message) {
-  return EndpointDescriptorConverter::ConvertFromVar(
-      var, result, error_message);
+bool VarAs(const pp::Var& var, EndpointDescriptor* result,
+           std::string* error_message) {
+  return EndpointDescriptorConverter::ConvertFromVar(var, result,
+                                                     error_message);
 }
 
-bool VarAs(
-    const pp::Var& var,
-    InterfaceDescriptor* result,
-    std::string* error_message) {
-  return InterfaceDescriptorConverter::ConvertFromVar(
-      var, result, error_message);
+bool VarAs(const pp::Var& var, InterfaceDescriptor* result,
+           std::string* error_message) {
+  return InterfaceDescriptorConverter::ConvertFromVar(var, result,
+                                                      error_message);
 }
 
-bool VarAs(
-    const pp::Var& var,
-    ConfigDescriptor* result,
-    std::string* error_message) {
+bool VarAs(const pp::Var& var, ConfigDescriptor* result,
+           std::string* error_message) {
   return ConfigDescriptorConverter::ConvertFromVar(var, result, error_message);
 }
 
@@ -522,12 +502,10 @@ pp::Var MakeVar(const ControlTransferInfo& value) {
   return ControlTransferInfoConverter::ConvertToVar(value);
 }
 
-bool VarAs(
-    const pp::Var& var,
-    TransferResultInfo* result,
-    std::string* error_message) {
-  return TransferResultInfoConverter::ConvertFromVar(
-      var, result, error_message);
+bool VarAs(const pp::Var& var, TransferResultInfo* result,
+           std::string* error_message) {
+  return TransferResultInfoConverter::ConvertFromVar(var, result,
+                                                     error_message);
 }
 
 pp::Var MakeVar(const DeviceFilter& value) {

--- a/third_party/libusb/naclport/src/chrome_usb/types.h
+++ b/third_party/libusb/naclport/src/chrome_usb/types.h
@@ -202,60 +202,42 @@ struct GetUserSelectedDevicesOptions {
 // to the JavaScript values used with chrome.usb API).
 //
 
-bool VarAs(
-    const pp::Var& var,
-    Direction* result,
-    std::string* error_message);
+bool VarAs(const pp::Var& var, Direction* result, std::string* error_message);
 
 pp::Var MakeVar(Direction value);
 
-bool VarAs(
-    const pp::Var& var, Device* result, std::string* error_message);
+bool VarAs(const pp::Var& var, Device* result, std::string* error_message);
 
 pp::Var MakeVar(const Device& value);
 
-bool VarAs(
-    const pp::Var& var,
-    ConnectionHandle* result,
-    std::string* error_message);
+bool VarAs(const pp::Var& var, ConnectionHandle* result,
+           std::string* error_message);
 
 pp::Var MakeVar(const ConnectionHandle& value);
 
-bool VarAs(
-    const pp::Var& var,
-    EndpointDescriptorType* result,
-    std::string* error_message);
+bool VarAs(const pp::Var& var, EndpointDescriptorType* result,
+           std::string* error_message);
 
 pp::Var MakeVar(EndpointDescriptorType value);
 
-bool VarAs(
-    const pp::Var& var,
-    EndpointDescriptorSynchronization* result,
-    std::string* error_message);
+bool VarAs(const pp::Var& var, EndpointDescriptorSynchronization* result,
+           std::string* error_message);
 
 pp::Var MakeVar(EndpointDescriptorSynchronization value);
 
-bool VarAs(
-    const pp::Var& var,
-    EndpointDescriptorUsage* result,
-    std::string* error_message);
+bool VarAs(const pp::Var& var, EndpointDescriptorUsage* result,
+           std::string* error_message);
 
 pp::Var MakeVar(EndpointDescriptorUsage value);
 
-bool VarAs(
-    const pp::Var& var,
-    EndpointDescriptor* result,
-    std::string* error_message);
+bool VarAs(const pp::Var& var, EndpointDescriptor* result,
+           std::string* error_message);
 
-bool VarAs(
-    const pp::Var& var,
-    InterfaceDescriptor* result,
-    std::string* error_message);
+bool VarAs(const pp::Var& var, InterfaceDescriptor* result,
+           std::string* error_message);
 
-bool VarAs(
-    const pp::Var& var,
-    ConfigDescriptor* result,
-    std::string* error_message);
+bool VarAs(const pp::Var& var, ConfigDescriptor* result,
+           std::string* error_message);
 
 pp::Var MakeVar(const GenericTransferInfo& value);
 
@@ -265,10 +247,8 @@ pp::Var MakeVar(ControlTransferInfoRequestType value);
 
 pp::Var MakeVar(const ControlTransferInfo& value);
 
-bool VarAs(
-    const pp::Var& var,
-    TransferResultInfo* result,
-    std::string* error_message);
+bool VarAs(const pp::Var& var, TransferResultInfo* result,
+           std::string* error_message);
 
 pp::Var MakeVar(const DeviceFilter& value);
 
@@ -323,8 +303,8 @@ struct ResetDeviceResult {
 
 // This type represents a callback that is used for receiving the asynchronous
 // transfer results.
-using AsyncTransferCallback = std::function<
-    void(RequestResult<TransferResult>)>;
+using AsyncTransferCallback =
+    std::function<void(RequestResult<TransferResult>)>;
 
 }  // namespace chrome_usb
 

--- a/third_party/libusb/naclport/src/google_smart_card_libusb/global.cc
+++ b/third_party/libusb/naclport/src/google_smart_card_libusb/global.cc
@@ -45,39 +45,32 @@ namespace google_smart_card {
 
 class LibusbOverChromeUsbGlobal::Impl final {
  public:
-  Impl(
-      TypedMessageRouter* typed_message_router,
-      pp::Instance* pp_instance,
-      pp::Core* pp_core)
-      : chrome_usb_api_bridge_(MakeRequester(
-            typed_message_router, pp_instance, pp_core)),
+  Impl(TypedMessageRouter* typed_message_router, pp::Instance* pp_instance,
+       pp::Core* pp_core)
+      : chrome_usb_api_bridge_(
+            MakeRequester(typed_message_router, pp_instance, pp_core)),
         libusb_over_chrome_usb_(&chrome_usb_api_bridge_) {
 #ifndef NDEBUG
-    libusb_tracing_wrapper_.reset(new LibusbTracingWrapper(
-        &libusb_over_chrome_usb_));
+    libusb_tracing_wrapper_.reset(
+        new LibusbTracingWrapper(&libusb_over_chrome_usb_));
 #endif  // NDEBUG
   }
 
   Impl(const Impl&) = delete;
 
-  void Detach() {
-    chrome_usb_api_bridge_.Detach();
-  }
+  void Detach() { chrome_usb_api_bridge_.Detach(); }
 
   LibusbInterface* libusb() {
-    if (libusb_tracing_wrapper_)
-      return libusb_tracing_wrapper_.get();
+    if (libusb_tracing_wrapper_) return libusb_tracing_wrapper_.get();
     return &libusb_over_chrome_usb_;
   }
 
  private:
   static std::unique_ptr<Requester> MakeRequester(
-      TypedMessageRouter* typed_message_router,
-      pp::Instance* pp_instance,
+      TypedMessageRouter* typed_message_router, pp::Instance* pp_instance,
       pp::Core* pp_core) {
     return std::unique_ptr<Requester>(new JsRequester(
-        chrome_usb::kApiBridgeRequesterName,
-        typed_message_router,
+        chrome_usb::kApiBridgeRequesterName, typed_message_router,
         MakeUnique<JsRequester::PpDelegateImpl>(pp_instance, pp_core)));
   }
 
@@ -87,8 +80,7 @@ class LibusbOverChromeUsbGlobal::Impl final {
 };
 
 LibusbOverChromeUsbGlobal::LibusbOverChromeUsbGlobal(
-    TypedMessageRouter* typed_message_router,
-    pp::Instance* pp_instance,
+    TypedMessageRouter* typed_message_router, pp::Instance* pp_instance,
     pp::Core* pp_core)
     : impl_(new Impl(typed_message_router, pp_instance, pp_core)) {
   GOOGLE_SMART_CARD_CHECK(!g_libusb);
@@ -100,9 +92,7 @@ LibusbOverChromeUsbGlobal::~LibusbOverChromeUsbGlobal() {
   g_libusb = nullptr;
 }
 
-void LibusbOverChromeUsbGlobal::Detach() {
-  impl_->Detach();
-}
+void LibusbOverChromeUsbGlobal::Detach() { impl_->Detach(); }
 
 }  // namespace google_smart_card
 
@@ -114,13 +104,13 @@ void LIBUSB_CALL libusb_exit(libusb_context* ctx) {
   GetGlobalLibusb()->LibusbExit(ctx);
 }
 
-ssize_t LIBUSB_CALL libusb_get_device_list(
-    libusb_context* ctx, libusb_device*** list) {
+ssize_t LIBUSB_CALL libusb_get_device_list(libusb_context* ctx,
+                                           libusb_device*** list) {
   return GetGlobalLibusb()->LibusbGetDeviceList(ctx, list);
 }
 
-void LIBUSB_CALL libusb_free_device_list(
-    libusb_device** list, int unref_devices) {
+void LIBUSB_CALL libusb_free_device_list(libusb_device** list,
+                                         int unref_devices) {
   GetGlobalLibusb()->LibusbFreeDeviceList(list, unref_devices);
 }
 
@@ -137,13 +127,13 @@ int LIBUSB_CALL libusb_get_active_config_descriptor(
   return GetGlobalLibusb()->LibusbGetActiveConfigDescriptor(dev, config);
 }
 
-void LIBUSB_CALL libusb_free_config_descriptor(
-    libusb_config_descriptor* config) {
+void LIBUSB_CALL
+libusb_free_config_descriptor(libusb_config_descriptor* config) {
   return GetGlobalLibusb()->LibusbFreeConfigDescriptor(config);
 }
 
-int LIBUSB_CALL libusb_get_device_descriptor(
-    libusb_device* dev, libusb_device_descriptor* desc) {
+int LIBUSB_CALL libusb_get_device_descriptor(libusb_device* dev,
+                                             libusb_device_descriptor* desc) {
   return GetGlobalLibusb()->LibusbGetDeviceDescriptor(dev, desc);
 }
 
@@ -163,13 +153,13 @@ void LIBUSB_CALL libusb_close(libusb_device_handle* dev_handle) {
   return GetGlobalLibusb()->LibusbClose(dev_handle);
 }
 
-int LIBUSB_CALL libusb_claim_interface(
-    libusb_device_handle* dev, int interface_number) {
+int LIBUSB_CALL libusb_claim_interface(libusb_device_handle* dev,
+                                       int interface_number) {
   return GetGlobalLibusb()->LibusbClaimInterface(dev, interface_number);
 }
 
-int LIBUSB_CALL libusb_release_interface(
-    libusb_device_handle* dev, int interface_number) {
+int LIBUSB_CALL libusb_release_interface(libusb_device_handle* dev,
+                                         int interface_number) {
   return GetGlobalLibusb()->LibusbReleaseInterface(dev, interface_number);
 }
 
@@ -193,44 +183,29 @@ int LIBUSB_CALL libusb_reset_device(libusb_device_handle* dev) {
   return GetGlobalLibusb()->LibusbResetDevice(dev);
 }
 
-int LIBUSB_CALL libusb_control_transfer(
-    libusb_device_handle* dev_handle,
-    uint8_t request_type,
-    uint8_t bRequest,
-    uint16_t wValue,
-    uint16_t wIndex,
-    unsigned char* data,
-    uint16_t wLength,
-    unsigned int timeout) {
-  return GetGlobalLibusb()->LibusbControlTransfer(
-      dev_handle,
-      request_type,
-      bRequest,
-      wValue,
-      wIndex,
-      data,
-      wLength,
-      timeout);
+int LIBUSB_CALL libusb_control_transfer(libusb_device_handle* dev_handle,
+                                        uint8_t request_type, uint8_t bRequest,
+                                        uint16_t wValue, uint16_t wIndex,
+                                        unsigned char* data, uint16_t wLength,
+                                        unsigned int timeout) {
+  return GetGlobalLibusb()->LibusbControlTransfer(dev_handle, request_type,
+                                                  bRequest, wValue, wIndex,
+                                                  data, wLength, timeout);
 }
 
-int LIBUSB_CALL libusb_bulk_transfer(
-    libusb_device_handle* dev_handle,
-    unsigned char endpoint,
-    unsigned char* data,
-    int length,
-    int* actual_length,
-    unsigned int timeout) {
-  return GetGlobalLibusb()->LibusbBulkTransfer(
-      dev_handle, endpoint, data, length, actual_length, timeout);
+int LIBUSB_CALL libusb_bulk_transfer(libusb_device_handle* dev_handle,
+                                     unsigned char endpoint,
+                                     unsigned char* data, int length,
+                                     int* actual_length, unsigned int timeout) {
+  return GetGlobalLibusb()->LibusbBulkTransfer(dev_handle, endpoint, data,
+                                               length, actual_length, timeout);
 }
 
-int LIBUSB_CALL libusb_interrupt_transfer(
-    libusb_device_handle* dev_handle,
-    unsigned char endpoint,
-    unsigned char* data,
-    int length,
-    int* actual_length,
-    unsigned int timeout) {
+int LIBUSB_CALL libusb_interrupt_transfer(libusb_device_handle* dev_handle,
+                                          unsigned char endpoint,
+                                          unsigned char* data, int length,
+                                          int* actual_length,
+                                          unsigned int timeout) {
   return GetGlobalLibusb()->LibusbInterruptTransfer(
       dev_handle, endpoint, data, length, actual_length, timeout);
 }
@@ -239,7 +214,7 @@ int LIBUSB_CALL libusb_handle_events(libusb_context* ctx) {
   return GetGlobalLibusb()->LibusbHandleEvents(ctx);
 }
 
-int LIBUSB_CALL libusb_handle_events_completed(
-    libusb_context* ctx, int* completed) {
+int LIBUSB_CALL libusb_handle_events_completed(libusb_context* ctx,
+                                               int* completed) {
   return GetGlobalLibusb()->LibusbHandleEventsCompleted(ctx, completed);
 }

--- a/third_party/libusb/naclport/src/google_smart_card_libusb/global.h
+++ b/third_party/libusb/naclport/src/google_smart_card_libusb/global.h
@@ -39,12 +39,12 @@ namespace google_smart_card {
 // concurrent libusb_* function calls.
 class LibusbOverChromeUsbGlobal final {
  public:
-  LibusbOverChromeUsbGlobal(
-      TypedMessageRouter* typed_message_router,
-      pp::Instance* pp_instance,
-      pp::Core* pp_core);
+  LibusbOverChromeUsbGlobal(TypedMessageRouter* typed_message_router,
+                            pp::Instance* pp_instance, pp::Core* pp_core);
 
   LibusbOverChromeUsbGlobal(const LibusbOverChromeUsbGlobal&) = delete;
+  LibusbOverChromeUsbGlobal& operator=(const LibusbOverChromeUsbGlobal&) =
+      delete;
 
   // Destroys the self instance and the owned LibusbOverChromeUsb instance.
   //

--- a/third_party/libusb/naclport/src/libusb_contexts_storage.cc
+++ b/third_party/libusb/naclport/src/libusb_contexts_storage.cc
@@ -18,6 +18,10 @@
 
 namespace google_smart_card {
 
+LibusbContextsStorage::LibusbContextsStorage() = default;
+
+LibusbContextsStorage::~LibusbContextsStorage() = default;
+
 std::shared_ptr<libusb_context> LibusbContextsStorage::CreateContext() {
   const std::unique_lock<std::mutex> lock(mutex_);
 

--- a/third_party/libusb/naclport/src/libusb_contexts_storage.h
+++ b/third_party/libusb/naclport/src/libusb_contexts_storage.h
@@ -35,8 +35,10 @@ namespace google_smart_card {
 // to the libusb_opaque_types.h header).
 class LibusbContextsStorage final {
  public:
-  LibusbContextsStorage() = default;
+  LibusbContextsStorage();
   LibusbContextsStorage(const LibusbContextsStorage&) = delete;
+  LibusbContextsStorage& operator=(const LibusbContextsStorage&) = delete;
+  ~LibusbContextsStorage();
 
   std::shared_ptr<libusb_context> CreateContext();
 
@@ -48,7 +50,7 @@ class LibusbContextsStorage final {
  private:
   mutable std::mutex mutex_;
   std::unordered_map<const libusb_context*, std::shared_ptr<libusb_context>>
-  mapping_;
+      mapping_;
 };
 
 }  // namespace google_smart_card

--- a/third_party/libusb/naclport/src/libusb_interface.h
+++ b/third_party/libusb/naclport/src/libusb_interface.h
@@ -36,10 +36,10 @@ class LibusbInterface {
   virtual int LibusbInit(libusb_context** ctx) = 0;
   virtual void LibusbExit(libusb_context* ctx) = 0;
 
-  virtual ssize_t LibusbGetDeviceList(
-      libusb_context* ctx, libusb_device*** list) = 0;
-  virtual void LibusbFreeDeviceList(
-      libusb_device** list, int unref_devices) = 0;
+  virtual ssize_t LibusbGetDeviceList(libusb_context* ctx,
+                                      libusb_device*** list) = 0;
+  virtual void LibusbFreeDeviceList(libusb_device** list,
+                                    int unref_devices) = 0;
 
   virtual libusb_device* LibusbRefDevice(libusb_device* dev) = 0;
   virtual void LibusbUnrefDevice(libusb_device* dev) = 0;
@@ -48,8 +48,8 @@ class LibusbInterface {
       libusb_device* dev, libusb_config_descriptor** config) = 0;
   virtual void LibusbFreeConfigDescriptor(libusb_config_descriptor* config) = 0;
 
-  virtual int LibusbGetDeviceDescriptor(
-      libusb_device* dev, libusb_device_descriptor* desc) = 0;
+  virtual int LibusbGetDeviceDescriptor(libusb_device* dev,
+                                        libusb_device_descriptor* desc) = 0;
 
   virtual uint8_t LibusbGetBusNumber(libusb_device* dev) = 0;
   virtual uint8_t LibusbGetDeviceAddress(libusb_device* dev) = 0;
@@ -57,10 +57,10 @@ class LibusbInterface {
   virtual int LibusbOpen(libusb_device* dev, libusb_device_handle** handle) = 0;
   virtual void LibusbClose(libusb_device_handle* handle) = 0;
 
-  virtual int LibusbClaimInterface(
-      libusb_device_handle* dev, int interface_number) = 0;
-  virtual int LibusbReleaseInterface(
-      libusb_device_handle* dev, int interface_number) = 0;
+  virtual int LibusbClaimInterface(libusb_device_handle* dev,
+                                   int interface_number) = 0;
+  virtual int LibusbReleaseInterface(libusb_device_handle* dev,
+                                     int interface_number) = 0;
 
   virtual int LibusbResetDevice(libusb_device_handle* dev) = 0;
 
@@ -69,33 +69,23 @@ class LibusbInterface {
   virtual int LibusbCancelTransfer(libusb_transfer* transfer) = 0;
   virtual void LibusbFreeTransfer(libusb_transfer* transfer) = 0;
 
-  virtual int LibusbControlTransfer(
-      libusb_device_handle* dev,
-      uint8_t bmRequestType,
-      uint8_t bRequest,
-      uint16_t wValue,
-      uint16_t wIndex,
-      unsigned char* data,
-      uint16_t wLength,
-      unsigned timeout) = 0;
-  virtual int LibusbBulkTransfer(
-      libusb_device_handle* dev,
-      unsigned char endpoint,
-      unsigned char* data,
-      int length,
-      int* actual_length,
-      unsigned timeout) = 0;
-  virtual int LibusbInterruptTransfer(
-      libusb_device_handle* dev,
-      unsigned char endpoint,
-      unsigned char* data,
-      int length,
-      int* actual_length,
-      unsigned timeout) = 0;
+  virtual int LibusbControlTransfer(libusb_device_handle* dev,
+                                    uint8_t bmRequestType, uint8_t bRequest,
+                                    uint16_t wValue, uint16_t wIndex,
+                                    unsigned char* data, uint16_t wLength,
+                                    unsigned timeout) = 0;
+  virtual int LibusbBulkTransfer(libusb_device_handle* dev,
+                                 unsigned char endpoint, unsigned char* data,
+                                 int length, int* actual_length,
+                                 unsigned timeout) = 0;
+  virtual int LibusbInterruptTransfer(libusb_device_handle* dev,
+                                      unsigned char endpoint,
+                                      unsigned char* data, int length,
+                                      int* actual_length, unsigned timeout) = 0;
 
   virtual int LibusbHandleEvents(libusb_context* ctx) = 0;
-  virtual int LibusbHandleEventsCompleted(
-      libusb_context* ctx, int* completed) = 0;
+  virtual int LibusbHandleEventsCompleted(libusb_context* ctx,
+                                          int* completed) = 0;
 };
 
 }  // namespace google_smart_card

--- a/third_party/libusb/naclport/src/libusb_opaque_types.h
+++ b/third_party/libusb/naclport/src/libusb_opaque_types.h
@@ -130,7 +130,7 @@ struct libusb_context final
   // <http://libusb.org/static/api-1.0/mtasync.html>.
   void WaitAndProcessAsyncTransferReceivedResults(
       const std::chrono::time_point<std::chrono::high_resolution_clock>&
-      timeout_time_point,
+          timeout_time_point,
       int* completed);
 
   // Tries to cancel the specified asynchronous transfer.
@@ -158,10 +158,9 @@ struct libusb_context final
       TransferRequestResult result);
 
  private:
-  void AddTransferInFlight(
-      TransferAsyncRequestStatePtr async_request_state,
-      const UsbTransferDestination& transfer_destination,
-      libusb_transfer* transfer);
+  void AddTransferInFlight(TransferAsyncRequestStatePtr async_request_state,
+                           const UsbTransferDestination& transfer_destination,
+                           libusb_transfer* transfer);
 
   void RemoveTransferInFlight(
       const TransferAsyncRequestState* async_request_state);
@@ -183,9 +182,8 @@ struct libusb_context final
       const UsbTransferDestination& transfer_destination,
       TransferRequestResult* result);
 
-  void SetTransferResult(
-      TransferAsyncRequestState* async_request_state,
-      TransferRequestResult result);
+  void SetTransferResult(TransferAsyncRequestState* async_request_state,
+                         TransferRequestResult result);
 
   mutable std::mutex mutex_;
   std::condition_variable condition_;
@@ -202,11 +200,11 @@ struct libusb_context final
   // Each transfers group is stored in a queue, which allows to preserve the
   // relative order in which they where received.
   std::map<UsbTransferDestination, std::queue<TransferRequestResult>>
-  received_input_transfer_result_map_;
+      received_input_transfer_result_map_;
   // This member stores the received data for the finished output transfer
   // requests.
   std::map<TransferAsyncRequestStatePtr, TransferRequestResult>
-  received_output_transfer_result_map_;
+      received_output_transfer_result_map_;
   // This set stores pointers to the transfers for which the cancellation was
   // requests.
   std::set<libusb_transfer*> transfers_to_cancel_;
@@ -217,9 +215,8 @@ struct libusb_context final
 // The structure corresponds to the Device structure in chrome.usb interface.
 struct libusb_device final {
   // Creates a new structure with the reference counter equal to 1.
-  libusb_device(
-      libusb_context* context,
-      const google_smart_card::chrome_usb::Device& chrome_usb_device);
+  libusb_device(libusb_context* context,
+                const google_smart_card::chrome_usb::Device& chrome_usb_device);
 
   ~libusb_device();
 
@@ -235,7 +232,7 @@ struct libusb_device final {
  private:
   libusb_context* context_;
   google_smart_card::chrome_usb::Device chrome_usb_device_;
-  std::atomic_int reference_count_;
+  std::atomic_int reference_count_{1};
 };
 
 // Definition of the libusb_device_handle type declared in the libusb headers.
@@ -245,10 +242,9 @@ struct libusb_device final {
 struct libusb_device_handle final {
   // Constructs the structure and increments the reference counter of the
   // specified libusb_device instance.
-  libusb_device_handle(
-      libusb_device* device,
-      const google_smart_card::chrome_usb::ConnectionHandle&
-          chrome_usb_connection_handle);
+  libusb_device_handle(libusb_device* device,
+                       const google_smart_card::chrome_usb::ConnectionHandle&
+                           chrome_usb_connection_handle);
 
   // Destructs the structure and decrements the reference counter of the
   // specified libusb_device instance.

--- a/third_party/libusb/naclport/src/libusb_over_chrome_usb.h
+++ b/third_party/libusb/naclport/src/libusb_over_chrome_usb.h
@@ -53,56 +53,45 @@ class LibusbOverChromeUsb final : public LibusbInterface {
   explicit LibusbOverChromeUsb(
       chrome_usb::ApiBridgeInterface* chrome_usb_api_bridge);
   LibusbOverChromeUsb(const LibusbOverChromeUsb&) = delete;
+  LibusbOverChromeUsb& operator=(const LibusbOverChromeUsb&) = delete;
+  ~LibusbOverChromeUsb();
 
   // LibusbInterface:
   int LibusbInit(libusb_context** ctx) override;
   void LibusbExit(libusb_context* ctx) override;
-  ssize_t LibusbGetDeviceList(
-      libusb_context* ctx, libusb_device*** list) override;
+  ssize_t LibusbGetDeviceList(libusb_context* ctx,
+                              libusb_device*** list) override;
   void LibusbFreeDeviceList(libusb_device** list, int unref_devices) override;
   libusb_device* LibusbRefDevice(libusb_device* dev) override;
   void LibusbUnrefDevice(libusb_device* dev) override;
   int LibusbGetActiveConfigDescriptor(
       libusb_device* dev, libusb_config_descriptor** config) override;
   void LibusbFreeConfigDescriptor(libusb_config_descriptor* config) override;
-  int LibusbGetDeviceDescriptor(
-      libusb_device* dev, libusb_device_descriptor* desc) override;
+  int LibusbGetDeviceDescriptor(libusb_device* dev,
+                                libusb_device_descriptor* desc) override;
   uint8_t LibusbGetBusNumber(libusb_device* dev) override;
   uint8_t LibusbGetDeviceAddress(libusb_device* dev) override;
   int LibusbOpen(libusb_device* dev, libusb_device_handle** handle) override;
   void LibusbClose(libusb_device_handle* handle) override;
-  int LibusbClaimInterface(
-      libusb_device_handle* dev, int interface_number) override;
-  int LibusbReleaseInterface(
-      libusb_device_handle* dev, int interface_number) override;
+  int LibusbClaimInterface(libusb_device_handle* dev,
+                           int interface_number) override;
+  int LibusbReleaseInterface(libusb_device_handle* dev,
+                             int interface_number) override;
   int LibusbResetDevice(libusb_device_handle* dev) override;
   libusb_transfer* LibusbAllocTransfer(int iso_packets) override;
   int LibusbSubmitTransfer(libusb_transfer* transfer) override;
   int LibusbCancelTransfer(libusb_transfer* transfer) override;
   void LibusbFreeTransfer(libusb_transfer* transfer) override;
-  int LibusbControlTransfer(
-      libusb_device_handle* dev,
-      uint8_t bmRequestType,
-      uint8_t bRequest,
-      uint16_t wValue,
-      uint16_t wIndex,
-      unsigned char* data,
-      uint16_t wLength,
-      unsigned timeout) override;
-  int LibusbBulkTransfer(
-      libusb_device_handle* dev,
-      unsigned char endpoint,
-      unsigned char* data,
-      int length,
-      int* actual_length,
-      unsigned timeout) override;
-  int LibusbInterruptTransfer(
-      libusb_device_handle* dev,
-      unsigned char endpoint,
-      unsigned char* data,
-      int length,
-      int* actual_length,
-      unsigned timeout) override;
+  int LibusbControlTransfer(libusb_device_handle* dev, uint8_t bmRequestType,
+                            uint8_t bRequest, uint16_t wValue, uint16_t wIndex,
+                            unsigned char* data, uint16_t wLength,
+                            unsigned timeout) override;
+  int LibusbBulkTransfer(libusb_device_handle* dev, unsigned char endpoint,
+                         unsigned char* data, int length, int* actual_length,
+                         unsigned timeout) override;
+  int LibusbInterruptTransfer(libusb_device_handle* dev, unsigned char endpoint,
+                              unsigned char* data, int length,
+                              int* actual_length, unsigned timeout) override;
   int LibusbHandleEvents(libusb_context* ctx) override;
   int LibusbHandleEventsCompleted(libusb_context* ctx, int* completed) override;
 
@@ -111,11 +100,11 @@ class LibusbOverChromeUsb final : public LibusbInterface {
 
   class SyncTransferHelper final {
    public:
-    SyncTransferHelper(
-        std::shared_ptr<libusb_context> context,
-        const UsbTransferDestination& transfer_destination);
-
+    SyncTransferHelper(std::shared_ptr<libusb_context> context,
+                       const UsbTransferDestination& transfer_destination);
     SyncTransferHelper(const SyncTransferHelper&) = delete;
+    SyncTransferHelper& operator=(const SyncTransferHelper&) = delete;
+    ~SyncTransferHelper();
 
     chrome_usb::AsyncTransferCallback chrome_usb_transfer_callback() const;
 
@@ -137,8 +126,8 @@ class LibusbOverChromeUsb final : public LibusbInterface {
       const libusb_transfer* transfer) const;
   TransferAsyncRequestCallback WrapLibusbTransferCallback(
       libusb_transfer* transfer);
-  int LibusbHandleEventsWithTimeout(
-      libusb_context* context, int timeout_seconds);
+  int LibusbHandleEventsWithTimeout(libusb_context* context,
+                                    int timeout_seconds);
 
   // map that holds the (fake) bus number for each device
   // keys are libusb_device->chrome_usb_device().device

--- a/third_party/libusb/naclport/src/libusb_over_chrome_usb_unittest.cc
+++ b/third_party/libusb/naclport/src/libusb_over_chrome_usb_unittest.cc
@@ -14,6 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#include "libusb_over_chrome_usb.h"
+
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -36,7 +38,6 @@
 
 #include "chrome_usb/api_bridge_interface.h"
 #include "chrome_usb/types.h"
-#include "libusb_over_chrome_usb.h"
 
 // Google Mock doesn't provide the C++11 "override" specifier for the mock
 // method definitions
@@ -55,90 +56,73 @@ using testing::MockFunction;
 using testing::ResultOf;
 using testing::Return;
 
-const char kBoolValues[] = {false, true};
-
 namespace google_smart_card {
 
 namespace {
 
+constexpr char kBoolValues[] = {false, true};
+
 class MockChromeUsbApiBridge final : public chrome_usb::ApiBridgeInterface {
  public:
-  MOCK_METHOD1(
-      GetDevices,
-      RequestResult<chrome_usb::GetDevicesResult>(
-          const chrome_usb::GetDevicesOptions& options));
+  MOCK_METHOD1(GetDevices, RequestResult<chrome_usb::GetDevicesResult>(
+                               const chrome_usb::GetDevicesOptions& options));
 
-  MOCK_METHOD1(
-      GetUserSelectedDevices,
-      RequestResult<chrome_usb::GetUserSelectedDevicesResult>(
-          const chrome_usb::GetUserSelectedDevicesOptions& options));
+  MOCK_METHOD1(GetUserSelectedDevices,
+               RequestResult<chrome_usb::GetUserSelectedDevicesResult>(
+                   const chrome_usb::GetUserSelectedDevicesOptions& options));
 
-  MOCK_METHOD1(
-      GetConfigurations,
-      RequestResult<chrome_usb::GetConfigurationsResult>(
-          const chrome_usb::Device& device));
+  MOCK_METHOD1(GetConfigurations,
+               RequestResult<chrome_usb::GetConfigurationsResult>(
+                   const chrome_usb::Device& device));
 
-  MOCK_METHOD1(
-      OpenDevice,
-      RequestResult<chrome_usb::OpenDeviceResult>(
-          const chrome_usb::Device& device));
+  MOCK_METHOD1(OpenDevice, RequestResult<chrome_usb::OpenDeviceResult>(
+                               const chrome_usb::Device& device));
 
-  MOCK_METHOD1(CloseDevice, RequestResult<chrome_usb::CloseDeviceResult>(
-      const chrome_usb::ConnectionHandle& connection_handle));
+  MOCK_METHOD1(CloseDevice,
+               RequestResult<chrome_usb::CloseDeviceResult>(
+                   const chrome_usb::ConnectionHandle& connection_handle));
 
-  MOCK_METHOD2(
-      SetConfiguration,
-      RequestResult<chrome_usb::SetConfigurationResult>(
-          const chrome_usb::ConnectionHandle& connection_handle,
-          int64_t configuration_value));
+  MOCK_METHOD2(SetConfiguration,
+               RequestResult<chrome_usb::SetConfigurationResult>(
+                   const chrome_usb::ConnectionHandle& connection_handle,
+                   int64_t configuration_value));
 
-  MOCK_METHOD1(
-      GetConfiguration,
-      RequestResult<chrome_usb::GetConfigurationResult>(
-          const chrome_usb::ConnectionHandle& connection_handle));
+  MOCK_METHOD1(GetConfiguration,
+               RequestResult<chrome_usb::GetConfigurationResult>(
+                   const chrome_usb::ConnectionHandle& connection_handle));
 
-  MOCK_METHOD1(
-      ListInterfaces,
-      RequestResult<chrome_usb::ListInterfacesResult>(
-          const chrome_usb::ConnectionHandle& connection_handle));
+  MOCK_METHOD1(ListInterfaces,
+               RequestResult<chrome_usb::ListInterfacesResult>(
+                   const chrome_usb::ConnectionHandle& connection_handle));
 
-  MOCK_METHOD2(
-      ClaimInterface,
-      RequestResult<chrome_usb::ClaimInterfaceResult>(
-          const chrome_usb::ConnectionHandle& connection_handle,
-          int64_t interface_number));
+  MOCK_METHOD2(ClaimInterface,
+               RequestResult<chrome_usb::ClaimInterfaceResult>(
+                   const chrome_usb::ConnectionHandle& connection_handle,
+                   int64_t interface_number));
 
-  MOCK_METHOD2(
-      ReleaseInterface,
-      RequestResult<chrome_usb::ReleaseInterfaceResult>(
-          const chrome_usb::ConnectionHandle& connection_handle,
-          int64_t interface_number));
+  MOCK_METHOD2(ReleaseInterface,
+               RequestResult<chrome_usb::ReleaseInterfaceResult>(
+                   const chrome_usb::ConnectionHandle& connection_handle,
+                   int64_t interface_number));
 
-  MOCK_METHOD3(
-      AsyncControlTransfer,
-      void(
-          const chrome_usb::ConnectionHandle& connection_handle,
-          const chrome_usb::ControlTransferInfo& transfer_info,
-          chrome_usb::AsyncTransferCallback callback));
+  MOCK_METHOD3(AsyncControlTransfer,
+               void(const chrome_usb::ConnectionHandle& connection_handle,
+                    const chrome_usb::ControlTransferInfo& transfer_info,
+                    chrome_usb::AsyncTransferCallback callback));
 
-  MOCK_METHOD3(
-      AsyncBulkTransfer,
-      void(
-          const chrome_usb::ConnectionHandle& connection_handle,
-          const chrome_usb::GenericTransferInfo& transfer_info,
-          chrome_usb::AsyncTransferCallback callback));
+  MOCK_METHOD3(AsyncBulkTransfer,
+               void(const chrome_usb::ConnectionHandle& connection_handle,
+                    const chrome_usb::GenericTransferInfo& transfer_info,
+                    chrome_usb::AsyncTransferCallback callback));
 
-  MOCK_METHOD3(
-      AsyncInterruptTransfer,
-      void(
-          const chrome_usb::ConnectionHandle& connection_handle,
-          const chrome_usb::GenericTransferInfo& transfer_info,
-          chrome_usb::AsyncTransferCallback callback));
+  MOCK_METHOD3(AsyncInterruptTransfer,
+               void(const chrome_usb::ConnectionHandle& connection_handle,
+                    const chrome_usb::GenericTransferInfo& transfer_info,
+                    chrome_usb::AsyncTransferCallback callback));
 
-  MOCK_METHOD1(
-      ResetDevice,
-      RequestResult<chrome_usb::ResetDeviceResult>(
-          const chrome_usb::ConnectionHandle& connection_handle));
+  MOCK_METHOD1(ResetDevice,
+               RequestResult<chrome_usb::ResetDeviceResult>(
+                   const chrome_usb::ConnectionHandle& connection_handle));
 };
 
 class LibusbOverChromeUsbTest : public ::testing::Test {
@@ -147,8 +131,8 @@ class LibusbOverChromeUsbTest : public ::testing::Test {
     ::testing::Test::SetUp();
 
     chrome_usb_api_bridge.reset(new MockChromeUsbApiBridge);
-    libusb_over_chrome_usb.reset(new LibusbOverChromeUsb(
-        chrome_usb_api_bridge.get()));
+    libusb_over_chrome_usb.reset(
+        new LibusbOverChromeUsb(chrome_usb_api_bridge.get()));
   }
 
   void TearDown() override {
@@ -185,25 +169,26 @@ TEST_F(LibusbOverChromeUsbTest, ContextsCreation) {
 }
 
 TEST_F(LibusbOverChromeUsbTest, DevicesListingWithFailure) {
-  EXPECT_CALL(*chrome_usb_api_bridge, GetDevices(_)).WillOnce(Return(
-      RequestResult<chrome_usb::GetDevicesResult>::CreateFailed(
-          "fake failure")));
+  EXPECT_CALL(*chrome_usb_api_bridge, GetDevices(_))
+      .WillOnce(
+          Return(RequestResult<chrome_usb::GetDevicesResult>::CreateFailed(
+              "fake failure")));
 
   libusb_device** device_list;
-  ASSERT_EQ(
-      LIBUSB_ERROR_OTHER,
-      libusb_over_chrome_usb->LibusbGetDeviceList(nullptr, &device_list));
+  ASSERT_EQ(LIBUSB_ERROR_OTHER,
+            libusb_over_chrome_usb->LibusbGetDeviceList(nullptr, &device_list));
 }
 
 TEST_F(LibusbOverChromeUsbTest, DevicesListingWithNoItems) {
   chrome_usb::GetDevicesResult chrome_usb_get_devices_result;
-  EXPECT_CALL(*chrome_usb_api_bridge, GetDevices(_)).WillOnce(Return(
-      RequestResult<chrome_usb::GetDevicesResult>::CreateSuccessful(
-          chrome_usb_get_devices_result)));
+  EXPECT_CALL(*chrome_usb_api_bridge, GetDevices(_))
+      .WillOnce(
+          Return(RequestResult<chrome_usb::GetDevicesResult>::CreateSuccessful(
+              chrome_usb_get_devices_result)));
 
   libusb_device** device_list = nullptr;
-  ASSERT_EQ(
-      0, libusb_over_chrome_usb->LibusbGetDeviceList(nullptr, &device_list));
+  ASSERT_EQ(0,
+            libusb_over_chrome_usb->LibusbGetDeviceList(nullptr, &device_list));
   ASSERT_TRUE(device_list);
   ASSERT_FALSE(device_list[0]);
 
@@ -222,13 +207,14 @@ TEST_F(LibusbOverChromeUsbTest, DevicesListingWithTwoItems) {
   chrome_usb_device_2.vendor_id = 0;
   chrome_usb_device_2.product_id = 0;
   chrome_usb_get_devices_result.devices.push_back(chrome_usb_device_2);
-  EXPECT_CALL(*chrome_usb_api_bridge, GetDevices(_)).WillOnce(Return(
-      RequestResult<chrome_usb::GetDevicesResult>::CreateSuccessful(
-          chrome_usb_get_devices_result)));
+  EXPECT_CALL(*chrome_usb_api_bridge, GetDevices(_))
+      .WillOnce(
+          Return(RequestResult<chrome_usb::GetDevicesResult>::CreateSuccessful(
+              chrome_usb_get_devices_result)));
 
   libusb_device** device_list = nullptr;
-  ASSERT_EQ(
-      2, libusb_over_chrome_usb->LibusbGetDeviceList(nullptr, &device_list));
+  ASSERT_EQ(2,
+            libusb_over_chrome_usb->LibusbGetDeviceList(nullptr, &device_list));
   ASSERT_TRUE(device_list);
   ASSERT_TRUE(device_list[0]);
   ASSERT_TRUE(device_list[1]);
@@ -248,8 +234,7 @@ namespace {
 class LibusbOverChromeUsbWithFakeDeviceTest : public LibusbOverChromeUsbTest {
  public:
   LibusbOverChromeUsbWithFakeDeviceTest()
-      : device(nullptr),
-        device_handle(nullptr) {
+      : device(nullptr), device_handle(nullptr) {
     chrome_usb_device.device = 1;
     chrome_usb_device.vendor_id = 2;
     chrome_usb_device.product_id = 3;
@@ -293,23 +278,26 @@ class LibusbOverChromeUsbWithFakeDeviceTest : public LibusbOverChromeUsbTest {
     chrome_usb::GetDevicesResult chrome_usb_get_devices_result;
     chrome_usb_get_devices_result.devices.push_back(chrome_usb_device);
     // TODO(emaxx): Add testing of the GetDevices method arguments
-    EXPECT_CALL(*chrome_usb_api_bridge, GetDevices(_)).WillRepeatedly(Return(
-        RequestResult<chrome_usb::GetDevicesResult>::CreateSuccessful(
-            chrome_usb_get_devices_result)));
+    EXPECT_CALL(*chrome_usb_api_bridge, GetDevices(_))
+        .WillRepeatedly(Return(
+            RequestResult<chrome_usb::GetDevicesResult>::CreateSuccessful(
+                chrome_usb_get_devices_result)));
 
     chrome_usb::OpenDeviceResult chrome_usb_open_device_result;
     chrome_usb_open_device_result.connection_handle =
         chrome_usb_connection_handle;
-    EXPECT_CALL(*chrome_usb_api_bridge, OpenDevice(chrome_usb_device)).WillOnce(
-        Return(RequestResult<chrome_usb::OpenDeviceResult>::CreateSuccessful(
-            chrome_usb_open_device_result)));
+    EXPECT_CALL(*chrome_usb_api_bridge, OpenDevice(chrome_usb_device))
+        .WillOnce(Return(
+            RequestResult<chrome_usb::OpenDeviceResult>::CreateSuccessful(
+                chrome_usb_open_device_result)));
 
     // TODO(emaxx): Add testing that calls of methods OpenDevice and CloseDevice
     // form a valid bracket sequence
     EXPECT_CALL(*chrome_usb_api_bridge,
-                CloseDevice(chrome_usb_connection_handle)).WillOnce(
-        Return(RequestResult<chrome_usb::CloseDeviceResult>::CreateSuccessful(
-            chrome_usb::CloseDeviceResult())));
+                CloseDevice(chrome_usb_connection_handle))
+        .WillOnce(Return(
+            RequestResult<chrome_usb::CloseDeviceResult>::CreateSuccessful(
+                chrome_usb::CloseDeviceResult())));
   }
 
   void ObtainLibusbDevice() {
@@ -323,9 +311,8 @@ class LibusbOverChromeUsbWithFakeDeviceTest : public LibusbOverChromeUsbTest {
   }
 
   void ObtainLibusbDeviceHandle() {
-    EXPECT_EQ(
-        LIBUSB_SUCCESS,
-        libusb_over_chrome_usb->LibusbOpen(device, &device_handle));
+    EXPECT_EQ(LIBUSB_SUCCESS,
+              libusb_over_chrome_usb->LibusbOpen(device, &device_handle));
     EXPECT_TRUE(device_handle);
   }
 };
@@ -337,31 +324,31 @@ class LibusbOverChromeUsbTransfersTest
     EXPECT_CALL(*chrome_usb_api_bridge,
                 AsyncControlTransfer(
                     chrome_usb_connection_handle,
-                    GenerateControlTransferInfo(transfer_index, is_output),
-                    _)).WillOnce(
-        InvokeArgument<2>(GenerateTransferRequestResult(
-            transfer_index, is_output)));
+                    GenerateControlTransferInfo(transfer_index, is_output), _))
+        .WillOnce(InvokeArgument<2>(
+            GenerateTransferRequestResult(transfer_index, is_output)));
   }
 
-  std::function<void()> SetUpMockForAsyncControlTransfer(
-      size_t transfer_index, bool is_output) {
+  std::function<void()> SetUpMockForAsyncControlTransfer(size_t transfer_index,
+                                                         bool is_output) {
     auto callback_holder =
         std::make_shared<chrome_usb::AsyncTransferCallback>();
-    EXPECT_CALL(
-        *chrome_usb_api_bridge,
-        AsyncControlTransfer(
-            chrome_usb_connection_handle,
-            GenerateControlTransferInfo(transfer_index, is_output),
-            _)).WillOnce(Invoke([callback_holder](
-                const chrome_usb::ConnectionHandle&,
-                const chrome_usb::ControlTransferInfo&,
-                chrome_usb::AsyncTransferCallback callback) mutable {
+    EXPECT_CALL(*chrome_usb_api_bridge,
+                AsyncControlTransfer(
+                    chrome_usb_connection_handle,
+                    GenerateControlTransferInfo(transfer_index, is_output), _))
+        .WillOnce(
+            Invoke([callback_holder](
+                       const chrome_usb::ConnectionHandle&,
+                       const chrome_usb::ControlTransferInfo&,
+                       chrome_usb::AsyncTransferCallback callback) mutable {
               *callback_holder = callback;
-            })).RetiresOnSaturation();
+            }))
+        .RetiresOnSaturation();
     return [this, transfer_index, is_output, callback_holder]() {
       GOOGLE_SMART_CARD_CHECK(callback_holder);
-      (*callback_holder)(GenerateTransferRequestResult(
-          transfer_index, is_output));
+      (*callback_holder)(
+          GenerateTransferRequestResult(transfer_index, is_output));
     };
   }
 
@@ -376,12 +363,8 @@ class LibusbOverChromeUsbTransfersTest
         device_handle,
         LIBUSB_RECIPIENT_ENDPOINT | LIBUSB_REQUEST_TYPE_STANDARD |
             (is_output ? LIBUSB_ENDPOINT_OUT : LIBUSB_ENDPOINT_IN),
-        kTransferRequestField,
-        kTransferValueField,
-        transfer_index,
-        data.empty() ? nullptr : &data[0],
-        data.size(),
-        kTransferTimeout);
+        kTransferRequestField, kTransferValueField, transfer_index,
+        data.empty() ? nullptr : &data[0], data.size(), kTransferTimeout);
 
     if (IsTransferToFail(transfer_index) ||
         IsTransferToFinishUnsuccessfully(transfer_index)) {
@@ -394,67 +377,54 @@ class LibusbOverChromeUsbTransfersTest
   }
 
   libusb_transfer* StartAsyncControlTransfer(
-      size_t transfer_index,
-      bool is_output,
+      size_t transfer_index, bool is_output,
       MockFunction<void(libusb_transfer_status)>* transfer_callback) {
-    const std::vector<uint8_t> actual_data = GenerateTransferData(
-        transfer_index, is_output);
+    const std::vector<uint8_t> actual_data =
+        GenerateTransferData(transfer_index, is_output);
     const size_t buffer_size = LIBUSB_CONTROL_SETUP_SIZE + actual_data.size();
     uint8_t* const buffer = static_cast<uint8_t*>(::malloc(buffer_size));
     if (is_output) {
-      std::copy(
-          actual_data.begin(),
-          actual_data.end(),
-          buffer + LIBUSB_CONTROL_SETUP_SIZE);
+      std::copy(actual_data.begin(), actual_data.end(),
+                buffer + LIBUSB_CONTROL_SETUP_SIZE);
     }
     libusb_fill_control_setup(
         buffer,
         LIBUSB_RECIPIENT_ENDPOINT | LIBUSB_REQUEST_TYPE_STANDARD |
             (is_output ? LIBUSB_ENDPOINT_OUT : LIBUSB_ENDPOINT_IN),
-        kTransferRequestField,
-        kTransferValueField,
-        transfer_index,
+        kTransferRequestField, kTransferValueField, transfer_index,
         actual_data.size());
 
     libusb_transfer* const transfer =
         libusb_over_chrome_usb->LibusbAllocTransfer(0);
     libusb_fill_control_transfer(
-        transfer,
-        device_handle,
-        buffer,
+        transfer, device_handle, buffer,
         &AsyncTransferCallbackWrapper::Callback,
-        new AsyncTransferCallbackWrapper(
-            this, transfer_index, is_output, transfer_callback),
+        new AsyncTransferCallbackWrapper(this, transfer_index, is_output,
+                                         transfer_callback),
         kTransferTimeout);
     transfer->flags =
         LIBUSB_TRANSFER_FREE_TRANSFER | LIBUSB_TRANSFER_FREE_BUFFER;
 
-    EXPECT_EQ(
-        LIBUSB_SUCCESS, libusb_over_chrome_usb->LibusbSubmitTransfer(transfer));
+    EXPECT_EQ(LIBUSB_SUCCESS,
+              libusb_over_chrome_usb->LibusbSubmitTransfer(transfer));
 
     return transfer;
   }
 
   void SetUpTransferCallbackMockExpectations(
-      size_t transfer_index,
-      bool /*is_output*/,
-      bool is_canceled,
+      size_t transfer_index, bool /*is_output*/, bool is_canceled,
       MockFunction<void(libusb_transfer_status)>* transfer_callback) {
-    EXPECT_CALL(
-        *transfer_callback,
-        Call(GetExpectedTransferStatus(transfer_index, is_canceled)));
+    EXPECT_CALL(*transfer_callback,
+                Call(GetExpectedTransferStatus(transfer_index, is_canceled)));
   }
 
   void SetUpTransferCallbackMockExpectations(
-      size_t transfer_index,
-      bool /*is_output*/,
-      bool is_canceled,
+      size_t transfer_index, bool /*is_output*/, bool is_canceled,
       MockFunction<void(libusb_transfer_status)>* transfer_callback,
       int* completed) {
-    EXPECT_CALL(
-        *transfer_callback,
-        Call(GetExpectedTransferStatus(transfer_index, is_canceled))).WillOnce(
-            Assign(completed, 1));
+    EXPECT_CALL(*transfer_callback,
+                Call(GetExpectedTransferStatus(transfer_index, is_canceled)))
+        .WillOnce(Assign(completed, 1));
   }
 
   static bool IsTransferToFail(size_t transfer_index) {
@@ -465,7 +435,7 @@ class LibusbOverChromeUsbTransfersTest
     return !IsTransferToFail(transfer_index) && transfer_index % 5 == 0;
   }
 
-private:
+ private:
   const uint8_t kTransferRequestField = 1;
   const uint16_t kTransferValueField = 2;
   const unsigned kTransferTimeout = 3;
@@ -473,8 +443,7 @@ private:
   class AsyncTransferCallbackWrapper {
    public:
     AsyncTransferCallbackWrapper(
-        LibusbOverChromeUsbTransfersTest* test_instance,
-        size_t transfer_index,
+        LibusbOverChromeUsbTransfersTest* test_instance, size_t transfer_index,
         bool is_output,
         MockFunction<void(libusb_transfer_status)>* transfer_callback)
         : test_instance_(test_instance),
@@ -510,8 +479,8 @@ private:
   chrome_usb::ControlTransferInfo GenerateControlTransferInfo(
       size_t transfer_index, bool is_output) {
     chrome_usb::ControlTransferInfo transfer_info;
-    transfer_info.direction = is_output ?
-        chrome_usb::Direction::kOut : chrome_usb::Direction::kIn;
+    transfer_info.direction =
+        is_output ? chrome_usb::Direction::kOut : chrome_usb::Direction::kIn;
     transfer_info.recipient =
         chrome_usb::ControlTransferInfoRecipient::kEndpoint;
     transfer_info.request_type =
@@ -519,8 +488,8 @@ private:
     transfer_info.request = kTransferRequestField;
     transfer_info.value = kTransferValueField;
     transfer_info.index = transfer_index;
-    const std::vector<uint8_t> data = GenerateTransferData(
-        transfer_index, is_output);
+    const std::vector<uint8_t> data =
+        GenerateTransferData(transfer_index, is_output);
     if (is_output)
       transfer_info.data = MakeVarArrayBuffer(data);
     else
@@ -529,8 +498,8 @@ private:
     return transfer_info;
   }
 
-  std::vector<uint8_t> GenerateTransferData(
-      size_t transfer_index, bool is_output) {
+  std::vector<uint8_t> GenerateTransferData(size_t transfer_index,
+                                            bool is_output) {
     std::vector<uint8_t> result;
     result.push_back(is_output);
     while (transfer_index) {
@@ -552,46 +521,42 @@ private:
       result.result_info.result_code =
           chrome_usb::kTransferResultInfoSuccessResultCode;
       if (!is_output) {
-        result.result_info.data = MakeVarArrayBuffer(GenerateTransferData(
-            transfer_index, false));
+        result.result_info.data =
+            MakeVarArrayBuffer(GenerateTransferData(transfer_index, false));
       }
     }
     return RequestResult<chrome_usb::TransferResult>::CreateSuccessful(result);
   }
 
   void OnAsyncControlTransferFinished(
-      libusb_transfer* transfer,
-      size_t transfer_index,
-      bool is_output,
+      libusb_transfer* transfer, size_t transfer_index, bool is_output,
       MockFunction<void(libusb_transfer_status)>* transfer_callback) {
     if (transfer->status != LIBUSB_TRANSFER_CANCELLED) {
-      EXPECT_EQ(
-          GetExpectedTransferStatus(transfer_index, false), transfer->status);
+      EXPECT_EQ(GetExpectedTransferStatus(transfer_index, false),
+                transfer->status);
     }
 
     if (transfer->status == LIBUSB_TRANSFER_COMPLETED) {
-      const std::vector<uint8_t> expected_data = GenerateTransferData(
-          transfer_index, is_output);
-      EXPECT_EQ(
-          static_cast<int>(expected_data.size()), transfer->actual_length);
+      const std::vector<uint8_t> expected_data =
+          GenerateTransferData(transfer_index, is_output);
+      EXPECT_EQ(static_cast<int>(expected_data.size()),
+                transfer->actual_length);
       if (!is_output) {
-        const uint8_t* data = transfer->type == LIBUSB_TRANSFER_TYPE_CONTROL ?
-            libusb_control_transfer_get_data(transfer) : transfer->buffer;
-        EXPECT_EQ(
-            expected_data,
-            std::vector<uint8_t>(data, data + transfer->actual_length));
+        const uint8_t* data = transfer->type == LIBUSB_TRANSFER_TYPE_CONTROL
+                                  ? libusb_control_transfer_get_data(transfer)
+                                  : transfer->buffer;
+        EXPECT_EQ(expected_data,
+                  std::vector<uint8_t>(data, data + transfer->actual_length));
       }
     }
 
     transfer_callback->Call(transfer->status);
   }
 
-  static libusb_transfer_status GetExpectedTransferStatus(
-      size_t transfer_index, bool is_canceled) {
-    if (is_canceled)
-      return LIBUSB_TRANSFER_CANCELLED;
-    if (IsTransferToFail(transfer_index))
-      return LIBUSB_TRANSFER_ERROR;
+  static libusb_transfer_status GetExpectedTransferStatus(size_t transfer_index,
+                                                          bool is_canceled) {
+    if (is_canceled) return LIBUSB_TRANSFER_CANCELLED;
+    if (IsTransferToFail(transfer_index)) return LIBUSB_TRANSFER_ERROR;
     if (IsTransferToFinishUnsuccessfully(transfer_index))
       return LIBUSB_TRANSFER_ERROR;
     return LIBUSB_TRANSFER_COMPLETED;
@@ -599,8 +564,8 @@ private:
 };
 
 struct LibusbOverChromeUsbSingleTransferTestParam {
-  LibusbOverChromeUsbSingleTransferTestParam(
-      size_t transfer_index, bool is_transfer_output)
+  LibusbOverChromeUsbSingleTransferTestParam(size_t transfer_index,
+                                             bool is_transfer_output)
       : transfer_index(transfer_index),
         is_transfer_output(is_transfer_output) {}
 
@@ -642,10 +607,10 @@ class LibusbOverChromeUsbSingleTransferTest
 // The transfer request is resolved immediately on the same thread that
 // initiated the transfer.
 TEST_P(LibusbOverChromeUsbSingleTransferTest, SyncControlTransfer) {
-  SetUpMockForSyncControlTransfer(
-      GetParam().transfer_index, GetParam().is_transfer_output);
-  TestSyncControlTransfer(
-      GetParam().transfer_index, GetParam().is_transfer_output);
+  SetUpMockForSyncControlTransfer(GetParam().transfer_index,
+                                  GetParam().is_transfer_output);
+  TestSyncControlTransfer(GetParam().transfer_index,
+                          GetParam().is_transfer_output);
 }
 
 // Test a simple asynchronous control transfer.
@@ -654,23 +619,19 @@ TEST_P(LibusbOverChromeUsbSingleTransferTest, SyncControlTransfer) {
 // transfer, before the libusb events handling starts.
 TEST_P(LibusbOverChromeUsbSingleTransferTest, AsyncControlTransfer) {
   const std::function<void()> chrome_usb_transfer_resolver =
-      SetUpMockForAsyncControlTransfer(
-            GetParam().transfer_index, GetParam().is_transfer_output);
+      SetUpMockForAsyncControlTransfer(GetParam().transfer_index,
+                                       GetParam().is_transfer_output);
 
   MockFunction<void(libusb_transfer_status)> transfer_callback;
-  StartAsyncControlTransfer(
-      GetParam().transfer_index,
-      GetParam().is_transfer_output,
-      &transfer_callback);
+  StartAsyncControlTransfer(GetParam().transfer_index,
+                            GetParam().is_transfer_output, &transfer_callback);
 
   chrome_usb_transfer_resolver();
 
   ASSERT_TRUE(Mock::VerifyAndClearExpectations(&transfer_callback));
-  SetUpTransferCallbackMockExpectations(
-      GetParam().transfer_index,
-      GetParam().is_transfer_output,
-      false,
-      &transfer_callback);
+  SetUpTransferCallbackMockExpectations(GetParam().transfer_index,
+                                        GetParam().is_transfer_output, false,
+                                        &transfer_callback);
   libusb_over_chrome_usb->LibusbHandleEvents(nullptr);
 }
 
@@ -679,29 +640,28 @@ TEST_P(LibusbOverChromeUsbSingleTransferTest, AsyncControlTransfer) {
 // Note that output control transfers cancellation never succeeds.
 TEST_P(LibusbOverChromeUsbSingleTransferTest, AsyncTransferCancellation) {
   const std::function<void()> chrome_usb_transfer_resolver =
-      SetUpMockForAsyncControlTransfer(
-            GetParam().transfer_index, GetParam().is_transfer_output);
+      SetUpMockForAsyncControlTransfer(GetParam().transfer_index,
+                                       GetParam().is_transfer_output);
 
   MockFunction<void(libusb_transfer_status)> transfer_callback;
   libusb_transfer* const transfer = StartAsyncControlTransfer(
-      GetParam().transfer_index,
-      GetParam().is_transfer_output,
+      GetParam().transfer_index, GetParam().is_transfer_output,
       &transfer_callback);
 
   // Output transfer cancellation is never successfull
   const bool is_cancellation_successful = !GetParam().is_transfer_output;
 
   if (is_cancellation_successful) {
-    EXPECT_EQ(
-        LIBUSB_SUCCESS, libusb_over_chrome_usb->LibusbCancelTransfer(transfer));
+    EXPECT_EQ(LIBUSB_SUCCESS,
+              libusb_over_chrome_usb->LibusbCancelTransfer(transfer));
   } else {
-    EXPECT_NE(
-        LIBUSB_SUCCESS, libusb_over_chrome_usb->LibusbCancelTransfer(transfer));
+    EXPECT_NE(LIBUSB_SUCCESS,
+              libusb_over_chrome_usb->LibusbCancelTransfer(transfer));
   }
 
   // Second attempt to cancel a transfer is never successful
-  EXPECT_NE(
-      LIBUSB_SUCCESS, libusb_over_chrome_usb->LibusbCancelTransfer(transfer));
+  EXPECT_NE(LIBUSB_SUCCESS,
+            libusb_over_chrome_usb->LibusbCancelTransfer(transfer));
 
   if (!is_cancellation_successful) {
     // Resolve the chrome.usb transfer if the transfer was an output transfer,
@@ -711,10 +671,8 @@ TEST_P(LibusbOverChromeUsbSingleTransferTest, AsyncTransferCancellation) {
 
   ASSERT_TRUE(Mock::VerifyAndClearExpectations(&transfer_callback));
   SetUpTransferCallbackMockExpectations(
-      GetParam().transfer_index,
-      GetParam().is_transfer_output,
-      is_cancellation_successful,
-      &transfer_callback);
+      GetParam().transfer_index, GetParam().is_transfer_output,
+      is_cancellation_successful, &transfer_callback);
   libusb_over_chrome_usb->LibusbHandleEvents(nullptr);
 }
 
@@ -729,49 +687,41 @@ TEST_P(LibusbOverChromeUsbSingleTransferTest,
   }
 
   const std::function<void()> first_chrome_usb_transfer_resolver =
-      SetUpMockForAsyncControlTransfer(
-            GetParam().transfer_index, GetParam().is_transfer_output);
+      SetUpMockForAsyncControlTransfer(GetParam().transfer_index,
+                                       GetParam().is_transfer_output);
   const std::function<void()> second_chrome_usb_transfer_resolver =
-      SetUpMockForAsyncControlTransfer(
-            GetParam().transfer_index, GetParam().is_transfer_output);
+      SetUpMockForAsyncControlTransfer(GetParam().transfer_index,
+                                       GetParam().is_transfer_output);
 
   MockFunction<void(libusb_transfer_status)> first_transfer_callback;
   libusb_transfer* const first_transfer = StartAsyncControlTransfer(
-      GetParam().transfer_index,
-      GetParam().is_transfer_output,
+      GetParam().transfer_index, GetParam().is_transfer_output,
       &first_transfer_callback);
 
   MockFunction<void(libusb_transfer_status)> second_transfer_callback;
-  StartAsyncControlTransfer(
-      GetParam().transfer_index,
-      GetParam().is_transfer_output,
-      &second_transfer_callback);
+  StartAsyncControlTransfer(GetParam().transfer_index,
+                            GetParam().is_transfer_output,
+                            &second_transfer_callback);
 
-  EXPECT_EQ(
-      LIBUSB_SUCCESS,
-      libusb_over_chrome_usb->LibusbCancelTransfer(first_transfer));
+  EXPECT_EQ(LIBUSB_SUCCESS,
+            libusb_over_chrome_usb->LibusbCancelTransfer(first_transfer));
 
   first_chrome_usb_transfer_resolver();
 
   ASSERT_TRUE(Mock::VerifyAndClearExpectations(&first_transfer_callback));
   ASSERT_TRUE(Mock::VerifyAndClearExpectations(&second_transfer_callback));
-  SetUpTransferCallbackMockExpectations(
-      GetParam().transfer_index,
-      GetParam().is_transfer_output,
-      true,
-      &first_transfer_callback);
-  SetUpTransferCallbackMockExpectations(
-      GetParam().transfer_index,
-      GetParam().is_transfer_output,
-      false,
-      &second_transfer_callback);
+  SetUpTransferCallbackMockExpectations(GetParam().transfer_index,
+                                        GetParam().is_transfer_output, true,
+                                        &first_transfer_callback);
+  SetUpTransferCallbackMockExpectations(GetParam().transfer_index,
+                                        GetParam().is_transfer_output, false,
+                                        &second_transfer_callback);
   libusb_over_chrome_usb->LibusbHandleEvents(nullptr);
   libusb_over_chrome_usb->LibusbHandleEvents(nullptr);
 }
 
 INSTANTIATE_TEST_CASE_P(
-    InputTransferTest,
-    LibusbOverChromeUsbSingleTransferTest,
+    InputTransferTest, LibusbOverChromeUsbSingleTransferTest,
     ::testing::Values(
         LibusbOverChromeUsbSingleTransferTestParam(
             LibusbOverChromeUsbSingleTransferTest::GetTransferIndexToSucceed(),
@@ -781,12 +731,11 @@ INSTANTIATE_TEST_CASE_P(
             false),
         LibusbOverChromeUsbSingleTransferTestParam(
             LibusbOverChromeUsbSingleTransferTest::
-            GetTransferIndexToFinishUnsuccessful(),
+                GetTransferIndexToFinishUnsuccessful(),
             false)));
 
 INSTANTIATE_TEST_CASE_P(
-    OutputTransferTest,
-    LibusbOverChromeUsbSingleTransferTest,
+    OutputTransferTest, LibusbOverChromeUsbSingleTransferTest,
     ::testing::Values(
         LibusbOverChromeUsbSingleTransferTestParam(
             LibusbOverChromeUsbSingleTransferTest::GetTransferIndexToSucceed(),
@@ -796,7 +745,7 @@ INSTANTIATE_TEST_CASE_P(
             true),
         LibusbOverChromeUsbSingleTransferTestParam(
             LibusbOverChromeUsbSingleTransferTest::
-            GetTransferIndexToFinishUnsuccessful(),
+                GetTransferIndexToFinishUnsuccessful(),
             true)));
 
 // Test the correctness of work of multiple threads issuing a sequence of
@@ -862,8 +811,7 @@ class LibusbOverChromeUsbAsyncTransfersMultiThreadingTest
   }
 
   bool WaitAndGetTransferInFlight(
-      size_t* transfer_index,
-      bool* is_transfer_output,
+      size_t* transfer_index, bool* is_transfer_output,
       std::function<void()>* chrome_usb_transfer_resolver) {
     std::unique_lock<std::mutex> lock(mutex_);
     for (;;) {
@@ -879,8 +827,7 @@ class LibusbOverChromeUsbAsyncTransfersMultiThreadingTest
         return true;
       }
 
-      if (chrome_usb_transfer_resolvers_.empty())
-        return false;
+      if (chrome_usb_transfer_resolvers_.empty()) return false;
 
       condition_.wait(lock);
     }
@@ -892,7 +839,7 @@ class LibusbOverChromeUsbAsyncTransfersMultiThreadingTest
   mutable std::mutex mutex_;
   std::condition_variable condition_;
   std::map<TransferIndexAndIsOutput, std::function<void()>>
-  chrome_usb_transfer_resolvers_;
+      chrome_usb_transfer_resolvers_;
   std::vector<TransferIndexAndIsOutput> transfers_in_flight_;
 };
 
@@ -912,19 +859,15 @@ TEST_F(LibusbOverChromeUsbAsyncTransfersMultiThreadingTest, ControlTransfers) {
            transfer_index <= kMaxTransferIndex;
            transfer_index += kThreadCount) {
         MockFunction<void(libusb_transfer_status)> transfer_callback[2];
-        int transfer_completed[2] = { 0 };
+        int transfer_completed[2] = {0};
 
         for (bool is_transfer_output : kBoolValues) {
           SetUpTransferCallbackMockExpectations(
-              transfer_index,
-              is_transfer_output,
-              false,
+              transfer_index, is_transfer_output, false,
               &transfer_callback[is_transfer_output],
               &transfer_completed[is_transfer_output]);
-          StartAsyncControlTransfer(
-              transfer_index,
-              is_transfer_output,
-              &transfer_callback[is_transfer_output]);
+          StartAsyncControlTransfer(transfer_index, is_transfer_output,
+                                    &transfer_callback[is_transfer_output]);
           AddTransferInFlight(transfer_index, is_transfer_output);
         }
 
@@ -942,10 +885,8 @@ TEST_F(LibusbOverChromeUsbAsyncTransfersMultiThreadingTest, ControlTransfers) {
     size_t transfer_index;
     bool is_transfer_output;
     std::function<void()> chrome_usb_transfer_resolver;
-    if (!WaitAndGetTransferInFlight(
-             &transfer_index,
-             &is_transfer_output,
-             &chrome_usb_transfer_resolver)) {
+    if (!WaitAndGetTransferInFlight(&transfer_index, &is_transfer_output,
+                                    &chrome_usb_transfer_resolver)) {
       break;
     }
     chrome_usb_transfer_resolver();

--- a/third_party/libusb/naclport/src/libusb_tracing_wrapper.cc
+++ b/third_party/libusb/naclport/src/libusb_tracing_wrapper.cc
@@ -24,11 +24,11 @@
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/logging/mask_dumping.h>
 
-const char kLoggingPrefix[] = "[libusb] ";
-
 namespace google_smart_card {
 
 namespace {
+
+constexpr char kLoggingPrefix[] = "[libusb] ";
 
 std::string DebugDumpLibusbReturnCode(int return_code) {
   std::string result = "\"";
@@ -50,14 +50,11 @@ std::string DebugDumpLibusbDevice(const libusb_device* device_list) {
 }
 
 std::string DebugDumpLibusbDeviceList(libusb_device* const* device_list) {
-  if (!device_list)
-    return "<NULL>";
+  if (!device_list) return "<NULL>";
   std::string result;
-  for (libusb_device* const* current_device = device_list;
-       *current_device;
+  for (libusb_device* const* current_device = device_list; *current_device;
        ++current_device) {
-    if (!result.empty())
-      result += ", ";
+    if (!result.empty()) result += ", ";
     result += DebugDumpLibusbDevice(*current_device);
   }
   return HexDumpPointer(device_list) + "([" + result + "])";
@@ -152,10 +149,11 @@ std::string DebugDumpLibusbEndpointDirection(uint8_t endpoint_direction) {
 
 std::string DebugDumpLibusbEndpointAddress(uint8_t endpoint_address) {
   return HexDumpInteger(endpoint_address) + "(number=" +
-      std::to_string(endpoint_address & LIBUSB_ENDPOINT_ADDRESS_MASK) +
-      ", direction=" +
-      DebugDumpLibusbEndpointDirection(
-          endpoint_address & LIBUSB_ENDPOINT_DIR_MASK) + ")";
+         std::to_string(endpoint_address & LIBUSB_ENDPOINT_ADDRESS_MASK) +
+         ", direction=" +
+         DebugDumpLibusbEndpointDirection(endpoint_address &
+                                          LIBUSB_ENDPOINT_DIR_MASK) +
+         ")";
 }
 
 std::string DebugDumpLibusbTransferType(uint8_t transfer_type) {
@@ -181,47 +179,46 @@ std::string DebugDumpLibusbEndpointAttributes(uint8_t endpoint_attributes) {
   // TODO(emaxx): Print the debug dump of the iso_sync_type and the
   // iso_usage_type submasks, once the isochronous transfers are supported.
   return HexDumpInteger(endpoint_attributes) + "(transfer_type=" +
-      DebugDumpLibusbTransferType(
-          endpoint_attributes & LIBUSB_TRANSFER_TYPE_MASK) +
-      ", iso_sync_type=" +
-      std::to_string(
-          (endpoint_attributes & LIBUSB_ISO_SYNC_TYPE_MASK)
-              >> kIsoSyncTypeShift) + ", iso_usage_type=" +
-      std::to_string(
-          (endpoint_attributes & LIBUSB_ISO_USAGE_TYPE_MASK)
-              >> kIsoUsageTypeShift) + ")";
+         DebugDumpLibusbTransferType(endpoint_attributes &
+                                     LIBUSB_TRANSFER_TYPE_MASK) +
+         ", iso_sync_type=" +
+         std::to_string((endpoint_attributes & LIBUSB_ISO_SYNC_TYPE_MASK) >>
+                        kIsoSyncTypeShift) +
+         ", iso_usage_type=" +
+         std::to_string((endpoint_attributes & LIBUSB_ISO_USAGE_TYPE_MASK) >>
+                        kIsoUsageTypeShift) +
+         ")";
 }
 
 std::string DebugDumpLibusbEndpointDescriptor(
     const libusb_endpoint_descriptor& endpoint_descriptor) {
   return "libusb_endpoint_descriptor(bLength=" +
-      std::to_string(endpoint_descriptor.bLength) + ", bDescriptorType=" +
-      DebugDumpLibusbDescriptorType(endpoint_descriptor.bDescriptorType) +
-      ", bEndpointAddress=" +
-      DebugDumpLibusbEndpointAddress(endpoint_descriptor.bEndpointAddress) +
-      ", bmAttributes=" +
-      DebugDumpLibusbEndpointAttributes(endpoint_descriptor.bmAttributes) +
-      ", wMaxPacketSize=" + std::to_string(endpoint_descriptor.wMaxPacketSize) +
-      ", bInterval=" + std::to_string(endpoint_descriptor.bInterval) +
-      ", bRefresh=" + std::to_string(endpoint_descriptor.bRefresh) +
-      ", bSynchAddress=" + std::to_string(endpoint_descriptor.bSynchAddress) +
-      ", extra=<" +
-      HexDumpBytes(
-          endpoint_descriptor.extra, endpoint_descriptor.extra_length) +
-      ">, extra_length=" + std::to_string(endpoint_descriptor.extra_length) +
-      ")";
+         std::to_string(endpoint_descriptor.bLength) + ", bDescriptorType=" +
+         DebugDumpLibusbDescriptorType(endpoint_descriptor.bDescriptorType) +
+         ", bEndpointAddress=" +
+         DebugDumpLibusbEndpointAddress(endpoint_descriptor.bEndpointAddress) +
+         ", bmAttributes=" +
+         DebugDumpLibusbEndpointAttributes(endpoint_descriptor.bmAttributes) +
+         ", wMaxPacketSize=" +
+         std::to_string(endpoint_descriptor.wMaxPacketSize) +
+         ", bInterval=" + std::to_string(endpoint_descriptor.bInterval) +
+         ", bRefresh=" + std::to_string(endpoint_descriptor.bRefresh) +
+         ", bSynchAddress=" +
+         std::to_string(endpoint_descriptor.bSynchAddress) + ", extra=<" +
+         HexDumpBytes(endpoint_descriptor.extra,
+                      endpoint_descriptor.extra_length) +
+         ">, extra_length=" + std::to_string(endpoint_descriptor.extra_length) +
+         ")";
 }
 
 std::string DebugDumpLibusbEndpointDescriptorList(
     const libusb_endpoint_descriptor* endpoint_descriptor_list, size_t size) {
-  if (!endpoint_descriptor_list)
-    return "<NULL>";
+  if (!endpoint_descriptor_list) return "<NULL>";
   std::string result;
   for (size_t index = 0; index < size; ++index) {
-    if (!result.empty())
-      result += ", ";
-    result += DebugDumpLibusbEndpointDescriptor(
-        endpoint_descriptor_list[index]);
+    if (!result.empty()) result += ", ";
+    result +=
+        DebugDumpLibusbEndpointDescriptor(endpoint_descriptor_list[index]);
   }
   return "[" + result + "]";
 }
@@ -229,54 +226,52 @@ std::string DebugDumpLibusbEndpointDescriptorList(
 std::string DebugDumpLibusbInterfaceDescriptor(
     const libusb_interface_descriptor& interface_descriptor) {
   return "libusb_interface_descriptor(bLength=" +
-      std::to_string(interface_descriptor.bLength) + ", bDescriptorType=" +
-      DebugDumpLibusbDescriptorType(interface_descriptor.bDescriptorType) +
-      ", bInterfaceNumber=" +
-      std::to_string(interface_descriptor.bInterfaceNumber) +
-      ", bAlternateSetting=" +
-      std::to_string(interface_descriptor.bAlternateSetting) +
-      ", bNumEndpoints=" + std::to_string(interface_descriptor.bNumEndpoints) +
-      ", bInterfaceClass=" +
-      DebugDumpLibusbClassCode(interface_descriptor.bInterfaceClass) +
-      ", endpoint=" +
-      DebugDumpLibusbEndpointDescriptorList(
-          interface_descriptor.endpoint, interface_descriptor.bNumEndpoints) +
-      ", extra=<" +
-      HexDumpBytes(
-          interface_descriptor.extra, interface_descriptor.extra_length) +
-      ">, extra_length=" + std::to_string(interface_descriptor.extra_length) +
-      ")";
+         std::to_string(interface_descriptor.bLength) + ", bDescriptorType=" +
+         DebugDumpLibusbDescriptorType(interface_descriptor.bDescriptorType) +
+         ", bInterfaceNumber=" +
+         std::to_string(interface_descriptor.bInterfaceNumber) +
+         ", bAlternateSetting=" +
+         std::to_string(interface_descriptor.bAlternateSetting) +
+         ", bNumEndpoints=" +
+         std::to_string(interface_descriptor.bNumEndpoints) +
+         ", bInterfaceClass=" +
+         DebugDumpLibusbClassCode(interface_descriptor.bInterfaceClass) +
+         ", endpoint=" +
+         DebugDumpLibusbEndpointDescriptorList(
+             interface_descriptor.endpoint,
+             interface_descriptor.bNumEndpoints) +
+         ", extra=<" +
+         HexDumpBytes(interface_descriptor.extra,
+                      interface_descriptor.extra_length) +
+         ">, extra_length=" +
+         std::to_string(interface_descriptor.extra_length) + ")";
 }
 
 std::string DebugDumpLibusbInterfaceDescriptorList(
     const libusb_interface_descriptor* interface_descriptor_list, size_t size) {
-  if (!interface_descriptor_list)
-    return "<NULL>";
+  if (!interface_descriptor_list) return "<NULL>";
   std::string result;
   for (size_t index = 0; index < size; ++index) {
-    if (!result.empty())
-      result += ", ";
-    result += DebugDumpLibusbInterfaceDescriptor(
-        interface_descriptor_list[index]);
+    if (!result.empty()) result += ", ";
+    result +=
+        DebugDumpLibusbInterfaceDescriptor(interface_descriptor_list[index]);
   }
   return "[" + result + "]";
 }
 
 std::string DebugDumpLibusbInterface(const libusb_interface& interface) {
   return "libusb_interface(altsetting=" +
-      DebugDumpLibusbInterfaceDescriptorList(
-          interface.altsetting, interface.num_altsetting) +
-      ", num_altsetting=" + std::to_string(interface.num_altsetting) + ")";
+         DebugDumpLibusbInterfaceDescriptorList(interface.altsetting,
+                                                interface.num_altsetting) +
+         ", num_altsetting=" + std::to_string(interface.num_altsetting) + ")";
 }
 
-std::string DebugDumpLibusbInterfaceList(
-    const libusb_interface* interface_list, size_t size) {
-  if (!interface_list)
-    return "<NULL>";
+std::string DebugDumpLibusbInterfaceList(const libusb_interface* interface_list,
+                                         size_t size) {
+  if (!interface_list) return "<NULL>";
   std::string result;
   for (size_t index = 0; index < size; ++index) {
-    if (!result.empty())
-      result += ", ";
+    if (!result.empty()) result += ", ";
     result += DebugDumpLibusbInterface(interface_list[index]);
   }
   return "[" + result + "]";
@@ -285,22 +280,24 @@ std::string DebugDumpLibusbInterfaceList(
 std::string DebugDumpLibusbConfigDescriptor(
     const libusb_config_descriptor& config_descriptor) {
   return "libusb_config_descriptor(bLength=" +
-      std::to_string(config_descriptor.bLength) +
-      ", bDescriptorType=" +
-      DebugDumpLibusbDescriptorType(config_descriptor.bDescriptorType) +
-      ", wTotalLength=" + std::to_string(config_descriptor.wTotalLength) +
-      ", bNumInterfaces=" + std::to_string(config_descriptor.bNumInterfaces) +
-      ", bConfigurationValue=" +
-      std::to_string(config_descriptor.bConfigurationValue) +
-      ", iConfiguration=" + std::to_string(config_descriptor.iConfiguration) +
-      ", bmAttributes=" + std::to_string(config_descriptor.bmAttributes) +
-      ", MaxPower=" + std::to_string(config_descriptor.MaxPower) +
-      ", interface=" +
-      DebugDumpLibusbInterfaceList(
-          config_descriptor.interface, config_descriptor.bNumInterfaces) +
-      ", extra=<" +
-      HexDumpBytes(config_descriptor.extra, config_descriptor.extra_length) +
-      ">, extra_length=" + std::to_string(config_descriptor.extra_length) + ")";
+         std::to_string(config_descriptor.bLength) + ", bDescriptorType=" +
+         DebugDumpLibusbDescriptorType(config_descriptor.bDescriptorType) +
+         ", wTotalLength=" + std::to_string(config_descriptor.wTotalLength) +
+         ", bNumInterfaces=" +
+         std::to_string(config_descriptor.bNumInterfaces) +
+         ", bConfigurationValue=" +
+         std::to_string(config_descriptor.bConfigurationValue) +
+         ", iConfiguration=" +
+         std::to_string(config_descriptor.iConfiguration) +
+         ", bmAttributes=" + std::to_string(config_descriptor.bmAttributes) +
+         ", MaxPower=" + std::to_string(config_descriptor.MaxPower) +
+         ", interface=" +
+         DebugDumpLibusbInterfaceList(config_descriptor.interface,
+                                      config_descriptor.bNumInterfaces) +
+         ", extra=<" +
+         HexDumpBytes(config_descriptor.extra, config_descriptor.extra_length) +
+         ">, extra_length=" + std::to_string(config_descriptor.extra_length) +
+         ")";
 }
 
 std::string DebugDumpLibusbConfigDescriptorPointer(
@@ -312,22 +309,25 @@ std::string DebugDumpLibusbConfigDescriptorPointer(
 std::string DebugDumpLibusbDeviceDescriptor(
     const libusb_device_descriptor& device_descriptor) {
   return "libusb_device_descriptor(bLength=" +
-      std::to_string(device_descriptor.bLength) + ", bDescriptorType=" +
-      DebugDumpLibusbDescriptorType(device_descriptor.bDescriptorType) +
-      ", bcdUSB=" + HexDumpInteger(device_descriptor.bcdUSB) +
-      ", bDeviceClass=" +
-      DebugDumpLibusbClassCode(device_descriptor.bDeviceClass) +
-      ", bDeviceSubClass=" + HexDumpInteger(device_descriptor.bDeviceSubClass) +
-      ", bDeviceProtocol=" + HexDumpInteger(device_descriptor.bDeviceProtocol) +
-      ", bMaxPacketSize0=" + std::to_string(device_descriptor.bMaxPacketSize0) +
-      ", idVendor=" + HexDumpInteger(device_descriptor.idVendor) +
-      ", idProduct=" + HexDumpInteger(device_descriptor.idProduct) +
-      ", bcdDevice=" + HexDumpInteger(device_descriptor.bcdDevice) +
-      ", iManufacturer=" + std::to_string(device_descriptor.iManufacturer) +
-      ", iProduct=" + std::to_string(device_descriptor.iProduct) +
-      ", iSerialNumber=" + std::to_string(device_descriptor.iSerialNumber) +
-      ", bNumConfigurations=" +
-      std::to_string(device_descriptor.bNumConfigurations) + ")";
+         std::to_string(device_descriptor.bLength) + ", bDescriptorType=" +
+         DebugDumpLibusbDescriptorType(device_descriptor.bDescriptorType) +
+         ", bcdUSB=" + HexDumpInteger(device_descriptor.bcdUSB) +
+         ", bDeviceClass=" +
+         DebugDumpLibusbClassCode(device_descriptor.bDeviceClass) +
+         ", bDeviceSubClass=" +
+         HexDumpInteger(device_descriptor.bDeviceSubClass) +
+         ", bDeviceProtocol=" +
+         HexDumpInteger(device_descriptor.bDeviceProtocol) +
+         ", bMaxPacketSize0=" +
+         std::to_string(device_descriptor.bMaxPacketSize0) +
+         ", idVendor=" + HexDumpInteger(device_descriptor.idVendor) +
+         ", idProduct=" + HexDumpInteger(device_descriptor.idProduct) +
+         ", bcdDevice=" + HexDumpInteger(device_descriptor.bcdDevice) +
+         ", iManufacturer=" + std::to_string(device_descriptor.iManufacturer) +
+         ", iProduct=" + std::to_string(device_descriptor.iProduct) +
+         ", iSerialNumber=" + std::to_string(device_descriptor.iSerialNumber) +
+         ", bNumConfigurations=" +
+         std::to_string(device_descriptor.bNumConfigurations) + ")";
 }
 
 std::string DebugDumpLibusbDeviceHandle(
@@ -370,33 +370,32 @@ std::string DebugDumpLibusbControlSetupRequestType(uint8_t request_type) {
   const int kRequestTypeMask = ((1 << 2) - 1) << 5;
   const int kDirectionMask = 1 << 7;
   return HexDumpInteger(request_type) + "(recipient=" +
-      DebugDumpLibusbRequestRecipient(request_type & kRequestRecipientMask) +
-      ", type=" + DebugDumpLibusbRequestType(request_type & kRequestTypeMask) +
-      ", direction=" +
-      DebugDumpLibusbEndpointDirection(request_type & kDirectionMask) + ")";
+         DebugDumpLibusbRequestRecipient(request_type & kRequestRecipientMask) +
+         ", type=" +
+         DebugDumpLibusbRequestType(request_type & kRequestTypeMask) +
+         ", direction=" +
+         DebugDumpLibusbEndpointDirection(request_type & kDirectionMask) + ")";
 }
 
-std::string DebugDumpInboundDataBuffer(
-    const void* data, size_t size, bool is_input_data) {
-  if (is_input_data)
-    return HexDumpPointer(data);
-  if (!data)
-    return "<NULL>";
+std::string DebugDumpInboundDataBuffer(const void* data, size_t size,
+                                       bool is_input_data) {
+  if (is_input_data) return HexDumpPointer(data);
+  if (!data) return "<NULL>";
   return HexDumpPointer(data) + "<" + HexDumpBytes(data, size) + ">";
 }
 
 std::string DebugDumpOutboundDataBuffer(const void* data, size_t size) {
-  if (!data)
-    return "<NULL>";
+  if (!data) return "<NULL>";
   return HexDumpPointer(data) + "<" + HexDumpBytes(data, size) + ">";
 }
 
 std::string DebugDumpLibusbTransferFlagsMask(uint8_t transfer_flags_mask) {
-  return DumpMask(transfer_flags_mask, {
-      {LIBUSB_TRANSFER_SHORT_NOT_OK, "LIBUSB_TRANSFER_SHORT_NOT_OK"},
-      {LIBUSB_TRANSFER_FREE_BUFFER, "LIBUSB_TRANSFER_FREE_BUFFER"},
-      {LIBUSB_TRANSFER_FREE_TRANSFER, "LIBUSB_TRANSFER_FREE_TRANSFER"},
-      {LIBUSB_TRANSFER_ADD_ZERO_PACKET, "LIBUSB_TRANSFER_ADD_ZERO_PACKET"}});
+  return DumpMask(
+      transfer_flags_mask,
+      {{LIBUSB_TRANSFER_SHORT_NOT_OK, "LIBUSB_TRANSFER_SHORT_NOT_OK"},
+       {LIBUSB_TRANSFER_FREE_BUFFER, "LIBUSB_TRANSFER_FREE_BUFFER"},
+       {LIBUSB_TRANSFER_FREE_TRANSFER, "LIBUSB_TRANSFER_FREE_TRANSFER"},
+       {LIBUSB_TRANSFER_ADD_ZERO_PACKET, "LIBUSB_TRANSFER_ADD_ZERO_PACKET"}});
 }
 
 std::string DebugDumpLibusbTransferStatus(int transfer_status) {
@@ -427,31 +426,32 @@ std::string DebugDumpLibusbControlSetup(
   // multi-byte fields (wValue, wIndex and wLength) must be carefully wrapped
   // through libusb_le16_to_cpu() macro.
   return "libusb_control_setup(bmRequestType=" +
-      DebugDumpLibusbControlSetupRequestType(control_setup->bmRequestType) +
-      ", bRequest=" + HexDumpInteger(control_setup->bRequest) + ", wValue=" +
-      HexDumpInteger(libusb_le16_to_cpu(control_setup->wValue)) + ", wIndex=" +
-      HexDumpInteger(libusb_le16_to_cpu(control_setup->wIndex)) + ", wLength=" +
-      std::to_string(control_setup->wLength) + ")";
+         DebugDumpLibusbControlSetupRequestType(control_setup->bmRequestType) +
+         ", bRequest=" + HexDumpInteger(control_setup->bRequest) + ", wValue=" +
+         HexDumpInteger(libusb_le16_to_cpu(control_setup->wValue)) +
+         ", wIndex=" +
+         HexDumpInteger(libusb_le16_to_cpu(control_setup->wIndex)) +
+         ", wLength=" + std::to_string(control_setup->wLength) + ")";
 }
 
-std::string DebugDumpLibusbTransfer(
-    libusb_transfer* transfer, bool is_inbound_argument) {
-  if (!transfer)
-    return "<NULL>";
+std::string DebugDumpLibusbTransfer(libusb_transfer* transfer,
+                                    bool is_inbound_argument) {
+  if (!transfer) return "<NULL>";
 
   const bool is_input_transfer =
       (transfer->endpoint & LIBUSB_ENDPOINT_DIR_MASK) == LIBUSB_ENDPOINT_IN;
   const bool is_control_transfer =
       transfer->type == LIBUSB_TRANSFER_TYPE_CONTROL;
-  const void* const data = is_control_transfer ?
-      libusb_control_transfer_get_data(transfer) : transfer->buffer;
+  const void* const data = is_control_transfer
+                               ? libusb_control_transfer_get_data(transfer)
+                               : transfer->buffer;
 
   std::string result = HexDumpPointer(transfer) + "(libusb_transfer(";
   result += "dev_handle=" + DebugDumpLibusbDeviceHandle(transfer->dev_handle) +
-      ", flags=" + DebugDumpLibusbTransferFlagsMask(transfer->flags) +
-      ", endpoint=" + DebugDumpLibusbEndpointAddress(transfer->endpoint) +
-      ", type=" + DebugDumpLibusbTransferType(transfer->type) +
-      ", timeout=" + std::to_string(transfer->timeout);
+            ", flags=" + DebugDumpLibusbTransferFlagsMask(transfer->flags) +
+            ", endpoint=" + DebugDumpLibusbEndpointAddress(transfer->endpoint) +
+            ", type=" + DebugDumpLibusbTransferType(transfer->type) +
+            ", timeout=" + std::to_string(transfer->timeout);
   if (!is_inbound_argument)
     result += ", status=" + DebugDumpLibusbTransferStatus(transfer->status);
   result += ", length=" + std::to_string(transfer->length);
@@ -464,11 +464,12 @@ std::string DebugDumpLibusbTransfer(
     result += ", buffer=";
     if (is_control_transfer) {
       result += HexDumpPointer(transfer->buffer) + " with " +
-                DebugDumpLibusbControlSetup(libusb_control_transfer_get_setup(
-                    transfer)) + " and data ";
+                DebugDumpLibusbControlSetup(
+                    libusb_control_transfer_get_setup(transfer)) +
+                " and data ";
     }
-    result += DebugDumpInboundDataBuffer(
-        data, transfer->length, is_input_transfer);
+    result +=
+        DebugDumpInboundDataBuffer(data, transfer->length, is_input_transfer);
   } else {
     if (is_input_transfer) {
       result += ", buffer=";
@@ -479,8 +480,8 @@ std::string DebugDumpLibusbTransfer(
   }
   // TODO(emaxx): Print the debug dump of the iso_packet_desc field value, once
   // the isochronous transfers are supported.
-  result += ", num_iso_packets=" + std::to_string(transfer->num_iso_packets) +
-            "))";
+  result +=
+      ", num_iso_packets=" + std::to_string(transfer->num_iso_packets) + "))";
   return result;
 }
 
@@ -501,16 +502,15 @@ class LibusbTransferTracingWrapper final {
     //
     // The created LibusbTransferTracingWrapper instance is destroyed in the
     // LibusbTransferCallback method.
-    LibusbTransferTracingWrapper* const wrapper =  // NOLINT
+    LibusbTransferTracingWrapper* const wrapper =                    // NOLINT
         new LibusbTransferTracingWrapper(transfer, wrapped_libusb);  // NOLINT
-    return wrapper->wrapper_transfer_;  // NOLINT
+    return wrapper->wrapper_transfer_;                               // NOLINT
   }
 
  private:
-  LibusbTransferTracingWrapper(
-      libusb_transfer* transfer, LibusbInterface* wrapped_libusb)
-      : transfer_(transfer),
-        wrapped_libusb_(wrapped_libusb) {
+  LibusbTransferTracingWrapper(libusb_transfer* transfer,
+                               LibusbInterface* wrapped_libusb)
+      : transfer_(transfer), wrapped_libusb_(wrapped_libusb) {
     GOOGLE_SMART_CARD_CHECK(transfer_);
     GOOGLE_SMART_CARD_CHECK(wrapped_libusb_);
 
@@ -535,8 +535,8 @@ class LibusbTransferTracingWrapper final {
     delete wrapper;
 
     FunctionCallTracer tracer("libusb_transfer->callback", kLoggingPrefix);
-    tracer.AddPassedArg(
-        "libusb_transfer", DebugDumpLibusbTransfer(original_transfer, false));
+    tracer.AddPassedArg("libusb_transfer",
+                        DebugDumpLibusbTransfer(original_transfer, false));
     tracer.LogEntrance();
 
     original_transfer->callback(original_transfer);
@@ -561,6 +561,8 @@ LibusbTracingWrapper::LibusbTracingWrapper(LibusbInterface* wrapped_libusb)
   GOOGLE_SMART_CARD_CHECK(wrapped_libusb_);
 }
 
+LibusbTracingWrapper::~LibusbTracingWrapper() = default;
+
 int LibusbTracingWrapper::LibusbInit(libusb_context** ctx) {
   FunctionCallTracer tracer("libusb_init", kLoggingPrefix);
   tracer.AddPassedArg("ctx", HexDumpPointer(ctx));
@@ -570,8 +572,7 @@ int LibusbTracingWrapper::LibusbInit(libusb_context** ctx) {
 
   tracer.AddReturnValue(DebugDumpLibusbReturnCode(return_code));
   if (return_code == LIBUSB_SUCCESS) {
-    if (ctx)
-      tracer.AddReturnedArg("*ctx", DebugDumpLibusbContext(*ctx));
+    if (ctx) tracer.AddReturnedArg("*ctx", DebugDumpLibusbContext(*ctx));
   }
   tracer.LogExit();
   return return_code;
@@ -587,8 +588,8 @@ void LibusbTracingWrapper::LibusbExit(libusb_context* ctx) {
   tracer.LogExit();
 }
 
-ssize_t LibusbTracingWrapper::LibusbGetDeviceList(
-    libusb_context* ctx, libusb_device*** list) {
+ssize_t LibusbTracingWrapper::LibusbGetDeviceList(libusb_context* ctx,
+                                                  libusb_device*** list) {
   FunctionCallTracer tracer("libusb_get_device_list", kLoggingPrefix);
   tracer.AddPassedArg("ctx", DebugDumpLibusbContext(ctx));
   tracer.AddPassedArg("list", HexDumpPointer(list));
@@ -596,18 +597,18 @@ ssize_t LibusbTracingWrapper::LibusbGetDeviceList(
 
   const int return_code = wrapped_libusb_->LibusbGetDeviceList(ctx, list);
 
-  tracer.AddReturnValue(return_code >= 0 ?
-      std::to_string(return_code) : DebugDumpLibusbReturnCode(return_code));
+  tracer.AddReturnValue(return_code >= 0
+                            ? std::to_string(return_code)
+                            : DebugDumpLibusbReturnCode(return_code));
   if (return_code >= 0) {
-    if (list)
-      tracer.AddReturnedArg("*list", DebugDumpLibusbDeviceList(*list));
+    if (list) tracer.AddReturnedArg("*list", DebugDumpLibusbDeviceList(*list));
   }
   tracer.LogExit();
   return return_code;
 }
 
-void LibusbTracingWrapper::LibusbFreeDeviceList(
-    libusb_device** list, int unref_devices) {
+void LibusbTracingWrapper::LibusbFreeDeviceList(libusb_device** list,
+                                                int unref_devices) {
   FunctionCallTracer tracer("libusb_free_device_list", kLoggingPrefix);
   tracer.AddPassedArg("list", DebugDumpLibusbDeviceList(list));
   tracer.AddPassedArg("unref_devices", std::to_string(unref_devices));
@@ -642,20 +643,20 @@ void LibusbTracingWrapper::LibusbUnrefDevice(libusb_device* dev) {
 
 int LibusbTracingWrapper::LibusbGetActiveConfigDescriptor(
     libusb_device* dev, libusb_config_descriptor** config) {
-  FunctionCallTracer tracer(
-      "libusb_get_active_config_descriptor", kLoggingPrefix);
+  FunctionCallTracer tracer("libusb_get_active_config_descriptor",
+                            kLoggingPrefix);
   tracer.AddPassedArg("dev", DebugDumpLibusbDevice(dev));
   tracer.AddPassedArg("config", HexDumpPointer(config));
   tracer.LogEntrance();
 
-  const int return_code = wrapped_libusb_->LibusbGetActiveConfigDescriptor(
-      dev, config);
+  const int return_code =
+      wrapped_libusb_->LibusbGetActiveConfigDescriptor(dev, config);
 
   tracer.AddReturnValue(DebugDumpLibusbReturnCode(return_code));
   if (return_code == LIBUSB_SUCCESS) {
     if (config) {
-      tracer.AddReturnedArg(
-          "*config", DebugDumpLibusbConfigDescriptorPointer(*config));
+      tracer.AddReturnedArg("*config",
+                            DebugDumpLibusbConfigDescriptorPointer(*config));
     }
   }
   tracer.LogExit();
@@ -715,8 +716,8 @@ uint8_t LibusbTracingWrapper::LibusbGetDeviceAddress(libusb_device* dev) {
   return result;
 }
 
-int LibusbTracingWrapper::LibusbOpen(
-    libusb_device* dev, libusb_device_handle** handle) {
+int LibusbTracingWrapper::LibusbOpen(libusb_device* dev,
+                                     libusb_device_handle** handle) {
   FunctionCallTracer tracer("libusb_open", kLoggingPrefix);
   tracer.AddPassedArg("dev", DebugDumpLibusbDevice(dev));
   tracer.AddPassedArg("handle", HexDumpPointer(handle));
@@ -743,30 +744,30 @@ void LibusbTracingWrapper::LibusbClose(libusb_device_handle* handle) {
   tracer.LogExit();
 }
 
-int LibusbTracingWrapper::LibusbClaimInterface(
-    libusb_device_handle* dev, int interface_number) {
+int LibusbTracingWrapper::LibusbClaimInterface(libusb_device_handle* dev,
+                                               int interface_number) {
   FunctionCallTracer tracer("libusb_claim_interface", kLoggingPrefix);
   tracer.AddPassedArg("dev", DebugDumpLibusbDeviceHandle(dev));
   tracer.AddPassedArg("interface_number", std::to_string(interface_number));
   tracer.LogEntrance();
 
-  const int return_code = wrapped_libusb_->LibusbClaimInterface(
-      dev, interface_number);
+  const int return_code =
+      wrapped_libusb_->LibusbClaimInterface(dev, interface_number);
 
   tracer.AddReturnValue(DebugDumpLibusbReturnCode(return_code));
   tracer.LogExit();
   return return_code;
 }
 
-int LibusbTracingWrapper::LibusbReleaseInterface(
-    libusb_device_handle* dev, int interface_number) {
+int LibusbTracingWrapper::LibusbReleaseInterface(libusb_device_handle* dev,
+                                                 int interface_number) {
   FunctionCallTracer tracer("libusb_release_interface", kLoggingPrefix);
   tracer.AddPassedArg("dev", DebugDumpLibusbDeviceHandle(dev));
   tracer.AddPassedArg("interface_number", std::to_string(interface_number));
   tracer.LogEntrance();
 
-  const int return_code = wrapped_libusb_->LibusbReleaseInterface(
-      dev, interface_number);
+  const int return_code =
+      wrapped_libusb_->LibusbReleaseInterface(dev, interface_number);
 
   tracer.AddReturnValue(DebugDumpLibusbReturnCode(return_code));
   tracer.LogExit();
@@ -790,8 +791,8 @@ libusb_transfer* LibusbTracingWrapper::LibusbAllocTransfer(int iso_packets) {
   tracer.AddPassedArg("iso_packets", std::to_string(iso_packets));
   tracer.LogEntrance();
 
-  libusb_transfer* const result = wrapped_libusb_->LibusbAllocTransfer(
-      iso_packets);
+  libusb_transfer* const result =
+      wrapped_libusb_->LibusbAllocTransfer(iso_packets);
 
   tracer.AddReturnValue(HexDumpPointer(result));
   tracer.LogExit();
@@ -807,12 +808,12 @@ int LibusbTracingWrapper::LibusbSubmitTransfer(libusb_transfer* transfer) {
   // callback is executed, a copy of transfer is created with a wrapper
   // callback.
   libusb_transfer* const wrapped_transfer =
-      LibusbTransferTracingWrapper::CreateWrappedTransfer(
-          transfer, wrapped_libusb_);
+      LibusbTransferTracingWrapper::CreateWrappedTransfer(transfer,
+                                                          wrapped_libusb_);
   AddOriginalToWrappedTransferMapItem(transfer, wrapped_transfer);
 
-  const int return_code = wrapped_libusb_->LibusbSubmitTransfer(
-      wrapped_transfer);
+  const int return_code =
+      wrapped_libusb_->LibusbSubmitTransfer(wrapped_transfer);
 
   tracer.AddReturnValue(DebugDumpLibusbReturnCode(return_code));
   tracer.LogExit();
@@ -830,8 +831,8 @@ int LibusbTracingWrapper::LibusbCancelTransfer(libusb_transfer* transfer) {
   libusb_transfer* const wrapped_transfer = GetWrappedTransfer(transfer);
   GOOGLE_SMART_CARD_CHECK(wrapped_transfer);
 
-  const int return_code = wrapped_libusb_->LibusbCancelTransfer(
-      wrapped_transfer);
+  const int return_code =
+      wrapped_libusb_->LibusbCancelTransfer(wrapped_transfer);
 
   tracer.AddReturnValue(DebugDumpLibusbReturnCode(return_code));
   tracer.LogExit();
@@ -854,18 +855,13 @@ void LibusbTracingWrapper::LibusbFreeTransfer(libusb_transfer* transfer) {
 }
 
 int LibusbTracingWrapper::LibusbControlTransfer(
-    libusb_device_handle* dev,
-    uint8_t bmRequestType,
-    uint8_t bRequest,
-    uint16_t wValue,
-    uint16_t wIndex,
-    unsigned char* data,
-    uint16_t wLength,
+    libusb_device_handle* dev, uint8_t bmRequestType, uint8_t bRequest,
+    uint16_t wValue, uint16_t wIndex, unsigned char* data, uint16_t wLength,
     unsigned timeout) {
   FunctionCallTracer tracer("libusb_control_transfer", kLoggingPrefix);
   tracer.AddPassedArg("dev", DebugDumpLibusbDeviceHandle(dev));
-  tracer.AddPassedArg(
-      "bmRequestType", DebugDumpLibusbControlSetupRequestType(bmRequestType));
+  tracer.AddPassedArg("bmRequestType",
+                      DebugDumpLibusbControlSetupRequestType(bmRequestType));
   tracer.AddPassedArg("bRequest", HexDumpInteger(bRequest));
   tracer.AddPassedArg("wValue", HexDumpInteger(wValue));
   tracer.AddPassedArg("wIndex", HexDumpInteger(wIndex));
@@ -880,25 +876,24 @@ int LibusbTracingWrapper::LibusbControlTransfer(
   const int return_code = wrapped_libusb_->LibusbControlTransfer(
       dev, bmRequestType, bRequest, wValue, wIndex, data, wLength, timeout);
 
-  tracer.AddReturnValue(return_code >= 0 ?
-      std::to_string(return_code) : DebugDumpLibusbReturnCode(return_code));
+  tracer.AddReturnValue(return_code >= 0
+                            ? std::to_string(return_code)
+                            : DebugDumpLibusbReturnCode(return_code));
   if (return_code >= 0) {
     if (is_input_transfer) {
-      tracer.AddReturnedArg(
-          "data", DebugDumpOutboundDataBuffer(data, return_code));
+      tracer.AddReturnedArg("data",
+                            DebugDumpOutboundDataBuffer(data, return_code));
     }
   }
   tracer.LogExit();
   return return_code;
 }
 
-int LibusbTracingWrapper::LibusbBulkTransfer(
-    libusb_device_handle* dev,
-    unsigned char endpoint,
-    unsigned char* data,
-    int length,
-    int* actual_length,
-    unsigned timeout) {
+int LibusbTracingWrapper::LibusbBulkTransfer(libusb_device_handle* dev,
+                                             unsigned char endpoint,
+                                             unsigned char* data, int length,
+                                             int* actual_length,
+                                             unsigned timeout) {
   FunctionCallTracer tracer("libusb_bulk_transfer", kLoggingPrefix);
   tracer.AddPassedArg("dev", DebugDumpLibusbDeviceHandle(dev));
   tracer.AddPassedArg("endpoint", DebugDumpLibusbEndpointAddress(endpoint));
@@ -917,8 +912,8 @@ int LibusbTracingWrapper::LibusbBulkTransfer(
   tracer.AddReturnValue(DebugDumpLibusbReturnCode(return_code));
   if (return_code == LIBUSB_SUCCESS) {
     if (is_input_transfer && actual_length) {
-      tracer.AddReturnedArg(
-          "data", DebugDumpOutboundDataBuffer(data, *actual_length));
+      tracer.AddReturnedArg("data",
+                            DebugDumpOutboundDataBuffer(data, *actual_length));
     }
     if (actual_length)
       tracer.AddReturnedArg("*actual_length", std::to_string(*actual_length));
@@ -928,12 +923,8 @@ int LibusbTracingWrapper::LibusbBulkTransfer(
 }
 
 int LibusbTracingWrapper::LibusbInterruptTransfer(
-    libusb_device_handle* dev,
-    unsigned char endpoint,
-    unsigned char* data,
-    int length,
-    int* actual_length,
-    unsigned timeout) {
+    libusb_device_handle* dev, unsigned char endpoint, unsigned char* data,
+    int length, int* actual_length, unsigned timeout) {
   FunctionCallTracer tracer("libusb_interrupt_transfer", kLoggingPrefix);
   tracer.AddPassedArg("dev", DebugDumpLibusbDeviceHandle(dev));
   tracer.AddPassedArg("endpoint", DebugDumpLibusbEndpointAddress(endpoint));
@@ -952,8 +943,8 @@ int LibusbTracingWrapper::LibusbInterruptTransfer(
   tracer.AddReturnValue(DebugDumpLibusbReturnCode(return_code));
   if (return_code == LIBUSB_SUCCESS) {
     if (is_input_transfer && actual_length) {
-      tracer.AddReturnedArg(
-          "data", DebugDumpOutboundDataBuffer(data, *actual_length));
+      tracer.AddReturnedArg("data",
+                            DebugDumpOutboundDataBuffer(data, *actual_length));
     }
     if (actual_length)
       tracer.AddReturnedArg("*actual_length", std::to_string(*actual_length));
@@ -974,15 +965,15 @@ int LibusbTracingWrapper::LibusbHandleEvents(libusb_context* ctx) {
   return return_code;
 }
 
-int LibusbTracingWrapper::LibusbHandleEventsCompleted(
-    libusb_context* ctx, int* completed) {
+int LibusbTracingWrapper::LibusbHandleEventsCompleted(libusb_context* ctx,
+                                                      int* completed) {
   FunctionCallTracer tracer("libusb_handle_events_completed", kLoggingPrefix);
   tracer.AddPassedArg("ctx", DebugDumpLibusbContext(ctx));
   tracer.AddPassedArg("completed", HexDumpPointer(completed));
   tracer.LogEntrance();
 
-  const int return_code = wrapped_libusb_->LibusbHandleEventsCompleted(
-      ctx, completed);
+  const int return_code =
+      wrapped_libusb_->LibusbHandleEventsCompleted(ctx, completed);
 
   tracer.AddReturnValue(DebugDumpLibusbReturnCode(return_code));
   tracer.LogExit();
@@ -1002,8 +993,7 @@ libusb_transfer* LibusbTracingWrapper::GetWrappedTransfer(
     libusb_transfer* original_transfer) const {
   const std::unique_lock<std::mutex> lock(mutex_);
   const auto iter = original_to_wrapped_transfer_map_.find(original_transfer);
-  if (iter == original_to_wrapped_transfer_map_.end())
-    return nullptr;
+  if (iter == original_to_wrapped_transfer_map_.end()) return nullptr;
   return iter->second;
 }
 

--- a/third_party/libusb/naclport/src/libusb_tracing_wrapper.h
+++ b/third_party/libusb/naclport/src/libusb_tracing_wrapper.h
@@ -34,62 +34,51 @@ class LibusbTracingWrapper : public LibusbInterface {
  public:
   LibusbTracingWrapper(LibusbInterface* wrapped_libusb);
   LibusbTracingWrapper(const LibusbTracingWrapper&) = delete;
+  LibusbTracingWrapper& operator=(const LibusbTracingWrapper&) = delete;
+  ~LibusbTracingWrapper();
 
   // LibusbInterface:
   int LibusbInit(libusb_context** ctx) override;
   void LibusbExit(libusb_context* ctx) override;
-  ssize_t LibusbGetDeviceList(
-      libusb_context* ctx, libusb_device*** list) override;
+  ssize_t LibusbGetDeviceList(libusb_context* ctx,
+                              libusb_device*** list) override;
   void LibusbFreeDeviceList(libusb_device** list, int unref_devices) override;
   libusb_device* LibusbRefDevice(libusb_device* dev) override;
   void LibusbUnrefDevice(libusb_device* dev) override;
   int LibusbGetActiveConfigDescriptor(
       libusb_device* dev, libusb_config_descriptor** config) override;
   void LibusbFreeConfigDescriptor(libusb_config_descriptor* config) override;
-  int LibusbGetDeviceDescriptor(
-      libusb_device* dev, libusb_device_descriptor* desc) override;
+  int LibusbGetDeviceDescriptor(libusb_device* dev,
+                                libusb_device_descriptor* desc) override;
   uint8_t LibusbGetBusNumber(libusb_device* dev) override;
   uint8_t LibusbGetDeviceAddress(libusb_device* dev) override;
   int LibusbOpen(libusb_device* dev, libusb_device_handle** handle) override;
   void LibusbClose(libusb_device_handle* handle) override;
-  int LibusbClaimInterface(
-      libusb_device_handle* dev, int interface_number) override;
-  int LibusbReleaseInterface(
-      libusb_device_handle* dev, int interface_number) override;
+  int LibusbClaimInterface(libusb_device_handle* dev,
+                           int interface_number) override;
+  int LibusbReleaseInterface(libusb_device_handle* dev,
+                             int interface_number) override;
   int LibusbResetDevice(libusb_device_handle* dev) override;
   libusb_transfer* LibusbAllocTransfer(int iso_packets) override;
   int LibusbSubmitTransfer(libusb_transfer* transfer) override;
   int LibusbCancelTransfer(libusb_transfer* transfer) override;
   void LibusbFreeTransfer(libusb_transfer* transfer) override;
-  int LibusbControlTransfer(
-      libusb_device_handle* dev,
-      uint8_t bmRequestType,
-      uint8_t bRequest,
-      uint16_t wValue,
-      uint16_t wIndex,
-      unsigned char* data,
-      uint16_t wLength,
-      unsigned timeout) override;
-  int LibusbBulkTransfer(
-      libusb_device_handle* dev,
-      unsigned char endpoint,
-      unsigned char* data,
-      int length,
-      int* actual_length,
-      unsigned timeout) override;
-  int LibusbInterruptTransfer(
-      libusb_device_handle* dev,
-      unsigned char endpoint,
-      unsigned char* data,
-      int length,
-      int* actual_length,
-      unsigned timeout) override;
+  int LibusbControlTransfer(libusb_device_handle* dev, uint8_t bmRequestType,
+                            uint8_t bRequest, uint16_t wValue, uint16_t wIndex,
+                            unsigned char* data, uint16_t wLength,
+                            unsigned timeout) override;
+  int LibusbBulkTransfer(libusb_device_handle* dev, unsigned char endpoint,
+                         unsigned char* data, int length, int* actual_length,
+                         unsigned timeout) override;
+  int LibusbInterruptTransfer(libusb_device_handle* dev, unsigned char endpoint,
+                              unsigned char* data, int length,
+                              int* actual_length, unsigned timeout) override;
   int LibusbHandleEvents(libusb_context* ctx) override;
   int LibusbHandleEventsCompleted(libusb_context* ctx, int* completed) override;
 
  private:
-  void AddOriginalToWrappedTransferMapItem(
-      libusb_transfer* original_transfer, libusb_transfer* wrapped_transfer);
+  void AddOriginalToWrappedTransferMapItem(libusb_transfer* original_transfer,
+                                           libusb_transfer* wrapped_transfer);
   libusb_transfer* GetWrappedTransfer(libusb_transfer* original_transfer) const;
   void RemoveOriginalToWrappedTransferMapItem(
       libusb_transfer* original_transfer);
@@ -97,7 +86,7 @@ class LibusbTracingWrapper : public LibusbInterface {
   LibusbInterface* const wrapped_libusb_;
   mutable std::mutex mutex_;
   std::unordered_map<libusb_transfer*, libusb_transfer*>
-  original_to_wrapped_transfer_map_;
+      original_to_wrapped_transfer_map_;
 };
 
 }  // namespace google_smart_card

--- a/third_party/libusb/naclport/src/usb_transfer_destination.cc
+++ b/third_party/libusb/naclport/src/usb_transfer_destination.cc
@@ -28,19 +28,18 @@
 
 namespace google_smart_card {
 
+UsbTransferDestination::UsbTransferDestination() = default;
+
+UsbTransferDestination::~UsbTransferDestination() = default;
+
 // static
 UsbTransferDestination
 UsbTransferDestination::CreateFromChromeUsbControlTransfer(
     const chrome_usb::ConnectionHandle& connection_handle,
     const chrome_usb::ControlTransferInfo& transfer_info) {
   return UsbTransferDestination(
-      connection_handle,
-      transfer_info.direction,
-      {},
-      transfer_info.recipient,
-      transfer_info.request_type,
-      transfer_info.request,
-      transfer_info.value,
+      connection_handle, transfer_info.direction, {}, transfer_info.recipient,
+      transfer_info.request_type, transfer_info.request, transfer_info.value,
       transfer_info.index);
 }
 
@@ -49,15 +48,8 @@ UsbTransferDestination
 UsbTransferDestination::CreateFromChromeUsbGenericTransfer(
     const chrome_usb::ConnectionHandle& connection_handle,
     const chrome_usb::GenericTransferInfo& transfer_info) {
-  return UsbTransferDestination(
-      connection_handle,
-      transfer_info.direction,
-      transfer_info.endpoint,
-      {},
-      {},
-      {},
-      {},
-      {});
+  return UsbTransferDestination(connection_handle, transfer_info.direction,
+                                transfer_info.endpoint, {}, {}, {}, {}, {});
 }
 
 bool UsbTransferDestination::IsInputDirection() const {
@@ -81,12 +73,11 @@ bool UsbTransferDestination::operator==(
 
 UsbTransferDestination::UsbTransferDestination(
     const chrome_usb::ConnectionHandle& connection_handle,
-    const chrome_usb::Direction& direction,
-    optional<int64_t> endpoint,
+    const chrome_usb::Direction& direction, optional<int64_t> endpoint,
     optional<chrome_usb::ControlTransferInfoRecipient>
-    control_transfer_recipient,
+        control_transfer_recipient,
     optional<chrome_usb::ControlTransferInfoRequestType>
-    control_transfer_request_type,
+        control_transfer_request_type,
     optional<int64_t> control_transfer_request,
     optional<int64_t> control_transfer_value,
     optional<int64_t> control_transfer_index)
@@ -103,10 +94,8 @@ namespace {
 
 template <typename T>
 int CompareValues(const T& lhs, const T& rhs) {
-  if (lhs < rhs)
-    return -1;
-  if (lhs > rhs)
-    return 1;
+  if (lhs < rhs) return -1;
+  if (lhs > rhs) return 1;
   return 0;
 }
 
@@ -114,28 +103,17 @@ int CompareValues(const T& lhs, const T& rhs) {
 
 int UsbTransferDestination::Compare(const UsbTransferDestination& other) const {
   return CompareValues(
+      std::tie(connection_handle_.handle, connection_handle_.vendor_id,
+               connection_handle_.product_id, direction_, endpoint_,
+               control_transfer_recipient_, control_transfer_request_type_,
+               control_transfer_request_, control_transfer_value_,
+               control_transfer_index_),
       std::tie(
-          connection_handle_.handle,
-          connection_handle_.vendor_id,
-          connection_handle_.product_id,
-          direction_,
-          endpoint_,
-          control_transfer_recipient_,
-          control_transfer_request_type_,
-          control_transfer_request_,
-          control_transfer_value_,
-          control_transfer_index_),
-      std::tie(
-          other.connection_handle_.handle,
-          other.connection_handle_.vendor_id,
-          other.connection_handle_.product_id,
-          other.direction_,
-          other.endpoint_,
-          other.control_transfer_recipient_,
-          other.control_transfer_request_type_,
-          other.control_transfer_request_,
-          other.control_transfer_value_,
-          other.control_transfer_index_));
+          other.connection_handle_.handle, other.connection_handle_.vendor_id,
+          other.connection_handle_.product_id, other.direction_,
+          other.endpoint_, other.control_transfer_recipient_,
+          other.control_transfer_request_type_, other.control_transfer_request_,
+          other.control_transfer_value_, other.control_transfer_index_));
 }
 
 }  // namespace google_smart_card

--- a/third_party/libusb/naclport/src/usb_transfer_destination.h
+++ b/third_party/libusb/naclport/src/usb_transfer_destination.h
@@ -31,7 +31,10 @@ namespace google_smart_card {
 // results (see the comments in the libusb_over_chrome_usb.h header).
 class UsbTransferDestination final {
  public:
-  UsbTransferDestination() = default;
+  UsbTransferDestination();
+  UsbTransferDestination(const UsbTransferDestination&) = default;
+  UsbTransferDestination& operator=(const UsbTransferDestination&) = default;
+  ~UsbTransferDestination();
 
   static UsbTransferDestination CreateFromChromeUsbControlTransfer(
       const chrome_usb::ConnectionHandle& connection_handle,
@@ -48,17 +51,16 @@ class UsbTransferDestination final {
   bool operator==(const UsbTransferDestination& other) const;
 
  private:
-  UsbTransferDestination(
-      const chrome_usb::ConnectionHandle& connection_handle,
-      const chrome_usb::Direction& direction,
-      optional<int64_t> endpoint,
-      optional<chrome_usb::ControlTransferInfoRecipient>
-      control_transfer_recipient,
-      optional<chrome_usb::ControlTransferInfoRequestType>
-      control_transfer_request_type,
-      optional<int64_t> control_transfer_request,
-      optional<int64_t> control_transfer_value,
-      optional<int64_t> control_transfer_index);
+  UsbTransferDestination(const chrome_usb::ConnectionHandle& connection_handle,
+                         const chrome_usb::Direction& direction,
+                         optional<int64_t> endpoint,
+                         optional<chrome_usb::ControlTransferInfoRecipient>
+                             control_transfer_recipient,
+                         optional<chrome_usb::ControlTransferInfoRequestType>
+                             control_transfer_request_type,
+                         optional<int64_t> control_transfer_request,
+                         optional<int64_t> control_transfer_value,
+                         optional<int64_t> control_transfer_index);
 
   int Compare(const UsbTransferDestination& other) const;
 
@@ -66,9 +68,9 @@ class UsbTransferDestination final {
   chrome_usb::Direction direction_;
   optional<int64_t> endpoint_;
   optional<chrome_usb::ControlTransferInfoRecipient>
-  control_transfer_recipient_;
+      control_transfer_recipient_;
   optional<chrome_usb::ControlTransferInfoRequestType>
-  control_transfer_request_type_;
+      control_transfer_request_type_;
   optional<int64_t> control_transfer_request_;
   optional<int64_t> control_transfer_value_;
   optional<int64_t> control_transfer_index_;

--- a/third_party/libusb/naclport/src/usb_transfers_parameters_storage.h
+++ b/third_party/libusb/naclport/src/usb_transfers_parameters_storage.h
@@ -50,16 +50,18 @@ class UsbTransfersParametersStorage final {
   using TransferAsyncRequestStatePtr =
       std::shared_ptr<TransferAsyncRequestState>;
 
-  UsbTransfersParametersStorage() = default;
+  UsbTransfersParametersStorage();
   UsbTransfersParametersStorage(const UsbTransfersParametersStorage&) = delete;
+  UsbTransfersParametersStorage& operator=(
+      const UsbTransfersParametersStorage&) = delete;
+  ~UsbTransfersParametersStorage();
 
   struct Item {
     Item();
 
-    Item(
-        TransferAsyncRequestStatePtr async_request_state,
-        const UsbTransferDestination& transfer_destination,
-        libusb_transfer* transfer);
+    Item(TransferAsyncRequestStatePtr async_request_state,
+         const UsbTransferDestination& transfer_destination,
+         libusb_transfer* transfer);
 
     TransferAsyncRequestStatePtr async_request_state;
     UsbTransferDestination transfer_destination;
@@ -68,10 +70,9 @@ class UsbTransfersParametersStorage final {
 
   void Add(const Item& item);
 
-  void Add(
-      TransferAsyncRequestStatePtr async_request_state,
-      const UsbTransferDestination& transfer_destination,
-      libusb_transfer* transfer);
+  void Add(TransferAsyncRequestStatePtr async_request_state,
+           const UsbTransferDestination& transfer_destination,
+           libusb_transfer* transfer);
 
   bool ContainsWithAsyncRequestState(
       const TransferAsyncRequestState* async_request_state) const;
@@ -98,17 +99,16 @@ class UsbTransfersParametersStorage final {
 
  private:
   bool FindByAsyncRequestState(
-      const TransferAsyncRequestState* async_request_state,
-      Item* result) const;
+      const TransferAsyncRequestState* async_request_state, Item* result) const;
   bool FindAsyncByDestination(
       const UsbTransferDestination& transfer_destination, Item* result) const;
-  bool FindAsyncByLibusbTransfer(
-      const libusb_transfer* transfer, Item* result) const;
+  bool FindAsyncByLibusbTransfer(const libusb_transfer* transfer,
+                                 Item* result) const;
 
   mutable std::mutex mutex_;
   std::map<const TransferAsyncRequestState*, Item> async_request_state_mapping_;
   std::map<UsbTransferDestination, std::set<const TransferAsyncRequestState*>>
-  async_destination_mapping_;
+      async_destination_mapping_;
   std::map<const libusb_transfer*, Item> async_libusb_transfer_mapping_;
 };
 

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite.h
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite.h
@@ -46,28 +46,21 @@ class PcscLite {
  public:
   virtual ~PcscLite() = default;
 
-  virtual LONG SCardEstablishContext(
-      DWORD dwScope,
-      LPCVOID pvReserved1,
-      LPCVOID pvReserved2,
-      LPSCARDCONTEXT phContext) = 0;
+  virtual LONG SCardEstablishContext(DWORD dwScope, LPCVOID pvReserved1,
+                                     LPCVOID pvReserved2,
+                                     LPSCARDCONTEXT phContext) = 0;
 
   virtual LONG SCardReleaseContext(SCARDCONTEXT hContext) = 0;
 
-  virtual LONG SCardConnect(
-      SCARDCONTEXT hContext,
-      LPCSTR szReader,
-      DWORD dwShareMode,
-      DWORD dwPreferredProtocols,
-      LPSCARDHANDLE phCard,
-      LPDWORD pdwActiveProtocol) = 0;
+  virtual LONG SCardConnect(SCARDCONTEXT hContext, LPCSTR szReader,
+                            DWORD dwShareMode, DWORD dwPreferredProtocols,
+                            LPSCARDHANDLE phCard,
+                            LPDWORD pdwActiveProtocol) = 0;
 
-  virtual LONG SCardReconnect(
-      SCARDHANDLE hCard,
-      DWORD dwShareMode,
-      DWORD dwPreferredProtocols,
-      DWORD dwInitialization,
-      LPDWORD pdwActiveProtocol) = 0;
+  virtual LONG SCardReconnect(SCARDHANDLE hCard, DWORD dwShareMode,
+                              DWORD dwPreferredProtocols,
+                              DWORD dwInitialization,
+                              LPDWORD pdwActiveProtocol) = 0;
 
   virtual LONG SCardDisconnect(SCARDHANDLE hCard, DWORD dwDisposition) = 0;
 
@@ -75,61 +68,39 @@ class PcscLite {
 
   virtual LONG SCardEndTransaction(SCARDHANDLE hCard, DWORD dwDisposition) = 0;
 
-  virtual LONG SCardStatus(
-      SCARDHANDLE hCard,
-      LPSTR szReaderName,
-      LPDWORD pcchReaderLen,
-      LPDWORD pdwState,
-      LPDWORD pdwProtocol,
-      LPBYTE pbAtr,
-      LPDWORD pcbAtrLen) = 0;
+  virtual LONG SCardStatus(SCARDHANDLE hCard, LPSTR szReaderName,
+                           LPDWORD pcchReaderLen, LPDWORD pdwState,
+                           LPDWORD pdwProtocol, LPBYTE pbAtr,
+                           LPDWORD pcbAtrLen) = 0;
 
-  virtual LONG SCardGetStatusChange(
-      SCARDCONTEXT hContext,
-      DWORD dwTimeout,
-      SCARD_READERSTATE* rgReaderStates,
-      DWORD cReaders) = 0;
+  virtual LONG SCardGetStatusChange(SCARDCONTEXT hContext, DWORD dwTimeout,
+                                    SCARD_READERSTATE* rgReaderStates,
+                                    DWORD cReaders) = 0;
 
-  virtual LONG SCardControl(
-      SCARDHANDLE hCard,
-      DWORD dwControlCode,
-      LPCVOID pbSendBuffer,
-      DWORD cbSendLength,
-      LPVOID pbRecvBuffer,
-      DWORD cbRecvLength,
-      LPDWORD lpBytesReturned) = 0;
+  virtual LONG SCardControl(SCARDHANDLE hCard, DWORD dwControlCode,
+                            LPCVOID pbSendBuffer, DWORD cbSendLength,
+                            LPVOID pbRecvBuffer, DWORD cbRecvLength,
+                            LPDWORD lpBytesReturned) = 0;
 
-  virtual LONG SCardGetAttrib(
-      SCARDHANDLE hCard,
-      DWORD dwAttrId,
-      LPBYTE pbAttr,
-      LPDWORD pcbAttrLen) = 0;
+  virtual LONG SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPBYTE pbAttr,
+                              LPDWORD pcbAttrLen) = 0;
 
-  virtual LONG SCardSetAttrib(
-      SCARDHANDLE hCard,
-      DWORD dwAttrId,
-      LPCBYTE pbAttr,
-      DWORD cbAttrLen) = 0;
+  virtual LONG SCardSetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPCBYTE pbAttr,
+                              DWORD cbAttrLen) = 0;
 
-  virtual LONG SCardTransmit(
-      SCARDHANDLE hCard,
-      const SCARD_IO_REQUEST* pioSendPci,
-      LPCBYTE pbSendBuffer,
-      DWORD cbSendLength,
-      SCARD_IO_REQUEST* pioRecvPci,
-      LPBYTE pbRecvBuffer,
-      LPDWORD pcbRecvLength) = 0;
+  virtual LONG SCardTransmit(SCARDHANDLE hCard,
+                             const SCARD_IO_REQUEST* pioSendPci,
+                             LPCBYTE pbSendBuffer, DWORD cbSendLength,
+                             SCARD_IO_REQUEST* pioRecvPci, LPBYTE pbRecvBuffer,
+                             LPDWORD pcbRecvLength) = 0;
 
-  virtual LONG SCardListReaders(
-      SCARDCONTEXT hContext,
-      LPCSTR mszGroups,
-      LPSTR mszReaders,
-      LPDWORD pcchReaders) = 0;
+  virtual LONG SCardListReaders(SCARDCONTEXT hContext, LPCSTR mszGroups,
+                                LPSTR mszReaders, LPDWORD pcchReaders) = 0;
 
   virtual LONG SCardFreeMemory(SCARDCONTEXT hContext, LPCVOID pvMem) = 0;
 
-  virtual LONG SCardListReaderGroups(
-      SCARDCONTEXT hContext, LPSTR mszGroups, LPDWORD pcchGroups) = 0;
+  virtual LONG SCardListReaderGroups(SCARDCONTEXT hContext, LPSTR mszGroups,
+                                     LPDWORD pcchGroups) = 0;
 
   virtual LONG SCardCancel(SCARDCONTEXT hContext) = 0;
 

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.cc
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.cc
@@ -25,17 +25,16 @@
 
 #include <google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.h>
 
+#include <reader.h>
+
 #include <google_smart_card_common/logging/function_call_tracer.h>
 #include <google_smart_card_common/logging/hex_dumping.h>
 #include <google_smart_card_pcsc_lite_common/scard_debug_dump.h>
 
-#include <reader.h>
-
 namespace google_smart_card {
 
 PcscLiteTracingWrapper::PcscLiteTracingWrapper(
-    PcscLite* pcsc_lite,
-    const std::string& logging_prefix,
+    PcscLite* pcsc_lite, const std::string& logging_prefix,
     LogSeverity log_severity)
     : pcsc_lite_(pcsc_lite),
       logging_prefix_(logging_prefix),
@@ -43,13 +42,14 @@ PcscLiteTracingWrapper::PcscLiteTracingWrapper(
   GOOGLE_SMART_CARD_CHECK(pcsc_lite_);
 }
 
-LONG PcscLiteTracingWrapper::SCardEstablishContext(
-    DWORD dwScope,
-    LPCVOID pvReserved1,
-    LPCVOID pvReserved2,
-    LPSCARDCONTEXT phContext) {
-  FunctionCallTracer tracer(
-      "SCardEstablishContext", logging_prefix_, log_severity_);
+PcscLiteTracingWrapper::~PcscLiteTracingWrapper() = default;
+
+LONG PcscLiteTracingWrapper::SCardEstablishContext(DWORD dwScope,
+                                                   LPCVOID pvReserved1,
+                                                   LPCVOID pvReserved2,
+                                                   LPSCARDCONTEXT phContext) {
+  FunctionCallTracer tracer("SCardEstablishContext", logging_prefix_,
+                            log_severity_);
   tracer.AddPassedArg("dwScope", DebugDumpSCardScope(dwScope));
   tracer.AddPassedArg("pvReserved1", HexDumpPointer(pvReserved1));
   tracer.AddPassedArg("pvReserved2", HexDumpPointer(pvReserved2));
@@ -62,8 +62,7 @@ LONG PcscLiteTracingWrapper::SCardEstablishContext(
   tracer.AddReturnValue(DebugDumpSCardReturnCode(return_code));
   if (return_code == SCARD_S_SUCCESS) {
     if (phContext) {
-      tracer.AddReturnedArg(
-          "*phContext", DebugDumpSCardContext(*phContext));
+      tracer.AddReturnedArg("*phContext", DebugDumpSCardContext(*phContext));
     }
   }
   tracer.LogExit();
@@ -72,8 +71,8 @@ LONG PcscLiteTracingWrapper::SCardEstablishContext(
 }
 
 LONG PcscLiteTracingWrapper::SCardReleaseContext(SCARDCONTEXT hContext) {
-  FunctionCallTracer tracer(
-      "SCardReleaseContext", logging_prefix_, log_severity_);
+  FunctionCallTracer tracer("SCardReleaseContext", logging_prefix_,
+                            log_severity_);
   tracer.AddPassedArg("hContext", DebugDumpSCardScope(hContext));
   tracer.LogEntrance();
 
@@ -85,38 +84,31 @@ LONG PcscLiteTracingWrapper::SCardReleaseContext(SCARDCONTEXT hContext) {
   return return_code;
 }
 
-LONG PcscLiteTracingWrapper::SCardConnect(
-    SCARDCONTEXT hContext,
-    LPCSTR szReader,
-    DWORD dwShareMode,
-    DWORD dwPreferredProtocols,
-    LPSCARDHANDLE phCard,
-    LPDWORD pdwActiveProtocol) {
+LONG PcscLiteTracingWrapper::SCardConnect(SCARDCONTEXT hContext,
+                                          LPCSTR szReader, DWORD dwShareMode,
+                                          DWORD dwPreferredProtocols,
+                                          LPSCARDHANDLE phCard,
+                                          LPDWORD pdwActiveProtocol) {
   FunctionCallTracer tracer("SCardConnect", logging_prefix_, log_severity_);
   tracer.AddPassedArg("hContext", DebugDumpSCardContext(hContext));
   tracer.AddPassedArg("szReader", DebugDumpSCardCString(szReader));
   tracer.AddPassedArg("dwShareMode", DebugDumpSCardShareMode(dwShareMode));
-  tracer.AddPassedArg(
-      "dwPreferredProtocols", DebugDumpSCardProtocols(dwPreferredProtocols));
+  tracer.AddPassedArg("dwPreferredProtocols",
+                      DebugDumpSCardProtocols(dwPreferredProtocols));
   tracer.AddPassedArg("phCard", HexDumpPointer(phCard));
   tracer.AddPassedArg("pdwActiveProtocol", HexDumpPointer(pdwActiveProtocol));
   tracer.LogEntrance();
 
-  const LONG return_code = pcsc_lite_->SCardConnect(
-      hContext,
-      szReader,
-      dwShareMode,
-      dwPreferredProtocols,
-      phCard,
-      pdwActiveProtocol);
+  const LONG return_code =
+      pcsc_lite_->SCardConnect(hContext, szReader, dwShareMode,
+                               dwPreferredProtocols, phCard, pdwActiveProtocol);
 
   tracer.AddReturnValue(DebugDumpSCardReturnCode(return_code));
   if (return_code == SCARD_S_SUCCESS) {
-    if (phCard)
-      tracer.AddReturnedArg("*phCard", DebugDumpSCardHandle(*phCard));
+    if (phCard) tracer.AddReturnedArg("*phCard", DebugDumpSCardHandle(*phCard));
     if (pdwActiveProtocol) {
-      tracer.AddReturnedArg(
-          "*pdwActiveProtocol", DebugDumpSCardProtocol(*pdwActiveProtocol));
+      tracer.AddReturnedArg("*pdwActiveProtocol",
+                            DebugDumpSCardProtocol(*pdwActiveProtocol));
     }
   }
   tracer.LogExit();
@@ -124,34 +116,30 @@ LONG PcscLiteTracingWrapper::SCardConnect(
   return return_code;
 }
 
-LONG PcscLiteTracingWrapper::SCardReconnect(
-    SCARDHANDLE hCard,
-    DWORD dwShareMode,
-    DWORD dwPreferredProtocols,
-    DWORD dwInitialization,
-    LPDWORD pdwActiveProtocol) {
+LONG PcscLiteTracingWrapper::SCardReconnect(SCARDHANDLE hCard,
+                                            DWORD dwShareMode,
+                                            DWORD dwPreferredProtocols,
+                                            DWORD dwInitialization,
+                                            LPDWORD pdwActiveProtocol) {
   FunctionCallTracer tracer("SCardReconnect", logging_prefix_, log_severity_);
   tracer.AddPassedArg("hCard", DebugDumpSCardHandle(hCard));
   tracer.AddPassedArg("dwShareMode", DebugDumpSCardShareMode(dwShareMode));
-  tracer.AddPassedArg(
-      "dwPreferredProtocols", DebugDumpSCardProtocols(dwPreferredProtocols));
-  tracer.AddPassedArg(
-      "dwInitialization", DebugDumpSCardDisposition(dwInitialization));
+  tracer.AddPassedArg("dwPreferredProtocols",
+                      DebugDumpSCardProtocols(dwPreferredProtocols));
+  tracer.AddPassedArg("dwInitialization",
+                      DebugDumpSCardDisposition(dwInitialization));
   tracer.AddPassedArg("pdwActiveProtocol", HexDumpPointer(pdwActiveProtocol));
   tracer.LogEntrance();
 
-  const LONG return_code = pcsc_lite_->SCardReconnect(
-      hCard,
-      dwShareMode,
-      dwPreferredProtocols,
-      dwInitialization,
-      pdwActiveProtocol);
+  const LONG return_code =
+      pcsc_lite_->SCardReconnect(hCard, dwShareMode, dwPreferredProtocols,
+                                 dwInitialization, pdwActiveProtocol);
 
   tracer.AddReturnValue(DebugDumpSCardReturnCode(return_code));
   if (return_code == SCARD_S_SUCCESS) {
     if (pdwActiveProtocol) {
-      tracer.AddReturnedArg(
-          "*pdwActiveProtocol", DebugDumpSCardProtocol(*pdwActiveProtocol));
+      tracer.AddReturnedArg("*pdwActiveProtocol",
+                            DebugDumpSCardProtocol(*pdwActiveProtocol));
     }
   }
   tracer.LogExit();
@@ -159,12 +147,12 @@ LONG PcscLiteTracingWrapper::SCardReconnect(
   return return_code;
 }
 
-LONG PcscLiteTracingWrapper::SCardDisconnect(
-    SCARDHANDLE hCard, DWORD dwDisposition) {
+LONG PcscLiteTracingWrapper::SCardDisconnect(SCARDHANDLE hCard,
+                                             DWORD dwDisposition) {
   FunctionCallTracer tracer("SCardDisconnect", logging_prefix_, log_severity_);
   tracer.AddPassedArg("hCard", DebugDumpSCardHandle(hCard));
-  tracer.AddPassedArg(
-      "dwDisposition", DebugDumpSCardDisposition(dwDisposition));
+  tracer.AddPassedArg("dwDisposition",
+                      DebugDumpSCardDisposition(dwDisposition));
   tracer.LogEntrance();
 
   const LONG return_code = pcsc_lite_->SCardDisconnect(hCard, dwDisposition);
@@ -176,8 +164,8 @@ LONG PcscLiteTracingWrapper::SCardDisconnect(
 }
 
 LONG PcscLiteTracingWrapper::SCardBeginTransaction(SCARDHANDLE hCard) {
-  FunctionCallTracer tracer(
-      "SCardBeginTransaction", logging_prefix_, log_severity_);
+  FunctionCallTracer tracer("SCardBeginTransaction", logging_prefix_,
+                            log_severity_);
   tracer.AddPassedArg("hCard", DebugDumpSCardHandle(hCard));
   tracer.LogEntrance();
 
@@ -189,17 +177,17 @@ LONG PcscLiteTracingWrapper::SCardBeginTransaction(SCARDHANDLE hCard) {
   return return_code;
 }
 
-LONG PcscLiteTracingWrapper::SCardEndTransaction(
-    SCARDHANDLE hCard, DWORD dwDisposition) {
-  FunctionCallTracer tracer(
-      "SCardEndTransaction", logging_prefix_, log_severity_);
+LONG PcscLiteTracingWrapper::SCardEndTransaction(SCARDHANDLE hCard,
+                                                 DWORD dwDisposition) {
+  FunctionCallTracer tracer("SCardEndTransaction", logging_prefix_,
+                            log_severity_);
   tracer.AddPassedArg("hCard", DebugDumpSCardHandle(hCard));
-  tracer.AddPassedArg(
-      "dwDisposition", DebugDumpSCardDisposition(dwDisposition));
+  tracer.AddPassedArg("dwDisposition",
+                      DebugDumpSCardDisposition(dwDisposition));
   tracer.LogEntrance();
 
-  const LONG return_code = pcsc_lite_->SCardEndTransaction(
-      hCard, dwDisposition);
+  const LONG return_code =
+      pcsc_lite_->SCardEndTransaction(hCard, dwDisposition);
 
   tracer.AddReturnValue(DebugDumpSCardReturnCode(return_code));
   tracer.LogExit();
@@ -207,61 +195,50 @@ LONG PcscLiteTracingWrapper::SCardEndTransaction(
   return return_code;
 }
 
-LONG PcscLiteTracingWrapper::SCardStatus(
-    SCARDHANDLE hCard,
-    LPSTR szReaderName,
-    LPDWORD pcchReaderLen,
-    LPDWORD pdwState,
-    LPDWORD pdwProtocol,
-    LPBYTE pbAtr,
-    LPDWORD pcbAtrLen) {
+LONG PcscLiteTracingWrapper::SCardStatus(SCARDHANDLE hCard, LPSTR szReaderName,
+                                         LPDWORD pcchReaderLen,
+                                         LPDWORD pdwState, LPDWORD pdwProtocol,
+                                         LPBYTE pbAtr, LPDWORD pcbAtrLen) {
   FunctionCallTracer tracer("SCardStatus", logging_prefix_, log_severity_);
   tracer.AddPassedArg("hCard", DebugDumpSCardHandle(hCard));
   tracer.AddPassedArg("szReaderName", HexDumpPointer(szReaderName));
-  tracer.AddPassedArg(
-      "pcchReaderLen", DebugDumpSCardBufferSizeInputPointer(pcchReaderLen));
+  tracer.AddPassedArg("pcchReaderLen",
+                      DebugDumpSCardBufferSizeInputPointer(pcchReaderLen));
   tracer.AddPassedArg("pdwState", HexDumpPointer(pdwState));
   tracer.AddPassedArg("pdwProtocol", HexDumpPointer(pdwProtocol));
   tracer.AddPassedArg("pbAtr", HexDumpPointer(pbAtr));
-  tracer.AddPassedArg(
-      "pcbAtrLen", DebugDumpSCardBufferSizeInputPointer(pcbAtrLen));
+  tracer.AddPassedArg("pcbAtrLen",
+                      DebugDumpSCardBufferSizeInputPointer(pcbAtrLen));
   tracer.LogEntrance();
   const bool is_reader_name_auto_allocation =
       pcchReaderLen && *pcchReaderLen == SCARD_AUTOALLOCATE;
   const bool is_atr_auto_allocation =
       pcbAtrLen && *pcbAtrLen == SCARD_AUTOALLOCATE;
 
-  const LONG return_code = pcsc_lite_->SCardStatus(
-      hCard,
-      szReaderName,
-      pcchReaderLen,
-      pdwState,
-      pdwProtocol,
-      pbAtr,
-      pcbAtrLen);
+  const LONG return_code =
+      pcsc_lite_->SCardStatus(hCard, szReaderName, pcchReaderLen, pdwState,
+                              pdwProtocol, pbAtr, pcbAtrLen);
 
   tracer.AddReturnValue(DebugDumpSCardReturnCode(return_code));
   if (return_code == SCARD_S_SUCCESS ||
       return_code == SCARD_E_INSUFFICIENT_BUFFER) {
     if (szReaderName && return_code == SCARD_S_SUCCESS) {
-      tracer.AddReturnedArg(
-          "*szReaderName",
-          DebugDumpSCardOutputCStringBuffer(
-              szReaderName, is_reader_name_auto_allocation));
+      tracer.AddReturnedArg("*szReaderName",
+                            DebugDumpSCardOutputCStringBuffer(
+                                szReaderName, is_reader_name_auto_allocation));
     }
     if (pcchReaderLen)
       tracer.AddReturnedArg("*pcchReaderLen", std::to_string(*pcchReaderLen));
     if (pdwState)
       tracer.AddReturnedArg("*pdwState", DebugDumpSCardState(*pdwState));
     if (pdwProtocol) {
-      tracer.AddReturnedArg(
-          "*pdwProtocol", DebugDumpSCardProtocol(*pdwProtocol));
+      tracer.AddReturnedArg("*pdwProtocol",
+                            DebugDumpSCardProtocol(*pdwProtocol));
     }
     if (pbAtr && return_code == SCARD_S_SUCCESS) {
       tracer.AddReturnedArg(
           "*pbAtr",
-          DebugDumpSCardOutputBuffer(
-              pbAtr, pcbAtrLen, is_atr_auto_allocation));
+          DebugDumpSCardOutputBuffer(pbAtr, pcbAtrLen, is_atr_auto_allocation));
     }
     if (pcbAtrLen)
       tracer.AddReturnedArg("*pcbAtrLen", std::to_string(*pcbAtrLen));
@@ -272,17 +249,14 @@ LONG PcscLiteTracingWrapper::SCardStatus(
 }
 
 LONG PcscLiteTracingWrapper::SCardGetStatusChange(
-    SCARDCONTEXT hContext,
-    DWORD dwTimeout,
-    SCARD_READERSTATE* rgReaderStates,
+    SCARDCONTEXT hContext, DWORD dwTimeout, SCARD_READERSTATE* rgReaderStates,
     DWORD cReaders) {
-  FunctionCallTracer tracer(
-      "SCardGetStatusChange", logging_prefix_, log_severity_);
+  FunctionCallTracer tracer("SCardGetStatusChange", logging_prefix_,
+                            log_severity_);
   tracer.AddPassedArg("hContext", DebugDumpSCardContext(hContext));
   tracer.AddPassedArg("dwTimeout", std::to_string(dwTimeout));
-  tracer.AddPassedArg(
-      "rgReaderStates",
-      DebugDumpSCardInputReaderStates(rgReaderStates, cReaders));
+  tracer.AddPassedArg("rgReaderStates", DebugDumpSCardInputReaderStates(
+                                            rgReaderStates, cReaders));
   tracer.AddPassedArg("cReaders", std::to_string(cReaders));
   tracer.LogEntrance();
 
@@ -291,9 +265,8 @@ LONG PcscLiteTracingWrapper::SCardGetStatusChange(
 
   tracer.AddReturnValue(DebugDumpSCardReturnCode(return_code));
   if (return_code == SCARD_S_SUCCESS) {
-    tracer.AddReturnedArg(
-        "*rgReaderStates",
-        DebugDumpSCardOutputReaderStates(rgReaderStates, cReaders));
+    tracer.AddReturnedArg("*rgReaderStates", DebugDumpSCardOutputReaderStates(
+                                                 rgReaderStates, cReaders));
   }
   tracer.LogExit();
 
@@ -301,33 +274,24 @@ LONG PcscLiteTracingWrapper::SCardGetStatusChange(
 }
 
 LONG PcscLiteTracingWrapper::SCardControl(
-    SCARDHANDLE hCard,
-    DWORD dwControlCode,
-    LPCVOID pbSendBuffer,
-    DWORD cbSendLength,
-    LPVOID pbRecvBuffer,
-    DWORD cbRecvLength,
+    SCARDHANDLE hCard, DWORD dwControlCode, LPCVOID pbSendBuffer,
+    DWORD cbSendLength, LPVOID pbRecvBuffer, DWORD cbRecvLength,
     LPDWORD lpBytesReturned) {
   FunctionCallTracer tracer("SCardControl", logging_prefix_, log_severity_);
   tracer.AddPassedArg("hCard", DebugDumpSCardHandle(hCard));
-  tracer.AddPassedArg(
-      "dwControlCode", DebugDumpSCardControlCode(dwControlCode));
-  tracer.AddPassedArg(
-      "pbSendBuffer", DebugDumpSCardInputBuffer(pbSendBuffer, cbSendLength));
+  tracer.AddPassedArg("dwControlCode",
+                      DebugDumpSCardControlCode(dwControlCode));
+  tracer.AddPassedArg("pbSendBuffer",
+                      DebugDumpSCardInputBuffer(pbSendBuffer, cbSendLength));
   tracer.AddPassedArg("cbSendLength", std::to_string(cbSendLength));
   tracer.AddPassedArg("pbRecvBuffer", HexDumpPointer(pbRecvBuffer));
   tracer.AddPassedArg("cbRecvLength", std::to_string(cbRecvLength));
   tracer.AddPassedArg("lpBytesReturned", HexDumpPointer(lpBytesReturned));
   tracer.LogEntrance();
 
-  const LONG return_code = pcsc_lite_->SCardControl(
-      hCard,
-      dwControlCode,
-      pbSendBuffer,
-      cbSendLength,
-      pbRecvBuffer,
-      cbRecvLength,
-      lpBytesReturned);
+  const LONG return_code =
+      pcsc_lite_->SCardControl(hCard, dwControlCode, pbSendBuffer, cbSendLength,
+                               pbRecvBuffer, cbRecvLength, lpBytesReturned);
 
   tracer.AddReturnValue(DebugDumpSCardReturnCode(return_code));
   if (return_code == SCARD_S_SUCCESS) {
@@ -349,20 +313,20 @@ LONG PcscLiteTracingWrapper::SCardControl(
   return return_code;
 }
 
-LONG PcscLiteTracingWrapper::SCardGetAttrib(
-    SCARDHANDLE hCard, DWORD dwAttrId, LPBYTE pbAttr, LPDWORD pcbAttrLen) {
+LONG PcscLiteTracingWrapper::SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId,
+                                            LPBYTE pbAttr, LPDWORD pcbAttrLen) {
   FunctionCallTracer tracer("SCardGetAttrib", logging_prefix_, log_severity_);
   tracer.AddPassedArg("hCard", DebugDumpSCardHandle(hCard));
   tracer.AddPassedArg("dwAttrId", DebugDumpSCardAttributeId(dwAttrId));
   tracer.AddPassedArg("pbAttr", HexDumpPointer(pbAttr));
-  tracer.AddPassedArg(
-      "pcbAttrLen", DebugDumpSCardBufferSizeInputPointer(pcbAttrLen));
+  tracer.AddPassedArg("pcbAttrLen",
+                      DebugDumpSCardBufferSizeInputPointer(pcbAttrLen));
   tracer.LogEntrance();
   const bool is_auto_allocation =
       pcbAttrLen && *pcbAttrLen == SCARD_AUTOALLOCATE;
 
-  const LONG return_code = pcsc_lite_->SCardGetAttrib(
-      hCard, dwAttrId, pbAttr, pcbAttrLen);
+  const LONG return_code =
+      pcsc_lite_->SCardGetAttrib(hCard, dwAttrId, pbAttr, pcbAttrLen);
 
   tracer.AddReturnValue(DebugDumpSCardReturnCode(return_code));
   if (return_code == SCARD_S_SUCCESS ||
@@ -380,8 +344,8 @@ LONG PcscLiteTracingWrapper::SCardGetAttrib(
   return return_code;
 }
 
-LONG PcscLiteTracingWrapper::SCardSetAttrib(
-    SCARDHANDLE hCard, DWORD dwAttrId, LPCBYTE pbAttr, DWORD cbAttrLen) {
+LONG PcscLiteTracingWrapper::SCardSetAttrib(SCARDHANDLE hCard, DWORD dwAttrId,
+                                            LPCBYTE pbAttr, DWORD cbAttrLen) {
   FunctionCallTracer tracer("SCardSetAttrib", logging_prefix_, log_severity_);
   tracer.AddPassedArg("hCard", DebugDumpSCardHandle(hCard));
   tracer.AddPassedArg("dwAttrId", DebugDumpSCardAttributeId(dwAttrId));
@@ -389,8 +353,8 @@ LONG PcscLiteTracingWrapper::SCardSetAttrib(
   tracer.AddPassedArg("cbAttrLen", std::to_string(cbAttrLen));
   tracer.LogEntrance();
 
-  const LONG return_code = pcsc_lite_->SCardSetAttrib(
-      hCard, dwAttrId, pbAttr, cbAttrLen);
+  const LONG return_code =
+      pcsc_lite_->SCardSetAttrib(hCard, dwAttrId, pbAttr, cbAttrLen);
 
   tracer.AddReturnValue(DebugDumpSCardReturnCode(return_code));
   tracer.LogExit();
@@ -399,45 +363,35 @@ LONG PcscLiteTracingWrapper::SCardSetAttrib(
 }
 
 LONG PcscLiteTracingWrapper::SCardTransmit(
-    SCARDHANDLE hCard,
-    const SCARD_IO_REQUEST* pioSendPci,
-    LPCBYTE pbSendBuffer,
-    DWORD cbSendLength,
-    SCARD_IO_REQUEST* pioRecvPci,
-    LPBYTE pbRecvBuffer,
+    SCARDHANDLE hCard, const SCARD_IO_REQUEST* pioSendPci, LPCBYTE pbSendBuffer,
+    DWORD cbSendLength, SCARD_IO_REQUEST* pioRecvPci, LPBYTE pbRecvBuffer,
     LPDWORD pcbRecvLength) {
   FunctionCallTracer tracer("SCardTransmit", logging_prefix_, log_severity_);
   tracer.AddPassedArg("hCard", DebugDumpSCardHandle(hCard));
   tracer.AddPassedArg("pioSendPci", DebugDumpSCardIoRequest(pioSendPci));
-  tracer.AddPassedArg(
-      "pbSendBuffer", DebugDumpSCardInputBuffer(pbSendBuffer, cbSendLength));
+  tracer.AddPassedArg("pbSendBuffer",
+                      DebugDumpSCardInputBuffer(pbSendBuffer, cbSendLength));
   tracer.AddPassedArg("cbSendLength", std::to_string(cbSendLength));
   tracer.AddPassedArg("pioRecvPci", HexDumpPointer(pioRecvPci));
   tracer.AddPassedArg("pbRecvBuffer", HexDumpPointer(pbRecvBuffer));
-  tracer.AddPassedArg(
-      "pcbRecvLength", DebugDumpSCardBufferSizeInputPointer(pcbRecvLength));
+  tracer.AddPassedArg("pcbRecvLength",
+                      DebugDumpSCardBufferSizeInputPointer(pcbRecvLength));
   tracer.LogEntrance();
 
-  const LONG return_code = pcsc_lite_->SCardTransmit(
-      hCard,
-      pioSendPci,
-      pbSendBuffer,
-      cbSendLength,
-      pioRecvPci,
-      pbRecvBuffer,
-      pcbRecvLength);
+  const LONG return_code =
+      pcsc_lite_->SCardTransmit(hCard, pioSendPci, pbSendBuffer, cbSendLength,
+                                pioRecvPci, pbRecvBuffer, pcbRecvLength);
 
   tracer.AddReturnValue(DebugDumpSCardReturnCode(return_code));
   if (return_code == SCARD_S_SUCCESS ||
       return_code == SCARD_E_INSUFFICIENT_BUFFER) {
     if (pioRecvPci && return_code == SCARD_S_SUCCESS) {
-      tracer.AddReturnedArg(
-          "*pioRecvPci", DebugDumpSCardIoRequest(*pioRecvPci));
+      tracer.AddReturnedArg("*pioRecvPci",
+                            DebugDumpSCardIoRequest(*pioRecvPci));
     }
     if (pbRecvBuffer && pcbRecvLength && return_code == SCARD_S_SUCCESS) {
-      tracer.AddReturnedArg(
-          "*pbRecvBuffer",
-          DebugDumpSCardOutputBuffer(pbRecvBuffer, *pcbRecvLength));
+      tracer.AddReturnedArg("*pbRecvBuffer", DebugDumpSCardOutputBuffer(
+                                                 pbRecvBuffer, *pcbRecvLength));
     }
     if (pcbRecvLength)
       tracer.AddReturnedArg("*pcbRecvLength", std::to_string(*pcbRecvLength));
@@ -447,17 +401,16 @@ LONG PcscLiteTracingWrapper::SCardTransmit(
   return return_code;
 }
 
-LONG PcscLiteTracingWrapper::SCardListReaders(
-    SCARDCONTEXT hContext,
-    LPCSTR mszGroups,
-    LPSTR mszReaders,
-    LPDWORD pcchReaders) {
+LONG PcscLiteTracingWrapper::SCardListReaders(SCARDCONTEXT hContext,
+                                              LPCSTR mszGroups,
+                                              LPSTR mszReaders,
+                                              LPDWORD pcchReaders) {
   FunctionCallTracer tracer("SCardListReaders", logging_prefix_, log_severity_);
   tracer.AddPassedArg("hContext", DebugDumpSCardContext(hContext));
   tracer.AddPassedArg("mszGroups", DebugDumpSCardMultiString(mszGroups));
   tracer.AddPassedArg("mszReaders", HexDumpPointer(mszReaders));
-  tracer.AddPassedArg(
-      "pcchReaders", DebugDumpSCardBufferSizeInputPointer(pcchReaders));
+  tracer.AddPassedArg("pcchReaders",
+                      DebugDumpSCardBufferSizeInputPointer(pcchReaders));
   tracer.LogEntrance();
   const bool is_auto_allocation =
       pcchReaders && *pcchReaders == SCARD_AUTOALLOCATE;
@@ -469,10 +422,9 @@ LONG PcscLiteTracingWrapper::SCardListReaders(
   if (return_code == SCARD_S_SUCCESS ||
       return_code == SCARD_E_INSUFFICIENT_BUFFER) {
     if (mszReaders && return_code == SCARD_S_SUCCESS) {
-      tracer.AddReturnedArg(
-          "*mszReaders",
-          DebugDumpSCardOutputMultiStringBuffer(
-              mszReaders, is_auto_allocation));
+      tracer.AddReturnedArg("*mszReaders",
+                            DebugDumpSCardOutputMultiStringBuffer(
+                                mszReaders, is_auto_allocation));
     }
     if (pcchReaders)
       tracer.AddReturnedArg("*pcchReaders", std::to_string(*pcchReaders));
@@ -482,8 +434,8 @@ LONG PcscLiteTracingWrapper::SCardListReaders(
   return return_code;
 }
 
-LONG PcscLiteTracingWrapper::SCardFreeMemory(
-    SCARDCONTEXT hContext, LPCVOID pvMem) {
+LONG PcscLiteTracingWrapper::SCardFreeMemory(SCARDCONTEXT hContext,
+                                             LPCVOID pvMem) {
   FunctionCallTracer tracer("SCardFreeMemory", logging_prefix_, log_severity_);
   tracer.AddPassedArg("hContext", DebugDumpSCardContext(hContext));
   tracer.AddPassedArg("pvMem", HexDumpPointer(pvMem));
@@ -497,28 +449,28 @@ LONG PcscLiteTracingWrapper::SCardFreeMemory(
   return return_code;
 }
 
-LONG PcscLiteTracingWrapper::SCardListReaderGroups(
-    SCARDCONTEXT hContext, LPSTR mszGroups, LPDWORD pcchGroups) {
-  FunctionCallTracer tracer(
-      "SCardListReaderGroups", logging_prefix_, log_severity_);
+LONG PcscLiteTracingWrapper::SCardListReaderGroups(SCARDCONTEXT hContext,
+                                                   LPSTR mszGroups,
+                                                   LPDWORD pcchGroups) {
+  FunctionCallTracer tracer("SCardListReaderGroups", logging_prefix_,
+                            log_severity_);
   tracer.AddPassedArg("hContext", DebugDumpSCardContext(hContext));
   tracer.AddPassedArg("mszGroups", HexDumpPointer(mszGroups));
-  tracer.AddPassedArg(
-      "pcchGroups", DebugDumpSCardBufferSizeInputPointer(pcchGroups));
+  tracer.AddPassedArg("pcchGroups",
+                      DebugDumpSCardBufferSizeInputPointer(pcchGroups));
   tracer.LogEntrance();
   const bool is_auto_allocation =
       pcchGroups && *pcchGroups == SCARD_AUTOALLOCATE;
 
-  const LONG return_code = pcsc_lite_->SCardListReaderGroups(
-      hContext, mszGroups, pcchGroups);
+  const LONG return_code =
+      pcsc_lite_->SCardListReaderGroups(hContext, mszGroups, pcchGroups);
 
   tracer.AddReturnValue(DebugDumpSCardReturnCode(return_code));
   if (return_code == SCARD_S_SUCCESS ||
       return_code == SCARD_E_INSUFFICIENT_BUFFER) {
     if (mszGroups && return_code == SCARD_S_SUCCESS) {
-      tracer.AddReturnedArg(
-          "*mszGroups",
-          DebugDumpSCardOutputMultiStringBuffer(mszGroups, is_auto_allocation));
+      tracer.AddReturnedArg("*mszGroups", DebugDumpSCardOutputMultiStringBuffer(
+                                              mszGroups, is_auto_allocation));
     }
     if (pcchGroups)
       tracer.AddReturnedArg("*pcchGroups", std::to_string(*pcchGroups));
@@ -542,8 +494,8 @@ LONG PcscLiteTracingWrapper::SCardCancel(SCARDCONTEXT hContext) {
 }
 
 LONG PcscLiteTracingWrapper::SCardIsValidContext(SCARDCONTEXT hContext) {
-  FunctionCallTracer tracer(
-      "SCardIsValidContext", logging_prefix_, log_severity_);
+  FunctionCallTracer tracer("SCardIsValidContext", logging_prefix_,
+                            log_severity_);
   tracer.AddPassedArg("hContext", DebugDumpSCardContext(hContext));
   tracer.LogEntrance();
 

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.h
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.h
@@ -42,81 +42,49 @@ namespace google_smart_card {
 class PcscLiteTracingWrapper final : public PcscLite {
  public:
   explicit PcscLiteTracingWrapper(
-      PcscLite* pcsc_lite,
-      const std::string& logging_prefix = "",
+      PcscLite* pcsc_lite, const std::string& logging_prefix = "",
       LogSeverity log_severity = LogSeverity::kDebug);
   PcscLiteTracingWrapper(const PcscLiteTracingWrapper&) = delete;
+  PcscLiteTracingWrapper& operator=(const PcscLiteTracingWrapper&) = delete;
+  ~PcscLiteTracingWrapper();
 
   // PcscLite:
-  LONG SCardEstablishContext(
-      DWORD dwScope,
-      LPCVOID pvReserved1,
-      LPCVOID pvReserved2,
-      LPSCARDCONTEXT phContext) override;
+  LONG SCardEstablishContext(DWORD dwScope, LPCVOID pvReserved1,
+                             LPCVOID pvReserved2,
+                             LPSCARDCONTEXT phContext) override;
   LONG SCardReleaseContext(SCARDCONTEXT hContext) override;
-  LONG SCardConnect(
-      SCARDCONTEXT hContext,
-      LPCSTR szReader,
-      DWORD dwShareMode,
-      DWORD dwPreferredProtocols,
-      LPSCARDHANDLE phCard,
-      LPDWORD pdwActiveProtocol) override;
-  LONG SCardReconnect(
-      SCARDHANDLE hCard,
-      DWORD dwShareMode,
-      DWORD dwPreferredProtocols,
-      DWORD dwInitialization,
-      LPDWORD pdwActiveProtocol) override;
+  LONG SCardConnect(SCARDCONTEXT hContext, LPCSTR szReader, DWORD dwShareMode,
+                    DWORD dwPreferredProtocols, LPSCARDHANDLE phCard,
+                    LPDWORD pdwActiveProtocol) override;
+  LONG SCardReconnect(SCARDHANDLE hCard, DWORD dwShareMode,
+                      DWORD dwPreferredProtocols, DWORD dwInitialization,
+                      LPDWORD pdwActiveProtocol) override;
   LONG SCardDisconnect(SCARDHANDLE hCard, DWORD dwDisposition) override;
   LONG SCardBeginTransaction(SCARDHANDLE hCard) override;
   LONG SCardEndTransaction(SCARDHANDLE hCard, DWORD dwDisposition) override;
-  LONG SCardStatus(
-      SCARDHANDLE hCard,
-      LPSTR szReaderName,
-      LPDWORD pcchReaderLen,
-      LPDWORD pdwState,
-      LPDWORD pdwProtocol,
-      LPBYTE pbAtr,
-      LPDWORD pcbAtrLen) override;
-  LONG SCardGetStatusChange(
-      SCARDCONTEXT hContext,
-      DWORD dwTimeout,
-      SCARD_READERSTATE* rgReaderStates,
-      DWORD cReaders) override;
-  LONG SCardControl(
-      SCARDHANDLE hCard,
-      DWORD dwControlCode,
-      LPCVOID pbSendBuffer,
-      DWORD cbSendLength,
-      LPVOID pbRecvBuffer,
-      DWORD cbRecvLength,
-      LPDWORD lpBytesReturned) override;
-  LONG SCardGetAttrib(
-      SCARDHANDLE hCard,
-      DWORD dwAttrId,
-      LPBYTE pbAttr,
-      LPDWORD pcbAttrLen) override;
-  LONG SCardSetAttrib(
-      SCARDHANDLE hCard,
-      DWORD dwAttrId,
-      LPCBYTE pbAttr,
-      DWORD cbAttrLen) override;
-  LONG SCardTransmit(
-      SCARDHANDLE hCard,
-      const SCARD_IO_REQUEST* pioSendPci,
-      LPCBYTE pbSendBuffer,
-      DWORD cbSendLength,
-      SCARD_IO_REQUEST* pioRecvPci,
-      LPBYTE pbRecvBuffer,
-      LPDWORD pcbRecvLength) override;
-  LONG SCardListReaders(
-      SCARDCONTEXT hContext,
-      LPCSTR mszGroups,
-      LPSTR mszReaders,
-      LPDWORD pcchReaders) override;
+  LONG SCardStatus(SCARDHANDLE hCard, LPSTR szReaderName, LPDWORD pcchReaderLen,
+                   LPDWORD pdwState, LPDWORD pdwProtocol, LPBYTE pbAtr,
+                   LPDWORD pcbAtrLen) override;
+  LONG SCardGetStatusChange(SCARDCONTEXT hContext, DWORD dwTimeout,
+                            SCARD_READERSTATE* rgReaderStates,
+                            DWORD cReaders) override;
+  LONG SCardControl(SCARDHANDLE hCard, DWORD dwControlCode,
+                    LPCVOID pbSendBuffer, DWORD cbSendLength,
+                    LPVOID pbRecvBuffer, DWORD cbRecvLength,
+                    LPDWORD lpBytesReturned) override;
+  LONG SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPBYTE pbAttr,
+                      LPDWORD pcbAttrLen) override;
+  LONG SCardSetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPCBYTE pbAttr,
+                      DWORD cbAttrLen) override;
+  LONG SCardTransmit(SCARDHANDLE hCard, const SCARD_IO_REQUEST* pioSendPci,
+                     LPCBYTE pbSendBuffer, DWORD cbSendLength,
+                     SCARD_IO_REQUEST* pioRecvPci, LPBYTE pbRecvBuffer,
+                     LPDWORD pcbRecvLength) override;
+  LONG SCardListReaders(SCARDCONTEXT hContext, LPCSTR mszGroups,
+                        LPSTR mszReaders, LPDWORD pcchReaders) override;
   LONG SCardFreeMemory(SCARDCONTEXT hContext, LPCVOID pvMem) override;
-  LONG SCardListReaderGroups(
-      SCARDCONTEXT hContext, LPSTR mszGroups, LPDWORD pcchGroups) override;
+  LONG SCardListReaderGroups(SCARDCONTEXT hContext, LPSTR mszGroups,
+                             LPDWORD pcchGroups) override;
   LONG SCardCancel(SCARDCONTEXT hContext) override;
   LONG SCardIsValidContext(SCARDCONTEXT hContext) override;
 

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_debug_dump.cc
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_debug_dump.cc
@@ -41,7 +41,7 @@ struct DwordValueAndName {
   const char* name;
 };
 
-const DwordValueAndName kAttributeIdNames[] = {
+constexpr DwordValueAndName kAttributeIdNames[] = {
     {SCARD_ATTR_ASYNC_PROTOCOL_TYPES, "SCARD_ATTR_ASYNC_PROTOCOL_TYPES"},
     {SCARD_ATTR_ATR_STRING, "SCARD_ATTR_ATR_STRING"},
     {SCARD_ATTR_CHANNEL_ID, "SCARD_ATTR_CHANNEL_ID"},
@@ -87,16 +87,15 @@ const DwordValueAndName kAttributeIdNames[] = {
     {SCARD_ATTR_VENDOR_NAME, "SCARD_ATTR_VENDOR_NAME"},
 };
 
-const DwordValueAndName kControlCodeNames[] = {
+constexpr DwordValueAndName kControlCodeNames[] = {
     {CM_IOCTL_GET_FEATURE_REQUEST, "CM_IOCTL_GET_FEATURE_REQUEST"},
 };
 
 template <size_t size>
-std::string GetDwordValueName(
-    DWORD value, const DwordValueAndName(& options)[size]) {
+std::string GetDwordValueName(DWORD value,
+                              const DwordValueAndName (&options)[size]) {
   for (const auto& option : options) {
-    if (value == option.value)
-      return option.name;
+    if (value == option.value) return option.name;
   }
   return HexDumpInteger(value);
 }
@@ -109,18 +108,15 @@ std::string DebugDumpSCardReturnCode(LONG return_code) {
 }
 
 std::string DebugDumpSCardCString(const char* value) {
-  if (!value)
-    return "<NULL string>";
+  if (!value) return "<NULL string>";
   return std::string("\"") + value + "\"";
 }
 
 std::string DebugDumpSCardMultiString(const char* value) {
-  if (!value)
-    return "<NULL multi-string>";
+  if (!value) return "<NULL multi-string>";
   std::string result;
   for (const std::string& item : ExtractMultiStringElements(value)) {
-    if (!result.empty())
-      result += ", ";
+    if (!result.empty()) result += ", ";
     result += "\"" + item + "\"";
   }
   return "MultiString[" + result + "]";
@@ -178,11 +174,10 @@ std::string DebugDumpSCardProtocol(DWORD protocol) {
 }
 
 std::string DebugDumpSCardProtocols(DWORD protocols) {
-  return DumpMask(protocols, {
-      {SCARD_PROTOCOL_T0, "SCARD_PROTOCOL_T0"},
-      {SCARD_PROTOCOL_T1, "SCARD_PROTOCOL_T1"},
-      {SCARD_PROTOCOL_RAW, "SCARD_PROTOCOL_RAW"},
-      {SCARD_PROTOCOL_T15, "SCARD_PROTOCOL_T15"}});
+  return DumpMask(protocols, {{SCARD_PROTOCOL_T0, "SCARD_PROTOCOL_T0"},
+                              {SCARD_PROTOCOL_T1, "SCARD_PROTOCOL_T1"},
+                              {SCARD_PROTOCOL_RAW, "SCARD_PROTOCOL_RAW"},
+                              {SCARD_PROTOCOL_T15, "SCARD_PROTOCOL_T15"}});
 }
 
 std::string DebugDumpSCardDisposition(DWORD disposition) {
@@ -206,16 +201,15 @@ std::string DebugDumpSCardState(DWORD state) {
   const int kEventCountMaskShift = 16;
   const DWORD event_count = (state & kEventCountMask) >> kEventCountMaskShift;
   state &= ~kEventCountMask;
-  if (event_count)
-    suffix = " with eventCount=" + std::to_string(event_count);
+  if (event_count) suffix = " with eventCount=" + std::to_string(event_count);
 
-  return DumpMask(state, {
-      {SCARD_ABSENT, "SCARD_ABSENT"},
-      {SCARD_PRESENT, "SCARD_PRESENT"},
-      {SCARD_SWALLOWED, "SCARD_SWALLOWED"},
-      {SCARD_POWERED, "SCARD_POWERED"},
-      {SCARD_NEGOTIABLE, "SCARD_NEGOTIABLE"},
-      {SCARD_SPECIFIC, "SCARD_SPECIFIC"}}) + suffix;
+  return DumpMask(state, {{SCARD_ABSENT, "SCARD_ABSENT"},
+                          {SCARD_PRESENT, "SCARD_PRESENT"},
+                          {SCARD_SWALLOWED, "SCARD_SWALLOWED"},
+                          {SCARD_POWERED, "SCARD_POWERED"},
+                          {SCARD_NEGOTIABLE, "SCARD_NEGOTIABLE"},
+                          {SCARD_SPECIFIC, "SCARD_SPECIFIC"}}) +
+         suffix;
 }
 
 std::string DebugDumpSCardEventState(DWORD event_state) {
@@ -225,23 +219,22 @@ std::string DebugDumpSCardEventState(DWORD event_state) {
   const DWORD event_count =
       (event_state & kEventCountMask) >> kEventCountMaskShift;
   event_state &= ~kEventCountMask;
-  if (event_count)
-    suffix = " with eventCount=" + std::to_string(event_count);
+  if (event_count) suffix = " with eventCount=" + std::to_string(event_count);
 
-  if (!event_state)
-    return "SCARD_STATE_UNAWARE" + suffix;
-  return DumpMask(event_state, {
-      {SCARD_STATE_IGNORE, "SCARD_STATE_IGNORE"},
-      {SCARD_STATE_CHANGED, "SCARD_STATE_CHANGED"},
-      {SCARD_STATE_UNKNOWN, "SCARD_STATE_UNKNOWN"},
-      {SCARD_STATE_UNAVAILABLE, "SCARD_STATE_UNAVAILABLE"},
-      {SCARD_STATE_EMPTY, "SCARD_STATE_EMPTY"},
-      {SCARD_STATE_PRESENT, "SCARD_STATE_PRESENT"},
-      {SCARD_STATE_ATRMATCH, "SCARD_STATE_ATRMATCH"},
-      {SCARD_STATE_EXCLUSIVE, "SCARD_STATE_EXCLUSIVE"},
-      {SCARD_STATE_INUSE, "SCARD_STATE_INUSE"},
-      {SCARD_STATE_MUTE, "SCARD_STATE_MUTE"},
-      {SCARD_STATE_UNPOWERED, "SCARD_STATE_UNPOWERED"}}) + suffix;
+  if (!event_state) return "SCARD_STATE_UNAWARE" + suffix;
+  return DumpMask(event_state,
+                  {{SCARD_STATE_IGNORE, "SCARD_STATE_IGNORE"},
+                   {SCARD_STATE_CHANGED, "SCARD_STATE_CHANGED"},
+                   {SCARD_STATE_UNKNOWN, "SCARD_STATE_UNKNOWN"},
+                   {SCARD_STATE_UNAVAILABLE, "SCARD_STATE_UNAVAILABLE"},
+                   {SCARD_STATE_EMPTY, "SCARD_STATE_EMPTY"},
+                   {SCARD_STATE_PRESENT, "SCARD_STATE_PRESENT"},
+                   {SCARD_STATE_ATRMATCH, "SCARD_STATE_ATRMATCH"},
+                   {SCARD_STATE_EXCLUSIVE, "SCARD_STATE_EXCLUSIVE"},
+                   {SCARD_STATE_INUSE, "SCARD_STATE_INUSE"},
+                   {SCARD_STATE_MUTE, "SCARD_STATE_MUTE"},
+                   {SCARD_STATE_UNPOWERED, "SCARD_STATE_UNPOWERED"}}) +
+         suffix;
 }
 
 std::string DebugDumpSCardAttributeId(DWORD attribute_id) {
@@ -253,36 +246,31 @@ std::string DebugDumpSCardControlCode(DWORD control_code) {
 }
 
 std::string DebugDumpSCardIoRequest(const SCARD_IO_REQUEST& value) {
-  if (&value == SCARD_PCI_T0)
-    return "SCARD_PCI_T0";
-  if (&value == SCARD_PCI_T1)
-    return "SCARD_PCI_T1";
-  if (&value == SCARD_PCI_RAW)
-    return "SCARD_PCI_RAW";
+  if (&value == SCARD_PCI_T0) return "SCARD_PCI_T0";
+  if (&value == SCARD_PCI_T1) return "SCARD_PCI_T1";
+  if (&value == SCARD_PCI_RAW) return "SCARD_PCI_RAW";
   return "SCARD_IO_REQUEST(dwProtocol=" +
          DebugDumpSCardProtocol(value.dwProtocol) + ")";
 }
 
 std::string DebugDumpSCardIoRequest(const SCARD_IO_REQUEST* value) {
-  if (!value)
-    return "NULL";
+  if (!value) return "NULL";
   return HexDumpPointer(value) + "(" + DebugDumpSCardIoRequest(*value) + ")";
 }
 
 std::string DebugDumpSCardInputReaderState(const SCARD_READERSTATE& value) {
   return "SCARD_READERSTATE(szReader=" + DebugDumpSCardCString(value.szReader) +
-      ", pvUserData=" + HexDumpPointer(value.pvUserData) + ", dwCurrentState=" +
-      DebugDumpSCardEventState(value.dwCurrentState) + ")";
+         ", pvUserData=" + HexDumpPointer(value.pvUserData) +
+         ", dwCurrentState=" + DebugDumpSCardEventState(value.dwCurrentState) +
+         ")";
 }
 
-std::string DebugDumpSCardInputReaderStates(
-    const SCARD_READERSTATE* begin, DWORD count) {
-  if (!begin)
-    return "NULL";
+std::string DebugDumpSCardInputReaderStates(const SCARD_READERSTATE* begin,
+                                            DWORD count) {
+  if (!begin) return "NULL";
   std::string result;
   for (DWORD index = 0; index < count; ++index) {
-    if (!result.empty())
-      result += ", ";
+    if (!result.empty()) result += ", ";
     result += DebugDumpSCardInputReaderState(begin[index]);
   }
   return HexDumpPointer(begin) + "([" + result + "])";
@@ -290,30 +278,27 @@ std::string DebugDumpSCardInputReaderStates(
 
 std::string DebugDumpSCardOutputReaderState(const SCARD_READERSTATE& value) {
   return "SCARD_READERSTATE(szReader=" + DebugDumpSCardCString(value.szReader) +
-      ", pvUserData=" + HexDumpPointer(value.pvUserData) + ", dwCurrentState=" +
-      DebugDumpSCardEventState(value.dwCurrentState) + ", dwEventState=" +
-      DebugDumpSCardEventState(value.dwEventState) + ", cbAtr=" +
-      std::to_string(value.cbAtr) + ", rgbAtr=<" +
-      HexDumpBytes(value.rgbAtr, value.cbAtr) + ">)";
+         ", pvUserData=" + HexDumpPointer(value.pvUserData) +
+         ", dwCurrentState=" + DebugDumpSCardEventState(value.dwCurrentState) +
+         ", dwEventState=" + DebugDumpSCardEventState(value.dwEventState) +
+         ", cbAtr=" + std::to_string(value.cbAtr) + ", rgbAtr=<" +
+         HexDumpBytes(value.rgbAtr, value.cbAtr) + ">)";
 }
 
-std::string DebugDumpSCardOutputReaderStates(
-    const SCARD_READERSTATE* begin, DWORD count) {
-  if (!begin)
-    return "NULL";
+std::string DebugDumpSCardOutputReaderStates(const SCARD_READERSTATE* begin,
+                                             DWORD count) {
+  if (!begin) return "NULL";
   std::string result;
   for (DWORD index = 0; index < count; ++index) {
-    if (!result.empty())
-      result += ", ";
+    if (!result.empty()) result += ", ";
     result += DebugDumpSCardOutputReaderState(begin[index]);
   }
   return HexDumpPointer(begin) + "([" + result + "])";
 }
 
-std::string DebugDumpSCardBufferContents(
-    const void* buffer, DWORD buffer_size) {
-  if (buffer_size)
-    GOOGLE_SMART_CARD_CHECK(buffer);
+std::string DebugDumpSCardBufferContents(const void* buffer,
+                                         DWORD buffer_size) {
+  if (buffer_size) GOOGLE_SMART_CARD_CHECK(buffer);
 #ifdef NDEBUG
   return "stripped data of length " + std::to_string(buffer_size);
 #else
@@ -322,58 +307,61 @@ std::string DebugDumpSCardBufferContents(
 }
 
 std::string DebugDumpSCardBufferContents(const std::vector<uint8_t>& buffer) {
-  return DebugDumpSCardBufferContents(
-      buffer.empty() ? nullptr : &buffer[0], buffer.size());
+  return DebugDumpSCardBufferContents(buffer.empty() ? nullptr : &buffer[0],
+                                      buffer.size());
 }
 
 std::string DebugDumpSCardInputBuffer(const void* buffer, DWORD buffer_size) {
-  if (!buffer)
-    return "NULL";
+  if (!buffer) return "NULL";
   return HexDumpPointer(buffer) + "(<" +
          DebugDumpSCardBufferContents(buffer, buffer_size) + ">)";
 }
 
 std::string DebugDumpSCardBufferSizeInputPointer(const DWORD* buffer_size) {
-  if (!buffer_size)
-    return "NULL";
-  const std::string dumped_value = *buffer_size == SCARD_AUTOALLOCATE ?
-      "SCARD_AUTOALLOCATE" : std::to_string(*buffer_size);
+  if (!buffer_size) return "NULL";
+  const std::string dumped_value = *buffer_size == SCARD_AUTOALLOCATE
+                                       ? "SCARD_AUTOALLOCATE"
+                                       : std::to_string(*buffer_size);
   return HexDumpPointer(buffer_size) + "(" + dumped_value + ")";
 }
 
-std::string DebugDumpSCardOutputBuffer(
-    const void* buffer, const DWORD* buffer_size, bool is_autoallocated) {
-  const void* const contents = is_autoallocated ?
-      *reinterpret_cast<const void* const*>(buffer) : buffer;
-  const std::string dumped_value = "<" +
-      (buffer_size ? DebugDumpSCardBufferContents(contents, *buffer_size) :
-           "DATA OF UNKNOWN LENGTH") + ">";
-  return is_autoallocated ? HexDumpPointer(buffer) + "(" + dumped_value + ")" :
-      dumped_value;
+std::string DebugDumpSCardOutputBuffer(const void* buffer,
+                                       const DWORD* buffer_size,
+                                       bool is_autoallocated) {
+  const void* const contents =
+      is_autoallocated ? *reinterpret_cast<const void* const*>(buffer) : buffer;
+  const std::string dumped_value =
+      "<" +
+      (buffer_size ? DebugDumpSCardBufferContents(contents, *buffer_size)
+                   : "DATA OF UNKNOWN LENGTH") +
+      ">";
+  return is_autoallocated ? HexDumpPointer(buffer) + "(" + dumped_value + ")"
+                          : dumped_value;
 }
 
 std::string DebugDumpSCardOutputBuffer(const void* buffer, DWORD buffer_size) {
   return "<" + DebugDumpSCardBufferContents(buffer, buffer_size) + ">";
 }
 
-std::string DebugDumpSCardOutputCStringBuffer(
-    LPCSTR buffer, bool is_autoallocated) {
-  const LPCSTR string_value = is_autoallocated ?
-      *reinterpret_cast<const LPCSTR*>(buffer) : buffer;
+std::string DebugDumpSCardOutputCStringBuffer(LPCSTR buffer,
+                                              bool is_autoallocated) {
+  const LPCSTR string_value =
+      is_autoallocated ? *reinterpret_cast<const LPCSTR*>(buffer) : buffer;
   const std::string dumped_value = DebugDumpSCardCString(string_value);
-  return is_autoallocated ?
-      HexDumpPointer(string_value) + "(" + dumped_value + ")" : dumped_value;
+  return is_autoallocated
+             ? HexDumpPointer(string_value) + "(" + dumped_value + ")"
+             : dumped_value;
 }
 
-std::string DebugDumpSCardOutputMultiStringBuffer(
-    LPCSTR buffer, bool is_autoallocated) {
-  const LPCSTR multi_string_value = is_autoallocated ?
-      *reinterpret_cast<const LPCSTR*>(buffer) : buffer;
-  const std::string dumped_value = DebugDumpSCardMultiString(
-      multi_string_value);
-  return is_autoallocated ?
-      HexDumpPointer(multi_string_value) + "(" + dumped_value + ")" :
-      dumped_value;
+std::string DebugDumpSCardOutputMultiStringBuffer(LPCSTR buffer,
+                                                  bool is_autoallocated) {
+  const LPCSTR multi_string_value =
+      is_autoallocated ? *reinterpret_cast<const LPCSTR*>(buffer) : buffer;
+  const std::string dumped_value =
+      DebugDumpSCardMultiString(multi_string_value);
+  return is_autoallocated
+             ? HexDumpPointer(multi_string_value) + "(" + dumped_value + ")"
+             : dumped_value;
 }
 
 }  // namespace google_smart_card

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_debug_dump.h
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_debug_dump.h
@@ -71,11 +71,11 @@ std::string DebugDumpSCardIoRequest(const SCARD_IO_REQUEST& value);
 std::string DebugDumpSCardIoRequest(const SCARD_IO_REQUEST* value);
 
 std::string DebugDumpSCardInputReaderState(const SCARD_READERSTATE& value);
-std::string DebugDumpSCardInputReaderStates(
-    const SCARD_READERSTATE* begin, DWORD count);
+std::string DebugDumpSCardInputReaderStates(const SCARD_READERSTATE* begin,
+                                            DWORD count);
 std::string DebugDumpSCardOutputReaderState(const SCARD_READERSTATE& value);
-std::string DebugDumpSCardOutputReaderStates(
-    const SCARD_READERSTATE* begin, DWORD count);
+std::string DebugDumpSCardOutputReaderStates(const SCARD_READERSTATE* begin,
+                                             DWORD count);
 
 std::string DebugDumpSCardBufferContents(const void* buffer, DWORD buffer_size);
 std::string DebugDumpSCardBufferContents(const std::vector<uint8_t>& buffer);
@@ -84,15 +84,16 @@ std::string DebugDumpSCardInputBuffer(const void* buffer, DWORD buffer_size);
 
 std::string DebugDumpSCardBufferSizeInputPointer(const DWORD* buffer_size);
 
-std::string DebugDumpSCardOutputBuffer(
-    const void* buffer, const DWORD* buffer_size, bool is_autoallocated);
+std::string DebugDumpSCardOutputBuffer(const void* buffer,
+                                       const DWORD* buffer_size,
+                                       bool is_autoallocated);
 std::string DebugDumpSCardOutputBuffer(const void* buffer, DWORD buffer_size);
 
-std::string DebugDumpSCardOutputCStringBuffer(
-    LPCSTR buffer, bool is_autoallocated);
+std::string DebugDumpSCardOutputCStringBuffer(LPCSTR buffer,
+                                              bool is_autoallocated);
 
-std::string DebugDumpSCardOutputMultiStringBuffer(
-    LPCSTR buffer, bool is_autoallocated);
+std::string DebugDumpSCardOutputMultiStringBuffer(LPCSTR buffer,
+                                                  bool is_autoallocated);
 
 }  // namespace google_smart_card
 

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.cc
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.cc
@@ -35,8 +35,7 @@ namespace {
 
 std::vector<uint8_t> GetSCardReaderStateAtr(
     const SCARD_READERSTATE& s_card_reader_state) {
-  if (!s_card_reader_state.cbAtr)
-    return {};
+  if (!s_card_reader_state.cbAtr) return {};
   GOOGLE_SMART_CARD_CHECK(s_card_reader_state.cbAtr <= MAX_ATR_SIZE);
   return std::vector<uint8_t>(
       s_card_reader_state.rgbAtr,
@@ -83,16 +82,15 @@ void StructConverter<OutboundSCardReaderState>::VisitFields(
 
 // static
 template <>
-constexpr const char*
-StructConverter<SCardIoRequest>::GetStructTypeName() {
+constexpr const char* StructConverter<SCardIoRequest>::GetStructTypeName() {
   return "SCARD_IO_REQUEST";
 }
 
 // static
 template <>
 template <typename Callback>
-void StructConverter<SCardIoRequest>::VisitFields(
-    const SCardIoRequest& value, Callback callback) {
+void StructConverter<SCardIoRequest>::VisitFields(const SCardIoRequest& value,
+                                                  Callback callback) {
   callback(&value.protocol, "protocol");
 }
 
@@ -102,8 +100,8 @@ InboundSCardReaderState InboundSCardReaderState::FromSCardReaderState(
   GOOGLE_SMART_CARD_CHECK(value.szReader);
   return InboundSCardReaderState(
       value.szReader,
-      value.pvUserData ?
-          reinterpret_cast<uintptr_t>(value.pvUserData) : optional<uintptr_t>(),
+      value.pvUserData ? reinterpret_cast<uintptr_t>(value.pvUserData)
+                       : optional<uintptr_t>(),
       value.dwCurrentState);
 }
 
@@ -113,11 +111,9 @@ OutboundSCardReaderState OutboundSCardReaderState::FromSCardReaderState(
   GOOGLE_SMART_CARD_CHECK(value.szReader);
   return OutboundSCardReaderState(
       value.szReader,
-      value.pvUserData ?
-          reinterpret_cast<uintptr_t>(value.pvUserData) : optional<uintptr_t>(),
-      value.dwCurrentState,
-      value.dwEventState,
-      GetSCardReaderStateAtr(value));
+      value.pvUserData ? reinterpret_cast<uintptr_t>(value.pvUserData)
+                       : optional<uintptr_t>(),
+      value.dwCurrentState, value.dwEventState, GetSCardReaderStateAtr(value));
 }
 
 SCARD_IO_REQUEST SCardIoRequest::AsSCardIoRequest() const {
@@ -139,8 +135,8 @@ pp::Var MakeVar(const SCARD_READERSTATE& value) {
   GOOGLE_SMART_CARD_CHECK(value.szReader);
   result_builder.Add("reader_name", value.szReader);
   if (value.pvUserData) {
-    result_builder.Add(
-        "user_data", reinterpret_cast<uintptr_t>(value.pvUserData));
+    result_builder.Add("user_data",
+                       reinterpret_cast<uintptr_t>(value.pvUserData));
   }
   result_builder.Add("current_state", value.dwCurrentState);
   result_builder.Add("event_state", value.dwEventState);
@@ -151,10 +147,8 @@ pp::Var MakeVar(const SCARD_READERSTATE& value) {
   return result_builder.Result();
 }
 
-bool VarAs(
-    const pp::Var& var,
-    InboundSCardReaderState* result,
-    std::string* error_message) {
+bool VarAs(const pp::Var& var, InboundSCardReaderState* result,
+           std::string* error_message) {
   return StructConverter<InboundSCardReaderState>::ConvertFromVar(
       var, result, error_message);
 }
@@ -164,10 +158,8 @@ pp::Var MakeVar(const InboundSCardReaderState& value) {
   return StructConverter<InboundSCardReaderState>::ConvertToVar(value);
 }
 
-bool VarAs(
-    const pp::Var& var,
-    OutboundSCardReaderState* result,
-    std::string* error_message) {
+bool VarAs(const pp::Var& var, OutboundSCardReaderState* result,
+           std::string* error_message) {
   return StructConverter<OutboundSCardReaderState>::ConvertFromVar(
       var, result, error_message);
 }
@@ -177,10 +169,10 @@ pp::Var MakeVar(const OutboundSCardReaderState& value) {
   return StructConverter<OutboundSCardReaderState>::ConvertToVar(value);
 }
 
-bool VarAs(
-    const pp::Var& var, SCardIoRequest* result, std::string* error_message) {
-  return StructConverter<SCardIoRequest>::ConvertFromVar(
-      var, result, error_message);
+bool VarAs(const pp::Var& var, SCardIoRequest* result,
+           std::string* error_message) {
+  return StructConverter<SCardIoRequest>::ConvertFromVar(var, result,
+                                                         error_message);
 }
 
 template <>

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.h
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.h
@@ -45,12 +45,12 @@
 #include <string>
 #include <vector>
 
-#include <ppapi/cpp/var.h>
-
 #include <pcsclite.h>
 #include <reader.h>
 #include <winscard.h>
 #include <wintypes.h>
+
+#include <ppapi/cpp/var.h>
 
 #include <google_smart_card_common/optional.h>
 #include <google_smart_card_common/pp_var_utils/construction.h>
@@ -68,10 +68,8 @@ namespace google_smart_card {
 struct InboundSCardReaderState {
   InboundSCardReaderState() = default;
 
-  InboundSCardReaderState(
-      const std::string& reader_name,
-      optional<uintptr_t> user_data,
-      DWORD current_state)
+  InboundSCardReaderState(const std::string& reader_name,
+                          optional<uintptr_t> user_data, DWORD current_state)
       : reader_name(reader_name),
         user_data(user_data),
         current_state(current_state) {}
@@ -95,12 +93,9 @@ struct InboundSCardReaderState {
 struct OutboundSCardReaderState {
   OutboundSCardReaderState() = default;
 
-  OutboundSCardReaderState(
-      const std::string& reader_name,
-      optional<uintptr_t> user_data,
-      DWORD current_state,
-      DWORD event_state,
-      const std::vector<uint8_t>& atr)
+  OutboundSCardReaderState(const std::string& reader_name,
+                           optional<uintptr_t> user_data, DWORD current_state,
+                           DWORD event_state, const std::vector<uint8_t>& atr)
       : reader_name(reader_name),
         user_data(user_data),
         current_state(current_state),
@@ -121,8 +116,7 @@ struct OutboundSCardReaderState {
 struct SCardIoRequest {
   SCardIoRequest() = default;
 
-  explicit SCardIoRequest(DWORD protocol)
-      : protocol(protocol) {}
+  explicit SCardIoRequest(DWORD protocol) : protocol(protocol) {}
 
   SCARD_IO_REQUEST AsSCardIoRequest() const;
 
@@ -131,24 +125,20 @@ struct SCardIoRequest {
   DWORD protocol;
 };
 
-bool VarAs(
-    const pp::Var& var,
-    InboundSCardReaderState* result,
-    std::string* error_message);
+bool VarAs(const pp::Var& var, InboundSCardReaderState* result,
+           std::string* error_message);
 
 template <>
 pp::Var MakeVar(const InboundSCardReaderState& value);
 
-bool VarAs(
-    const pp::Var& var,
-    OutboundSCardReaderState* result,
-    std::string* error_message);
+bool VarAs(const pp::Var& var, OutboundSCardReaderState* result,
+           std::string* error_message);
 
 template <>
 pp::Var MakeVar(const OutboundSCardReaderState& value);
 
-bool VarAs(
-    const pp::Var& var, SCardIoRequest* result, std::string* error_message);
+bool VarAs(const pp::Var& var, SCardIoRequest* result,
+           std::string* error_message);
 
 template <>
 pp::Var MakeVar(const SCardIoRequest& value);

--- a/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.h
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.h
@@ -48,12 +48,12 @@ namespace google_smart_card {
 // concurrent PC/SC-Lite client API function calls.
 class PcscLiteOverRequesterGlobal final {
  public:
-  PcscLiteOverRequesterGlobal(
-      TypedMessageRouter* typed_message_router,
-      pp::Instance* pp_instance,
-      pp::Core* pp_core);
+  PcscLiteOverRequesterGlobal(TypedMessageRouter* typed_message_router,
+                              pp::Instance* pp_instance, pp::Core* pp_core);
 
   PcscLiteOverRequesterGlobal(const PcscLiteOverRequesterGlobal&) = delete;
+  PcscLiteOverRequesterGlobal& operator=(const PcscLiteOverRequesterGlobal&) =
+      delete;
 
   // Destroys the self instance and the owned PcscLiteOverRequester instance.
   //

--- a/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.cc
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.cc
@@ -43,11 +43,11 @@
 #include <google_smart_card_common/pp_var_utils/extraction.h>
 #include <google_smart_card_pcsc_lite_common/scard_structs_serialization.h>
 
-const char kLoggingPrefix[] = "[PC/SC-Lite over requester] ";
-
 namespace google_smart_card {
 
 namespace {
+
+constexpr char kLoggingPrefix[] = "[PC/SC-Lite over requester] ";
 
 // This type is used to hold temporarily the allocated memory for the PC/SC-Lite
 // client API functions.
@@ -79,12 +79,9 @@ SCardUniquePtr<T> CreateSCardUniquePtr() {
 // PC/SC-Lite client API, refer, for instance, to
 // <https://pcsclite.alioth.debian.org/api/group__API.html#gaacfec51917255b7a25b94c5104961602>.
 template <typename IterT, typename T>
-LONG FillOutputBufferArguments(
-    IterT input_begin,
-    IterT input_end,
-    T* output,
-    LPDWORD output_size,
-    SCardUniquePtr<T>* allocated_buffer_holder) {
+LONG FillOutputBufferArguments(IterT input_begin, IterT input_end, T* output,
+                               LPDWORD output_size,
+                               SCardUniquePtr<T>* allocated_buffer_holder) {
   const size_t input_size = std::distance(input_begin, input_end);
 
   T* target_buffer_begin = nullptr;
@@ -104,8 +101,7 @@ LONG FillOutputBufferArguments(
       // output argument is actually a T** in that case, and it will receive
       // pointer to the allocated buffer (so this argument is checked to be
       // non-null).
-      if (!output)
-        return SCARD_E_INVALID_PARAMETER;
+      if (!output) return SCARD_E_INVALID_PARAMETER;
       target_buffer_begin = reinterpret_cast<T*>(std::malloc(input_size));
       GOOGLE_SMART_CARD_CHECK(target_buffer_begin);
       allocated_buffer_holder->reset(target_buffer_begin);
@@ -138,51 +134,54 @@ LONG FillOutputBufferArguments(
 // PC/SC-Lite return code as the first argument (for the documentation, see
 // <https://pcsclite.alioth.debian.org/api/group__ErrorCodes.html>) and the
 // function output arguments as the following array items.
-template <typename ... Results>
+template <typename... Results>
 LONG ExtractRequestResultsAndCode(
     const std::string& function_name,
-    const GenericRequestResult& generic_request_result,
-    Results* ... results) {
+    const GenericRequestResult& generic_request_result, Results*... results) {
   const std::string logging_prefix =
       kLoggingPrefix + function_name + " function call: ";
 
   if (!generic_request_result.is_successful()) {
-    GOOGLE_SMART_CARD_LOG_WARNING << logging_prefix << "Failed: " <<
-        generic_request_result.error_message();
+    GOOGLE_SMART_CARD_LOG_WARNING
+        << logging_prefix
+        << "Failed: " << generic_request_result.error_message();
     return SCARD_F_INTERNAL_ERROR;
   }
 
   std::string error_message;
   pp::VarArray var_array;
   if (!VarAs(generic_request_result.payload(), &var_array, &error_message)) {
-    GOOGLE_SMART_CARD_LOG_FATAL << logging_prefix << "Failed to extract the " <<
-        "response payload items: " << error_message;
+    GOOGLE_SMART_CARD_LOG_FATAL << logging_prefix << "Failed to extract the "
+                                << "response payload items: " << error_message;
   }
 
   if (!GetVarArraySize(var_array)) {
-    GOOGLE_SMART_CARD_LOG_FATAL << logging_prefix << "Failed to extract the " <<
-        "response payload items: the response is an empty array";
+    GOOGLE_SMART_CARD_LOG_FATAL
+        << logging_prefix << "Failed to extract the "
+        << "response payload items: the response is an empty array";
   }
 
   LONG result_code;
   if (!VarAs(var_array.Get(0), &result_code, &error_message)) {
-    GOOGLE_SMART_CARD_LOG_FATAL << logging_prefix << "Failed to extract the " <<
-        "response payload items: Error while extracting result code: " <<
-        error_message;
+    GOOGLE_SMART_CARD_LOG_FATAL
+        << logging_prefix << "Failed to extract the "
+        << "response payload items: Error while extracting result code: "
+        << error_message;
   }
   if (result_code != SCARD_S_SUCCESS) {
     if (GetVarArraySize(var_array) != 1) {
-      GOOGLE_SMART_CARD_LOG_FATAL << logging_prefix << "Failed to extract " <<
-          "the response payload items: Extra data is supplied along with an " <<
-          "erroneous result code";
+      GOOGLE_SMART_CARD_LOG_FATAL
+          << logging_prefix << "Failed to extract "
+          << "the response payload items: Extra data is supplied along with an "
+          << "erroneous result code";
     }
     return result_code;
   }
 
-  if (!TryGetVarArrayItems(
-           var_array, &error_message, &result_code, results...)) {
-    GOOGLE_SMART_CARD_LOG_FATAL << logging_prefix << "Failed to extract the " <<
-        "response payload items: " << error_message;
+  if (!TryGetVarArrayItems(var_array, &error_message, &result_code,
+                           results...)) {
+    GOOGLE_SMART_CARD_LOG_FATAL << logging_prefix << "Failed to extract the "
+                                << "response payload items: " << error_message;
   }
   return result_code;
 }
@@ -194,17 +193,14 @@ PcscLiteOverRequester::PcscLiteOverRequester(
     : requester_(std::move(requester)),
       remote_call_adaptor_(requester_.get()) {}
 
-void PcscLiteOverRequester::Detach() {
-  requester_->Detach();
-}
+PcscLiteOverRequester::~PcscLiteOverRequester() = default;
+
+void PcscLiteOverRequester::Detach() { requester_->Detach(); }
 
 LONG PcscLiteOverRequester::SCardEstablishContext(
-    DWORD scope,
-    LPCVOID reserved_1,
-    LPCVOID reserved_2,
+    DWORD scope, LPCVOID reserved_1, LPCVOID reserved_2,
     LPSCARDCONTEXT s_card_context) {
-  if (!s_card_context)
-    return SCARD_E_INVALID_PARAMETER;
+  if (!s_card_context) return SCARD_E_INVALID_PARAMETER;
   if (reserved_1 || reserved_2) {
     // Only the NULL values of these parameters are supported by this PC/SC-Lite
     // client implementation. Anyway, PC/SC-Lite API states that these
@@ -214,8 +210,8 @@ LONG PcscLiteOverRequester::SCardEstablishContext(
 
   return ExtractRequestResultsAndCode(
       "SCardEstablishContext",
-      remote_call_adaptor_.SyncCall(
-          "SCardEstablishContext", scope, pp::Var::Null(), pp::Var::Null()),
+      remote_call_adaptor_.SyncCall("SCardEstablishContext", scope,
+                                    pp::Var::Null(), pp::Var::Null()),
       s_card_context);
 }
 
@@ -225,56 +221,40 @@ LONG PcscLiteOverRequester::SCardReleaseContext(SCARDCONTEXT s_card_context) {
       remote_call_adaptor_.SyncCall("SCardReleaseContext", s_card_context));
 }
 
-LONG PcscLiteOverRequester::SCardConnect(
-    SCARDCONTEXT s_card_context,
-    LPCSTR reader_name,
-    DWORD share_mode,
-    DWORD preferred_protocols,
-    LPSCARDHANDLE s_card_handle,
-    LPDWORD active_protocol) {
-  if (!s_card_handle || !active_protocol)
-    return SCARD_E_INVALID_PARAMETER;
-  if (!reader_name)
-    return SCARD_E_UNKNOWN_READER;
+LONG PcscLiteOverRequester::SCardConnect(SCARDCONTEXT s_card_context,
+                                         LPCSTR reader_name, DWORD share_mode,
+                                         DWORD preferred_protocols,
+                                         LPSCARDHANDLE s_card_handle,
+                                         LPDWORD active_protocol) {
+  if (!s_card_handle || !active_protocol) return SCARD_E_INVALID_PARAMETER;
+  if (!reader_name) return SCARD_E_UNKNOWN_READER;
 
   return ExtractRequestResultsAndCode(
       "SCardConnect",
-      remote_call_adaptor_.SyncCall(
-          "SCardConnect",
-          s_card_context,
-          reader_name,
-          share_mode,
-          preferred_protocols),
-      s_card_handle,
-      active_protocol);
+      remote_call_adaptor_.SyncCall("SCardConnect", s_card_context, reader_name,
+                                    share_mode, preferred_protocols),
+      s_card_handle, active_protocol);
 }
 
-LONG PcscLiteOverRequester::SCardReconnect(
-    SCARDHANDLE s_card_handle,
-    DWORD share_mode,
-    DWORD preferred_protocols,
-    DWORD initialization_action,
-    LPDWORD active_protocol) {
-  if (!active_protocol)
-    return SCARD_E_INVALID_PARAMETER;
+LONG PcscLiteOverRequester::SCardReconnect(SCARDHANDLE s_card_handle,
+                                           DWORD share_mode,
+                                           DWORD preferred_protocols,
+                                           DWORD initialization_action,
+                                           LPDWORD active_protocol) {
+  if (!active_protocol) return SCARD_E_INVALID_PARAMETER;
 
   return ExtractRequestResultsAndCode(
       "SCardReconnect",
-      remote_call_adaptor_.SyncCall(
-          "SCardReconnect",
-          s_card_handle,
-          share_mode,
-          preferred_protocols,
-          initialization_action),
+      remote_call_adaptor_.SyncCall("SCardReconnect", s_card_handle, share_mode,
+                                    preferred_protocols, initialization_action),
       active_protocol);
 }
 
-LONG PcscLiteOverRequester::SCardDisconnect(
-    SCARDHANDLE s_card_handle, DWORD disposition) {
+LONG PcscLiteOverRequester::SCardDisconnect(SCARDHANDLE s_card_handle,
+                                            DWORD disposition) {
   return ExtractRequestResultsAndCode(
-      "SCardDisconnect",
-      remote_call_adaptor_.SyncCall(
-          "SCardDisconnect", s_card_handle, disposition));
+      "SCardDisconnect", remote_call_adaptor_.SyncCall(
+                             "SCardDisconnect", s_card_handle, disposition));
 }
 
 LONG PcscLiteOverRequester::SCardBeginTransaction(SCARDHANDLE s_card_handle) {
@@ -283,22 +263,19 @@ LONG PcscLiteOverRequester::SCardBeginTransaction(SCARDHANDLE s_card_handle) {
       remote_call_adaptor_.SyncCall("SCardBeginTransaction", s_card_handle));
 }
 
-LONG PcscLiteOverRequester::SCardEndTransaction(
-    SCARDHANDLE s_card_handle, DWORD disposition_action) {
+LONG PcscLiteOverRequester::SCardEndTransaction(SCARDHANDLE s_card_handle,
+                                                DWORD disposition_action) {
   return ExtractRequestResultsAndCode(
       "SCardEndTransaction",
-      remote_call_adaptor_.SyncCall(
-          "SCardEndTransaction", s_card_handle, disposition_action));
+      remote_call_adaptor_.SyncCall("SCardEndTransaction", s_card_handle,
+                                    disposition_action));
 }
 
-LONG PcscLiteOverRequester::SCardStatus(
-    SCARDHANDLE s_card_handle,
-    LPSTR reader_name,
-    LPDWORD reader_name_length,
-    LPDWORD state,
-    LPDWORD protocol,
-    LPBYTE atr,
-    LPDWORD atr_length) {
+LONG PcscLiteOverRequester::SCardStatus(SCARDHANDLE s_card_handle,
+                                        LPSTR reader_name,
+                                        LPDWORD reader_name_length,
+                                        LPDWORD state, LPDWORD protocol,
+                                        LPBYTE atr, LPDWORD atr_length) {
   std::string reader_name_string;
   DWORD state_copy;
   DWORD protocol_copy;
@@ -306,35 +283,24 @@ LONG PcscLiteOverRequester::SCardStatus(
   const LONG result_code = ExtractRequestResultsAndCode(
       "SCardStatus",
       remote_call_adaptor_.SyncCall("SCardStatus", s_card_handle),
-      &reader_name_string,
-      &state_copy,
-      &protocol_copy,
-      &atr_vector);
+      &reader_name_string, &state_copy, &protocol_copy, &atr_vector);
   GOOGLE_SMART_CARD_CHECK(result_code != SCARD_E_INSUFFICIENT_BUFFER);
-  if (result_code != SCARD_S_SUCCESS)
-    return result_code;
+  if (result_code != SCARD_S_SUCCESS) return result_code;
 
   SCardUniquePtr<char> reader_name_buffer_holder = CreateSCardUniquePtr<char>();
   const LONG reader_name_filling_result_code = FillOutputBufferArguments(
       reader_name_string.c_str(),
-      reader_name_string.c_str() + reader_name_string.length() + 1,
-      reader_name,
-      reader_name_length,
-      &reader_name_buffer_holder);
+      reader_name_string.c_str() + reader_name_string.length() + 1, reader_name,
+      reader_name_length, &reader_name_buffer_holder);
 
-  if (state)
-    *state = state_copy;
+  if (state) *state = state_copy;
 
-  if (protocol)
-    *protocol = protocol_copy;
+  if (protocol) *protocol = protocol_copy;
 
   SCardUniquePtr<BYTE> atr_buffer_holder = CreateSCardUniquePtr<BYTE>();
-  const LONG atr_filling_result_code = FillOutputBufferArguments(
-      atr_vector.begin(),
-      atr_vector.end(),
-      atr,
-      atr_length,
-      &atr_buffer_holder);
+  const LONG atr_filling_result_code =
+      FillOutputBufferArguments(atr_vector.begin(), atr_vector.end(), atr,
+                                atr_length, &atr_buffer_holder);
 
   if (reader_name_filling_result_code != SCARD_S_SUCCESS)
     return reader_name_filling_result_code;
@@ -346,12 +312,9 @@ LONG PcscLiteOverRequester::SCardStatus(
 }
 
 LONG PcscLiteOverRequester::SCardGetStatusChange(
-    SCARDCONTEXT s_card_context,
-    DWORD timeout,
-    SCARD_READERSTATE* reader_states,
-    DWORD reader_states_size) {
-  if (!reader_states && reader_states_size)
-    return SCARD_E_INVALID_PARAMETER;
+    SCARDCONTEXT s_card_context, DWORD timeout,
+    SCARD_READERSTATE* reader_states, DWORD reader_states_size) {
+  if (!reader_states && reader_states_size) return SCARD_E_INVALID_PARAMETER;
 
   std::vector<InboundSCardReaderState> reader_states_vector;
   for (DWORD index = 0; index < reader_states_size; ++index) {
@@ -362,52 +325,41 @@ LONG PcscLiteOverRequester::SCardGetStatusChange(
   std::vector<OutboundSCardReaderState> returned_reader_states_vector;
   const LONG result_code = ExtractRequestResultsAndCode(
       "SCardGetStatusChange",
-      remote_call_adaptor_.SyncCall(
-          "SCardGetStatusChange",
-          s_card_context,
-          timeout,
-          reader_states_vector),
+      remote_call_adaptor_.SyncCall("SCardGetStatusChange", s_card_context,
+                                    timeout, reader_states_vector),
       &returned_reader_states_vector);
-  if (result_code != SCARD_S_SUCCESS)
-    return result_code;
+  if (result_code != SCARD_S_SUCCESS) return result_code;
 
-  GOOGLE_SMART_CARD_CHECK(
-      returned_reader_states_vector.size() == reader_states_size);
+  GOOGLE_SMART_CARD_CHECK(returned_reader_states_vector.size() ==
+                          reader_states_size);
   for (DWORD index = 0; index < reader_states_size; ++index) {
     const OutboundSCardReaderState& current_returned_item =
         returned_reader_states_vector[index];
     SCARD_READERSTATE* const current_item = &reader_states[index];
 
-    GOOGLE_SMART_CARD_CHECK(
-        current_returned_item.reader_name == current_item->szReader);
+    GOOGLE_SMART_CARD_CHECK(current_returned_item.reader_name ==
+                            current_item->szReader);
 
-    GOOGLE_SMART_CARD_CHECK(
-        current_returned_item.current_state == current_item->dwCurrentState);
+    GOOGLE_SMART_CARD_CHECK(current_returned_item.current_state ==
+                            current_item->dwCurrentState);
 
     current_item->dwEventState = current_returned_item.event_state;
 
     GOOGLE_SMART_CARD_CHECK(current_returned_item.atr.size() <= MAX_ATR_SIZE);
     current_item->cbAtr = static_cast<DWORD>(current_returned_item.atr.size());
     if (!current_returned_item.atr.empty()) {
-      std::memcpy(
-          current_item->rgbAtr,
-          &current_returned_item.atr[0],
-          current_returned_item.atr.size());
+      std::memcpy(current_item->rgbAtr, &current_returned_item.atr[0],
+                  current_returned_item.atr.size());
     }
   }
   return SCARD_S_SUCCESS;
 }
 
 LONG PcscLiteOverRequester::SCardControl(
-    SCARDHANDLE s_card_handle,
-    DWORD control_code,
-    LPCVOID send_buffer,
-    DWORD send_buffer_length,
-    LPVOID receive_buffer,
-    DWORD receive_buffer_length,
-    LPDWORD bytes_returned) {
-  if (send_buffer_length)
-    GOOGLE_SMART_CARD_CHECK(send_buffer);
+    SCARDHANDLE s_card_handle, DWORD control_code, LPCVOID send_buffer,
+    DWORD send_buffer_length, LPVOID receive_buffer,
+    DWORD receive_buffer_length, LPDWORD bytes_returned) {
+  if (send_buffer_length) GOOGLE_SMART_CARD_CHECK(send_buffer);
   GOOGLE_SMART_CARD_CHECK(receive_buffer);
 
   std::vector<uint8_t> send_buffer_vector;
@@ -420,63 +372,52 @@ LONG PcscLiteOverRequester::SCardControl(
   std::vector<uint8_t> received_buffer_vector;
   const LONG result_code = ExtractRequestResultsAndCode(
       "SCardControl",
-      remote_call_adaptor_.SyncCall(
-          "SCardControl", s_card_handle, control_code, send_buffer_vector),
+      remote_call_adaptor_.SyncCall("SCardControl", s_card_handle, control_code,
+                                    send_buffer_vector),
       &received_buffer_vector);
   if (bytes_returned) {
     // According to PC/SC-Lite and CCID sources, zero number of written bytes is
     // reported in case of any error.
     *bytes_returned = 0;
   }
-  if (result_code != SCARD_S_SUCCESS)
-    return result_code;
+  if (result_code != SCARD_S_SUCCESS) return result_code;
 
   if (received_buffer_vector.size() > receive_buffer_length)
     return SCARD_E_INSUFFICIENT_BUFFER;
   if (!received_buffer_vector.empty()) {
-    std::memcpy(
-        receive_buffer,
-        &received_buffer_vector[0],
-        received_buffer_vector.size());
+    std::memcpy(receive_buffer, &received_buffer_vector[0],
+                received_buffer_vector.size());
   }
-  if (bytes_returned)
-    *bytes_returned = received_buffer_vector.size();
+  if (bytes_returned) *bytes_returned = received_buffer_vector.size();
   return SCARD_S_SUCCESS;
 }
 
-LONG PcscLiteOverRequester::SCardGetAttrib(
-    SCARDHANDLE s_card_handle,
-    DWORD attribute_id,
-    LPBYTE attribute,
-    LPDWORD attribute_length) {
+LONG PcscLiteOverRequester::SCardGetAttrib(SCARDHANDLE s_card_handle,
+                                           DWORD attribute_id, LPBYTE attribute,
+                                           LPDWORD attribute_length) {
   std::vector<uint8_t> attribute_vector;
   const LONG result_code = ExtractRequestResultsAndCode(
       "SCardGetAttrib",
-      remote_call_adaptor_.SyncCall(
-          "SCardGetAttrib", s_card_handle, attribute_id),
+      remote_call_adaptor_.SyncCall("SCardGetAttrib", s_card_handle,
+                                    attribute_id),
       &attribute_vector);
   GOOGLE_SMART_CARD_CHECK(result_code != SCARD_E_INSUFFICIENT_BUFFER);
-  if (result_code != SCARD_S_SUCCESS)
-    return result_code;
+  if (result_code != SCARD_S_SUCCESS) return result_code;
 
   SCardUniquePtr<BYTE> attribute_buffer_holder = CreateSCardUniquePtr<BYTE>();
   const LONG attribute_filling_result_code = FillOutputBufferArguments(
-      attribute_vector.begin(),
-      attribute_vector.end(),
-      attribute,
-      attribute_length,
-      &attribute_buffer_holder);
+      attribute_vector.begin(), attribute_vector.end(), attribute,
+      attribute_length, &attribute_buffer_holder);
   if (attribute_filling_result_code != SCARD_S_SUCCESS)
     return attribute_filling_result_code;
   attribute_buffer_holder.release();
   return SCARD_S_SUCCESS;
 }
 
-LONG PcscLiteOverRequester::SCardSetAttrib(
-    SCARDHANDLE s_card_handle,
-    DWORD attribute_id,
-    LPCBYTE attribute_buffer,
-    DWORD attribute_buffer_length) {
+LONG PcscLiteOverRequester::SCardSetAttrib(SCARDHANDLE s_card_handle,
+                                           DWORD attribute_id,
+                                           LPCBYTE attribute_buffer,
+                                           DWORD attribute_buffer_length) {
   if (!attribute_buffer || !attribute_buffer_length)
     return SCARD_E_INVALID_PARAMETER;
 
@@ -486,21 +427,15 @@ LONG PcscLiteOverRequester::SCardSetAttrib(
 
   return ExtractRequestResultsAndCode(
       "SCardSetAttrib",
-      remote_call_adaptor_.SyncCall(
-          "SCardSetAttrib",
-          s_card_handle,
-          attribute_id,
-          attribute_buffer_vector));
+      remote_call_adaptor_.SyncCall("SCardSetAttrib", s_card_handle,
+                                    attribute_id, attribute_buffer_vector));
 }
 
 LONG PcscLiteOverRequester::SCardTransmit(
     SCARDHANDLE s_card_handle,
-    const SCARD_IO_REQUEST* send_protocol_information,
-    LPCBYTE send_buffer,
-    DWORD send_buffer_length,
-    SCARD_IO_REQUEST* receive_protocol_information,
-    LPBYTE receive_buffer,
-    LPDWORD receive_buffer_length) {
+    const SCARD_IO_REQUEST* send_protocol_information, LPCBYTE send_buffer,
+    DWORD send_buffer_length, SCARD_IO_REQUEST* receive_protocol_information,
+    LPBYTE receive_buffer, LPDWORD receive_buffer_length) {
   if (!send_protocol_information || !send_buffer || !receive_buffer ||
       !receive_buffer_length) {
     return SCARD_E_INVALID_PARAMETER;
@@ -513,8 +448,8 @@ LONG PcscLiteOverRequester::SCardTransmit(
       send_buffer, send_buffer + send_buffer_length);
   optional<SCardIoRequest> input_receive_protocol_information;
   if (receive_protocol_information) {
-    input_receive_protocol_information = SCardIoRequest::FromSCardIoRequest(
-        *receive_protocol_information);
+    input_receive_protocol_information =
+        SCardIoRequest::FromSCardIoRequest(*receive_protocol_information);
   }
 
   SCardIoRequest receive_protocol_information_copy;
@@ -522,15 +457,11 @@ LONG PcscLiteOverRequester::SCardTransmit(
   const LONG result_code = ExtractRequestResultsAndCode(
       "SCardTransmit",
       remote_call_adaptor_.SyncCall(
-          "SCardTransmit",
-          s_card_handle,
+          "SCardTransmit", s_card_handle,
           SCardIoRequest::FromSCardIoRequest(*send_protocol_information),
-          send_buffer_vector,
-          input_receive_protocol_information),
-      &receive_protocol_information_copy,
-      &received_buffer_vector);
-  if (result_code != SCARD_S_SUCCESS)
-    return result_code;
+          send_buffer_vector, input_receive_protocol_information),
+      &receive_protocol_information_copy, &received_buffer_vector);
+  if (result_code != SCARD_S_SUCCESS) return result_code;
 
   if (receive_protocol_information) {
     *receive_protocol_information =
@@ -539,81 +470,69 @@ LONG PcscLiteOverRequester::SCardTransmit(
   if (received_buffer_vector.size() > *receive_buffer_length)
     return SCARD_E_INSUFFICIENT_BUFFER;
   if (!received_buffer_vector.empty()) {
-    std::memcpy(
-        receive_buffer,
-        &received_buffer_vector[0],
-        received_buffer_vector.size());
+    std::memcpy(receive_buffer, &received_buffer_vector[0],
+                received_buffer_vector.size());
   }
   *receive_buffer_length = received_buffer_vector.size();
   return SCARD_S_SUCCESS;
 }
 
-LONG PcscLiteOverRequester::SCardListReaders(
-    SCARDCONTEXT s_card_context,
-    LPCSTR groups,
-    LPSTR readers,
-    LPDWORD readers_size) {
+LONG PcscLiteOverRequester::SCardListReaders(SCARDCONTEXT s_card_context,
+                                             LPCSTR groups, LPSTR readers,
+                                             LPDWORD readers_size) {
   if (groups) {
     // Only the NULL value of this parameter is supported by this PC/SC-Lite
     // client implementation. Anyway, PC/SC-Lite API states that this
     // parameter is not used now, so it doesn't harm much limiting to NULL.
     return SCARD_E_INVALID_PARAMETER;
   }
-  if (!readers_size)
-    return SCARD_E_INVALID_PARAMETER;
+  if (!readers_size) return SCARD_E_INVALID_PARAMETER;
   GOOGLE_SMART_CARD_CHECK(readers_size);
 
   std::vector<std::string> readers_vector;
   const LONG result_code = ExtractRequestResultsAndCode(
       "SCardListReaders",
-      remote_call_adaptor_.SyncCall(
-          "SCardListReaders", s_card_context, pp::Var::Null()),
+      remote_call_adaptor_.SyncCall("SCardListReaders", s_card_context,
+                                    pp::Var::Null()),
       &readers_vector);
   GOOGLE_SMART_CARD_CHECK(result_code != SCARD_E_INSUFFICIENT_BUFFER);
-  if (result_code != SCARD_S_SUCCESS)
-    return result_code;
+  if (result_code != SCARD_S_SUCCESS) return result_code;
 
   const std::string dumped_readers = CreateMultiString(readers_vector);
 
   SCardUniquePtr<char> readers_buffer_holder = CreateSCardUniquePtr<char>();
-  const LONG readers_filling_result_code = FillOutputBufferArguments(
-      dumped_readers.begin(),
-      dumped_readers.end(),
-      readers,
-      readers_size,
-      &readers_buffer_holder);
+  const LONG readers_filling_result_code =
+      FillOutputBufferArguments(dumped_readers.begin(), dumped_readers.end(),
+                                readers, readers_size, &readers_buffer_holder);
   if (readers_filling_result_code != SCARD_S_SUCCESS)
     return readers_filling_result_code;
   readers_buffer_holder.release();
   return SCARD_S_SUCCESS;
 }
 
-LONG PcscLiteOverRequester::SCardFreeMemory(
-    SCARDCONTEXT /*s_card_context*/, LPCVOID memory) {
+LONG PcscLiteOverRequester::SCardFreeMemory(SCARDCONTEXT /*s_card_context*/,
+                                            LPCVOID memory) {
   std::free(const_cast<void*>(memory));
   return SCARD_S_SUCCESS;
 }
 
-LONG PcscLiteOverRequester::SCardListReaderGroups(
-    SCARDCONTEXT s_card_context, LPSTR groups, LPDWORD groups_size) {
+LONG PcscLiteOverRequester::SCardListReaderGroups(SCARDCONTEXT s_card_context,
+                                                  LPSTR groups,
+                                                  LPDWORD groups_size) {
   std::vector<std::string> groups_vector;
   const LONG result_code = ExtractRequestResultsAndCode(
       "SCardListReaderGroups",
       remote_call_adaptor_.SyncCall("SCardListReaderGroups", s_card_context),
       &groups_vector);
   GOOGLE_SMART_CARD_CHECK(result_code != SCARD_E_INSUFFICIENT_BUFFER);
-  if (result_code != SCARD_S_SUCCESS)
-    return result_code;
+  if (result_code != SCARD_S_SUCCESS) return result_code;
 
   const std::string dumped_groups = CreateMultiString(groups_vector);
 
   SCardUniquePtr<char> groups_buffer_holder = CreateSCardUniquePtr<char>();
-  const LONG groups_filling_result_code = FillOutputBufferArguments(
-      dumped_groups.begin(),
-      dumped_groups.end(),
-      groups,
-      groups_size,
-      &groups_buffer_holder);
+  const LONG groups_filling_result_code =
+      FillOutputBufferArguments(dumped_groups.begin(), dumped_groups.end(),
+                                groups, groups_size, &groups_buffer_holder);
   if (groups_filling_result_code != SCARD_S_SUCCESS)
     return groups_filling_result_code;
   groups_buffer_holder.release();

--- a/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.h
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.h
@@ -32,17 +32,21 @@
 #include <winscard.h>
 #include <wintypes.h>
 
-#include <google_smart_card_common/requesting/requester.h>
-#include <google_smart_card_common/requesting/request_result.h>
 #include <google_smart_card_common/requesting/remote_call_adaptor.h>
+#include <google_smart_card_common/requesting/request_result.h>
+#include <google_smart_card_common/requesting/requester.h>
 #include <google_smart_card_pcsc_lite_common/pcsc_lite.h>
 
 namespace google_smart_card {
+
+namespace {
 
 // The name of the requester that should be used for the requests made by the
 // PcscLiteOverRequester class (see also the
 // google_smart_card_common/requesting/requester.h header).
 constexpr char kPcscLiteRequesterName[] = "pcsc_lite";
+
+}  // namespace
 
 // This class provides an implementation for the PC/SC-Lite client API that
 // forwards all calls through the passed requester to its counterpart library
@@ -62,6 +66,9 @@ class PcscLiteOverRequester final : public PcscLite {
   explicit PcscLiteOverRequester(std::unique_ptr<Requester> requester);
 
   PcscLiteOverRequester(const PcscLiteOverRequester&) = delete;
+  PcscLiteOverRequester& operator=(const PcscLiteOverRequester&) = delete;
+
+  ~PcscLiteOverRequester();
 
   // Detaches the linked requester, which prevents making any further requests
   // through it and prevents waiting for the responses of the already started
@@ -81,76 +88,48 @@ class PcscLiteOverRequester final : public PcscLite {
   void Detach();
 
   // PcscLite:
-  LONG SCardEstablishContext(
-      DWORD scope,
-      LPCVOID reserved_1,
-      LPCVOID reserved_2,
-      LPSCARDCONTEXT s_card_context) override;
+  LONG SCardEstablishContext(DWORD scope, LPCVOID reserved_1,
+                             LPCVOID reserved_2,
+                             LPSCARDCONTEXT s_card_context) override;
   LONG SCardReleaseContext(SCARDCONTEXT s_card_context) override;
-  LONG SCardConnect(
-      SCARDCONTEXT s_card_context,
-      LPCSTR reader_name,
-      DWORD share_mode,
-      DWORD preferred_protocols,
-      LPSCARDHANDLE s_card_handle,
-      LPDWORD active_protocol) override;
-  LONG SCardReconnect(
-      SCARDHANDLE s_card_handle,
-      DWORD share_mode,
-      DWORD preferred_protocols,
-      DWORD initialization_action,
-      LPDWORD active_protocol) override;
+  LONG SCardConnect(SCARDCONTEXT s_card_context, LPCSTR reader_name,
+                    DWORD share_mode, DWORD preferred_protocols,
+                    LPSCARDHANDLE s_card_handle,
+                    LPDWORD active_protocol) override;
+  LONG SCardReconnect(SCARDHANDLE s_card_handle, DWORD share_mode,
+                      DWORD preferred_protocols, DWORD initialization_action,
+                      LPDWORD active_protocol) override;
   LONG SCardDisconnect(SCARDHANDLE s_card_handle, DWORD disposition) override;
   LONG SCardBeginTransaction(SCARDHANDLE s_card_handle) override;
-  LONG SCardEndTransaction(
-      SCARDHANDLE s_card_handle, DWORD disposition_action) override;
-  LONG SCardStatus(
-      SCARDHANDLE s_card_handle,
-      LPSTR reader_name,
-      LPDWORD reader_name_length,
-      LPDWORD state,
-      LPDWORD protocol,
-      LPBYTE atr,
-      LPDWORD atr_length) override;
-  LONG SCardGetStatusChange(
-      SCARDCONTEXT s_card_context,
-      DWORD timeout,
-      SCARD_READERSTATE* reader_states,
-      DWORD reader_states_size) override;
-  LONG SCardControl(
-      SCARDHANDLE s_card_handle,
-      DWORD control_code,
-      LPCVOID send_buffer,
-      DWORD send_buffer_length,
-      LPVOID receive_buffer,
-      DWORD receive_buffer_length,
-      LPDWORD bytes_returned) override;
-  LONG SCardGetAttrib(
-      SCARDHANDLE s_card_handle,
-      DWORD attribute_id,
-      LPBYTE attribute_buffer,
-      LPDWORD attribute_buffer_length) override;
-  LONG SCardSetAttrib(
-      SCARDHANDLE s_card_handle,
-      DWORD attribute_id,
-      LPCBYTE attribute_buffer,
-      DWORD attribute_buffer_length) override;
-  LONG SCardTransmit(
-      SCARDHANDLE s_card_handle,
-      const SCARD_IO_REQUEST* send_protocol_information,
-      LPCBYTE send_buffer,
-      DWORD send_buffer_length,
-      SCARD_IO_REQUEST* receive_protocol_information,
-      LPBYTE receive_buffer,
-      LPDWORD receive_buffer_length) override;
-  LONG SCardListReaders(
-      SCARDCONTEXT s_card_context,
-      LPCSTR groups,
-      LPSTR readers,
-      LPDWORD readers_size) override;
+  LONG SCardEndTransaction(SCARDHANDLE s_card_handle,
+                           DWORD disposition_action) override;
+  LONG SCardStatus(SCARDHANDLE s_card_handle, LPSTR reader_name,
+                   LPDWORD reader_name_length, LPDWORD state, LPDWORD protocol,
+                   LPBYTE atr, LPDWORD atr_length) override;
+  LONG SCardGetStatusChange(SCARDCONTEXT s_card_context, DWORD timeout,
+                            SCARD_READERSTATE* reader_states,
+                            DWORD reader_states_size) override;
+  LONG SCardControl(SCARDHANDLE s_card_handle, DWORD control_code,
+                    LPCVOID send_buffer, DWORD send_buffer_length,
+                    LPVOID receive_buffer, DWORD receive_buffer_length,
+                    LPDWORD bytes_returned) override;
+  LONG SCardGetAttrib(SCARDHANDLE s_card_handle, DWORD attribute_id,
+                      LPBYTE attribute_buffer,
+                      LPDWORD attribute_buffer_length) override;
+  LONG SCardSetAttrib(SCARDHANDLE s_card_handle, DWORD attribute_id,
+                      LPCBYTE attribute_buffer,
+                      DWORD attribute_buffer_length) override;
+  LONG SCardTransmit(SCARDHANDLE s_card_handle,
+                     const SCARD_IO_REQUEST* send_protocol_information,
+                     LPCBYTE send_buffer, DWORD send_buffer_length,
+                     SCARD_IO_REQUEST* receive_protocol_information,
+                     LPBYTE receive_buffer,
+                     LPDWORD receive_buffer_length) override;
+  LONG SCardListReaders(SCARDCONTEXT s_card_context, LPCSTR groups,
+                        LPSTR readers, LPDWORD readers_size) override;
   LONG SCardFreeMemory(SCARDCONTEXT s_card_context, LPCVOID memory) override;
-  LONG SCardListReaderGroups(
-      SCARDCONTEXT s_card_context, LPSTR groups, LPDWORD groups_size) override;
+  LONG SCardListReaderGroups(SCARDCONTEXT s_card_context, LPSTR groups,
+                             LPDWORD groups_size) override;
   LONG SCardCancel(SCARDCONTEXT s_card_context) override;
   LONG SCardIsValidContext(SCARDCONTEXT s_card_context) override;
 

--- a/third_party/pcsc-lite/naclport/server/src/auth_nacl.cc
+++ b/third_party/pcsc-lite/naclport/server/src/auth_nacl.cc
@@ -30,8 +30,8 @@ extern "C" {
 #include "auth.h"
 }
 
-unsigned IsClientAuthorized(
-    int socket, const char* action, const char* reader) {
+unsigned IsClientAuthorized(int socket, const char* action,
+                            const char* reader) {
   // This naclport of pcsc-lite library doesn't have a polkit authorization of
   // clients, so just allowing arbitrary client connections here.
   return 1;

--- a/third_party/pcsc-lite/naclport/server/src/dyn_nacl.cc
+++ b/third_party/pcsc-lite/naclport/server/src/dyn_nacl.cc
@@ -51,43 +51,35 @@ extern "C" {
 
 #include <google_smart_card_common/logging/logging.h>
 
+namespace {
+
 // This is a fake value that we supply instead of the dynamically loaded library
 // handles which are used by pcsc-lite normally.
-const char kFakeLHandle[] = "fake_pcsclite_lhandle";
-
-namespace {
+constexpr char kFakeLHandle[] = "fake_pcsclite_lhandle";
 
 struct FunctionNameAndAddress {
   const char* name;
   void* address;
 };
 
-}  // namespace
-
 // Fake export table of the driver functions (the function pointers here point
 // directly to the statically linked driver functions).
 const FunctionNameAndAddress kDriverIfdhandlerFunctions[] = {
-  {"IFDHCreateChannelByName",
-   reinterpret_cast<void*>(&IFDHCreateChannelByName)},
-  {"IFDHCreateChannel",
-   reinterpret_cast<void*>(&IFDHCreateChannel)},
-  {"IFDHCloseChannel",
-   reinterpret_cast<void*>(&IFDHCloseChannel)},
-  {"IFDHGetCapabilities",
-   reinterpret_cast<void*>(&IFDHGetCapabilities)},
-  {"IFDHSetCapabilities",
-   reinterpret_cast<void*>(&IFDHSetCapabilities)},
-  {"IFDHSetProtocolParameters",
-   reinterpret_cast<void*>(&IFDHSetProtocolParameters)},
-  {"IFDHPowerICC",
-   reinterpret_cast<void*>(&IFDHPowerICC)},
-  {"IFDHTransmitToICC",
-   reinterpret_cast<void*>(&IFDHTransmitToICC)},
-  {"IFDHControl",
-   reinterpret_cast<void*>(&IFDHControl)},
-  {"IFDHICCPresence",
-   reinterpret_cast<void*>(&IFDHICCPresence)},
+    {"IFDHCreateChannelByName",
+     reinterpret_cast<void*>(&IFDHCreateChannelByName)},
+    {"IFDHCreateChannel", reinterpret_cast<void*>(&IFDHCreateChannel)},
+    {"IFDHCloseChannel", reinterpret_cast<void*>(&IFDHCloseChannel)},
+    {"IFDHGetCapabilities", reinterpret_cast<void*>(&IFDHGetCapabilities)},
+    {"IFDHSetCapabilities", reinterpret_cast<void*>(&IFDHSetCapabilities)},
+    {"IFDHSetProtocolParameters",
+     reinterpret_cast<void*>(&IFDHSetProtocolParameters)},
+    {"IFDHPowerICC", reinterpret_cast<void*>(&IFDHPowerICC)},
+    {"IFDHTransmitToICC", reinterpret_cast<void*>(&IFDHTransmitToICC)},
+    {"IFDHControl", reinterpret_cast<void*>(&IFDHControl)},
+    {"IFDHICCPresence", reinterpret_cast<void*>(&IFDHICCPresence)},
 };
+
+}  // namespace
 
 INTERNAL LONG DYN_LoadLibrary(void** pvLHandle, char* pcLibrary) {
   *pvLHandle = static_cast<void*>(const_cast<char*>(kFakeLHandle));
@@ -100,16 +92,13 @@ INTERNAL LONG DYN_CloseLibrary(void** pvLHandle) {
   return SCARD_S_SUCCESS;
 }
 
-INTERNAL LONG DYN_GetAddress(
-    void* pvLHandle,
-    void** pvFHandle,
-    const char* pcFunction,
-    int /*mayfail*/) {
+INTERNAL LONG DYN_GetAddress(void* pvLHandle, void** pvFHandle,
+                             const char* pcFunction, int /*mayfail*/) {
   GOOGLE_SMART_CARD_CHECK(pvLHandle == kFakeLHandle);
 
   std::string function = pcFunction;
-  for (const FunctionNameAndAddress& driver_ifdhandler_function
-       : kDriverIfdhandlerFunctions) {
+  for (const FunctionNameAndAddress& driver_ifdhandler_function :
+       kDriverIfdhandlerFunctions) {
     if (function == driver_ifdhandler_function.name) {
       *pvFHandle = driver_ifdhandler_function.address;
       return SCARD_S_SUCCESS;

--- a/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.h
+++ b/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.h
@@ -47,6 +47,7 @@ class PcscLiteServerGlobal final {
  public:
   explicit PcscLiteServerGlobal(pp::Instance* pp_instance);
   PcscLiteServerGlobal(const PcscLiteServerGlobal&) = delete;
+  PcscLiteServerGlobal& operator=(const PcscLiteServerGlobal&) = delete;
   ~PcscLiteServerGlobal();
 
   // Detaches from the Pepper instance which prevents making any further
@@ -83,8 +84,8 @@ class PcscLiteServerGlobal final {
   void PostReaderRemoveMessage(const char* reader_name, int port) const;
 
  private:
-  void PostMessage(
-      const char* type, const pp::VarDictionary& message_data) const;
+  void PostMessage(const char* type,
+                   const pp::VarDictionary& message_data) const;
 
   mutable std::mutex mutex_;
   pp::Instance* pp_instance_;

--- a/third_party/pcsc-lite/naclport/server/src/readerfactory_nacl.cc
+++ b/third_party/pcsc-lite/naclport/server/src/readerfactory_nacl.cc
@@ -27,11 +27,14 @@
 // PC/SC-Lite internal implementation.
 
 #include <google_smart_card_pcsc_lite_server/global.h>
+
 #include <wintypes.h>
 
 extern "C" {
 #include "readerfactory.h"
+}
 
+extern "C" {
 LONG RFAddReaderOriginal(const char* reader_name, int port, const char* library,
                          const char* device);
 LONG RFRemoveReaderOriginal(const char* reader_name, int port);

--- a/third_party/pcsc-lite/naclport/server/src/readerfactory_nacl.cc
+++ b/third_party/pcsc-lite/naclport/server/src/readerfactory_nacl.cc
@@ -27,19 +27,18 @@
 // PC/SC-Lite internal implementation.
 
 #include <google_smart_card_pcsc_lite_server/global.h>
-
 #include <wintypes.h>
 
 extern "C" {
 #include "readerfactory.h"
 
-LONG RFAddReaderOriginal(
-    const char* reader_name, int port, const char* library, const char* device);
+LONG RFAddReaderOriginal(const char* reader_name, int port, const char* library,
+                         const char* device);
 LONG RFRemoveReaderOriginal(const char* reader_name, int port);
 }
 
 LONG RFAddReader(const char* reader_name, int port, const char* library,
-    const char* device) {
+                 const char* device) {
   google_smart_card::PcscLiteServerGlobal::GetInstance()
       ->PostReaderInitAddMessage(reader_name, port, device);
 

--- a/third_party/pcsc-lite/naclport/server/src/server_sockets_manager.cc
+++ b/third_party/pcsc-lite/naclport/server/src/server_sockets_manager.cc
@@ -55,14 +55,16 @@ void PcscLiteServerSocketsManager::Push(int server_socket_file_descriptor) {
 
 int PcscLiteServerSocketsManager::WaitAndPop() {
   std::unique_lock<std::mutex> lock(mutex_);
-  condition_.wait(
-      lock,
-      [this]() {
-        return !server_socket_file_descriptors_queue_.empty();
-      });
+  condition_.wait(lock, [this]() {
+    return !server_socket_file_descriptors_queue_.empty();
+  });
   int result = server_socket_file_descriptors_queue_.front();
   server_socket_file_descriptors_queue_.pop();
   return result;
 }
+
+PcscLiteServerSocketsManager::PcscLiteServerSocketsManager() = default;
+
+PcscLiteServerSocketsManager::~PcscLiteServerSocketsManager() = default;
 
 }  // namespace google_smart_card

--- a/third_party/pcsc-lite/naclport/server/src/server_sockets_manager.h
+++ b/third_party/pcsc-lite/naclport/server/src/server_sockets_manager.h
@@ -49,8 +49,11 @@ class PcscLiteServerSocketsManager final {
   int WaitAndPop();
 
  private:
-  PcscLiteServerSocketsManager() = default;
+  PcscLiteServerSocketsManager();
   PcscLiteServerSocketsManager(const PcscLiteServerSocketsManager&) = delete;
+  PcscLiteServerSocketsManager& operator=(const PcscLiteServerSocketsManager&) =
+      delete;
+  ~PcscLiteServerSocketsManager();
 
   std::mutex mutex_;
   std::condition_variable condition_;

--- a/third_party/pcsc-lite/naclport/server/src/socketpair_emulation.cc
+++ b/third_party/pcsc-lite/naclport/server/src/socketpair_emulation.cc
@@ -33,11 +33,11 @@
 
 #include <google_smart_card_common/logging/logging.h>
 
-const char kLoggingPrefix[] = "[emulated domain socket] ";
-
 namespace google_smart_card {
 
 namespace {
+
+constexpr char kLoggingPrefix[] = "[emulated domain socket] ";
 
 SocketpairEmulationManager* g_socketpair_emulation_manager = nullptr;
 
@@ -46,52 +46,50 @@ SocketpairEmulationManager* g_socketpair_emulation_manager = nullptr;
 class SocketpairEmulationManager::Socket final {
  public:
   explicit Socket(int file_descriptor)
-      : file_descriptor_(file_descriptor),
-        is_closed_(false) {
-    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "A socket " <<
-        file_descriptor << " is created";
+      : file_descriptor_(file_descriptor) {
+    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "A socket "
+                                << file_descriptor << " is created";
   }
 
   Socket(const Socket&) = delete;
+  Socket& operator=(const Socket&) = delete;
 
   ~Socket() {
-    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "The socket " <<
-        file_descriptor() << " is destroyed";
+    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "The socket "
+                                << file_descriptor() << " is destroyed";
     GOOGLE_SMART_CARD_CHECK(is_closed_);
   }
 
-  int file_descriptor() const {
-    return file_descriptor_;
-  }
+  int file_descriptor() const { return file_descriptor_; }
 
   void SetOtherEnd(std::weak_ptr<Socket> other_end) {
     GOOGLE_SMART_CARD_CHECK(!other_end.expired());
     GOOGLE_SMART_CARD_CHECK(other_end_.expired());
     other_end_ = other_end;
-    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "The socket " <<
-        file_descriptor() << " is connected to the emulated domain socket " <<
-        other_end_.lock()->file_descriptor();
+    GOOGLE_SMART_CARD_LOG_DEBUG
+        << kLoggingPrefix << "The socket " << file_descriptor()
+        << " is connected to the emulated domain socket "
+        << other_end_.lock()->file_descriptor();
   }
 
   void Close() {
     if (SetIsClosed()) {
       const std::shared_ptr<Socket> locked_other_end = other_end_.lock();
-      if (locked_other_end)
-        locked_other_end->SetIsClosed();
+      if (locked_other_end) locked_other_end->SetIsClosed();
     }
   }
 
   void Write(const uint8_t* data, int64_t size, bool* is_failure) {
     GOOGLE_SMART_CARD_CHECK(size >= 0);
-    if (!size)
-      return;
+    if (!size) return;
     GOOGLE_SMART_CARD_CHECK(data);
     const std::shared_ptr<Socket> locked_other_end = other_end_.lock();
     if (!locked_other_end) {
       *is_failure = true;
-      GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Writing to the " <<
-          "socket " << file_descriptor() << " failed: the other end has " <<
-          "already been closed and destroyed";
+      GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Writing to the "
+                                  << "socket " << file_descriptor()
+                                  << " failed: the other end has "
+                                  << "already been closed and destroyed";
       return;
     }
     locked_other_end->PushToReadBuffer(data, size, is_failure);
@@ -99,14 +97,14 @@ class SocketpairEmulationManager::Socket final {
 
   void SelectForReading(bool* is_failure) {
     std::unique_lock<std::mutex> lock(mutex_);
-    condition_.wait(lock, [this]() {
-      return is_closed_ || !read_buffer_.empty();
-    });
+    condition_.wait(lock,
+                    [this]() { return is_closed_ || !read_buffer_.empty(); });
     if (is_closed_) {
       *is_failure = true;
-      GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Selecting from the " <<
-          "socket " << file_descriptor() << " failed: the socket has " <<
-          "already been closed";
+      GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Selecting from the "
+                                  << "socket " << file_descriptor()
+                                  << " failed: the socket has "
+                                  << "already been closed";
     }
   }
 
@@ -114,14 +112,14 @@ class SocketpairEmulationManager::Socket final {
     GOOGLE_SMART_CARD_CHECK(timeout_milliseconds >= 0);
     std::unique_lock<std::mutex> lock(mutex_);
     condition_.wait_for(
-        lock, std::chrono::milliseconds(timeout_milliseconds), [this]() {
-          return is_closed_ || !read_buffer_.empty();
-        });
+        lock, std::chrono::milliseconds(timeout_milliseconds),
+        [this]() { return is_closed_ || !read_buffer_.empty(); });
     if (is_closed_) {
       *is_failure = true;
-      GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Selecting from the " <<
-          "socket " << file_descriptor() << " failed: the socket has " <<
-          "already been closed";
+      GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Selecting from the "
+                                  << "socket " << file_descriptor()
+                                  << " failed: the socket has "
+                                  << "already been closed";
       return false;
     }
     return !read_buffer_.empty();
@@ -133,30 +131,29 @@ class SocketpairEmulationManager::Socket final {
     std::unique_lock<std::mutex> lock(mutex_);
     if (is_closed_) {
       *is_failure = true;
-      GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Reading from the " <<
-          "socket " << file_descriptor() << " failed: the socket has " <<
-          "already been closed";
+      GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Reading from the "
+                                  << "socket " << file_descriptor()
+                                  << " failed: the socket has "
+                                  << "already been closed";
       return false;
     }
-    if (read_buffer_.empty())
-      return false;
-    *in_out_size = std::min(
-        *in_out_size, static_cast<int64_t>(read_buffer_.size()));
-    std::copy(
-        read_buffer_.begin(), read_buffer_.begin() + *in_out_size, buffer);
-    read_buffer_.erase(
-        read_buffer_.begin(), read_buffer_.begin() + *in_out_size);
+    if (read_buffer_.empty()) return false;
+    *in_out_size =
+        std::min(*in_out_size, static_cast<int64_t>(read_buffer_.size()));
+    std::copy(read_buffer_.begin(), read_buffer_.begin() + *in_out_size,
+              buffer);
+    read_buffer_.erase(read_buffer_.begin(),
+                       read_buffer_.begin() + *in_out_size);
     return true;
   }
 
  private:
   bool SetIsClosed() {
     const std::unique_lock<std::mutex> lock(mutex_);
-    if (is_closed_)
-      return false;
+    if (is_closed_) return false;
     is_closed_ = true;
-    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "The socket " <<
-        file_descriptor() << " is closed";
+    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "The socket "
+                                << file_descriptor() << " is closed";
     condition_.notify_all();
     return true;
   }
@@ -165,9 +162,10 @@ class SocketpairEmulationManager::Socket final {
     const std::unique_lock<std::mutex> lock(mutex_);
     if (is_closed_) {
       *is_failure = true;
-      GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Failed to push data " <<
-          "into the socket " << file_descriptor() << ": the socket is " <<
-          "already closed";
+      GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Failed to push data "
+                                  << "into the socket " << file_descriptor()
+                                  << ": the socket is "
+                                  << "already closed";
       return;
     }
     read_buffer_.insert(read_buffer_.end(), data, data + size);
@@ -177,7 +175,7 @@ class SocketpairEmulationManager::Socket final {
   const int file_descriptor_;
   mutable std::mutex mutex_;
   std::condition_variable condition_;
-  bool is_closed_;
+  bool is_closed_ = false;
   std::weak_ptr<Socket> other_end_;
   std::deque<uint8_t> read_buffer_;
 };
@@ -194,8 +192,8 @@ SocketpairEmulationManager* SocketpairEmulationManager::GetInstance() {
   return g_socketpair_emulation_manager;
 }
 
-void SocketpairEmulationManager::Create(
-    int* file_descriptor_1, int* file_descriptor_2) {
+void SocketpairEmulationManager::Create(int* file_descriptor_1,
+                                        int* file_descriptor_2) {
   GOOGLE_SMART_CARD_CHECK(file_descriptor_1);
   GOOGLE_SMART_CARD_CHECK(file_descriptor_2);
   *file_descriptor_1 = GenerateNewFileDescriptor();
@@ -213,78 +211,82 @@ void SocketpairEmulationManager::Close(int file_descriptor, bool* is_failure) {
   const auto socket_map_iter = socket_map_.find(file_descriptor);
   if (socket_map_iter == socket_map_.end()) {
     *is_failure = true;
-    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Closing of the socket " <<
-        file_descriptor << " failed: the requested socket is " << "already " <<
-        "destroyed or never existed";
+    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Closing of the socket "
+                                << file_descriptor
+                                << " failed: the requested socket is "
+                                << "already "
+                                << "destroyed or never existed";
   }
   socket_map_iter->second->Close();
   socket_map_.erase(socket_map_iter);
 }
 
-void SocketpairEmulationManager::Write(
-    int file_descriptor, const uint8_t* data, int64_t size, bool* is_failure) {
-  const std::shared_ptr<Socket> socket = FindSocketByFileDescriptor(
-      file_descriptor);
+void SocketpairEmulationManager::Write(int file_descriptor, const uint8_t* data,
+                                       int64_t size, bool* is_failure) {
+  const std::shared_ptr<Socket> socket =
+      FindSocketByFileDescriptor(file_descriptor);
   if (!socket) {
     *is_failure = true;
-    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Writing to the socket " <<
-        file_descriptor << " failed: the requested socket is already " <<
-        "destroyed or never existed";
+    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Writing to the socket "
+                                << file_descriptor
+                                << " failed: the requested socket is already "
+                                << "destroyed or never existed";
     return;
   }
   socket->Write(data, size, is_failure);
 }
 
-void SocketpairEmulationManager::SelectForReading(
-    int file_descriptor, bool* is_failure) {
-  const std::shared_ptr<Socket> socket = FindSocketByFileDescriptor(
-      file_descriptor);
+void SocketpairEmulationManager::SelectForReading(int file_descriptor,
+                                                  bool* is_failure) {
+  const std::shared_ptr<Socket> socket =
+      FindSocketByFileDescriptor(file_descriptor);
   if (!socket) {
     *is_failure = true;
-    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Selecting from the " <<
-        "socket " << file_descriptor << " failed: the requested socket is " <<
-        "already destroyed or never existed";
+    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Selecting from the "
+                                << "socket " << file_descriptor
+                                << " failed: the requested socket is "
+                                << "already destroyed or never existed";
     return;
   }
   socket->SelectForReading(is_failure);
 }
 
-bool SocketpairEmulationManager::SelectForReading(
-    int file_descriptor, int64_t timeout_milliseconds, bool* is_failure) {
-  const std::shared_ptr<Socket> socket = FindSocketByFileDescriptor(
-      file_descriptor);
+bool SocketpairEmulationManager::SelectForReading(int file_descriptor,
+                                                  int64_t timeout_milliseconds,
+                                                  bool* is_failure) {
+  const std::shared_ptr<Socket> socket =
+      FindSocketByFileDescriptor(file_descriptor);
   if (!socket) {
     *is_failure = true;
-    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Selecting from the " <<
-        "socket " << file_descriptor << " failed: the requested socket is " <<
-        "already destroyed or never existed";
+    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Selecting from the "
+                                << "socket " << file_descriptor
+                                << " failed: the requested socket is "
+                                << "already destroyed or never existed";
     return false;
   }
   return socket->SelectForReading(timeout_milliseconds, is_failure);
 }
 
-bool SocketpairEmulationManager::Read(
-    int file_descriptor,
-    uint8_t* buffer,
-    int64_t* in_out_size,
-    bool* is_failure) {
-  const std::shared_ptr<Socket> socket = FindSocketByFileDescriptor(
-      file_descriptor);
+bool SocketpairEmulationManager::Read(int file_descriptor, uint8_t* buffer,
+                                      int64_t* in_out_size, bool* is_failure) {
+  const std::shared_ptr<Socket> socket =
+      FindSocketByFileDescriptor(file_descriptor);
   if (!socket) {
     *is_failure = true;
-    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Reading from the " <<
-        "socket " << file_descriptor << " failed: the requested socket is " <<
-        "already destroyed or never existed";
+    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Reading from the "
+                                << "socket " << file_descriptor
+                                << " failed: the requested socket is "
+                                << "already destroyed or never existed";
     return false;
   }
-  if (!socket->Read(buffer, in_out_size, is_failure))
-    return false;
+  if (!socket->Read(buffer, in_out_size, is_failure)) return false;
   GOOGLE_SMART_CARD_CHECK(*in_out_size > 0);
   return true;
 }
 
-SocketpairEmulationManager::SocketpairEmulationManager()
-    : next_free_file_descriptor_(1) {}
+SocketpairEmulationManager::SocketpairEmulationManager() = default;
+
+SocketpairEmulationManager::~SocketpairEmulationManager() = default;
 
 int SocketpairEmulationManager::GenerateNewFileDescriptor() {
   const std::unique_lock<std::mutex> lock(mutex_);
@@ -298,8 +300,8 @@ void SocketpairEmulationManager::AddSocket(std::shared_ptr<Socket> socket) {
   GOOGLE_SMART_CARD_CHECK(socket);
   GOOGLE_SMART_CARD_CHECK(socket.unique());
   const std::unique_lock<std::mutex> lock(mutex_);
-  GOOGLE_SMART_CARD_CHECK(socket_map_.emplace(
-      socket->file_descriptor(), std::move(socket)).second);
+  GOOGLE_SMART_CARD_CHECK(
+      socket_map_.emplace(socket->file_descriptor(), std::move(socket)).second);
 }
 
 std::shared_ptr<SocketpairEmulationManager::Socket>
@@ -307,44 +309,40 @@ SocketpairEmulationManager::FindSocketByFileDescriptor(
     int file_descriptor) const {
   const std::unique_lock<std::mutex> lock(mutex_);
   const auto socket_map_iter = socket_map_.find(file_descriptor);
-  if (socket_map_iter == socket_map_.end())
-    return {};
+  if (socket_map_iter == socket_map_.end()) return {};
   return socket_map_iter->second;
 }
 
 namespace socketpair_emulation {
 
 void Create(int* file_descriptor_1, int* file_descriptor_2) {
-  SocketpairEmulationManager::GetInstance()->Create(
-      file_descriptor_1, file_descriptor_2);
+  SocketpairEmulationManager::GetInstance()->Create(file_descriptor_1,
+                                                    file_descriptor_2);
 }
 
 void Close(int file_descriptor, bool* is_failure) {
   SocketpairEmulationManager::GetInstance()->Close(file_descriptor, is_failure);
 }
 
-void Write(
-    int file_descriptor, const uint8_t* data, int64_t size, bool* is_failure) {
-  SocketpairEmulationManager::GetInstance()->Write(
-      file_descriptor, data, size, is_failure);
+void Write(int file_descriptor, const uint8_t* data, int64_t size,
+           bool* is_failure) {
+  SocketpairEmulationManager::GetInstance()->Write(file_descriptor, data, size,
+                                                   is_failure);
 }
 
 void SelectForReading(int file_descriptor, bool* is_failure) {
-  SocketpairEmulationManager::GetInstance()->SelectForReading(
-      file_descriptor, is_failure);
+  SocketpairEmulationManager::GetInstance()->SelectForReading(file_descriptor,
+                                                              is_failure);
 }
 
-bool SelectForReading(
-    int file_descriptor, int64_t timeout_milliseconds, bool* is_failure) {
+bool SelectForReading(int file_descriptor, int64_t timeout_milliseconds,
+                      bool* is_failure) {
   return SocketpairEmulationManager::GetInstance()->SelectForReading(
       file_descriptor, timeout_milliseconds, is_failure);
 }
 
-bool Read(
-    int file_descriptor,
-    uint8_t* buffer,
-    int64_t* in_out_size,
-    bool* is_failure) {
+bool Read(int file_descriptor, uint8_t* buffer, int64_t* in_out_size,
+          bool* is_failure) {
   return SocketpairEmulationManager::GetInstance()->Read(
       file_descriptor, buffer, in_out_size, is_failure);
 }

--- a/third_party/pcsc-lite/naclport/server/src/socketpair_emulation.h
+++ b/third_party/pcsc-lite/naclport/server/src/socketpair_emulation.h
@@ -83,8 +83,8 @@ class SocketpairEmulationManager final {
   //
   // If the specified file descriptor is unknown (or already closed), the error
   // is reported through the is_failure argument.
-  void Write(
-      int file_descriptor, const uint8_t* data, int64_t size, bool* is_failure);
+  void Write(int file_descriptor, const uint8_t* data, int64_t size,
+             bool* is_failure);
 
   // Blocks until any data becomes available at the specified end of the socket
   // pair.
@@ -100,8 +100,8 @@ class SocketpairEmulationManager final {
   //
   // If the specified file descriptor is unknown (or already closed), the error
   // is reported through the is_failure argument.
-  bool SelectForReading(
-      int file_descriptor, int64_t timeout_milliseconds, bool* is_failure);
+  bool SelectForReading(int file_descriptor, int64_t timeout_milliseconds,
+                        bool* is_failure);
 
   // Reads specified number of bytes from the specified end of the socket pair.
   //
@@ -113,17 +113,17 @@ class SocketpairEmulationManager final {
   //
   // If the specified file descriptor is unknown (or already closed), the error
   // is reported through the is_failure argument.
-  bool Read(
-      int file_descriptor,
-      uint8_t* buffer,
-      int64_t* in_out_size,
-      bool* is_failure);
+  bool Read(int file_descriptor, uint8_t* buffer, int64_t* in_out_size,
+            bool* is_failure);
 
  private:
   class Socket;
 
   SocketpairEmulationManager();
   SocketpairEmulationManager(const SocketpairEmulationManager&) = delete;
+  SocketpairEmulationManager& operator=(const SocketpairEmulationManager&) =
+      delete;
+  ~SocketpairEmulationManager();
 
   int GenerateNewFileDescriptor();
 
@@ -132,7 +132,7 @@ class SocketpairEmulationManager final {
   std::shared_ptr<Socket> FindSocketByFileDescriptor(int file_descriptor) const;
 
   mutable std::mutex mutex_;
-  int next_free_file_descriptor_;
+  int next_free_file_descriptor_ = 1;
   std::unordered_map<int, const std::shared_ptr<Socket>> socket_map_;
 };
 
@@ -151,18 +151,15 @@ void Create(int* file_descriptor_1, int* file_descriptor_2);
 
 void Close(int file_descriptor, bool* is_failure);
 
-void Write(
-    int file_descriptor, const uint8_t* data, int64_t size, bool* is_failure);
+void Write(int file_descriptor, const uint8_t* data, int64_t size,
+           bool* is_failure);
 
 void SelectForReading(int file_descriptor, bool* is_failure);
-bool SelectForReading(
-    int file_descriptor, int64_t timeout_milliseconds, bool* is_failure);
+bool SelectForReading(int file_descriptor, int64_t timeout_milliseconds,
+                      bool* is_failure);
 
-bool Read(
-    int file_descriptor,
-    uint8_t* buffer,
-    int64_t* in_out_size,
-    bool* is_failure);
+bool Read(int file_descriptor, uint8_t* buffer, int64_t* in_out_size,
+          bool* is_failure);
 
 }  // namespace socketpair_emulation
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_handles_registry.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_handles_registry.cc
@@ -45,23 +45,25 @@ bool PcscLiteClientHandlesRegistry::ContainsContext(
 void PcscLiteClientHandlesRegistry::AddContext(SCARDCONTEXT s_card_context) {
   const std::unique_lock<std::mutex> lock(mutex_);
 
-  GOOGLE_SMART_CARD_CHECK(context_to_handles_map_.emplace(
-      s_card_context, std::unordered_set<SCARDHANDLE>()).second);
+  GOOGLE_SMART_CARD_CHECK(
+      context_to_handles_map_
+          .emplace(s_card_context, std::unordered_set<SCARDHANDLE>())
+          .second);
 }
 
 void PcscLiteClientHandlesRegistry::RemoveContext(SCARDCONTEXT s_card_context) {
   const std::unique_lock<std::mutex> lock(mutex_);
 
-  const auto context_to_handles_iter = context_to_handles_map_.find(
-      s_card_context);
-  GOOGLE_SMART_CARD_CHECK(
-      context_to_handles_iter != context_to_handles_map_.end());
+  const auto context_to_handles_iter =
+      context_to_handles_map_.find(s_card_context);
+  GOOGLE_SMART_CARD_CHECK(context_to_handles_iter !=
+                          context_to_handles_map_.end());
 
   for (SCARDHANDLE s_card_handle : context_to_handles_iter->second) {
-    const auto handle_to_context_iter = handle_to_context_map_.find(
-        s_card_handle);
-    GOOGLE_SMART_CARD_CHECK(
-        handle_to_context_iter != handle_to_context_map_.end());
+    const auto handle_to_context_iter =
+        handle_to_context_map_.find(s_card_handle);
+    GOOGLE_SMART_CARD_CHECK(handle_to_context_iter !=
+                            handle_to_context_map_.end());
     GOOGLE_SMART_CARD_CHECK(handle_to_context_iter->second == s_card_context);
     handle_to_context_map_.erase(handle_to_context_iter);
   }
@@ -101,37 +103,37 @@ bool PcscLiteClientHandlesRegistry::ContainsHandle(
   return handle_to_context_map_.count(s_card_handle);
 }
 
-void PcscLiteClientHandlesRegistry::AddHandle(
-    SCARDCONTEXT s_card_context, SCARDHANDLE s_card_handle) {
+void PcscLiteClientHandlesRegistry::AddHandle(SCARDCONTEXT s_card_context,
+                                              SCARDHANDLE s_card_handle) {
   const std::unique_lock<std::mutex> lock(mutex_);
 
   GOOGLE_SMART_CARD_CHECK(!handle_to_context_map_.count(s_card_handle));
 
-  const auto context_to_handles_iter = context_to_handles_map_.find(
-      s_card_context);
+  const auto context_to_handles_iter =
+      context_to_handles_map_.find(s_card_context);
+  GOOGLE_SMART_CARD_CHECK(context_to_handles_iter !=
+                          context_to_handles_map_.end());
   GOOGLE_SMART_CARD_CHECK(
-      context_to_handles_iter != context_to_handles_map_.end());
-  GOOGLE_SMART_CARD_CHECK(context_to_handles_iter->second.insert(
-      s_card_handle).second);
+      context_to_handles_iter->second.insert(s_card_handle).second);
 
-  GOOGLE_SMART_CARD_CHECK(handle_to_context_map_.emplace(
-      s_card_handle, s_card_context).second);
+  GOOGLE_SMART_CARD_CHECK(
+      handle_to_context_map_.emplace(s_card_handle, s_card_context).second);
 }
 
 void PcscLiteClientHandlesRegistry::RemoveHandle(SCARDHANDLE s_card_handle) {
   const std::unique_lock<std::mutex> lock(mutex_);
 
-  const auto handle_to_context_iter = handle_to_context_map_.find(
-      s_card_handle);
-  GOOGLE_SMART_CARD_CHECK(
-      handle_to_context_iter != handle_to_context_map_.end());
+  const auto handle_to_context_iter =
+      handle_to_context_map_.find(s_card_handle);
+  GOOGLE_SMART_CARD_CHECK(handle_to_context_iter !=
+                          handle_to_context_map_.end());
   const SCARDCONTEXT s_card_context = handle_to_context_iter->second;
   handle_to_context_map_.erase(handle_to_context_iter);
 
-  const auto context_to_handles_iter = context_to_handles_map_.find(
-      s_card_context);
-  GOOGLE_SMART_CARD_CHECK(
-      context_to_handles_iter != context_to_handles_map_.end());
+  const auto context_to_handles_iter =
+      context_to_handles_map_.find(s_card_context);
+  GOOGLE_SMART_CARD_CHECK(context_to_handles_iter !=
+                          context_to_handles_map_.end());
   GOOGLE_SMART_CARD_CHECK(context_to_handles_iter->second.erase(s_card_handle));
 }
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_handles_registry.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_handles_registry.h
@@ -46,6 +46,8 @@ class PcscLiteClientHandlesRegistry final {
  public:
   PcscLiteClientHandlesRegistry();
   PcscLiteClientHandlesRegistry(const PcscLiteClientHandlesRegistry&) = delete;
+  PcscLiteClientHandlesRegistry& operator=(
+      const PcscLiteClientHandlesRegistry&) = delete;
   ~PcscLiteClientHandlesRegistry();
 
   bool ContainsContext(SCARDCONTEXT s_card_context) const;

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h
@@ -34,13 +34,13 @@
 #include <unordered_map>
 #include <vector>
 
-#include <ppapi/cpp/var.h>
-#include <ppapi/cpp/var_array.h>
-
 #include <pcsclite.h>
 #include <reader.h>
 #include <winscard.h>
 #include <wintypes.h>
+
+#include <ppapi/cpp/var.h>
+#include <ppapi/cpp/var_array.h>
 
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/optional.h>
@@ -94,13 +94,15 @@ namespace google_smart_card {
 //
 // FIXME(emaxx): Add assertions that the methods are called on the right
 // threads.
-class PcscLiteClientRequestProcessor final :
-    public std::enable_shared_from_this<PcscLiteClientRequestProcessor> {
+class PcscLiteClientRequestProcessor final
+    : public std::enable_shared_from_this<PcscLiteClientRequestProcessor> {
  public:
-  PcscLiteClientRequestProcessor(
-      int64_t client_handler_id, const optional<std::string>& client_app_id);
+  PcscLiteClientRequestProcessor(int64_t client_handler_id,
+                                 const optional<std::string>& client_app_id);
   PcscLiteClientRequestProcessor(const PcscLiteClientRequestProcessor&) =
       delete;
+  PcscLiteClientRequestProcessor& operator=(
+      const PcscLiteClientRequestProcessor&) = delete;
 
   ~PcscLiteClientRequestProcessor();
 
@@ -120,16 +122,14 @@ class PcscLiteClientRequestProcessor final :
   //
   // This method is safe to be called from any thread, except the main Pepper
   // thread (which could lead to a deadlock).
-  void ProcessRequest(
-      const std::string& function_name,
-      const pp::VarArray& arguments,
-      RequestReceiver::ResultCallback result_callback);
+  void ProcessRequest(const std::string& function_name,
+                      const pp::VarArray& arguments,
+                      RequestReceiver::ResultCallback result_callback);
 
   // Start processing the given PC/SC-Lite request in a background thread.
   static void AsyncProcessRequest(
       std::shared_ptr<PcscLiteClientRequestProcessor> request_processor,
-      const std::string& function_name,
-      const pp::VarArray& arguments,
+      const std::string& function_name, const pp::VarArray& arguments,
       RequestReceiver::ResultCallback result_callback);
 
  private:
@@ -139,62 +139,58 @@ class PcscLiteClientRequestProcessor final :
 
   void BuildHandlerMap();
 
-  template <typename ... Args>
+  template <typename... Args>
   void AddHandlerToHandlerMap(
       const std::string& name,
-      GenericRequestResult(PcscLiteClientRequestProcessor::*handler)(
-          Args ... args));
+      GenericRequestResult (PcscLiteClientRequestProcessor::*handler)(
+          Args... args));
 
-  template <typename ArgsTuple, typename F, size_t ... arg_indexes>
+  template <typename ArgsTuple, typename F, size_t... arg_indexes>
   Handler WrapHandler(F handler, ArgIndexes<arg_indexes...> /*unused*/);
 
-  GenericRequestResult FindHandlerAndCall(
-      const std::string& function_name, const pp::VarArray& arguments);
+  GenericRequestResult FindHandlerAndCall(const std::string& function_name,
+                                          const pp::VarArray& arguments);
 
   void ScheduleHandlesCleanup();
 
   GenericRequestResult PcscLiteVersionNumber();
   GenericRequestResult PcscStringifyError(LONG error);
-  GenericRequestResult SCardEstablishContext(
-      DWORD scope, pp::Var::Null reserved_1, pp::Var::Null reserved_2);
+  GenericRequestResult SCardEstablishContext(DWORD scope,
+                                             pp::Var::Null reserved_1,
+                                             pp::Var::Null reserved_2);
   GenericRequestResult SCardReleaseContext(SCARDCONTEXT s_card_context);
-  GenericRequestResult SCardConnect(
-      SCARDCONTEXT s_card_context,
-      const std::string& reader_name,
-      DWORD share_mode,
-      DWORD preferred_protocols);
-  GenericRequestResult SCardReconnect(
-      SCARDHANDLE s_card_handle,
-      DWORD share_mode,
-      DWORD preferred_protocols,
-      DWORD initialization_action);
-  GenericRequestResult SCardDisconnect(
-      SCARDHANDLE s_card_handle, DWORD disposition_action);
+  GenericRequestResult SCardConnect(SCARDCONTEXT s_card_context,
+                                    const std::string& reader_name,
+                                    DWORD share_mode,
+                                    DWORD preferred_protocols);
+  GenericRequestResult SCardReconnect(SCARDHANDLE s_card_handle,
+                                      DWORD share_mode,
+                                      DWORD preferred_protocols,
+                                      DWORD initialization_action);
+  GenericRequestResult SCardDisconnect(SCARDHANDLE s_card_handle,
+                                       DWORD disposition_action);
   GenericRequestResult SCardBeginTransaction(SCARDHANDLE s_card_handle);
-  GenericRequestResult SCardEndTransaction(
-      SCARDHANDLE s_card_handle, DWORD disposition_action);
+  GenericRequestResult SCardEndTransaction(SCARDHANDLE s_card_handle,
+                                           DWORD disposition_action);
   GenericRequestResult SCardStatus(SCARDHANDLE s_card_handle);
   GenericRequestResult SCardGetStatusChange(
-      SCARDCONTEXT s_card_context,
-      DWORD timeout,
+      SCARDCONTEXT s_card_context, DWORD timeout,
       const std::vector<InboundSCardReaderState>& reader_states);
-  GenericRequestResult SCardControl(
-      SCARDHANDLE s_card_handle,
-      DWORD control_code,
-      const std::vector<uint8_t>& data_to_send);
-  GenericRequestResult SCardGetAttrib(
-      SCARDHANDLE s_card_handle, DWORD attribute_id);
-  GenericRequestResult SCardSetAttrib(
-      SCARDHANDLE s_card_handle,
-      DWORD attribute_id,
-      const std::vector<uint8_t>& attribute);
+  GenericRequestResult SCardControl(SCARDHANDLE s_card_handle,
+                                    DWORD control_code,
+                                    const std::vector<uint8_t>& data_to_send);
+  GenericRequestResult SCardGetAttrib(SCARDHANDLE s_card_handle,
+                                      DWORD attribute_id);
+  GenericRequestResult SCardSetAttrib(SCARDHANDLE s_card_handle,
+                                      DWORD attribute_id,
+                                      const std::vector<uint8_t>& attribute);
   GenericRequestResult SCardTransmit(
       SCARDHANDLE s_card_handle,
       const SCardIoRequest& send_protocol_information,
       const std::vector<uint8_t>& data_to_send,
       const optional<SCardIoRequest>& response_protocol_information);
-  GenericRequestResult SCardListReaders(
-      SCARDCONTEXT s_card_context, pp::Var::Null groups);
+  GenericRequestResult SCardListReaders(SCARDCONTEXT s_card_context,
+                                        pp::Var::Null groups);
   GenericRequestResult SCardListReaderGroups(SCARDCONTEXT s_card_context);
   GenericRequestResult SCardCancel(SCARDCONTEXT s_card_context);
   GenericRequestResult SCardIsValidContext(SCARDCONTEXT s_card_context);

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h
@@ -84,10 +84,12 @@ namespace google_smart_card {
 // the same thread.
 class PcscLiteServerClientsManager final {
  public:
-  PcscLiteServerClientsManager(
-      pp::Instance* pp_instance, TypedMessageRouter* typed_message_router);
+  PcscLiteServerClientsManager(pp::Instance* pp_instance,
+                               TypedMessageRouter* typed_message_router);
 
   PcscLiteServerClientsManager(const PcscLiteServerClientsManager&) = delete;
+  PcscLiteServerClientsManager& operator=(const PcscLiteServerClientsManager&) =
+      delete;
 
   ~PcscLiteServerClientsManager();
 
@@ -134,11 +136,9 @@ class PcscLiteServerClientsManager final {
   // a client (and delivered here by the JavaScript side).
   class Handler final : public RequestHandler {
    public:
-    Handler(
-        int64_t handler_id,
-        const optional<std::string>& client_app_id,
-        pp::Instance* pp_instance,
-        TypedMessageRouter* typed_message_router);
+    Handler(int64_t handler_id, const optional<std::string>& client_app_id,
+            pp::Instance* pp_instance,
+            TypedMessageRouter* typed_message_router);
     Handler(const Handler&) = delete;
 
     ~Handler() override;
@@ -158,8 +158,8 @@ class PcscLiteServerClientsManager final {
     std::shared_ptr<JsRequestReceiver> request_receiver_;
   };
 
-  void CreateHandler(
-      int64_t handler_id, const optional<std::string>& client_app_id);
+  void CreateHandler(int64_t handler_id,
+                     const optional<std::string>& client_app_id);
   void DeleteHandler(int64_t client_handler_id);
   void DeleteAllHandlers();
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.cc
@@ -37,9 +37,7 @@ class PcscLiteServerClientsManagementBackend::Impl final {
 
   Impl(const Impl&) = delete;
 
-  ~Impl() {
-    clients_manager_.Detach();
-  }
+  ~Impl() { clients_manager_.Detach(); }
 
  private:
   TypedMessageRouter* typed_message_router_;
@@ -51,6 +49,6 @@ PcscLiteServerClientsManagementBackend::PcscLiteServerClientsManagementBackend(
     : impl_(new Impl(pp_instance, typed_message_router)) {}
 
 PcscLiteServerClientsManagementBackend::
-~PcscLiteServerClientsManagementBackend() {}
+    ~PcscLiteServerClientsManagementBackend() {}
 
 }  // namespace google_smart_card

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.h
@@ -48,6 +48,11 @@ class PcscLiteServerClientsManagementBackend final {
   PcscLiteServerClientsManagementBackend(
       pp::Instance* pp_instance, TypedMessageRouter* typed_message_router);
 
+  PcscLiteServerClientsManagementBackend(
+      const PcscLiteServerClientsManagementBackend&) = delete;
+  PcscLiteServerClientsManagementBackend& operator=(
+      const PcscLiteServerClientsManagementBackend&) = delete;
+
   ~PcscLiteServerClientsManagementBackend();
 
  private:

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/ready_message.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/ready_message.cc
@@ -24,6 +24,7 @@
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <google_smart_card_pcsc_lite_server_clients_management/ready_message.h>
+
 #include <ppapi/cpp/var_dictionary.h>
 
 namespace google_smart_card {

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/ready_message.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/ready_message.cc
@@ -24,19 +24,14 @@
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <google_smart_card_pcsc_lite_server_clients_management/ready_message.h>
-
 #include <ppapi/cpp/var_dictionary.h>
-
-const char kMessageType[] = "pcsc_lite_ready";
 
 namespace google_smart_card {
 
-std::string GetPcscLiteServerReadyMessageType() {
-  return kMessageType;
-}
+constexpr char kMessageType[] = "pcsc_lite_ready";
 
-pp::Var MakePcscLiteServerReadyMessageData() {
-  return pp::VarDictionary();
-}
+std::string GetPcscLiteServerReadyMessageType() { return kMessageType; }
+
+pp::Var MakePcscLiteServerReadyMessageData() { return pp::VarDictionary(); }
 
 }  // namespace google_smart_card


### PR DESCRIPTION
Reformat all C++ code written in this project (i.e., not verbatim
imported from third-party projects) according to clang-format with
"Google" Style Guide.

Additionally manually do a few other style fixes that aren't performed
automatically by clang-format, namely:

* Use "constexpr" instead of "const" whenever possible;
* Put constants into unnamed namespaces;
* Explicitly denote C++ classes as copyable/movable/non-movable;
* Initialize class members in the class definition when possible.