### PR TITLE
Add conversion from NaCl's pp::Var into Value

### DIFF
--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.cc
@@ -35,17 +35,6 @@
 
 namespace google_smart_card {
 
-namespace internal {
-
-const char kUnsupportedPpVarTypeConversionError[] =
-    "Error converting: unsupported type \"%s\"";
-const char kPpVarDictionaryItemConversionError[] =
-    "Error converting dictionary item \"%s\": %s";
-const char kPpVarArrayItemConversionError[] =
-    "Error converting array item #%d: %s";
-
-}  // namespace internal
-
 namespace {
 
 pp::Var CreateIntegerVar(int64_t integer_value) {
@@ -99,7 +88,7 @@ optional<Value> CreateValueFromPpVarArray(const pp::VarArray& var,
     if (!converted_item) {
       if (error_message) {
         *error_message = FormatPrintfTemplate(
-            internal::kPpVarArrayItemConversionError, static_cast<int>(index),
+            "Error converting array item #%d: %s", static_cast<int>(index),
             error_message->c_str());
       }
       return {};
@@ -122,7 +111,7 @@ optional<Value> CreateValueFromPpVarDictionary(const pp::VarDictionary& var,
     if (!converted_item_value) {
       if (error_message) {
         *error_message = FormatPrintfTemplate(
-            internal::kPpVarDictionaryItemConversionError,
+            "Error converting dictionary item \"%s\": %s",
             item_key.AsString().c_str(), error_message->c_str());
       }
       return {};
@@ -172,7 +161,7 @@ optional<Value> ConvertPpVarToValue(const pp::Var& var,
   if (var.is_object() || var.is_resource()) {
     if (error_message) {
       *error_message =
-          FormatPrintfTemplate(internal::kUnsupportedPpVarTypeConversionError,
+          FormatPrintfTemplate("Error converting: unsupported type \"%s\"",
                                var.is_object() ? "object" : "resource");
     }
     return {};

--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h
@@ -27,13 +27,19 @@
 
 namespace google_smart_card {
 
+namespace internal {
+extern const char kUnsupportedPpVarTypeConversionError[];
+extern const char kPpVarDictionaryItemConversionError[];
+extern const char kPpVarArrayItemConversionError[];
+}  // namespace internal
+
 // Converts the given `Value` into a `pp::Var`.
 pp::Var ConvertValueToPpVar(const Value& value);
 
 // Converts the given `pp::Var` into a `Value`.
 //
 // When the conversion isn't possible (e.g., when the passed variable contains a
-// Pepper Resource object), returns a null optional and, if provided, sets
+// `pp::Resource` object), returns a null optional and, if provided, sets
 // `*error_message`.
 optional<Value> ConvertPpVarToValue(const pp::Var& var,
                                     std::string* error_message = nullptr);

--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h
@@ -18,14 +18,25 @@
 #ifndef GOOGLE_SMART_CARD_COMMON_VALUE_NACL_PP_VAR_CONVERSION_H_
 #define GOOGLE_SMART_CARD_COMMON_VALUE_NACL_PP_VAR_CONVERSION_H_
 
+#include <string>
+
 #include <ppapi/cpp/var.h>
 
+#include <google_smart_card_common/optional.h>
 #include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
 
 // Converts the given `Value` into a `pp::Var`.
 pp::Var ConvertValueToPpVar(const Value& value);
+
+// Converts the given `pp::Var` into a `Value`.
+//
+// When the conversion isn't possible (e.g., when the passed variable contains a
+// Pepper Resource object), returns a null optional and, if provided, sets
+// `*error_message`.
+optional<Value> ConvertPpVarToValue(const pp::Var& var,
+                                    std::string* error_message = nullptr);
 
 }  // namespace google_smart_card
 

--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h
@@ -27,12 +27,6 @@
 
 namespace google_smart_card {
 
-namespace internal {
-extern const char kUnsupportedPpVarTypeConversionError[];
-extern const char kPpVarDictionaryItemConversionError[];
-extern const char kPpVarArrayItemConversionError[];
-}  // namespace internal
-
 // Converts the given `Value` into a `pp::Var`.
 pp::Var ConvertValueToPpVar(const Value& value);
 

--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion_unittest.cc
@@ -279,9 +279,7 @@ TEST(ValueNaclPpVarConversion, ResourcePpVar) {
     std::string error_message;
     const optional<Value> value =
         ConvertPpVarToValue(pp::Var(pp::Resource()), &error_message);
-    EXPECT_EQ(error_message,
-              FormatPrintfTemplate(
-                  internal::kUnsupportedPpVarTypeConversionError, "resource"));
+    EXPECT_EQ(error_message, "Error converting: unsupported type \"resource\"");
     EXPECT_FALSE(value);
   }
 }
@@ -375,29 +373,19 @@ TEST(ValueNaclPpVarConversion, PpVarDictionaryWithBadItem) {
     std::string error_message;
     const optional<Value> value =
         ConvertPpVarToValue(inner_var_dict, &error_message);
-    EXPECT_EQ(
-        error_message,
-        FormatPrintfTemplate(
-            internal::kPpVarDictionaryItemConversionError, "someInnerKey",
-            FormatPrintfTemplate(internal::kUnsupportedPpVarTypeConversionError,
-                                 "resource")
-                .c_str()));
+    EXPECT_EQ(error_message,
+              "Error converting dictionary item \"someInnerKey\": Error "
+              "converting: unsupported type \"resource\"");
     EXPECT_FALSE(value);
   }
 
   {
     std::string error_message;
     const optional<Value> value = ConvertPpVarToValue(var_dict, &error_message);
-    EXPECT_EQ(
-        error_message,
-        FormatPrintfTemplate(
-            internal::kPpVarDictionaryItemConversionError, "someKey",
-            FormatPrintfTemplate(
-                internal::kPpVarDictionaryItemConversionError, "someInnerKey",
-                FormatPrintfTemplate(
-                    internal::kUnsupportedPpVarTypeConversionError, "resource")
-                    .c_str())
-                .c_str()));
+    EXPECT_EQ(error_message,
+              "Error converting dictionary item \"someKey\": Error converting "
+              "dictionary item \"someInnerKey\": Error converting: unsupported "
+              "type \"resource\"");
     EXPECT_FALSE(value);
   }
 }
@@ -458,13 +446,9 @@ TEST(ValueNaclPpVarConversion, PpVarArrayWithBadItem) {
     std::string error_message;
     const optional<Value> value =
         ConvertPpVarToValue(inner_var_array, &error_message);
-    EXPECT_EQ(
-        error_message,
-        FormatPrintfTemplate(
-            internal::kPpVarArrayItemConversionError, 0,
-            FormatPrintfTemplate(internal::kUnsupportedPpVarTypeConversionError,
-                                 "resource")
-                .c_str()));
+    EXPECT_EQ(error_message,
+              "Error converting array item #0: Error converting: unsupported "
+              "type \"resource\"");
     EXPECT_FALSE(value);
   }
 
@@ -472,16 +456,9 @@ TEST(ValueNaclPpVarConversion, PpVarArrayWithBadItem) {
     std::string error_message;
     const optional<Value> value =
         ConvertPpVarToValue(var_array, &error_message);
-    EXPECT_EQ(
-        error_message,
-        FormatPrintfTemplate(
-            internal::kPpVarArrayItemConversionError, 1,
-            FormatPrintfTemplate(
-                internal::kPpVarArrayItemConversionError, 0,
-                FormatPrintfTemplate(
-                    internal::kUnsupportedPpVarTypeConversionError, "resource")
-                    .c_str())
-                .c_str()));
+    EXPECT_EQ(error_message,
+              "Error converting array item #1: Error converting array item #0: "
+              "Error converting: unsupported type \"resource\"");
     EXPECT_FALSE(value);
   }
 }


### PR DESCRIPTION
Implement helper function that transforms a Native Client SDK's
pp::Var object into a Value object.

This helper will be used in follow-ups in order to make most of the
//common/cpp library be toolchain-independent and work under both Native
Client and WebAssembly (as tracker by #185), since the Value class is
toolchain-independent.