### PR TITLE
Add optional::reset() method

### DIFF
--- a/common/cpp/src/google_smart_card_common/optional.h
+++ b/common/cpp/src/google_smart_card_common/optional.h
@@ -80,6 +80,8 @@ class optional final {
 
   T&& value() && { return operator*(); }
 
+  void reset() { storage_.reset(); }
+
   bool operator<(const optional& other) const {
     if (!*this || !other) return !*this && other;
     return value() < other.value();

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/extraction.h
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/extraction.h
@@ -105,7 +105,7 @@ template <typename T>
 inline bool VarAs(const pp::Var& var, optional<T>* result,
                   std::string* error_message) {
   if (var.is_undefined() || var.is_null()) {
-    *result = optional<T>();
+    result->reset();
     return true;
   }
   T result_value;
@@ -340,7 +340,7 @@ class VarDictValuesExtractor final {
     std::string extraction_error_message;
     pp::Var var_value;
     if (!GetVarDictValue(var_, key, &var_value, &extraction_error_message)) {
-      *result = optional<T>();
+      result->reset();
     } else {
       *result = T();
       if (!VarAs(var_value, &result->value(), &extraction_error_message))


### PR DESCRIPTION
Extend our polyfill for the "optional" C++ class to have the reset()
method, and use it in places where the optional was reset by other
means.

Historically, the original C++ Standard proposal for the std::optional
type didn't have the reset() method, which is why we didn't add into our
polyfill as well. However, afterwards this method was added into the
final std::optional interface, which went into C++17.

In the future, once we fully migrate to WebAssembly and drop the Google
Native Client support, we'll be able to delete the whole polyfill class
and use the "optional" class provided by the C++ Standard Library.