### PR TITLE
Fix compilation warnings in Value implementation

### DIFF
--- a/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
@@ -805,8 +805,6 @@ TEST(ValueConversion, FloatValueToInt64) {
 }
 
 TEST(ValueConversion, ValueToInt64Error) {
-  constexpr int64_t kInt64Max = std::numeric_limits<int64_t>::max();
-  constexpr int64_t kInt64Min = std::numeric_limits<int64_t>::min();
   int64_t converted;
 
   {

--- a/common/cpp/src/google_smart_card_common/value_debug_dumping.cc
+++ b/common/cpp/src/google_smart_card_common/value_debug_dumping.cc
@@ -24,7 +24,7 @@ namespace google_smart_card {
 
 namespace {
 
-std::string GetValueTypeTitle(const Value& value) {
+__attribute__((unused)) std::string GetValueTypeTitle(const Value& value) {
   switch (value.type()) {
     case Value::Type::kNull:
       return Value::kNullTypeTitle;


### PR DESCRIPTION
Fix "unused variable" and "unused function" warnings that were somehow
missed while landing previous patchsets (namely, #189 and #193).