### PR TITLE
Add identity transform for Value into itself

### DIFF
--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -184,6 +184,12 @@ class EnumValueDescriptor {
 // and the last one isn't useful in this context (as helpers in this file are
 // about converting between a `Value` and a non-`Value` object).
 
+inline bool ConvertToValue(Value source_value, Value* target_value,
+                           std::string* /*error_message*/ = nullptr) {
+  *target_value = std::move(source_value);
+  return true;
+}
+
 inline bool ConvertToValue(bool boolean, Value* value,
                            std::string* /*error_message*/ = nullptr) {
   *value = Value(boolean);
@@ -261,6 +267,13 @@ typename std::enable_if<std::is_enum<T>::value, bool>::type ConvertToValue(
 ///////////// ConvertFromValue ///////////////
 
 // Group of overloads that perform trivial conversions from `Value`.
+
+inline bool ConvertFromValue(Value source_value, Value* target_value,
+                             std::string* /*error_message*/ = nullptr) {
+  *target_value = std::move(source_value);
+  return true;
+}
+
 bool ConvertFromValue(Value value, bool* boolean,
                       std::string* error_message = nullptr);
 bool ConvertFromValue(Value value, int* number,

--- a/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
@@ -42,6 +42,39 @@ EnumValueDescriptor<SomeEnum>::GetDescription() {
       .WithItem(SomeEnum::kSomeThird, "someThird");
 }
 
+TEST(ValueConversion, ValueToValue) {
+  {
+    std::string error_message;
+    Value converted;
+    EXPECT_TRUE(ConvertToValue(Value(123), &converted, &error_message));
+    EXPECT_TRUE(error_message.empty());
+    ASSERT_TRUE(converted.is_integer());
+    EXPECT_EQ(converted.GetInteger(), 123);
+  }
+
+  {
+    Value converted;
+    EXPECT_TRUE(ConvertToValue(Value(), &converted));
+    EXPECT_TRUE(converted.is_null());
+  }
+
+  {
+    std::string error_message;
+    Value converted;
+    EXPECT_TRUE(ConvertFromValue(Value("foo"), &converted, &error_message));
+    EXPECT_TRUE(error_message.empty());
+    ASSERT_TRUE(converted.is_string());
+    EXPECT_EQ(converted.GetString(), "foo");
+  }
+
+  {
+    Value converted;
+    EXPECT_TRUE(ConvertFromValue(Value(Value::Type::kDictionary), &converted));
+    ASSERT_TRUE(converted.is_dictionary());
+    EXPECT_TRUE(converted.GetDictionary().empty());
+  }
+}
+
 TEST(ValueConversion, BoolToValue) {
   {
     std::string error_message;


### PR DESCRIPTION
Add overloads for the ConvertToValue/ConvertFromValue functions that
perform identity transform, i.e., return the input argument without
changes.

This is needed in order to make generic transformation code work in case
when the same Value class is used in both source and destination
representation - for example, the TypedMessage struct's |data| field.

This is part of the effort on migrating the //common/cpp library to use
the toolchain-independent Value class, making it work under both
Native Client and WebAssembly (#185).