### PR TITLE
Script for auto-formatting code via clang-format

### DIFF
--- a/format-code.sh
+++ b/format-code.sh
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script formats via clang-format the modified C++ files according to the
+# This script formats the modified C++ files via clang-format according to the
 # Google C++ Style Guide.
-# Considered are only files that are known to Git and belonging to the diff to
-# the "master" branch.
+# Only files that are known to Git and belong to the diff of the "master" branch
+# are considered.
 #
 # Note: Sorting of #include's is currently disabled, since the standard
 # algorithm reorders them incorrectly (e.g., it puts includes within our project
@@ -29,10 +29,11 @@ set -eu
 cd $(dirname $(realpath ${0}))
 
 # Find all relevant touched files. Bail out if nothing is found.
+# Note: "d" in --diff-filter means excluding deleted files - otherwise
+# clang-format fails on these non-existing files.
 FILES=$(git diff --name-only --diff-filter=d master -- "*.cc" "*.h")
 [ "${FILES}" ] || exit 0
 
-# Note: "d" in --diff-filter means excluding deleted files - otherwise
-# clang-format would fail on these non-existing files.
+# Run clang-format on every found file.
 echo "${FILES}" | \
   xargs clang-format -i --style=Google --sort-includes=false

--- a/format-code.sh
+++ b/format-code.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script formats via clang-format the modified C++ files according to the
+# Google C++ Style Guide.
+# Considered are only files that are known to Git and belonging to the diff to
+# the "master" branch.
+#
+# Note: Sorting of #include's is currently disabled, since the standard
+# algorithm reorders them incorrectly (e.g., it puts includes within our project
+# into the same group as C system headers).
+
+set -eu
+
+# Go to the root directory of the repository.
+cd $(dirname $(realpath ${0}))
+
+# Find all relevant touched files. Bail out if nothing is found.
+FILES=$(git diff --name-only --diff-filter=d master -- "*.cc" "*.h")
+[ "${FILES}" ] || exit 0
+
+# Note: "d" in --diff-filter means excluding deleted files - otherwise
+# clang-format would fail on these non-existing files.
+echo "${FILES}" | \
+  xargs clang-format -i --style=Google --sort-includes=false


### PR DESCRIPTION
Add a small script that can be used when developing locally in order to
automatically format the touched C++ files according to the Google C++
Style Guide. The script is based on the "clang-format" tool.

The script assumes that the "clang-format" program is installed into the
system and is in $PATH.