### PR TITLE
Use -Wall -pedantic in more places

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -60,6 +60,8 @@ TEST_SUPPORT_SOURCES := \
 
 CXXFLAGS := \
 	-I$(ROOT_SOURCES_PATH)/ \
+	-pedantic \
+	-Wall \
 	-Wextra \
 	-std=gnu++11 \
 

--- a/common/cpp/src/google_smart_card_common/value_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_unittest.cc
@@ -340,7 +340,10 @@ TEST(ValueTest, MoveAssignment) {
 
 TEST(ValueTest, MoveAssignmentToItself) {
   Value value("foo");
-  value = std::move(value);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-move"
+   value = std::move(value);
+#pragma clang diagnostic pop
   ASSERT_TRUE(value.is_string());
   EXPECT_EQ(value.GetString(), "foo");
 }

--- a/common/integration_testing/build/Makefile
+++ b/common/integration_testing/build/Makefile
@@ -31,6 +31,8 @@ SOURCES := \
 
 CXXFLAGS := \
 	-I$(SOURCES_PATH) \
+	-pedantic \
+	-Wall \
 	-Wextra \
 	-std=gnu++11 \
 

--- a/common/tests_runner/build.mk
+++ b/common/tests_runner/build.mk
@@ -96,6 +96,7 @@ LIBS := \
 CPPFLAGS := \
 	-pedantic \
 	-std=gnu++11 \
+	-Wall \
 	-Wextra \
 	-Wno-zero-length-array \
 	$(ADDITIONAL_TEST_CPPFLAGS)

--- a/example_cpp_smart_card_client_app/build/integration_tests/Makefile
+++ b/example_cpp_smart_card_client_app/build/integration_tests/Makefile
@@ -61,6 +61,7 @@ CPPFLAGS := \
 	-I$(SOURCE_DIR) \
 	-pedantic \
 	-std=gnu++11 \
+	-Wall \
 	-Wextra \
 	-Wno-zero-length-array \
 

--- a/example_cpp_smart_card_client_app/build/nacl_module/Makefile
+++ b/example_cpp_smart_card_client_app/build/nacl_module/Makefile
@@ -56,6 +56,7 @@ DEPS := \
 CPPFLAGS := \
 	-I$(SOURCES_DIR) \
 	-I$(PCSC_LITE_CLIENT_INCLUDE_PATH) \
+	-Wall \
 	-Wextra \
 	-Wno-zero-length-array \
 	-pedantic \

--- a/smart_card_connector_app/build/nacl_module/Makefile
+++ b/smart_card_connector_app/build/nacl_module/Makefile
@@ -64,6 +64,7 @@ $(eval $(call DEPEND_RULE,nacl_io))
 
 CXXFLAGS := \
 	-I$(PCSC_LITE_SERVER_INCLUDE_PATH) \
+	-Wall \
 	-Wextra \
 	-Wno-zero-length-array \
 	-pedantic \

--- a/third_party/libusb/naclport/build/Makefile
+++ b/third_party/libusb/naclport/build/Makefile
@@ -54,6 +54,7 @@ SOURCES := \
 CPPFLAGS := \
 	-I$(LIBUSB_NACL_SOURCES_PATH) \
 	-I$(LIBUSB_SOURCES_PATH)/libusb \
+	-Wall \
 	-Wextra \
 	-Wno-sign-compare \
 

--- a/third_party/pcsc-lite/naclport/common/build/Makefile
+++ b/third_party/pcsc-lite/naclport/common/build/Makefile
@@ -46,7 +46,10 @@ SOURCES := \
 CXXFLAGS := \
 	-I$(PCSC_LITE_ORIGINAL_HEADERS_DIR_PATH) \
 	-I$(SOURCES_PATH) \
+	-pedantic \
+	-Wall \
 	-Wextra \
+	-Wno-zero-length-array \
 	-std=gnu++11 \
 
 $(foreach src,$(SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))


### PR DESCRIPTION
Add "-Wall" and "-pedantic" C/C++ compilation flags in all places where
this doesn't break the compilation. Suppress particular warnings in a
couple of places where they are expected or hard to fix.

This should help maintaining the code base by using compiler built-in
diagnostics to a larger extent.