### PR TITLE
Helper for creating error messages if requested

### DIFF
--- a/common/cpp/build/tests/Makefile
+++ b/common/cpp/build/tests/Makefile
@@ -39,6 +39,7 @@ TEST_SOURCES_PATH := ../../src
 TEST_SOURCES_SUBDIR := google_smart_card_common
 
 TEST_SOURCES := \
+	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/formatting_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/logging/hex_dumping_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/messaging/typed_message_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/messaging/typed_message_router_unittest.cc \

--- a/common/cpp/src/google_smart_card_common/formatting.cc
+++ b/common/cpp/src/google_smart_card_common/formatting.cc
@@ -15,6 +15,7 @@
 #include <google_smart_card_common/formatting.h>
 
 #include <cstdio>
+#include <utility>
 #include <vector>
 
 namespace google_smart_card {

--- a/common/cpp/src/google_smart_card_common/formatting.cc
+++ b/common/cpp/src/google_smart_card_common/formatting.cc
@@ -51,13 +51,11 @@ std::string FormatPrintfTemplate(const char* format, va_list var_args) {
 
 void FormatPrintfTemplateAndSet(std::string* output_string, const char* format,
                                 ...) {
+  if (!output_string) return;
   va_list var_args;
   va_start(var_args, format);
-  std::string formatted = FormatPrintfTemplate(format, var_args);
+  *output_string = FormatPrintfTemplate(format, var_args);
   va_end(var_args);
-  // Note: It's incorrect to move this check to the beginning of the function,
-  // since we need to read the variable arguments off the stack in any case.
-  if (output_string) *output_string = std::move(formatted);
 }
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/formatting.cc
+++ b/common/cpp/src/google_smart_card_common/formatting.cc
@@ -48,4 +48,15 @@ std::string FormatPrintfTemplate(const char* format, va_list var_args) {
   }
 }
 
+void FormatPrintfTemplateAndSet(std::string* output_string, const char* format,
+                                ...) {
+  va_list var_args;
+  va_start(var_args, format);
+  std::string formatted = FormatPrintfTemplate(format, var_args);
+  va_end(var_args);
+  // Note: It's incorrect to move this check to the beginning of the function,
+  // since we need to read the variable arguments off the stack in any case.
+  if (output_string) *output_string = std::move(formatted);
+}
+
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/formatting.h
+++ b/common/cpp/src/google_smart_card_common/formatting.h
@@ -27,6 +27,11 @@ std::string FormatPrintfTemplate(const char* format, ...)
 
 std::string FormatPrintfTemplate(const char* format, va_list var_args);
 
+// Same as `FormatPrintfTemplate()`, but stores the result in `output_string`.
+// Does nothing if `output_string` is null.
+void FormatPrintfTemplateAndSet(std::string* output_string, const char* format,
+                                ...) __attribute__((format(__printf__, 2, 3)));
+
 }  // namespace google_smart_card
 
 #endif  // GOOGLE_SMART_CARD_COMMON_FORMATTING_H_

--- a/common/cpp/src/google_smart_card_common/formatting_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/formatting_unittest.cc
@@ -1,0 +1,62 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google_smart_card_common/formatting.h>
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace google_smart_card {
+
+TEST(FormatPrintfTemplateAndSet, Basic) {
+  {
+    std::string formatted;
+    FormatPrintfTemplateAndSet(&formatted, /*format=*/"");
+    EXPECT_EQ(formatted, "");
+  }
+
+  {
+    std::string formatted;
+    FormatPrintfTemplateAndSet(&formatted, "%d", 123);
+    EXPECT_EQ(formatted, "123");
+  }
+
+  {
+    std::string formatted;
+    FormatPrintfTemplateAndSet(&formatted, "string=%s int=%d", "foo", 123);
+    EXPECT_EQ(formatted, "string=foo int=123");
+  }
+}
+
+// Test that FormatPrintfTemplateAndSet() doesn't crash when the output string
+// is a null pointer.
+TEST(FormatPrintfTemplateAndSet, NullPointer) {
+  FormatPrintfTemplateAndSet(/*output_string=*/nullptr, /*format=*/"");
+  FormatPrintfTemplateAndSet(/*output_string=*/nullptr, "%d", 123);
+  FormatPrintfTemplateAndSet(/*output_string=*/nullptr, "string=%s int=%d",
+                             "foo", 123);
+}
+
+// Test that FormatPrintfTemplateAndSet() correctly handles the case when the
+// resulting string is quite long.
+TEST(FormatPrintfTemplateAndSet, HugeResult) {
+  constexpr int kLength = 100 * 1000;
+  const std::string kParameter(kLength, 'a');
+  std::string formatted;
+  FormatPrintfTemplateAndSet(&formatted, "%s", kParameter.c_str());
+  EXPECT_EQ(formatted, kParameter);
+}
+
+}  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_router.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_router.cc
@@ -57,19 +57,16 @@ bool TypedMessageRouter::OnMessageReceived(Value message,
   // TODO: Delete `local_error_message` in favor of (optional) `error_message`.
   std::string local_error_message;
   if (!VarAs(pp_message, &typed_message, &local_error_message)) {
-    if (error_message) {
-      *error_message = FormatPrintfTemplate("Cannot parse typed message: %s",
-                                            local_error_message.c_str());
-    }
+    FormatPrintfTemplateAndSet(error_message, "Cannot parse typed message: %s",
+                               local_error_message.c_str());
+
     return false;
   }
 
   TypedMessageListener* const listener = FindListenerByType(typed_message.type);
   if (!listener) {
-    if (error_message) {
-      *error_message = FormatPrintfTemplate("Cannot find listener for %s",
-                                            typed_message.type.c_str());
-    }
+    FormatPrintfTemplateAndSet(error_message, "Cannot find listener for %s",
+                               typed_message.type.c_str());
     return false;
   }
 

--- a/common/cpp/src/google_smart_card_common/numeric_conversions.cc
+++ b/common/cpp/src/google_smart_card_common/numeric_conversions.cc
@@ -32,14 +32,11 @@ bool CastDoubleToInt64(double value, int64_t* result,
                        std::string* error_message) {
   if (!(internal::kDoubleExactRangeMin <= value &&
         value <= internal::kDoubleExactRangeMax)) {
-    if (error_message) {
-      *error_message = FormatPrintfTemplate(
-          "The real value is outside the exact integer representation range: "
-          "%f "
-          "not in [%" PRId64 "; %" PRId64 "]",
-          value, internal::kDoubleExactRangeMin,
-          internal::kDoubleExactRangeMax);
-    }
+    FormatPrintfTemplateAndSet(
+        error_message,
+        "The real value is outside the exact integer representation range: %f "
+        "not in [%" PRId64 "; %" PRId64 "]",
+        value, internal::kDoubleExactRangeMin, internal::kDoubleExactRangeMax);
     return false;
   }
   *result = static_cast<int64_t>(value);

--- a/common/cpp/src/google_smart_card_common/numeric_conversions.h
+++ b/common/cpp/src/google_smart_card_common/numeric_conversions.h
@@ -97,14 +97,14 @@ inline bool CastInteger(SourceType source_value, const char* target_type_name,
     *target_value = static_cast<TargetType>(source_value);
     return true;
   }
-  if (error_message) {
-    *error_message = FormatPrintfTemplate(
-        "The integer value is outside the range of type \"%s\": %s not in [%s; "
-        "%s] range",
-        target_type_name, std::to_string(source_value).c_str(),
-        std::to_string(std::numeric_limits<TargetType>::min()).c_str(),
-        std::to_string(std::numeric_limits<TargetType>::max()).c_str());
-  }
+  FormatPrintfTemplateAndSet(
+      error_message,
+      "The integer value is outside the range of type \"%s\": %s not in [%s; "
+      "%s] range",
+      target_type_name, std::to_string(source_value).c_str(),
+      std::to_string(std::numeric_limits<TargetType>::min()).c_str(),
+      std::to_string(std::numeric_limits<TargetType>::max()).c_str());
+
   return false;
 }
 
@@ -119,14 +119,13 @@ inline bool CastIntegerToDouble(T value, double* result,
     *result = static_cast<double>(value);
     return true;
   }
-  if (error_message) {
-    *error_message = FormatPrintfTemplate(
-        "The integer %s cannot be converted into a floating-point double value "
-        "without loss of precision: it is outside [%" PRId64 "; %" PRId64
-        "] range",
-        std::to_string(value).c_str(), internal::kDoubleExactRangeMin,
-        internal::kDoubleExactRangeMax);
-  }
+  FormatPrintfTemplateAndSet(
+      error_message,
+      "The integer %s cannot be converted into a floating-point double value "
+      "without loss of precision: it is outside [%" PRId64 "; %" PRId64
+      "] range",
+      std::to_string(value).c_str(), internal::kDoubleExactRangeMin,
+      internal::kDoubleExactRangeMax);
   return false;
 }
 

--- a/common/cpp/src/google_smart_card_common/value_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion.cc
@@ -45,11 +45,9 @@ bool ConvertIntegerFromValue(Value value, const char* type_name, T* number,
     if (!CastDoubleToInt64(value.GetFloat(), &int64_number, error_message))
       return false;
   } else {
-    if (error_message) {
-      *error_message =
-          FormatPrintfTemplate(kErrorWrongType, Value::kIntegerTypeTitle,
+    FormatPrintfTemplateAndSet(error_message, kErrorWrongType,
+                               Value::kIntegerTypeTitle,
                                DebugDumpValueSanitized(value).c_str());
-    }
     return false;
   }
   return CastInteger(int64_number, type_name, number, error_message);
@@ -95,11 +93,9 @@ bool ConvertFromValue(Value value, bool* boolean, std::string* error_message) {
     *boolean = value.GetBoolean();
     return true;
   }
-  if (error_message) {
-    *error_message =
-        FormatPrintfTemplate(kErrorWrongType, Value::kBooleanTypeTitle,
+  FormatPrintfTemplateAndSet(error_message, kErrorWrongType,
+                             Value::kBooleanTypeTitle,
                              DebugDumpValueSanitized(value).c_str());
-  }
   return false;
 }
 
@@ -144,14 +140,12 @@ bool ConvertFromValue(Value value, double* number, std::string* error_message) {
     *number = value.GetFloat();
     return true;
   }
-  if (error_message) {
-    *error_message = FormatPrintfTemplate(
-        kErrorWrongType,
-        FormatPrintfTemplate("%s or %s", Value::kIntegerTypeTitle,
-                             Value::kFloatTypeTitle)
-            .c_str(),
-        DebugDumpValueSanitized(value).c_str());
-  }
+  FormatPrintfTemplateAndSet(
+      error_message, kErrorWrongType,
+      FormatPrintfTemplate("%s or %s", Value::kIntegerTypeTitle,
+                           Value::kFloatTypeTitle)
+          .c_str(),
+      DebugDumpValueSanitized(value).c_str());
   return false;
 }
 
@@ -161,11 +155,9 @@ bool ConvertFromValue(Value value, std::string* characters,
     *characters = value.GetString();
     return true;
   }
-  if (error_message) {
-    *error_message =
-        FormatPrintfTemplate(kErrorWrongType, Value::kStringTypeTitle,
+  FormatPrintfTemplateAndSet(error_message, kErrorWrongType,
+                             Value::kStringTypeTitle,
                              DebugDumpValueSanitized(value).c_str());
-  }
   return false;
 }
 


### PR DESCRIPTION
Add another variant of the FormatPrintfTemplate() C++ function that
writes its result to the given pointer, after checking the latter for
being non-null.

This allows to simplify code to avoid writing boilerplate "if
(error_message)" conditions. This change isn't expected to cause any
real-world performance regressions, despite generating error message
parameters even in cases when the result is not used, since it only
affects "unsuccessful" code paths that should only be triggered rarely.