### PR TITLE
Split out toolchain-specific .mk build rules

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -16,7 +16,7 @@ TARGET := google_smart_card_common
 
 include ../../make/common.mk
 
-include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
+include $(COMMON_DIR_PATH)/make/executable_building.mk
 
 include ../include.mk
 

--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -16,7 +16,7 @@ TARGET := google_smart_card_common
 
 include ../../make/common.mk
 
-include $(COMMON_DIR_PATH)/make/nacl_module_building_common.mk
+include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
 
 include ../include.mk
 

--- a/common/cpp/dependency.mk
+++ b/common/cpp/dependency.mk
@@ -17,7 +17,7 @@
 # Including of this file creates a NaCl module building dependency on this
 # library.
 #
-# /common/make/common.mk, /common/make/binary_executable_building.mk and
+# /common/make/common.mk, /common/make/executable_building.mk and
 # include.mk must be included before including this file.
 #
 

--- a/common/cpp/dependency.mk
+++ b/common/cpp/dependency.mk
@@ -17,7 +17,7 @@
 # Including of this file creates a NaCl module building dependency on this
 # library.
 #
-# /common/make/common.mk, /common/make/nacl_module_building_common.mk and
+# /common/make/common.mk, /common/make/binary_executable_building.mk and
 # include.mk must be included before including this file.
 #
 

--- a/common/cpp/include.mk
+++ b/common/cpp/include.mk
@@ -16,7 +16,7 @@
 #
 # This file contains helper definitions for using this library.
 #
-# /common/make/common.mk and /common/make/nacl_module_building_common.mk must be
+# /common/make/common.mk and /common/make/binary_executable_building.mk must be
 # included before including this file.
 #
 

--- a/common/cpp/include.mk
+++ b/common/cpp/include.mk
@@ -16,7 +16,7 @@
 #
 # This file contains helper definitions for using this library.
 #
-# /common/make/common.mk and /common/make/binary_executable_building.mk must be
+# /common/make/common.mk and /common/make/executable_building.mk must be
 # included before including this file.
 #
 

--- a/common/integration_testing/build/Makefile
+++ b/common/integration_testing/build/Makefile
@@ -16,7 +16,7 @@ TARGET := google_smart_card_integration_testing
 
 include ../../make/common.mk
 
-include $(COMMON_DIR_PATH)/make/nacl_module_building_common.mk
+include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
 
 include ../include.mk
 

--- a/common/integration_testing/dependency.mk
+++ b/common/integration_testing/dependency.mk
@@ -17,7 +17,7 @@
 # Including of this file creates a NaCl module building dependency on this
 # library.
 #
-# /common/make/common.mk, /common/make/nacl_module_building_common.mk and
+# /common/make/common.mk, /common/make/binary_executable_building.mk and
 # include.mk must be included before including this file.
 #
 

--- a/common/integration_testing/include.mk
+++ b/common/integration_testing/include.mk
@@ -16,7 +16,7 @@
 #
 # This file contains helper definitions for using this library.
 #
-# /common/make/common.mk and /common/make/nacl_module_building_common.mk must be
+# /common/make/common.mk and /common/make/binary_executable_building.mk must be
 # included before including this file.
 #
 

--- a/common/make/binary_executable_building.mk
+++ b/common/make/binary_executable_building.mk
@@ -1,0 +1,90 @@
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains helper definitions for building an executable binary that
+# can be run in web-based applications.
+#
+# The actually used technology depends on the TOOLCHAIN environment variable.
+# Currently, the only supported value is "pnacl", which corresponds to the
+# Google Native Client technology.
+#
+# common.mk must be included before including this file.
+
+# Default to using the "pnacl" toolchain.
+TOOLCHAIN ?= pnacl
+
+# Common documentation for definitions provided by this file (they are
+# implemented in toolchain-specific .mk files, but share the same interface):
+#
+# * COMPILE_RULE macro:
+#   Generates object files from the given C/C++ files.
+#   Arguments:
+#   $1 ("SOURCES"): Source file paths,
+#   $2 ("CFLAGS", optional): C/C++ compiler flags.
+#
+# * LIB_RULE macro:
+#   Links object files that correspond to the given source files into a static
+#   library file. The resulting file is put into a shared library directory.
+#   Arguments:
+#   $1 ("TARGET"): Library name (without the "lib" prefix or the extension),
+#   $2 ("SOURCES"): Source file paths.
+#
+# * LINK_EXECUTABLE_RULE macro:
+#   Links object files that correspond to the given source files into an
+#   executable program. The resulting files are put into the out directory.
+#   Arguments:
+#   $1 ("SOURCES"): Source file paths,
+#   $2 ("LIBS", optional): Static libraries to link against,
+#   $3 ("DEPS", optional): Libraries whose building will be added as
+#     dependencies of this target.
+#   $4 ("LDFLAGS", optional): Linker flags.
+#
+# * NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH variable:
+#   Path where library headers are installed by the
+#   NACL_LIBRARY_HEADERS_INSTALLATION_RULE macro.
+#
+# * NACL_LIBRARY_HEADERS_INSTALLATION_RULE macro:
+#   Installs specified headers into $NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH.
+#   Arguments:
+#   $1 ("INSTALLING_HEADERS"): List of header descriptions, where each list item
+#     should contain colon-separated destination directory (relative to
+#     NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH), source directory and source
+#     file path (relative to the source directory). Example:
+#     "foolib:../src:a.h foolib:../src:b/c.h", which denotes installation of
+#     file ../src/a.h into
+#     $NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH/libfoo/a.h and of file
+#     ../src/b/c.h into
+#     $NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH/libfoo/b/c.h.
+#
+# * DEPEND_COMPILE_ON_NACL_LIBRARY_HEADERS macro:
+#   Adds the specified library as a prerequisite for compilation rule of the
+#   the specified file.
+#   Arguments:
+#   $1 ("SOURCES"): Source file paths,
+#   $2 ("STAMP_FILE"): The library's header installation stamp file, defined via
+#     the DEFINE_NACL_LIBRARY_HEADERS_INSTALLATION_TARGET rule.
+#
+# * DEFINE_NACL_LIBRARY_HEADERS_INSTALLATION_TARGET macro:
+#   Defines the target for the library headers installation and sets the
+#   variable containing the target name.
+#   Arguments:
+#   $1 ("STAMP_FILE_VAR"): Variable to be set to the stamp file name.
+#   $2 ("LIB_DIR"): Path to the library's build directory.
+
+# Load the toolchain-specific file.
+ifeq ($(TOOLCHAIN),pnacl)
+include $(COMMON_DIR_PATH)/make/internal/binary_executable_building_nacl.mk
+else
+$(error Unknown TOOLCHAIN "$(TOOLCHAIN)".)
+endif

--- a/common/make/executable_building.mk
+++ b/common/make/executable_building.mk
@@ -51,10 +51,12 @@ TOOLCHAIN ?= pnacl
 #   $4 ("LDFLAGS", optional): Linker flags.
 #
 # * NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH variable:
+#   TODO(#177): Rename to a toolchain-independent name.
 #   Path where library headers are installed by the
 #   NACL_LIBRARY_HEADERS_INSTALLATION_RULE macro.
 #
 # * NACL_LIBRARY_HEADERS_INSTALLATION_RULE macro:
+#   TODO(#177): Rename to a toolchain-independent name.
 #   Installs specified headers into $NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH.
 #   Arguments:
 #   $1 ("INSTALLING_HEADERS"): List of header descriptions, where each list item
@@ -68,6 +70,7 @@ TOOLCHAIN ?= pnacl
 #     $NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH/libfoo/b/c.h.
 #
 # * DEPEND_COMPILE_ON_NACL_LIBRARY_HEADERS macro:
+#   TODO(#177): Rename to a toolchain-independent name.
 #   Adds the specified library as a prerequisite for compilation rule of the
 #   the specified file.
 #   Arguments:
@@ -76,6 +79,7 @@ TOOLCHAIN ?= pnacl
 #     the DEFINE_NACL_LIBRARY_HEADERS_INSTALLATION_TARGET rule.
 #
 # * DEFINE_NACL_LIBRARY_HEADERS_INSTALLATION_TARGET macro:
+#   TODO(#177): Rename to a toolchain-independent name.
 #   Defines the target for the library headers installation and sets the
 #   variable containing the target name.
 #   Arguments:
@@ -84,7 +88,7 @@ TOOLCHAIN ?= pnacl
 
 # Load the toolchain-specific file.
 ifeq ($(TOOLCHAIN),pnacl)
-include $(COMMON_DIR_PATH)/make/internal/binary_executable_building_nacl.mk
+include $(COMMON_DIR_PATH)/make/internal/executable_building_nacl.mk
 else
 $(error Unknown TOOLCHAIN "$(TOOLCHAIN)".)
 endif

--- a/common/make/internal/binary_executable_building_nacl.mk
+++ b/common/make/internal/binary_executable_building_nacl.mk
@@ -14,8 +14,8 @@
 
 
 #
-# This file contains some helper definitions for building Chrome Native Client
-# modules and libraries.
+# This file contains the implementation of the ../binary_executable_building.mk
+# that builds using Chrome Native Client.
 #
 # common.mk must be included before including this file.
 #
@@ -36,8 +36,6 @@ endif
 #
 
 VALID_TOOLCHAINS ?= pnacl
-
-TOOLCHAIN ?= pnacl
 
 
 #
@@ -61,36 +59,19 @@ DEFAULT_NACL_LIBS := \
 
 
 #
-# Macro rule that adds various rules for building the resulting NaCl module in
-# the out directory. It is only assumed that the compilation rules (COMPILE_RULE
-# from the NaCl SDK definitions) are already invoked.
-#
-# Arguments:
-#    $1: Source file paths,
-#    $2: LIBS,
-#    $3: DEPS,
-#    $4: (optional) Linker command-line switches.
+# Documented at ../binary_executable_building.mk.
 #
 
 define LINK_EXECUTABLE_RULE
-
 $(eval $(call NACL_MODULE_LINK_INTERNAL_RULE,$(1),$(2),$(3),$(4)))
-
 $(eval $(call NACL_MODULE_COPY_BINARIES_INTERNAL_RULE))
-
 $(eval $(call NMF_RULE,$(TARGET),--pnacl-optlevel=0 --pnacl-debug-optlevel=0))
-
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(OUTDIR)/$(TARGET).nmf))
-
 endef
 
 
 #
-# Target directory for installing the library header files.
-#
-# This directory is under the NaCl SDK libraries directory, so after installing
-# into it the consumer applications can just compile with the library headers
-# without specifying any additional search paths.
+# Documented at ../binary_executable_building.mk.
 #
 
 NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH := \
@@ -105,22 +86,7 @@ NACL_LIBRARY_HEADERS_INSTALLATION_STAMP_FILE_NAME := headers_installed.stamp
 
 
 #
-# Macro rule that adds rule for the headers installation.
-#
-# The headers are installed into subdirectories of
-# $NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH. It is assumed that no two
-# libraries share the same destination directory.
-#
-# Arguments:
-#    $1: List of header descriptions, where each list item should contain
-#        colon-separated destination directory (relative to
-#        NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH), source directory and
-#        source file path (relative to the source directory). Example:
-#        "foolib:../src:a.h foolib:../src:b/c.h", which denotes installation of
-#        file ../src/a.h into
-#        $NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH/libfoo/a.h and of file
-#        ../src/b/c.h into
-#        $NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH/libfoo/b/c.h.
+# Documented at ../binary_executable_building.mk.
 #
 
 define NACL_LIBRARY_HEADERS_INSTALLATION_RULE
@@ -142,13 +108,7 @@ endef
 
 
 #
-# Macro rule that adds the specified library as a prerequisite for compilation
-# rule of the specified file.
-#
-# Arguments:
-#    $1: Source (C/C++) file path.
-#    $2: Name of the target representing the headers installation of the
-#        library.
+# Documented at ../binary_executable_building.mk.
 #
 
 define DEPEND_COMPILE_ON_NACL_LIBRARY_HEADERS
@@ -159,12 +119,7 @@ endef
 
 
 #
-# Macro rule that defines the target for the library headers installation and
-# the variable containing the target name.
-#
-# Arguments:
-#    $1: Name of the variable to contain the headers installation target name.
-#    $2: Path to the library's build directory.
+# Documented at ../binary_executable_building.mk.
 #
 
 define DEFINE_NACL_LIBRARY_HEADERS_INSTALLATION_TARGET
@@ -184,7 +139,7 @@ endef
 # NaCl, only produce a stripped binary in Release builds.
 #
 
-ifneq (,$(or $(findstring pnacl,$(TOOLCHAIN)),$(findstring Release,$(CONFIG))))
+ifneq (,$(or $(findstring pnacl,$(TOOLCHAIN)),$(and $(findstring nacl,$(TOOLCHAIN), $(findstring Release,$(CONFIG))))))
 
 define NACL_MODULE_LINK_INTERNAL_RULE
 $(eval $(call LINK_RULE,$(TARGET)_unstripped,$(1),$(2),$(3),$(4)))

--- a/common/make/internal/binary_executable_building_nacl.mk
+++ b/common/make/internal/binary_executable_building_nacl.mk
@@ -15,7 +15,7 @@
 
 #
 # This file contains the implementation of the ../binary_executable_building.mk
-# that builds using Chrome Native Client.
+# interface that builds using Chrome Native Client.
 #
 # common.mk must be included before including this file.
 #
@@ -63,10 +63,15 @@ DEFAULT_NACL_LIBS := \
 #
 
 define LINK_EXECUTABLE_RULE
+
 $(eval $(call NACL_MODULE_LINK_INTERNAL_RULE,$(1),$(2),$(3),$(4)))
+
 $(eval $(call NACL_MODULE_COPY_BINARIES_INTERNAL_RULE))
+
 $(eval $(call NMF_RULE,$(TARGET),--pnacl-optlevel=0 --pnacl-debug-optlevel=0))
+
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(OUTDIR)/$(TARGET).nmf))
+
 endef
 
 
@@ -139,7 +144,7 @@ endef
 # NaCl, only produce a stripped binary in Release builds.
 #
 
-ifneq (,$(or $(findstring pnacl,$(TOOLCHAIN)),$(and $(findstring nacl,$(TOOLCHAIN), $(findstring Release,$(CONFIG))))))
+ifneq (,$(or $(findstring pnacl,$(TOOLCHAIN)),$(findstring Release,$(CONFIG))))
 
 define NACL_MODULE_LINK_INTERNAL_RULE
 $(eval $(call LINK_RULE,$(TARGET)_unstripped,$(1),$(2),$(3),$(4)))

--- a/common/make/internal/executable_building_nacl.mk
+++ b/common/make/internal/executable_building_nacl.mk
@@ -14,7 +14,7 @@
 
 
 #
-# This file contains the implementation of the ../binary_executable_building.mk
+# This file contains the implementation of the ../executable_building.mk
 # interface that builds using Chrome Native Client.
 #
 # common.mk must be included before including this file.

--- a/common/tests_runner/build.mk
+++ b/common/tests_runner/build.mk
@@ -31,7 +31,7 @@ include $(TESTS_RUNNER_DIR)/../make/common.mk
 
 PAGE := $(OUT_DIR_PATH)/index.html
 
-include $(COMMON_DIR_PATH)/make/nacl_module_building_common.mk
+include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
 
 
 #

--- a/example_cpp_smart_card_client_app/build/integration_tests/Makefile
+++ b/example_cpp_smart_card_client_app/build/integration_tests/Makefile
@@ -24,7 +24,7 @@ include ../../../common/make/common.mk
 PAGE := $(OUT_DIR_PATH)/index.html
 
 include $(COMMON_DIR_PATH)/make/js_building_common.mk
-include $(COMMON_DIR_PATH)/make/nacl_module_building_common.mk
+include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
 include $(COMMON_DIR_PATH)/cpp/include.mk
 include $(COMMON_DIR_PATH)/cpp/dependency.mk
 include $(COMMON_DIR_PATH)/js/include.mk

--- a/example_cpp_smart_card_client_app/build/integration_tests/Makefile
+++ b/example_cpp_smart_card_client_app/build/integration_tests/Makefile
@@ -24,7 +24,7 @@ include ../../../common/make/common.mk
 PAGE := $(OUT_DIR_PATH)/index.html
 
 include $(COMMON_DIR_PATH)/make/js_building_common.mk
-include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
+include $(COMMON_DIR_PATH)/make/executable_building.mk
 include $(COMMON_DIR_PATH)/cpp/include.mk
 include $(COMMON_DIR_PATH)/cpp/dependency.mk
 include $(COMMON_DIR_PATH)/js/include.mk

--- a/example_cpp_smart_card_client_app/build/nacl_module/Makefile
+++ b/example_cpp_smart_card_client_app/build/nacl_module/Makefile
@@ -17,7 +17,7 @@ TARGET := nacl_module
 
 include ../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/nacl_module_building_common.mk
+include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
 
 include $(COMMON_DIR_PATH)/cpp/include.mk
 include $(COMMON_DIR_PATH)/cpp/dependency.mk

--- a/example_cpp_smart_card_client_app/build/nacl_module/Makefile
+++ b/example_cpp_smart_card_client_app/build/nacl_module/Makefile
@@ -17,7 +17,7 @@ TARGET := nacl_module
 
 include ../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
+include $(COMMON_DIR_PATH)/make/executable_building.mk
 
 include $(COMMON_DIR_PATH)/cpp/include.mk
 include $(COMMON_DIR_PATH)/cpp/dependency.mk

--- a/smart_card_connector_app/build/nacl_module/Makefile
+++ b/smart_card_connector_app/build/nacl_module/Makefile
@@ -17,7 +17,7 @@ TARGET := nacl_module
 
 include ../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/nacl_module_building_common.mk
+include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
 
 include $(COMMON_DIR_PATH)/cpp/include.mk
 include $(COMMON_DIR_PATH)/cpp/dependency.mk

--- a/smart_card_connector_app/build/nacl_module/Makefile
+++ b/smart_card_connector_app/build/nacl_module/Makefile
@@ -17,7 +17,7 @@ TARGET := nacl_module
 
 include ../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
+include $(COMMON_DIR_PATH)/make/executable_building.mk
 
 include $(COMMON_DIR_PATH)/cpp/include.mk
 include $(COMMON_DIR_PATH)/cpp/dependency.mk

--- a/third_party/ccid/naclport/build/Makefile
+++ b/third_party/ccid/naclport/build/Makefile
@@ -23,7 +23,7 @@ TARGET := google_smart_card_ccid
 
 include ../../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/nacl_module_building_common.mk
+include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
 
 include $(COMMON_DIR_PATH)/cpp/include.mk
 

--- a/third_party/ccid/naclport/build/Makefile
+++ b/third_party/ccid/naclport/build/Makefile
@@ -23,7 +23,7 @@ TARGET := google_smart_card_ccid
 
 include ../../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
+include $(COMMON_DIR_PATH)/make/executable_building.mk
 
 include $(COMMON_DIR_PATH)/cpp/include.mk
 

--- a/third_party/ccid/naclport/dependency.mk
+++ b/third_party/ccid/naclport/dependency.mk
@@ -19,7 +19,7 @@
 # Including of this file creates a NaCl module building dependency on this
 # library.
 #
-# /common/make/common.mk, /common/make/nacl_module_building_common.mk and
+# /common/make/common.mk, /common/make/binary_executable_building.mk and
 # include.mk must be included before including this file.
 #
 

--- a/third_party/ccid/naclport/dependency.mk
+++ b/third_party/ccid/naclport/dependency.mk
@@ -19,8 +19,8 @@
 # Including of this file creates a NaCl module building dependency on this
 # library.
 #
-# /common/make/common.mk, /common/make/binary_executable_building.mk and
-# include.mk must be included before including this file.
+# /common/make/common.mk, /common/make/executable_building.mk and include.mk
+# must be included before including this file.
 #
 
 

--- a/third_party/ccid/naclport/include.mk
+++ b/third_party/ccid/naclport/include.mk
@@ -18,7 +18,7 @@
 #
 # This file contains helper definitions for using this library.
 #
-# /common/make/common.mk and /common/make/nacl_module_building_common.mk must be
+# /common/make/common.mk and /common/make/binary_executable_building.mk must be
 # included before including this file.
 #
 

--- a/third_party/ccid/naclport/include.mk
+++ b/third_party/ccid/naclport/include.mk
@@ -18,7 +18,7 @@
 #
 # This file contains helper definitions for using this library.
 #
-# /common/make/common.mk and /common/make/binary_executable_building.mk must be
+# /common/make/common.mk and /common/make/executable_building.mk must be
 # included before including this file.
 #
 

--- a/third_party/libusb/naclport/build/Makefile
+++ b/third_party/libusb/naclport/build/Makefile
@@ -19,7 +19,7 @@ TARGET := google_smart_card_libusb
 
 include ../../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/nacl_module_building_common.mk
+include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
 
 include $(COMMON_DIR_PATH)/cpp/include.mk
 

--- a/third_party/libusb/naclport/build/Makefile
+++ b/third_party/libusb/naclport/build/Makefile
@@ -19,7 +19,7 @@ TARGET := google_smart_card_libusb
 
 include ../../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
+include $(COMMON_DIR_PATH)/make/executable_building.mk
 
 include $(COMMON_DIR_PATH)/cpp/include.mk
 

--- a/third_party/libusb/naclport/dependency.mk
+++ b/third_party/libusb/naclport/dependency.mk
@@ -19,7 +19,7 @@
 # Including of this file creates a NaCl module building dependency on this
 # library.
 #
-# /common/make/common.mk, /common/make/nacl_module_building_common.mk and
+# /common/make/common.mk, /common/make/binary_executable_building.mk and
 # include.mk must be included before including this file.
 #
 

--- a/third_party/libusb/naclport/dependency.mk
+++ b/third_party/libusb/naclport/dependency.mk
@@ -19,8 +19,8 @@
 # Including of this file creates a NaCl module building dependency on this
 # library.
 #
-# /common/make/common.mk, /common/make/binary_executable_building.mk and
-# include.mk must be included before including this file.
+# /common/make/common.mk, /common/make/executable_building.mk and include.mk
+# must be included before including this file.
 #
 
 

--- a/third_party/libusb/naclport/include.mk
+++ b/third_party/libusb/naclport/include.mk
@@ -18,7 +18,7 @@
 #
 # This file contains helper definitions for using this library.
 #
-# /common/make/common.mk and /common/make/nacl_module_building_common.mk must be
+# /common/make/common.mk and /common/make/binary_executable_building.mk must be
 # included before including this file.
 #
 

--- a/third_party/libusb/naclport/include.mk
+++ b/third_party/libusb/naclport/include.mk
@@ -18,7 +18,7 @@
 #
 # This file contains helper definitions for using this library.
 #
-# /common/make/common.mk and /common/make/binary_executable_building.mk must be
+# /common/make/common.mk and /common/make/executable_building.mk must be
 # included before including this file.
 #
 

--- a/third_party/pcsc-lite/naclport/common/build/Makefile
+++ b/third_party/pcsc-lite/naclport/common/build/Makefile
@@ -28,7 +28,7 @@ TARGET := google_smart_card_pcsc_lite_common
 
 include ../../../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/nacl_module_building_common.mk
+include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
 
 include $(COMMON_DIR_PATH)/cpp/include.mk
 

--- a/third_party/pcsc-lite/naclport/common/build/Makefile
+++ b/third_party/pcsc-lite/naclport/common/build/Makefile
@@ -28,7 +28,7 @@ TARGET := google_smart_card_pcsc_lite_common
 
 include ../../../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
+include $(COMMON_DIR_PATH)/make/executable_building.mk
 
 include $(COMMON_DIR_PATH)/cpp/include.mk
 

--- a/third_party/pcsc-lite/naclport/common/dependency.mk
+++ b/third_party/pcsc-lite/naclport/common/dependency.mk
@@ -28,7 +28,7 @@
 # Including of this file creates a NaCl module building dependency on this
 # library.
 #
-# /common/make/common.mk, /common/make/nacl_module_building_common.mk and
+# /common/make/common.mk, /common/make/binary_executable_building.mk and
 # include.mk must be included before including this file.
 #
 

--- a/third_party/pcsc-lite/naclport/common/dependency.mk
+++ b/third_party/pcsc-lite/naclport/common/dependency.mk
@@ -28,8 +28,8 @@
 # Including of this file creates a NaCl module building dependency on this
 # library.
 #
-# /common/make/common.mk, /common/make/binary_executable_building.mk and
-# include.mk must be included before including this file.
+# /common/make/common.mk, /common/make/executable_building.mk and include.mk
+# must be included before including this file.
 #
 
 

--- a/third_party/pcsc-lite/naclport/cpp_client/build/Makefile
+++ b/third_party/pcsc-lite/naclport/cpp_client/build/Makefile
@@ -28,7 +28,7 @@ TARGET := google_smart_card_pcsc_lite_client
 
 include ../../../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
+include $(COMMON_DIR_PATH)/make/executable_building.mk
 
 include $(COMMON_DIR_PATH)/cpp/include.mk
 

--- a/third_party/pcsc-lite/naclport/cpp_client/build/Makefile
+++ b/third_party/pcsc-lite/naclport/cpp_client/build/Makefile
@@ -28,7 +28,7 @@ TARGET := google_smart_card_pcsc_lite_client
 
 include ../../../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/nacl_module_building_common.mk
+include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
 
 include $(COMMON_DIR_PATH)/cpp/include.mk
 

--- a/third_party/pcsc-lite/naclport/cpp_client/dependency.mk
+++ b/third_party/pcsc-lite/naclport/cpp_client/dependency.mk
@@ -28,7 +28,7 @@
 # Including of this file creates a NaCl module building dependency on this
 # library.
 #
-# /common/make/common.mk, /common/make/nacl_module_building_common.mk and
+# /common/make/common.mk, /common/make/binary_executable_building.mk and
 # include.mk must be included before including this file.
 #
 

--- a/third_party/pcsc-lite/naclport/cpp_client/dependency.mk
+++ b/third_party/pcsc-lite/naclport/cpp_client/dependency.mk
@@ -28,8 +28,8 @@
 # Including of this file creates a NaCl module building dependency on this
 # library.
 #
-# /common/make/common.mk, /common/make/binary_executable_building.mk and
-# include.mk must be included before including this file.
+# /common/make/common.mk, /common/make/executable_building.mk and include.mk
+# must be included before including this file.
 #
 
 

--- a/third_party/pcsc-lite/naclport/cpp_client/include.mk
+++ b/third_party/pcsc-lite/naclport/cpp_client/include.mk
@@ -27,7 +27,7 @@
 #
 # This file contains helper definitions for using this library.
 #
-# /common/make/common.mk and /common/make/binary_executable_building.mk must be
+# /common/make/common.mk and /common/make/executable_building.mk must be
 # included before including this file.
 #
 

--- a/third_party/pcsc-lite/naclport/cpp_client/include.mk
+++ b/third_party/pcsc-lite/naclport/cpp_client/include.mk
@@ -27,7 +27,7 @@
 #
 # This file contains helper definitions for using this library.
 #
-# /common/make/common.mk and /common/make/nacl_module_building_common.mk must be
+# /common/make/common.mk and /common/make/binary_executable_building.mk must be
 # included before including this file.
 #
 

--- a/third_party/pcsc-lite/naclport/cpp_demo/build/Makefile
+++ b/third_party/pcsc-lite/naclport/cpp_demo/build/Makefile
@@ -28,7 +28,7 @@ TARGET := google_smart_card_pcsc_lite_cpp_demo
 
 include ../../../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
+include $(COMMON_DIR_PATH)/make/executable_building.mk
 
 include $(COMMON_DIR_PATH)/cpp/include.mk
 

--- a/third_party/pcsc-lite/naclport/cpp_demo/build/Makefile
+++ b/third_party/pcsc-lite/naclport/cpp_demo/build/Makefile
@@ -28,7 +28,7 @@ TARGET := google_smart_card_pcsc_lite_cpp_demo
 
 include ../../../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/nacl_module_building_common.mk
+include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
 
 include $(COMMON_DIR_PATH)/cpp/include.mk
 

--- a/third_party/pcsc-lite/naclport/cpp_demo/dependency.mk
+++ b/third_party/pcsc-lite/naclport/cpp_demo/dependency.mk
@@ -28,7 +28,7 @@
 # Including of this file creates a NaCl module building dependency on this
 # library.
 #
-# /common/make/common.mk, /common/make/nacl_module_building_common.mk and
+# /common/make/common.mk, /common/make/binary_executable_building.mk and
 # include.mk must be included before including this file.
 #
 

--- a/third_party/pcsc-lite/naclport/cpp_demo/dependency.mk
+++ b/third_party/pcsc-lite/naclport/cpp_demo/dependency.mk
@@ -28,8 +28,8 @@
 # Including of this file creates a NaCl module building dependency on this
 # library.
 #
-# /common/make/common.mk, /common/make/binary_executable_building.mk and
-# include.mk must be included before including this file.
+# /common/make/common.mk, /common/make/executable_building.mk and include.mk
+# must be included before including this file.
 #
 
 

--- a/third_party/pcsc-lite/naclport/server/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server/build/Makefile
@@ -34,7 +34,7 @@ TARGET := google_smart_card_pcsc_lite_server
 
 include ../../../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
+include $(COMMON_DIR_PATH)/make/executable_building.mk
 
 include $(COMMON_DIR_PATH)/cpp/include.mk
 

--- a/third_party/pcsc-lite/naclport/server/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server/build/Makefile
@@ -34,7 +34,7 @@ TARGET := google_smart_card_pcsc_lite_server
 
 include ../../../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/nacl_module_building_common.mk
+include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
 
 include $(COMMON_DIR_PATH)/cpp/include.mk
 

--- a/third_party/pcsc-lite/naclport/server/dependency.mk
+++ b/third_party/pcsc-lite/naclport/server/dependency.mk
@@ -28,7 +28,7 @@
 # Including of this file creates a NaCl module building dependency on this
 # library.
 #
-# /common/make/common.mk, /common/make/nacl_module_building_common.mk and
+# /common/make/common.mk, /common/make/binary_executable_building.mk and
 # include.mk must be included before including this file.
 #
 

--- a/third_party/pcsc-lite/naclport/server/dependency.mk
+++ b/third_party/pcsc-lite/naclport/server/dependency.mk
@@ -28,8 +28,8 @@
 # Including of this file creates a NaCl module building dependency on this
 # library.
 #
-# /common/make/common.mk, /common/make/binary_executable_building.mk and
-# include.mk must be included before including this file.
+# /common/make/common.mk, /common/make/executable_building.mk and include.mk
+# must be included before including this file.
 #
 
 

--- a/third_party/pcsc-lite/naclport/server/include.mk
+++ b/third_party/pcsc-lite/naclport/server/include.mk
@@ -27,7 +27,7 @@
 #
 # This file contains helper definitions for using this library.
 #
-# /common/make/common.mk and /common/make/binary_executable_building.mk must be
+# /common/make/common.mk and /common/make/executable_building.mk must be
 # included before including this file.
 #
 

--- a/third_party/pcsc-lite/naclport/server/include.mk
+++ b/third_party/pcsc-lite/naclport/server/include.mk
@@ -27,7 +27,7 @@
 #
 # This file contains helper definitions for using this library.
 #
-# /common/make/common.mk and /common/make/nacl_module_building_common.mk must be
+# /common/make/common.mk and /common/make/binary_executable_building.mk must be
 # included before including this file.
 #
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server_clients_management/build/Makefile
@@ -27,7 +27,7 @@ TARGET := google_smart_card_pcsc_lite_server_clients_management
 
 include ../../../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
+include $(COMMON_DIR_PATH)/make/executable_building.mk
 
 include $(COMMON_DIR_PATH)/make/js_building_common.mk
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server_clients_management/build/Makefile
@@ -27,7 +27,7 @@ TARGET := google_smart_card_pcsc_lite_server_clients_management
 
 include ../../../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/nacl_module_building_common.mk
+include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
 
 include $(COMMON_DIR_PATH)/make/js_building_common.mk
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/dependency.mk
+++ b/third_party/pcsc-lite/naclport/server_clients_management/dependency.mk
@@ -28,7 +28,7 @@
 # Including of this file creates a NaCl module building dependency on this
 # library.
 #
-# /common/make/common.mk, /common/make/nacl_module_building_common.mk and
+# /common/make/common.mk, /common/make/binary_executable_building.mk and
 # include.mk must be included before including this file.
 #
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/dependency.mk
+++ b/third_party/pcsc-lite/naclport/server_clients_management/dependency.mk
@@ -28,8 +28,8 @@
 # Including of this file creates a NaCl module building dependency on this
 # library.
 #
-# /common/make/common.mk, /common/make/binary_executable_building.mk and
-# include.mk must be included before including this file.
+# /common/make/common.mk, /common/make/executable_building.mk and include.mk
+# must be included before including this file.
 #
 
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/include.mk
+++ b/third_party/pcsc-lite/naclport/server_clients_management/include.mk
@@ -27,7 +27,7 @@
 #
 # This file contains helper definitions for using this library.
 #
-# /common/make/common.mk and /common/make/binary_executable_building.mk must be
+# /common/make/common.mk and /common/make/executable_building.mk must be
 # included before including this file.
 #
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/include.mk
+++ b/third_party/pcsc-lite/naclport/server_clients_management/include.mk
@@ -27,7 +27,7 @@
 #
 # This file contains helper definitions for using this library.
 #
-# /common/make/common.mk and /common/make/nacl_module_building_common.mk must be
+# /common/make/common.mk and /common/make/binary_executable_building.mk must be
 # included before including this file.
 #
 


### PR DESCRIPTION
Add single nacl_module_building_common.mk file that provides a
toolchain-independent interface for building C/C++ code, and move the
Native Client specific implementation of this interface into
internal/binary_executable_building_nacl.mk.

This structure is one of the steps of adding the support of WebAssembly
builds (as tracked by #177) while keeping the Native Client support for
the transition period.

This is a mechanical change, except minor changes in the build rules
documentation.