### PR TITLE
Add Value debug dumping helpers

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -53,6 +53,7 @@ SOURCES := \
 	$(SOURCES_PATH)/requesting/request_receiver.cc \
 	$(SOURCES_PATH)/requesting/request_result.cc \
 	$(SOURCES_PATH)/value.cc \
+	$(SOURCES_PATH)/value_debug_dumping.cc \
 	$(SOURCES_PATH)/value_nacl_pp_var_conversion.cc \
 
 TEST_SUPPORT_SOURCES := \

--- a/common/cpp/build/tests/Makefile
+++ b/common/cpp/build/tests/Makefile
@@ -48,6 +48,7 @@ TEST_SOURCES := \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/pp_var_utils/struct_converter_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/requesting/async_request_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/requesting/async_requests_storage_unittest.cc \
+	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_debug_dumping_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_nacl_pp_var_conversion_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_unittest.cc \
 

--- a/common/cpp/src/google_smart_card_common/value.cc
+++ b/common/cpp/src/google_smart_card_common/value.cc
@@ -22,6 +22,15 @@
 
 namespace google_smart_card {
 
+const char* const Value::kNullTypeTitle = "null";
+const char* const Value::kBooleanTypeTitle = "boolean";
+const char* const Value::kIntegerTypeTitle = "integer";
+const char* const Value::kFloatTypeTitle = "float";
+const char* const Value::kStringTypeTitle = "string";
+const char* const Value::kBinaryTypeTitle = "binary";
+const char* const Value::kDictionaryTypeTitle = "dictionary";
+const char* const Value::kArrayTypeTitle = "array";
+
 Value::Value() {
   // Note: Cannot use "= default", because the inner union's default constructor
   // is deleted.

--- a/common/cpp/src/google_smart_card_common/value.h
+++ b/common/cpp/src/google_smart_card_common/value.h
@@ -50,6 +50,17 @@ class Value final {
   using DictionaryStorage = std::map<std::string, std::unique_ptr<Value>>;
   using ArrayStorage = std::vector<std::unique_ptr<Value>>;
 
+  // String representation of the `Type` enum item. Intended to be used for
+  // logging purposes.
+  static const char* const kNullTypeTitle;
+  static const char* const kBooleanTypeTitle;
+  static const char* const kIntegerTypeTitle;
+  static const char* const kFloatTypeTitle;
+  static const char* const kStringTypeTitle;
+  static const char* const kBinaryTypeTitle;
+  static const char* const kDictionaryTypeTitle;
+  static const char* const kArrayTypeTitle;
+
   Value();
   explicit Value(Type type);
   explicit Value(bool boolean_value);

--- a/common/cpp/src/google_smart_card_common/value_debug_dumping.cc
+++ b/common/cpp/src/google_smart_card_common/value_debug_dumping.cc
@@ -1,0 +1,124 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google_smart_card_common/value_debug_dumping.h>
+
+#include <string>
+
+#include <google_smart_card_common/logging/hex_dumping.h>
+#include <google_smart_card_common/logging/logging.h>
+#include <google_smart_card_common/value.h>
+
+namespace google_smart_card {
+
+namespace {
+
+std::string GetValueTypeTitle(const Value& value) {
+  switch (value.type()) {
+    case Value::Type::kNull:
+      return Value::kNullTypeTitle;
+    case Value::Type::kBoolean:
+      return Value::kBooleanTypeTitle;
+    case Value::Type::kInteger:
+      return Value::kIntegerTypeTitle;
+    case Value::Type::kFloat:
+      return Value::kFloatTypeTitle;
+    case Value::Type::kString:
+      return Value::kStringTypeTitle;
+    case Value::Type::kBinary:
+      return Value::kBinaryTypeTitle;
+    case Value::Type::kDictionary:
+      return Value::kDictionaryTypeTitle;
+    case Value::Type::kArray:
+      return Value::kArrayTypeTitle;
+  }
+  GOOGLE_SMART_CARD_NOTREACHED;
+}
+
+std::string DebugDumpBoolean(bool value) { return value ? "true" : "false"; }
+
+std::string DebugDumpString(const std::string& value) {
+  return '"' + value + '"';
+}
+
+std::string DebugDumpArray(const Value::ArrayStorage& array_value) {
+  std::string result = "[";
+  for (size_t index = 0; index < array_value.size(); ++index) {
+    if (index > 0) result += ", ";
+    result += DebugDumpValueFull(*array_value[index]);
+  }
+  result += "]";
+  return result;
+}
+
+std::string DebugDumpDictionary(
+    const Value::DictionaryStorage& dictionary_value) {
+  std::string result = "{";
+  bool is_first_item = true;
+  for (const auto& item : dictionary_value) {
+    const std::string& item_key = item.first;
+    const Value& item_value = *item.second;
+    if (!is_first_item) result += ", ";
+    is_first_item = false;
+    result += DebugDumpString(item_key);
+    result += ": ";
+    result += DebugDumpValueFull(item_value);
+  }
+  result += "}";
+  return result;
+}
+
+std::string DebugDumpBinary(const Value::BinaryStorage& binary_value) {
+  std::string result = std::string(Value::kBinaryTypeTitle) + "[";
+  for (size_t offset = 0; offset < binary_value.size(); ++offset) {
+    if (offset > 0) result += ", ";
+    result += HexDumpByte(binary_value[offset]);
+  }
+  result += "]";
+  return result;
+}
+
+}  // namespace
+
+std::string DebugDumpValueSanitized(const Value& value) {
+#ifdef NDEBUG
+  return GetValueTypeTitle(value);
+#else
+  return DebugDumpValueFull(value);
+#endif
+}
+
+std::string DebugDumpValueFull(const Value& value) {
+  switch (value.type()) {
+    case Value::Type::kNull:
+      return Value::kNullTypeTitle;
+    case Value::Type::kBoolean:
+      return DebugDumpBoolean(value.GetBoolean());
+    case Value::Type::kInteger:
+      return HexDumpUnknownSizeInteger(value.GetInteger());
+    case Value::Type::kFloat:
+      return std::to_string(value.GetFloat());
+    case Value::Type::kString:
+      return DebugDumpString(value.GetString());
+    case Value::Type::kBinary:
+      return DebugDumpBinary(value.GetBinary());
+    case Value::Type::kDictionary:
+      return DebugDumpDictionary(value.GetDictionary());
+    case Value::Type::kArray:
+      return DebugDumpArray(value.GetArray());
+  }
+  GOOGLE_SMART_CARD_NOTREACHED;
+}
+
+}  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/value_debug_dumping.cc
+++ b/common/cpp/src/google_smart_card_common/value_debug_dumping.cc
@@ -80,6 +80,10 @@ std::string DebugDumpDictionary(
 }
 
 std::string DebugDumpBinary(const Value::BinaryStorage& binary_value) {
+  // Put the type title in front of the dump, so that it can be distinguished
+  // from a dump of an array value. We don't put the title in all other cases,
+  // since all of them can be unambiguously interpreted based on their format,
+  // and for the sake of keeping the dumps easy to read.
   std::string result = std::string(Value::kBinaryTypeTitle) + "[";
   for (size_t offset = 0; offset < binary_value.size(); ++offset) {
     if (offset > 0) result += ", ";

--- a/common/cpp/src/google_smart_card_common/value_debug_dumping.h
+++ b/common/cpp/src/google_smart_card_common/value_debug_dumping.h
@@ -1,0 +1,38 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_SMART_CARD_COMMON_VALUE_DEBUG_DUMPING_H_
+#define GOOGLE_SMART_CARD_COMMON_VALUE_DEBUG_DUMPING_H_
+
+#include <string>
+
+#include <google_smart_card_common/value.h>
+
+namespace google_smart_card {
+
+// Generates a sanitized debug representation of the given value. In Release
+// builds, this only dumps the title of the value's type; in Debug builds, this
+// is equivalent to `DebugDumpValueFull()`.
+std::string DebugDumpValueSanitized(const Value& value);
+
+// Generates a full debug representation of the given value.
+//
+// NOTE: It's dangerous to use this function with variables that might
+// potentially contain privacy/security sensitive data. Use
+// `DebugDumpValueSanitized()` instead.
+std::string DebugDumpValueFull(const Value& value);
+
+}  // namespace google_smart_card
+
+#endif  // GOOGLE_SMART_CARD_COMMON_VALUE_DEBUG_DUMPING_H_

--- a/common/cpp/src/google_smart_card_common/value_debug_dumping_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_debug_dumping_unittest.cc
@@ -23,8 +23,6 @@
 
 #include <gtest/gtest.h>
 
-#include <google_smart_card_common/formatting.h>
-#include <google_smart_card_common/logging/hex_dumping.h>
 #include <google_smart_card_common/unique_ptr_utils.h>
 #include <google_smart_card_common/value.h>
 
@@ -60,9 +58,9 @@ TEST(ValueDebugDumpingTest, Integer) {
   const std::string full_int = DebugDumpValueFull(Value(kInteger));
   const std::string full_max = DebugDumpValueFull(Value(kMax));
   const std::string full_min = DebugDumpValueFull(Value(kMin));
-  EXPECT_EQ(full_int, HexDumpUnknownSizeInteger(kInteger));
-  EXPECT_EQ(full_max, HexDumpUnknownSizeInteger(kMax));
-  EXPECT_EQ(full_min, HexDumpUnknownSizeInteger(kMin));
+  EXPECT_EQ(full_int, "0x7B");
+  EXPECT_EQ(full_max, "0x7FFFFFFFFFFFFFFF");
+  EXPECT_EQ(full_min, "0x8000000000000000");
 
   const std::string sanitized_int = DebugDumpValueSanitized(Value(kInteger));
   const std::string sanitized_max = DebugDumpValueSanitized(Value(kMax));
@@ -120,11 +118,8 @@ TEST(ValueDebugDumpingTest, Binary) {
 
   const std::string full_blank = DebugDumpValueFull(kBlank);
   const std::string full_blob = DebugDumpValueFull(kBlob);
-  EXPECT_EQ(full_blank, FormatPrintfTemplate("%s[]", Value::kBinaryTypeTitle));
-  EXPECT_EQ(full_blob,
-            FormatPrintfTemplate("%s[%s, %s]", Value::kBinaryTypeTitle,
-                                 HexDumpByte(kBlobBytes[0]).c_str(),
-                                 HexDumpByte(kBlobBytes[1]).c_str()));
+  EXPECT_EQ(full_blank, "binary[]");
+  EXPECT_EQ(full_blob, "binary[0x00, 0xFF]");
 
   const std::string sanitized_blank = DebugDumpValueSanitized(kBlank);
   const std::string sanitized_blob = DebugDumpValueSanitized(kBlob);
@@ -148,9 +143,7 @@ TEST(ValueDebugDumpingTest, Dictionary) {
   const std::string full_blank = DebugDumpValueFull(kBlank);
   const std::string full_dict = DebugDumpValueFull(dict);
   EXPECT_EQ(full_blank, "{}");
-  EXPECT_EQ(full_dict, FormatPrintfTemplate(
-                           "{\"bar\": %s, \"foo\": %s}", Value::kNullTypeTitle,
-                           HexDumpUnknownSizeInteger(kInteger).c_str()));
+  EXPECT_EQ(full_dict, "{\"bar\": null, \"foo\": 0x7B}");
 
   const std::string sanitized_blank = DebugDumpValueSanitized(kBlank);
   const std::string sanitized_dict = DebugDumpValueSanitized(dict);
@@ -175,9 +168,7 @@ TEST(ValueDebugDumpingTest, Array) {
   const std::string full_blank = DebugDumpValueFull(kBlank);
   const std::string full_array = DebugDumpValueFull(kArray);
   EXPECT_EQ(full_blank, "[]");
-  EXPECT_EQ(full_array,
-            FormatPrintfTemplate("[%s, %s]", Value::kNullTypeTitle,
-                                 HexDumpUnknownSizeInteger(kInteger).c_str()));
+  EXPECT_EQ(full_array, "[null, 0x7B]");
 
   const std::string sanitized_blank = DebugDumpValueSanitized(kBlank);
   const std::string sanitized_array = DebugDumpValueSanitized(kArray);

--- a/common/cpp/src/google_smart_card_common/value_debug_dumping_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_debug_dumping_unittest.cc
@@ -88,7 +88,7 @@ TEST(ValueDebugDumpingTest, Float) {
 #ifdef NDEBUG
   EXPECT_EQ(sanitized_float, Value::kFloatTypeTitle);
 #else
-  EXPECT_DOUBLE_EQ(std::stod(sanitized_float, kFloat));
+  EXPECT_DOUBLE_EQ(std::stod(sanitized_float), kFloat);
 #endif
 }
 

--- a/common/cpp/src/google_smart_card_common/value_debug_dumping_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_debug_dumping_unittest.cc
@@ -1,0 +1,193 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google_smart_card_common/value_debug_dumping.h>
+
+#include <stdint.h>
+
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <google_smart_card_common/formatting.h>
+#include <google_smart_card_common/logging/hex_dumping.h>
+#include <google_smart_card_common/unique_ptr_utils.h>
+#include <google_smart_card_common/value.h>
+
+namespace google_smart_card {
+
+TEST(ValueDebugDumpingTest, Null) {
+  EXPECT_EQ(DebugDumpValueSanitized(Value()), Value::kNullTypeTitle);
+  EXPECT_EQ(DebugDumpValueFull(Value()), Value::kNullTypeTitle);
+}
+
+TEST(ValueDebugDumpingTest, Boolean) {
+  const std::string full_false = DebugDumpValueFull(Value(false));
+  const std::string full_true = DebugDumpValueFull(Value(true));
+  EXPECT_EQ(full_false, "false");
+  EXPECT_EQ(full_true, "true");
+
+  const std::string sanitized_false = DebugDumpValueSanitized(Value(false));
+  const std::string sanitized_true = DebugDumpValueSanitized(Value(true));
+#ifdef NDEBUG
+  EXPECT_EQ(sanitized_false, Value::kBooleanTypeTitle);
+  EXPECT_EQ(sanitized_true, Value::kBooleanTypeTitle);
+#else
+  EXPECT_EQ(sanitized_false, full_false);
+  EXPECT_EQ(sanitized_true, full_true);
+#endif
+}
+
+TEST(ValueDebugDumpingTest, Integer) {
+  constexpr int64_t kInteger = 123;
+  constexpr int64_t kMax = std::numeric_limits<int64_t>::max();
+  constexpr int64_t kMin = std::numeric_limits<int64_t>::min();
+
+  const std::string full_int = DebugDumpValueFull(Value(kInteger));
+  const std::string full_max = DebugDumpValueFull(Value(kMax));
+  const std::string full_min = DebugDumpValueFull(Value(kMin));
+  EXPECT_EQ(full_int, HexDumpUnknownSizeInteger(kInteger));
+  EXPECT_EQ(full_max, HexDumpUnknownSizeInteger(kMax));
+  EXPECT_EQ(full_min, HexDumpUnknownSizeInteger(kMin));
+
+  const std::string sanitized_int = DebugDumpValueSanitized(Value(kInteger));
+  const std::string sanitized_max = DebugDumpValueSanitized(Value(kMax));
+  const std::string sanitized_min = DebugDumpValueSanitized(Value(kMin));
+#ifdef NDEBUG
+  EXPECT_EQ(sanitized_int, Value::kIntegerTypeTitle);
+  EXPECT_EQ(sanitized_max, Value::kIntegerTypeTitle);
+  EXPECT_EQ(sanitized_min, Value::kIntegerTypeTitle);
+#else
+  EXPECT_EQ(sanitized_int, full_int);
+  EXPECT_EQ(sanitized_max, full_max);
+  EXPECT_EQ(sanitized_min, full_min);
+#endif
+}
+
+TEST(ValueDebugDumpingTest, Float) {
+  constexpr double kFloat = 123.456;
+
+  const std::string full_float = DebugDumpValueFull(Value(kFloat));
+  EXPECT_DOUBLE_EQ(std::stod(full_float), kFloat);
+
+  const std::string sanitized_float = DebugDumpValueSanitized(Value(kFloat));
+#ifdef NDEBUG
+  EXPECT_EQ(sanitized_float, Value::kFloatTypeTitle);
+#else
+  EXPECT_DOUBLE_EQ(std::stod(sanitized_float, kFloat));
+#endif
+}
+
+TEST(ValueDebugDumpingTest, String) {
+  constexpr char kFooString[] = "foo";
+  const Value kBlank("");
+  const Value kFoo(kFooString);
+
+  const std::string full_blank = DebugDumpValueFull(kBlank);
+  const std::string full_foo = DebugDumpValueFull(kFoo);
+  EXPECT_EQ(full_blank, "\"\"");
+  EXPECT_EQ(full_foo, '"' + std::string(kFooString) + '"');
+
+  const std::string sanitized_blank = DebugDumpValueSanitized(kBlank);
+  const std::string sanitized_foo = DebugDumpValueSanitized(kFoo);
+#ifdef NDEBUG
+  EXPECT_EQ(sanitized_blank, Value::kStringTypeTitle);
+  EXPECT_EQ(sanitized_foo, Value::kStringTypeTitle);
+#else
+  EXPECT_EQ(sanitized_blank, full_blank);
+  EXPECT_EQ(sanitized_foo, full_foo);
+#endif
+}
+
+TEST(ValueDebugDumpingTest, Binary) {
+  const std::vector<uint8_t> kBlobBytes = {0, 255};
+  const Value kBlank(Value::Type::kBinary);
+  const Value kBlob(kBlobBytes);
+
+  const std::string full_blank = DebugDumpValueFull(kBlank);
+  const std::string full_blob = DebugDumpValueFull(kBlob);
+  EXPECT_EQ(full_blank, FormatPrintfTemplate("%s[]", Value::kBinaryTypeTitle));
+  EXPECT_EQ(full_blob,
+            FormatPrintfTemplate("%s[%s, %s]", Value::kBinaryTypeTitle,
+                                 HexDumpByte(kBlobBytes[0]).c_str(),
+                                 HexDumpByte(kBlobBytes[1]).c_str()));
+
+  const std::string sanitized_blank = DebugDumpValueSanitized(kBlank);
+  const std::string sanitized_blob = DebugDumpValueSanitized(kBlob);
+#ifdef NDEBUG
+  EXPECT_EQ(sanitized_blank, Value::kBinaryTypeTitle);
+  EXPECT_EQ(sanitized_blob, Value::kBinaryTypeTitle);
+#else
+  EXPECT_EQ(sanitized_blank, full_blank);
+  EXPECT_EQ(sanitized_blob, full_blob);
+#endif
+}
+
+TEST(ValueDebugDumpingTest, Dictionary) {
+  const Value kBlank(Value::Type::kDictionary);
+
+  const int64_t kInteger = 123;
+  Value dict(Value::Type::kDictionary);  // {"bar": null, "foo": 123}
+  dict.SetDictionaryItem("bar", Value());
+  dict.SetDictionaryItem("foo", Value(kInteger));
+
+  const std::string full_blank = DebugDumpValueFull(kBlank);
+  const std::string full_dict = DebugDumpValueFull(dict);
+  EXPECT_EQ(full_blank, "{}");
+  EXPECT_EQ(full_dict, FormatPrintfTemplate(
+                           "{\"bar\": %s, \"foo\": %s}", Value::kNullTypeTitle,
+                           HexDumpUnknownSizeInteger(kInteger).c_str()));
+
+  const std::string sanitized_blank = DebugDumpValueSanitized(kBlank);
+  const std::string sanitized_dict = DebugDumpValueSanitized(dict);
+#ifdef NDEBUG
+  EXPECT_EQ(sanitized_blank, Value::kDictionaryTypeTitle);
+  EXPECT_EQ(sanitized_dict, Value::kDictionaryTypeTitle);
+#else
+  EXPECT_EQ(sanitized_blank, full_blank);
+  EXPECT_EQ(sanitized_dict, full_dict);
+#endif
+}
+
+TEST(ValueDebugDumpingTest, Array) {
+  const Value kBlank(Value::Type::kArray);
+
+  const int64_t kInteger = 123;
+  Value::ArrayStorage array_items;
+  array_items.push_back(MakeUnique<Value>());
+  array_items.push_back(MakeUnique<Value>(kInteger));
+  const Value kArray(std::move(array_items));  // [null, 123]
+
+  const std::string full_blank = DebugDumpValueFull(kBlank);
+  const std::string full_array = DebugDumpValueFull(kArray);
+  EXPECT_EQ(full_blank, "[]");
+  EXPECT_EQ(full_array,
+            FormatPrintfTemplate("[%s, %s]", Value::kNullTypeTitle,
+                                 HexDumpUnknownSizeInteger(kInteger).c_str()));
+
+  const std::string sanitized_blank = DebugDumpValueSanitized(kBlank);
+  const std::string sanitized_array = DebugDumpValueSanitized(kArray);
+#ifdef NDEBUG
+  EXPECT_EQ(sanitized_blank, Value::kArrayTypeTitle);
+  EXPECT_EQ(sanitized_array, Value::kArrayTypeTitle);
+#else
+  EXPECT_EQ(sanitized_blank, full_blank);
+  EXPECT_EQ(sanitized_array, full_array);
+#endif
+}
+
+}  // namespace google_smart_card


### PR DESCRIPTION
Add functions that generate debug dumps of Value instances, for logging
purposes.

This is equivalent to the currently existing helpers in
//common/cpp/src/pp_var_utils/debug_dump.h. As in those existing
helpers, two versions are provided: the full dump and the privacy-safe
compact dump.

These helpers for Value instances is a preparation step for migrating the
//common/cpp library under WebAssembly (as tracked by #185).