### PR TITLE
Use StructConverter for typed messages

### DIFF
--- a/common/cpp/src/google_smart_card_common/messaging/typed_message.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message.cc
@@ -14,36 +14,37 @@
 
 #include <google_smart_card_common/messaging/typed_message.h>
 
-#include <ppapi/cpp/var_dictionary.h>
+#include <string>
 
-#include <google_smart_card_common/pp_var_utils/construction.h>
-#include <google_smart_card_common/pp_var_utils/extraction.h>
+#include <ppapi/cpp/var.h>
+
+#include <google_smart_card_common/pp_var_utils/struct_converter.h>
 
 namespace google_smart_card {
 
-namespace {
-
-constexpr char kTypeMessageKey[] = "type";
-constexpr char kDataMessageKey[] = "data";
-
-}  // namespace
-
-bool ParseTypedMessage(const pp::Var& message, std::string* type,
-                       pp::Var* data) {
-  std::string error_message;
-  pp::VarDictionary message_dict;
-  if (!VarAs(message, &message_dict, &error_message)) return false;
-  return VarDictValuesExtractor(message_dict)
-      .Extract(kTypeMessageKey, type)
-      .Extract(kDataMessageKey, data)
-      .GetSuccessWithNoExtraKeysAllowed(&error_message);
+// static
+template <>
+constexpr const char* StructConverter<TypedMessage>::GetStructTypeName() {
+  return "TypedMessage";
 }
 
-pp::Var MakeTypedMessage(const std::string& type, const pp::Var& data) {
-  return VarDictBuilder()
-      .Add(kTypeMessageKey, type)
-      .Add(kDataMessageKey, data)
-      .Result();
+// static
+template <>
+template <typename Callback>
+void StructConverter<TypedMessage>::VisitFields(const TypedMessage& value,
+                                                Callback callback) {
+  callback(&value.type, "type");
+  callback(&value.data, "data");
+}
+
+bool VarAs(const pp::Var& var, TypedMessage* result,
+           std::string* error_message) {
+  return StructConverter<TypedMessage>::ConvertFromVar(var, result,
+                                                       error_message);
+}
+
+pp::Var MakeVar(const TypedMessage& value) {
+  return StructConverter<TypedMessage>::ConvertToVar(value);
 }
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message.h
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message.h
@@ -45,7 +45,7 @@ namespace google_smart_card {
 //   type = "log_message"
 //   data = {"log-level": ..., "text": ...}
 // This typed message is then packed into a single variable that is sent to
-// JavaScript code:
+// the JavaScript code:
 //   {"type": "log_message", "data": {"log-level": ..., "text": ...}}
 // On the JavaScript side, the message channel listener extracts the value of
 // the "type" property, finds the handler (service) that has been registered for

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message.h
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message.h
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file contains helper definitions for dealing with the "typed" Pepper
-// messages.
+// This file contains helper definitions for dealing with the "typed" messages.
 //
-// A "typed" Pepper message is a dictionary value with exactly two keys: one
-// containing the message type (a string value), and another containing the
+// A "typed" message is a pair of the message type (a string value) and the
 // message data (can be an arbitrary value).
 //
-// FIXME(emaxx): Add CHECKs for correspondence with the JavaScript side (looks
-// like the data should always be a non-null Object).
+// FIXME(emaxx): Investigate whether there should be CHECKs for correspondence
+// with the JavaScript side (looks like the data should always be a non-null
+// Object).
 
 #ifndef GOOGLE_SMART_CARD_COMMON_MESSAGING_TYPED_MESSAGE_H_
 #define GOOGLE_SMART_CARD_COMMON_MESSAGING_TYPED_MESSAGE_H_
@@ -29,15 +28,37 @@
 
 #include <ppapi/cpp/var.h>
 
+#include <google_smart_card_common/pp_var_utils/construction.h>
+#include <google_smart_card_common/pp_var_utils/extraction.h>
+
 namespace google_smart_card {
 
-// Parses the typed message, splitting it into two components: the message type
-// and the message data.
-bool ParseTypedMessage(const pp::Var& message, std::string* type,
-                       pp::Var* data);
+// A typed message is a pair of message type and message data.
+//
+// It's intended to be used for sending/receiving information through generic
+// data channels, e.g., when communicating to JavaScript code. The type field
+// determines the recipient of the associated data; the recipient should know
+// how to interpret the data.
+//
+// For example, our C++ logging code creates the following typed message when
+// emitting a log:
+//   type = "log_message"
+//   data = {"log-level": ..., "text": ...}
+// This typed message is then packed into a single variable that is sent to
+// JavaScript code:
+//   {"type": "log_message", "data": {"log-level": ..., "text": ...}}
+// On the JavaScript side, the message channel listener extracts the value of
+// the "type" property, finds the handler (service) that has been registered for
+// the "log_message" type, and passes the "data" property to it. The latter does
+// the intended operation, after parsing the "log-level" and "text" properties.
+struct TypedMessage {
+  std::string type;
+  pp::Var data;
+};
 
-// Creates a typed message having the specified message type and message data.
-pp::Var MakeTypedMessage(const std::string& type, const pp::Var& data);
+bool VarAs(const pp::Var& var, TypedMessage* result,
+           std::string* error_message);
+pp::Var MakeVar(const TypedMessage& value);
 
 }  // namespace google_smart_card
 

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_router.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_router.cc
@@ -44,14 +44,14 @@ void TypedMessageRouter::RemoveRoute(TypedMessageListener* listener) {
 }
 
 bool TypedMessageRouter::OnMessageReceived(const pp::Var& message) {
-  std::string type;
-  pp::Var data;
-  if (!ParseTypedMessage(message, &type, &data)) return false;
+  std::string error_message;
+  TypedMessage typed_message;
+  if (!VarAs(message, &typed_message, &error_message)) return false;
 
-  TypedMessageListener* const listener = FindListenerByType(type);
+  TypedMessageListener* const listener = FindListenerByType(typed_message.type);
   if (!listener) return false;
 
-  return listener->OnTypedMessageReceived(data);
+  return listener->OnTypedMessageReceived(typed_message.data);
 }
 
 TypedMessageListener* TypedMessageRouter::FindListenerByType(

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_router_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_router_unittest.cc
@@ -72,9 +72,9 @@ TEST(MessagingTypedMessageRouterTest, Basic) {
 
   // Initially, the router contains no route, so no listeners are invoked
   EXPECT_FALSE(router.OnMessageReceived(
-      MakeTypedMessage(kSampleType1, MakeSampleData(1))));
+      MakeVar(TypedMessage{kSampleType1, MakeSampleData(1)})));
   EXPECT_FALSE(router.OnMessageReceived(
-      MakeTypedMessage(kSampleType2, MakeSampleData(2))));
+      MakeVar(TypedMessage{kSampleType2, MakeSampleData(2)})));
 
   // After the first listener is registered, it is invoked by the router on the
   // corresponding message receival
@@ -83,16 +83,16 @@ TEST(MessagingTypedMessageRouterTest, Basic) {
                               GetMessageDataString, Eq(MakeSampleData(3)))))
       .WillOnce(Return(true));
   EXPECT_TRUE(router.OnMessageReceived(
-      MakeTypedMessage(kSampleType1, MakeSampleData(3))));
+      MakeVar(TypedMessage{kSampleType1, MakeSampleData(3)})));
   EXPECT_FALSE(router.OnMessageReceived(
-      MakeTypedMessage(kSampleType2, MakeSampleData(4))));
+      MakeVar(TypedMessage{kSampleType2, MakeSampleData(4)})));
 
   // When the listener returns false, the router returns false too
   EXPECT_CALL(listener_1, OnTypedMessageReceived(ResultOf(
                               GetMessageDataString, Eq(MakeSampleData(5)))))
       .WillOnce(Return(false));
   EXPECT_FALSE(router.OnMessageReceived(
-      MakeTypedMessage(kSampleType1, MakeSampleData(5))));
+      MakeVar(TypedMessage{kSampleType1, MakeSampleData(5)})));
 
   // After the second listener is registered, it is invoked by the router on the
   // corresponding message receival
@@ -101,12 +101,12 @@ TEST(MessagingTypedMessageRouterTest, Basic) {
                               GetMessageDataString, Eq(MakeSampleData(6)))))
       .WillOnce(Return(true));
   EXPECT_TRUE(router.OnMessageReceived(
-      MakeTypedMessage(kSampleType2, MakeSampleData(6))));
+      MakeVar(TypedMessage{kSampleType2, MakeSampleData(6)})));
 
   // After the first listener is removed, it is no more invoked by the router
   router.RemoveRoute(&listener_1);
   EXPECT_FALSE(router.OnMessageReceived(
-      MakeTypedMessage(kSampleType1, MakeSampleData(7))));
+      MakeVar(TypedMessage{kSampleType1, MakeSampleData(7)})));
 }
 
 TEST(MessagingTypedMessageRouterTest, MultiThreading) {
@@ -134,8 +134,8 @@ TEST(MessagingTypedMessageRouterTest, MultiThreading) {
     }
   });
   std::thread message_pushing_thread([&router] {
-    const pp::Var message_1 = MakeTypedMessage(kSampleType1, MakeSampleData(0));
-    const pp::Var message_2 = MakeTypedMessage(kSampleType2, MakeSampleData(0));
+    const pp::Var message_1 = MakeVar(TypedMessage{kSampleType1, MakeSampleData(0)});
+    const pp::Var message_2 = MakeVar(TypedMessage{kSampleType2, MakeSampleData(0)});
     for (int iteration = 0; iteration < kIterationCount; ++iteration) {
       router.OnMessageReceived(message_1);
       router.OnMessageReceived(message_2);

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_unittest.cc
@@ -40,33 +40,56 @@ TEST(MessagingTypedMessageTest, CorrectTypedMessageParsing) {
                                     .Add(kDataMessageKey, kSampleData)
                                     .Result();
 
-  std::string type;
-  pp::Var data;
-  ASSERT_TRUE(ParseTypedMessage(var, &type, &data));
-  EXPECT_EQ(kSampleType, type);
-  EXPECT_EQ(kSampleData, VarAs<std::string>(data));
+  TypedMessage typed_message;
+  std::string error_message;
+  ASSERT_TRUE(VarAs(var, &typed_message, &error_message));
+  EXPECT_TRUE(error_message.empty());
+  EXPECT_EQ(kSampleType, typed_message.type);
+  EXPECT_EQ(kSampleData, VarAs<std::string>(typed_message.data));
 }
 
 TEST(MessagingTypedMessageTest, BadTypedMessageParsing) {
-  std::string type;
-  pp::Var data;
-  EXPECT_FALSE(ParseTypedMessage(pp::Var(), &type, &data));
-  EXPECT_FALSE(ParseTypedMessage(pp::VarDictionary(), &type, &data));
-  EXPECT_FALSE(ParseTypedMessage(
-      VarDictBuilder().Add(kTypeMessageKey, kSampleType).Result(), &type,
-      &data));
-  EXPECT_FALSE(ParseTypedMessage(
-      VarDictBuilder().Add(kDataMessageKey, kSampleData).Result(), &type,
-      &data));
-  EXPECT_FALSE(ParseTypedMessage(VarDictBuilder()
-                                     .Add(kTypeMessageKey, 123)
-                                     .Add(kDataMessageKey, kSampleData)
-                                     .Result(),
-                                 &type, &data));
+  TypedMessage typed_message;
+  {
+    std::string error_message;
+    EXPECT_FALSE(VarAs(pp::Var(), &typed_message, &error_message));
+    EXPECT_FALSE(error_message.empty());
+  }
+  {
+    std::string error_message;
+    EXPECT_FALSE(VarAs(pp::VarDictionary(), &typed_message, &error_message));
+    EXPECT_FALSE(error_message.empty());
+  }
+  {
+    std::string error_message;
+    EXPECT_FALSE(
+        VarAs(VarDictBuilder().Add(kTypeMessageKey, kSampleType).Result(),
+              &typed_message, &error_message));
+    EXPECT_FALSE(error_message.empty());
+  }
+  {
+    std::string error_message;
+    EXPECT_FALSE(
+        VarAs(VarDictBuilder().Add(kDataMessageKey, kSampleData).Result(),
+              &typed_message, &error_message));
+    EXPECT_FALSE(error_message.empty());
+  }
+  {
+    std::string error_message;
+    EXPECT_FALSE(VarAs(VarDictBuilder()
+                           .Add(kTypeMessageKey, 123)
+                           .Add(kDataMessageKey, kSampleData)
+                           .Result(),
+                       &typed_message, &error_message));
+    EXPECT_FALSE(error_message.empty());
+  }
 }
 
 TEST(MessagingTypedMessageTest, TypedMessageMaking) {
-  const pp::Var var = MakeTypedMessage(kSampleType, kSampleData);
+  TypedMessage typed_message;
+  typed_message.type = kSampleType;
+  typed_message.data = kSampleData;
+  const pp::Var var = MakeVar(typed_message);
 
   const pp::VarDictionary var_dict = VarAs<pp::VarDictionary>(var);
   EXPECT_EQ(kSampleType,

--- a/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.cc
@@ -57,9 +57,10 @@ void JsRequestReceiver::Detach() {
 
 void JsRequestReceiver::PostResult(RequestId request_id,
                                    GenericRequestResult request_result) {
-  PostResultMessage(MakeTypedMessage(
-      GetResponseMessageType(name()),
-      MakeResponseMessageData(request_id, std::move(request_result))));
+  TypedMessage message;
+  message.type = GetResponseMessageType(name());
+  message.data = MakeResponseMessageData(request_id, std::move(request_result));
+  PostResultMessage(MakeVar(message));
 }
 
 std::string JsRequestReceiver::GetListenedMessageType() const {

--- a/common/cpp/src/google_smart_card_common/requesting/js_requester.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/js_requester.cc
@@ -76,10 +76,10 @@ void JsRequester::StartAsyncRequest(const pp::Var& payload,
   RequestId request_id;
   *async_request = CreateAsyncRequest(payload, callback, &request_id);
 
-  const pp::Var request_message_data =
-      MakeRequestMessageData(request_id, payload);
-  const pp::Var request_message =
-      MakeTypedMessage(GetRequestMessageType(name()), request_message_data);
+  TypedMessage typed_message;
+  typed_message.type = GetRequestMessageType(name());
+  typed_message.data = MakeRequestMessageData(request_id, payload);
+  const pp::Var request_message = MakeVar(typed_message);
 
   if (!PostPpMessage(request_message)) {
     SetAsyncRequestResult(request_id, GenericRequestResult::CreateFailed(

--- a/example_cpp_smart_card_client_app/src/ui_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/ui_bridge.cc
@@ -86,11 +86,13 @@ void UiBridge::SetHandler(std::weak_ptr<MessageFromUiHandler> handler) {
 void UiBridge::RemoveHandler() { message_from_ui_handler_.reset(); }
 
 void UiBridge::SendMessageToUi(const pp::Var& message) {
-  const pp::Var typed_message =
-      gsc::MakeTypedMessage(kOutgoingMessageType, message);
+  gsc::TypedMessage typed_message;
+  typed_message.type = kOutgoingMessageType;
+  typed_message.data = message;
+  const pp::Var typed_message_var = gsc::MakeVar(typed_message);
   const gsc::ThreadSafeUniquePtr<AttachedState>::Locked locked_state =
       attached_state_.Lock();
-  if (locked_state) locked_state->pp_instance->PostMessage(typed_message);
+  if (locked_state) locked_state->pp_instance->PostMessage(typed_message_var);
 }
 
 std::string UiBridge::GetListenedMessageType() const {

--- a/smart_card_connector_app/src/pp_module.cc
+++ b/smart_card_connector_app/src/pp_module.cc
@@ -90,8 +90,10 @@ class PpInstance final : public pp::Instance {
 
     GOOGLE_SMART_CARD_LOG_DEBUG << "All services are successfully "
                                 << "initialized, posting ready message...";
-    PostMessage(MakeTypedMessage(GetPcscLiteServerReadyMessageType(),
-                                 MakePcscLiteServerReadyMessageData()));
+    TypedMessage ready_message;
+    ready_message.type = GetPcscLiteServerReadyMessageType();
+    ready_message.data = MakePcscLiteServerReadyMessageData();
+    PostMessage(MakeVar(ready_message));
   }
 
   TypedMessageRouter typed_message_router_;

--- a/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.cc
+++ b/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.cc
@@ -227,8 +227,12 @@ void PcscLiteServerGlobal::PostReaderRemoveMessage(const char* reader_name,
 void PcscLiteServerGlobal::PostMessage(
     const char* type, const pp::VarDictionary& message_data) const {
   const std::unique_lock<std::mutex> lock(mutex_);
-  if (pp_instance_)
-    pp_instance_->PostMessage(MakeTypedMessage(type, message_data));
+  if (pp_instance_) {
+    TypedMessage typed_message;
+    typed_message.type = type;
+    typed_message.data = message_data;
+    pp_instance_->PostMessage(MakeVar(typed_message));
+  }
 }
 
 }  // namespace google_smart_card


### PR DESCRIPTION
Refactor the code that creates/parses "typed message" dictionaries to
hold the data in a dedicated struct and to use the StructConverter for
conversion to/from pp::Var instances.

This refactoring removes one particular usage of the
"VarDictValuesExtractor" converter class; the goal is to get rid of all
usages except the internal usage within the StructConverter class.
This will make it easier to migrate to the Value class in the future
(which is part of the WebAssembly migration tracked by #185), since
the Value-based conversions will work via an interface similar to
StructConverter.