### PR TITLE
Add conversions for Value to/from C++ structs

### DIFF
--- a/common/cpp/src/google_smart_card_common/value.cc
+++ b/common/cpp/src/google_smart_card_common/value.cc
@@ -134,6 +134,11 @@ const Value::DictionaryStorage& Value::GetDictionary() const {
   return dictionary_value_;
 }
 
+Value::DictionaryStorage& Value::GetDictionary() {
+  GOOGLE_SMART_CARD_CHECK(is_dictionary());
+  return dictionary_value_;
+}
+
 const Value::ArrayStorage& Value::GetArray() const {
   GOOGLE_SMART_CARD_CHECK(is_array());
   return array_value_;

--- a/common/cpp/src/google_smart_card_common/value.h
+++ b/common/cpp/src/google_smart_card_common/value.h
@@ -99,6 +99,7 @@ class Value final {
   const std::string& GetString() const;
   const BinaryStorage& GetBinary() const;
   const DictionaryStorage& GetDictionary() const;
+  DictionaryStorage& GetDictionary();
   const ArrayStorage& GetArray() const;
 
   // Returns null when the key isn't present.

--- a/common/cpp/src/google_smart_card_common/value_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion.cc
@@ -119,18 +119,16 @@ void StructToValueConverterBase::HandleFieldConversionError(
     const char* dictionary_key_name) {
   succeeded_ = false;
   inner_error_message_ =
-      FormatPrintfTemplate("error creating property %s: %s",
+      FormatPrintfTemplate("Error creating property %s: %s",
                            dictionary_key_name, inner_error_message_.c_str());
 }
 
 bool StructToValueConverterBase::FinishConversion(
     const char* type_name, std::string* error_message) const {
   if (succeeded_) return true;
-  if (error_message) {
-    *error_message =
-        FormatPrintfTemplate("Cannot convert struct %s to value: %s", type_name,
+  FormatPrintfTemplateAndSet(error_message,
+                             "Cannot convert struct %s to value: %s", type_name,
                              inner_error_message_.c_str());
-  }
   return false;
 }
 
@@ -139,7 +137,7 @@ StructFromValueConverterBase::StructFromValueConverterBase(
     : value_to_convert_(std::move(value_to_convert)) {
   if (!value_to_convert_.is_dictionary()) {
     succeeded_ = false;
-    inner_error_message_ = "value is not a dictionary";
+    inner_error_message_ = "Value is not a dictionary";
   }
 }
 
@@ -162,7 +160,7 @@ bool StructFromValueConverterBase::ExtractKey(const char* dictionary_key_name,
   }
   succeeded_ = false;
   inner_error_message_ =
-      FormatPrintfTemplate("missing key \"%s\"", dictionary_key_name);
+      FormatPrintfTemplate("Missing key \"%s\"", dictionary_key_name);
   return false;
 }
 
@@ -170,25 +168,23 @@ void StructFromValueConverterBase::HandleFieldConversionError(
     const char* dictionary_key_name) {
   succeeded_ = false;
   inner_error_message_ =
-      FormatPrintfTemplate("error in property \"%s\": %s", dictionary_key_name,
+      FormatPrintfTemplate("Error in property \"%s\": %s", dictionary_key_name,
                            inner_error_message_.c_str());
 }
 
 bool StructFromValueConverterBase::FinishConversion(
     const char* type_name, std::string* error_message) {
   if (succeeded_ && !value_to_convert_.GetDictionary().empty()) {
+    succeeded_ = false;
     const std::string& first_unexpected_key =
         value_to_convert_.GetDictionary().begin()->first;
-    succeeded_ = false;
-    inner_error_message_ = FormatPrintfTemplate("unexpected key \"%s\"",
+    inner_error_message_ = FormatPrintfTemplate("Unexpected key \"%s\"",
                                                 first_unexpected_key.c_str());
   }
   if (succeeded_) return true;
-  if (error_message) {
-    *error_message =
-        FormatPrintfTemplate("Cannot convert value to struct %s: %s", type_name,
+  FormatPrintfTemplateAndSet(error_message,
+                             "Cannot convert value to struct %s: %s", type_name,
                              inner_error_message_.c_str());
-  }
   return false;
 }
 

--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -348,7 +348,7 @@ class StructValueDescriptor {
 
     // Adds the given field into the struct's description: |dictionary_key_name|
     // is the key in the dictionary `Value` representation of |field_ptr|.
-    // Returns a rvalue reference to |this| and uses the "&&" ref-qualifier, so
+    // Returns an rvalue reference to |this| and uses the "&&" ref-qualifier, so
     // that the method calls can be easily chained and the final result can be
     // returned without an explicit std::move() boilerplate.
     template <typename FieldT>

--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -208,8 +208,8 @@ class StructValueDescriptor {
   static_assert(std::is_class<T>::value,
                 "The StructValueDescriptor parameter must be a class");
 
-  // Class that should be used for describing items of the enum type. Should be
-  // instantiated via the `Describe()` method.
+  // Class that should be used for describing fields of the struct type. Should
+  // be instantiated via the `Describe()` method.
   class Description final {
    public:
     Description(const char* type_name,

--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -29,7 +29,7 @@
 //
 // The same helpers can also be enabled for custom types:
 // * a custom enum can be registered via the `EnumValueDescriptor` class for
-//   conversion to/from a string `Value`.
+//   conversion to/from a string `Value`;
 // * a custom struct can be registered via the `StructValueDescriptor` class for
 //   conversion to/from a dictionary `Value`.
 //

--- a/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
@@ -1200,7 +1200,7 @@ TEST(ValueConversion, ValueToStructError) {
     EXPECT_FALSE(ConvertFromValue(Value(), &converted, &error_message));
     EXPECT_EQ(
         error_message,
-        "Cannot convert value to struct SomeStruct: value is not a dictionary");
+        "Cannot convert value to struct SomeStruct: Value is not a dictionary");
   }
 
   {
@@ -1208,7 +1208,7 @@ TEST(ValueConversion, ValueToStructError) {
     EXPECT_FALSE(ConvertFromValue(Value(Value::Type::kDictionary), &converted,
                                   &error_message));
     EXPECT_EQ(error_message,
-              "Cannot convert value to struct SomeStruct: missing key "
+              "Cannot convert value to struct SomeStruct: Missing key "
               "\"intField\"");
   }
 
@@ -1221,7 +1221,7 @@ TEST(ValueConversion, ValueToStructError) {
         ConvertFromValue(std::move(value), &converted, &error_message));
     EXPECT_EQ(
         error_message,
-        "Cannot convert value to struct SomeStruct: error in property "
+        "Cannot convert value to struct SomeStruct: Error in property "
         "\"intField\": Expected value of type integer, instead got: null");
   }
 
@@ -1235,7 +1235,7 @@ TEST(ValueConversion, ValueToStructError) {
         ConvertFromValue(std::move(value), &converted, &error_message));
     EXPECT_EQ(
         error_message,
-        "Cannot convert value to struct SomeStruct: error in property "
+        "Cannot convert value to struct SomeStruct: Error in property "
         "\"stringField\": Expected value of type string, instead got: null");
   }
 
@@ -1248,7 +1248,7 @@ TEST(ValueConversion, ValueToStructError) {
     EXPECT_FALSE(
         ConvertFromValue(std::move(value), &converted, &error_message));
     EXPECT_EQ(error_message,
-              "Cannot convert value to struct SomeStruct: unexpected key "
+              "Cannot convert value to struct SomeStruct: Unexpected key "
               "\"nonExisting\"");
   }
 }
@@ -1297,9 +1297,9 @@ TEST(ValueConversion, ValueToNestedStructError) {
     EXPECT_FALSE(
         ConvertFromValue(std::move(value), &converted, &error_message));
     EXPECT_EQ(error_message,
-              "Cannot convert value to struct OuterStruct: error in property "
+              "Cannot convert value to struct OuterStruct: Error in property "
               "\"someField\": Cannot convert value to struct SomeStruct: "
-              "missing key \"intField\"");
+              "Missing key \"intField\"");
   }
 
   {
@@ -1310,8 +1310,8 @@ TEST(ValueConversion, ValueToNestedStructError) {
     EXPECT_FALSE(
         ConvertFromValue(std::move(value), &converted, &error_message));
     EXPECT_EQ(error_message,
-              "Cannot convert value to struct OuterStruct: error in property "
-              "\"someField\": Cannot convert value to struct SomeStruct: value "
+              "Cannot convert value to struct OuterStruct: Error in property "
+              "\"someField\": Cannot convert value to struct SomeStruct: Value "
               "is not a dictionary");
   }
 }

--- a/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
@@ -24,12 +24,41 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <google_smart_card_common/optional.h>
 #include <google_smart_card_common/value.h>
 
 using testing::MatchesRegex;
 using testing::StartsWith;
 
 namespace google_smart_card {
+
+namespace {
+
+struct SomeStruct {
+  int int_field;
+  optional<std::string> string_field;
+};
+
+struct OuterStruct {
+  SomeStruct some_field;
+};
+
+}  // namespace
+
+template <>
+StructValueDescriptor<SomeStruct>::Description
+StructValueDescriptor<SomeStruct>::GetDescription() {
+  return Describe("SomeStruct")
+      .WithField(&SomeStruct::int_field, "intField")
+      .WithField(&SomeStruct::string_field, "stringField");
+}
+
+template <>
+StructValueDescriptor<OuterStruct>::Description
+StructValueDescriptor<OuterStruct>::GetDescription() {
+  return Describe("OuterStruct")
+      .WithField(&OuterStruct::some_field, "someField");
+}
 
 TEST(ValueConversion, BoolToValue) {
   {
@@ -1000,6 +1029,188 @@ TEST(ValueConversion, ValueToStringError) {
   EXPECT_FALSE(ConvertFromValue(Value(false), &converted));
 
   EXPECT_FALSE(ConvertFromValue(Value(123), &converted));
+}
+
+TEST(ValueConversion, StructToValue) {
+  {
+    const SomeStruct kSome = {123, std::string("foo")};
+    Value value;
+    EXPECT_TRUE(ConvertToValue(kSome, &value));
+    ASSERT_TRUE(value.is_dictionary());
+    EXPECT_EQ(value.GetDictionary().size(), 2U);
+    const Value* int_field = value.GetDictionaryItem("intField");
+    ASSERT_TRUE(int_field);
+    ASSERT_TRUE(int_field->is_integer());
+    EXPECT_EQ(int_field->GetInteger(), 123);
+    const Value* string_field = value.GetDictionaryItem("stringField");
+    ASSERT_TRUE(string_field);
+    ASSERT_TRUE(string_field->is_string());
+    EXPECT_EQ(string_field->GetString(), "foo");
+  }
+
+  {
+    const SomeStruct kSome = {123, {}};
+    Value value;
+    EXPECT_TRUE(ConvertToValue(kSome, &value));
+    ASSERT_TRUE(value.is_dictionary());
+    EXPECT_EQ(value.GetDictionary().size(), 1U);
+    const Value* int_field = value.GetDictionaryItem("intField");
+    ASSERT_TRUE(int_field);
+    ASSERT_TRUE(int_field->is_integer());
+    EXPECT_EQ(int_field->GetInteger(), 123);
+  }
+}
+
+TEST(ValueConversion, ValueToStruct) {
+  {
+    Value value(Value::Type::kDictionary);
+    value.SetDictionaryItem("intField", Value(123));
+    value.SetDictionaryItem("stringField", Value("foo"));
+
+    std::string error_message;
+    SomeStruct converted = {};
+    EXPECT_TRUE(ConvertFromValue(std::move(value), &converted, &error_message));
+    EXPECT_TRUE(error_message.empty());
+    EXPECT_EQ(converted.int_field, 123);
+    ASSERT_TRUE(converted.string_field);
+    EXPECT_EQ(*converted.string_field, "foo");
+  }
+
+  {
+    Value value(Value::Type::kDictionary);
+    value.SetDictionaryItem("intField", Value(123));
+
+    std::string error_message;
+    SomeStruct converted = {};
+    EXPECT_TRUE(ConvertFromValue(std::move(value), &converted, &error_message));
+    EXPECT_TRUE(error_message.empty());
+    EXPECT_EQ(converted.int_field, 123);
+    EXPECT_FALSE(converted.string_field);
+  }
+}
+
+TEST(ValueConversion, ValueToStructError) {
+  SomeStruct converted;
+
+  {
+    std::string error_message;
+    EXPECT_FALSE(ConvertFromValue(Value(), &converted, &error_message));
+    EXPECT_EQ(
+        error_message,
+        "Cannot convert value to struct SomeStruct: value is not a dictionary");
+  }
+
+  {
+    std::string error_message;
+    EXPECT_FALSE(ConvertFromValue(Value(Value::Type::kDictionary), &converted,
+                                  &error_message));
+    EXPECT_EQ(error_message,
+              "Cannot convert value to struct SomeStruct: missing key "
+              "\"intField\"");
+  }
+
+  {
+    Value value(Value::Type::kDictionary);
+    value.SetDictionaryItem("intField", Value());
+
+    std::string error_message;
+    EXPECT_FALSE(
+        ConvertFromValue(std::move(value), &converted, &error_message));
+    EXPECT_EQ(
+        error_message,
+        "Cannot convert value to struct SomeStruct: error in property "
+        "\"intField\": Expected value of type integer, instead got: null");
+  }
+
+  {
+    Value value(Value::Type::kDictionary);
+    value.SetDictionaryItem("intField", Value(123));
+    value.SetDictionaryItem("stringField", Value());
+
+    std::string error_message;
+    EXPECT_FALSE(
+        ConvertFromValue(std::move(value), &converted, &error_message));
+    EXPECT_EQ(
+        error_message,
+        "Cannot convert value to struct SomeStruct: error in property "
+        "\"stringField\": Expected value of type string, instead got: null");
+  }
+
+  {
+    Value value(Value::Type::kDictionary);
+    value.SetDictionaryItem("intField", Value(123));
+    value.SetDictionaryItem("nonExisting", Value());
+
+    std::string error_message;
+    EXPECT_FALSE(
+        ConvertFromValue(std::move(value), &converted, &error_message));
+    EXPECT_EQ(error_message,
+              "Cannot convert value to struct SomeStruct: unexpected key "
+              "\"nonExisting\"");
+  }
+}
+
+TEST(ValueConversion, NestedStructToValue) {
+  const SomeStruct kSome = {123, {}};
+  const OuterStruct kOuter = {kSome};
+  Value value;
+  EXPECT_TRUE(ConvertToValue(kOuter, &value));
+  ASSERT_TRUE(value.is_dictionary());
+  EXPECT_EQ(value.GetDictionary().size(), 1U);
+  const Value* some_field = value.GetDictionaryItem("someField");
+  ASSERT_TRUE(some_field);
+  ASSERT_TRUE(some_field->is_dictionary());
+  EXPECT_EQ(some_field->GetDictionary().size(), 1U);
+  const Value* int_field = some_field->GetDictionaryItem("intField");
+  ASSERT_TRUE(int_field);
+  ASSERT_TRUE(int_field->is_integer());
+  EXPECT_EQ(int_field->GetInteger(), 123);
+}
+
+TEST(ValueConversion, ValueToNestedStruct) {
+  Value inner_value(Value::Type::kDictionary);
+  inner_value.SetDictionaryItem("intField", Value(123));
+  inner_value.SetDictionaryItem("stringField", Value("foo"));
+  Value value(Value::Type::kDictionary);
+  value.SetDictionaryItem("someField", std::move(inner_value));
+
+  std::string error_message;
+  OuterStruct converted = {};
+  EXPECT_TRUE(ConvertFromValue(std::move(value), &converted, &error_message));
+  EXPECT_TRUE(error_message.empty());
+  EXPECT_EQ(converted.some_field.int_field, 123);
+  ASSERT_TRUE(converted.some_field.string_field);
+  EXPECT_EQ(*converted.some_field.string_field, "foo");
+}
+
+TEST(ValueConversion, ValueToNestedStructError) {
+  OuterStruct converted = {};
+
+  {
+    Value value(Value::Type::kDictionary);
+    value.SetDictionaryItem("someField", Value(Value::Type::kDictionary));
+
+    std::string error_message;
+    EXPECT_FALSE(
+        ConvertFromValue(std::move(value), &converted, &error_message));
+    EXPECT_EQ(error_message,
+              "Cannot convert value to struct OuterStruct: error in property "
+              "\"someField\": Cannot convert value to struct SomeStruct: "
+              "missing key \"intField\"");
+  }
+
+  {
+    Value value(Value::Type::kDictionary);
+    value.SetDictionaryItem("someField", Value());
+
+    std::string error_message;
+    EXPECT_FALSE(
+        ConvertFromValue(std::move(value), &converted, &error_message));
+    EXPECT_EQ(error_message,
+              "Cannot convert value to struct OuterStruct: error in property "
+              "\"someField\": Cannot convert value to struct SomeStruct: value "
+              "is not a dictionary");
+  }
 }
 
 }  // namespace google_smart_card


### PR DESCRIPTION
Implement helpers for semi-automated implementation that maps between
C++ structs and JSON-like dictionary Values.

This extends the set of helpers for converting between Value instances
and C/C++ objects, paving the way for migrating the rest of //common/cpp
library to become toolchain-independent (as tracked by #185).

This commit implements analogous functionality similar to the already
existing Native Client pp::Var specific helpers (in
pp_var_utils/struct_converter.h), however this new implementation requires
much less boilerplate code to be written for every struct.