### PR TITLE
Migrate non-//common to Value-based TypedMessage

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -112,6 +112,7 @@ INSTALLING_HEADERS := \
 	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):tuple_unpacking.h \
 	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):unique_ptr_utils.h \
 	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):value.h \
+	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):value_conversion.h \
 	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):value_nacl_pp_var_conversion.h \
 
 $(eval $(call NACL_LIBRARY_HEADERS_INSTALLATION_RULE,$(INSTALLING_HEADERS)))

--- a/smart_card_connector_app/src/pp_module.cc
+++ b/smart_card_connector_app/src/pp_module.cc
@@ -31,6 +31,7 @@
 #include <google_smart_card_common/optional.h>
 #include <google_smart_card_common/pp_var_utils/debug_dump.h>
 #include <google_smart_card_common/value.h>
+#include <google_smart_card_common/value_conversion.h>
 #include <google_smart_card_common/value_nacl_pp_var_conversion.h>
 #include <google_smart_card_libusb/global.h>
 #include <google_smart_card_pcsc_lite_server/global.h>
@@ -104,8 +105,12 @@ class PpInstance final : public pp::Instance {
                                 << "initialized, posting ready message...";
     TypedMessage ready_message;
     ready_message.type = GetPcscLiteServerReadyMessageType();
-    ready_message.data = MakePcscLiteServerReadyMessageData();
-    PostMessage(MakeVar(ready_message));
+    // TODO: Directly create `Value` instead of transforming from `pp::Var`.
+    ready_message.data =
+        ConvertPpVarToValueOrDie(MakePcscLiteServerReadyMessageData());
+    Value ready_message_value = ConvertToValueOrDie(std::move(ready_message));
+    // TODO: Directly post `Value` instead of `pp::Var`.
+    PostMessage(ConvertValueToPpVar(ready_message_value));
   }
 
   TypedMessageRouter typed_message_router_;

--- a/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.cc
+++ b/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.cc
@@ -43,6 +43,9 @@ extern "C" {
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/messaging/typed_message.h>
 #include <google_smart_card_common/pp_var_utils/construction.h>
+#include <google_smart_card_common/value.h>
+#include <google_smart_card_common/value_conversion.h>
+#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
 
 #include "server_sockets_manager.h"
 #include "socketpair_emulation.h"
@@ -230,8 +233,11 @@ void PcscLiteServerGlobal::PostMessage(
   if (pp_instance_) {
     TypedMessage typed_message;
     typed_message.type = type;
-    typed_message.data = message_data;
-    pp_instance_->PostMessage(MakeVar(typed_message));
+    // TODO: Directly receive `Value` instead of transforming from `pp::Var`.
+    typed_message.data = ConvertPpVarToValueOrDie(message_data);
+    Value typed_message_value = ConvertToValueOrDie(std::move(typed_message));
+    // TODO: Directly post `Value` instead of `pp::Var`.
+    pp_instance_->PostMessage(ConvertValueToPpVar(typed_message_value));
   }
 }
 


### PR DESCRIPTION
Adjust the C++ code outside //common/cpp to the new implementation of
TypedMessage that doesn't support pp::Var anymore.

This CL is a follow-up to #201, and is a stop-gap solution to make the
whole project still compile and work while we're working on the migration
of the //common/cpp library (as tracked by #185). After completion of
that part, we'll clean up the non-//common code to delete all those
back-and-forth pp::Var conversions and to use Value wherever possible.