### PR TITLE
Add "OrDie" Value conversion variants

### DIFF
--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_router_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_router_unittest.cc
@@ -67,7 +67,7 @@ std::string GetMessageDataString(const pp::Var& data) {
 
 Value MakeTypedMessageValue(const TypedMessage& typed_message) {
   // TODO: Create `Value` directly, without going through `pp::Var`.
-  return *ConvertPpVarToValue(MakeVar(typed_message));
+  return ConvertPpVarToValueOrDie(MakeVar(typed_message));
 }
 
 }  // namespace

--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -258,6 +258,17 @@ typename std::enable_if<std::is_enum<T>::value, bool>::type ConvertToValue(
                                       error_message);
 }
 
+// Synonym to other `ConvertToValue()` overloads, but immediately crashes the
+// program if the conversion fails.
+template <typename T>
+Value ConvertToValueOrDie(T object) {
+  Value value;
+  std::string error_message;
+  if (!ConvertToValue(std::move(object), &value, &error_message))
+    GOOGLE_SMART_CARD_LOG_FATAL << error_message;
+  return value;
+}
+
 ///////////// ConvertFromValue ///////////////
 
 // Group of overloads that perform trivial conversions from `Value`.
@@ -300,6 +311,17 @@ typename std::enable_if<std::is_enum<T>::value, bool>::type ConvertFromValue(
   }
   *enum_value = static_cast<T>(converted_enum_number);
   return true;
+}
+
+// Synonym to other `ConvertFromValue()` overloads, but immediately crashes the
+// program if the conversion fails.
+template <typename T>
+T ConvertFromValueOrDie(Value value) {
+  T object;
+  std::string error_message;
+  if (!ConvertFromValue(std::move(value), &object, &error_message))
+    GOOGLE_SMART_CARD_LOG_FATAL << error_message;
+  return object;
 }
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
@@ -1105,4 +1105,45 @@ TEST(ValueConversion, ValueToEnumError) {
   EXPECT_FALSE(ConvertFromValue(Value(Value::Type::kDictionary), &converted));
 }
 
+// Test that `ConvertToValueOrDie()` succeeds on supported inputs. As death
+// tests aren't supported, we don't test failure scenarios.
+TEST(ValueConversion, ToValueOrDie) {
+  {
+    const Value value = ConvertToValueOrDie(false);
+    ASSERT_TRUE(value.is_boolean());
+    EXPECT_EQ(value.GetBoolean(), false);
+  }
+
+  {
+    const Value value = ConvertToValueOrDie(123);
+    ASSERT_TRUE(value.is_integer());
+    EXPECT_EQ(value.GetInteger(), 123);
+  }
+
+  {
+    const Value value = ConvertToValueOrDie(SomeEnum::kFirst);
+    ASSERT_TRUE(value.is_string());
+    EXPECT_EQ(value.GetString(), "first");
+  }
+}
+
+// Test that `ConvertFromValueOrDie()` succeeds on supported inputs. As death
+// tests aren't supported, we don't test failure scenarios.
+TEST(ValueConversion, FromValueOrDie) {
+  {
+    const bool converted = ConvertFromValueOrDie<bool>(Value(true));
+    EXPECT_EQ(converted, true);
+  }
+
+  {
+    const int converted = ConvertFromValueOrDie<int>(Value(-1));
+    EXPECT_EQ(converted, -1);
+  }
+
+  {
+    const SomeEnum converted = ConvertFromValueOrDie<SomeEnum>(Value("second"));
+    EXPECT_EQ(converted, SomeEnum::kSecond);
+  }
+}
+
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.cc
@@ -175,4 +175,11 @@ optional<Value> ConvertPpVarToValue(const pp::Var& var,
   GOOGLE_SMART_CARD_NOTREACHED;
 }
 
+Value ConvertPpVarToValueOrDie(const pp::Var& var) {
+  std::string error_message;
+  optional<Value> value = ConvertPpVarToValue(var, &error_message);
+  if (!value) GOOGLE_SMART_CARD_LOG_FATAL << error_message;
+  return std::move(*value);
+}
+
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h
@@ -38,6 +38,10 @@ pp::Var ConvertValueToPpVar(const Value& value);
 optional<Value> ConvertPpVarToValue(const pp::Var& var,
                                     std::string* error_message = nullptr);
 
+// Same as `ConvertPpVarToValue()`, but immediately crashes the program if the
+// conversion fails.
+Value ConvertPpVarToValueOrDie(const pp::Var& var);
+
 }  // namespace google_smart_card
 
 #endif  // GOOGLE_SMART_CARD_COMMON_VALUE_NACL_PP_VAR_CONVERSION_H_

--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion_unittest.cc
@@ -463,4 +463,33 @@ TEST(ValueNaclPpVarConversion, PpVarArrayWithBadItem) {
   }
 }
 
+// Test that `ConvertPpVarToValueOrDie()` succeeds on supported inputs. As death
+// tests aren't supported, we don't test failure scenarios.
+TEST(ValueNaclPpVarConversion, PpVarOrDie) {
+  {
+    constexpr bool kBoolean = false;
+    const Value value = ConvertPpVarToValueOrDie(pp::Var(kBoolean));
+    ASSERT_TRUE(value.is_boolean());
+    EXPECT_EQ(value.GetBoolean(), kBoolean);
+  }
+
+  {
+    const int kInteger = 123;
+    const Value value = ConvertPpVarToValueOrDie(pp::Var(kInteger));
+    ASSERT_TRUE(value.is_integer());
+    EXPECT_EQ(value.GetInteger(), kInteger);
+  }
+
+  {
+    pp::VarDictionary var_dict;
+    ASSERT_TRUE(var_dict.Set("foo", pp::Var(pp::Var::Null())));
+    const Value value = ConvertPpVarToValueOrDie(var_dict);
+    ASSERT_TRUE(value.is_dictionary());
+    EXPECT_EQ(value.GetDictionary().size(), 1U);
+    const Value* foo_value = value.GetDictionaryItem("foo");
+    ASSERT_TRUE(foo_value);
+    EXPECT_TRUE(foo_value->is_null());
+  }
+}
+
 }  // namespace google_smart_card


### PR DESCRIPTION
Add new variants of the ConvertToValue/ConvertFromValue functions that
immediately crash the program in case the conversion fails.

These functions should be used in cases when the error is really
unexpected (e.g., when the input data is guaranteed to be of specific
form) and/or when there's no recovery possible from the error.

This is part of the effort on migrating the //common/cpp library to use
the toolchain-independent Value class, making it work under both
Native Client and WebAssembly (#185).