### PR TITLE
Migrate typed_message_listener.h to Value

### DIFF
--- a/common/cpp/src/google_smart_card_common/external_logs_printer.cc
+++ b/common/cpp/src/google_smart_card_common/external_logs_printer.cc
@@ -17,9 +17,13 @@
 #include <iostream>
 #include <string>
 
+#include <ppapi/cpp/var.h>
+
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/messaging/typed_message_listener.h>
 #include <google_smart_card_common/pp_var_utils/struct_converter.h>
+#include <google_smart_card_common/value.h>
+#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
 
 namespace google_smart_card {
 
@@ -63,11 +67,13 @@ std::string ExternalLogsPrinter::GetListenedMessageType() const {
   return listened_message_type_;
 }
 
-bool ExternalLogsPrinter::OnTypedMessageReceived(const pp::Var& data) {
+bool ExternalLogsPrinter::OnTypedMessageReceived(Value data) {
+  // TODO(#185): Parse `Value` directly instead of transforming into `pp::Var`.
+  pp::Var data_var = ConvertValueToPpVar(data);
   ExternalLogMessageData message_data;
   std::string error_message;
   if (!StructConverter<ExternalLogMessageData>::ConvertFromVar(
-          data, &message_data, &error_message)) {
+          data_var, &message_data, &error_message)) {
     GOOGLE_SMART_CARD_LOG_FATAL << "Failed to parse external log message: "
                                 << error_message;
   }

--- a/common/cpp/src/google_smart_card_common/external_logs_printer.h
+++ b/common/cpp/src/google_smart_card_common/external_logs_printer.h
@@ -21,6 +21,7 @@
 #include <string>
 
 #include <google_smart_card_common/messaging/typed_message_listener.h>
+#include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
 
@@ -33,7 +34,7 @@ class ExternalLogsPrinter final : public TypedMessageListener {
 
   // TypedMessageListener:
   std::string GetListenedMessageType() const override;
-  bool OnTypedMessageReceived(const pp::Var& data) override;
+  bool OnTypedMessageReceived(Value data) override;
 
  private:
   const std::string listened_message_type_;

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_listener.h
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_listener.h
@@ -17,7 +17,7 @@
 
 #include <string>
 
-#include <ppapi/cpp/var.h>
+#include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
 
@@ -39,7 +39,7 @@ class TypedMessageListener {
   // please refer to the typed_message.h file).
   //
   // Returns whether the message was handled.
-  virtual bool OnTypedMessageReceived(const pp::Var& data) = 0;
+  virtual bool OnTypedMessageReceived(Value data) = 0;
 };
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_router.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_router.cc
@@ -17,13 +17,10 @@
 #include <algorithm>
 #include <string>
 
-#include <ppapi/cpp/var.h>
-
 #include <google_smart_card_common/formatting.h>
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/messaging/typed_message.h>
 #include <google_smart_card_common/value_conversion.h>
-#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
 
 namespace google_smart_card {
 
@@ -67,9 +64,7 @@ bool TypedMessageRouter::OnMessageReceived(Value message,
     return false;
   }
 
-  // TODO(#185): Pass `Value` instead of transforming into `pp::Var`.
-  if (!listener->OnTypedMessageReceived(
-          ConvertValueToPpVar(typed_message.data))) {
+  if (!listener->OnTypedMessageReceived(std::move(typed_message.data))) {
     // TODO: Receive `error_message` from the listener.
     return false;
   }

--- a/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.cc
@@ -16,6 +16,8 @@
 
 #include <utility>
 
+#include <ppapi/cpp/var.h>
+
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/messaging/typed_message.h>
 #include <google_smart_card_common/requesting/requester_message.h>
@@ -74,10 +76,13 @@ std::string JsRequestReceiver::GetListenedMessageType() const {
   return GetRequestMessageType(name());
 }
 
-bool JsRequestReceiver::OnTypedMessageReceived(const pp::Var& data) {
+bool JsRequestReceiver::OnTypedMessageReceived(Value data) {
+  // TODO(#185): Parse `Value` directly instead of transforming into `pp::Var`.
+  const pp::Var data_var = ConvertValueToPpVar(data);
   RequestId request_id;
   pp::Var payload;
-  GOOGLE_SMART_CARD_CHECK(ParseRequestMessageData(data, &request_id, &payload));
+  GOOGLE_SMART_CARD_CHECK(
+      ParseRequestMessageData(data_var, &request_id, &payload));
   HandleRequest(request_id, payload);
   return true;
 }

--- a/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.h
+++ b/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.h
@@ -29,6 +29,7 @@
 #include <google_smart_card_common/requesting/request_receiver.h>
 #include <google_smart_card_common/requesting/request_result.h>
 #include <google_smart_card_common/thread_safe_unique_ptr.h>
+#include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
 
@@ -99,7 +100,7 @@ class JsRequestReceiver final : public RequestReceiver,
 
   // TypedMessageListener:
   std::string GetListenedMessageType() const override;
-  bool OnTypedMessageReceived(const pp::Var& data) override;
+  bool OnTypedMessageReceived(Value data) override;
 
   void PostResultMessage(const pp::Var& message);
 

--- a/common/cpp/src/google_smart_card_common/requesting/js_requester.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/js_requester.cc
@@ -16,6 +16,8 @@
 
 #include <utility>
 
+#include <ppapi/cpp/var.h>
+
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/messaging/typed_message.h>
 #include <google_smart_card_common/requesting/request_id.h>
@@ -103,11 +105,13 @@ std::string JsRequester::GetListenedMessageType() const {
   return GetResponseMessageType(name());
 }
 
-bool JsRequester::OnTypedMessageReceived(const pp::Var& data) {
+bool JsRequester::OnTypedMessageReceived(Value data) {
+  // TODO(#185): Parse `Value` directly instead of transforming into `pp::Var`.
+  const pp::Var data_var = ConvertValueToPpVar(data);
   RequestId request_id;
   GenericRequestResult request_result;
   GOOGLE_SMART_CARD_CHECK(
-      ParseResponseMessageData(data, &request_id, &request_result));
+      ParseResponseMessageData(data_var, &request_id, &request_result));
   GOOGLE_SMART_CARD_CHECK(
       SetAsyncRequestResult(request_id, std::move(request_result)));
   return true;

--- a/common/cpp/src/google_smart_card_common/requesting/js_requester.h
+++ b/common/cpp/src/google_smart_card_common/requesting/js_requester.h
@@ -28,6 +28,7 @@
 #include <google_smart_card_common/requesting/requester.h>
 #include <google_smart_card_common/requesting/requester_message.h>
 #include <google_smart_card_common/thread_safe_unique_ptr.h>
+#include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
 
@@ -103,7 +104,7 @@ class JsRequester final : public Requester, public TypedMessageListener {
  private:
   // TypedMessageListener implementation
   std::string GetListenedMessageType() const override;
-  bool OnTypedMessageReceived(const pp::Var& data) override;
+  bool OnTypedMessageReceived(Value data) override;
 
   bool PostPpMessage(const pp::Var& message);
   bool IsMainPpThread() const;

--- a/example_cpp_smart_card_client_app/src/ui_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/ui_bridge.cc
@@ -107,8 +107,10 @@ std::string UiBridge::GetListenedMessageType() const {
   return kIncomingMessageType;
 }
 
-bool UiBridge::OnTypedMessageReceived(const pp::Var& data) {
-  std::thread(&ProcessMessageFromUi, data, message_from_ui_handler_,
+bool UiBridge::OnTypedMessageReceived(gsc::Value data) {
+  // TODO: Use `Value` directly instead of transforming into `pp::Var`.
+  const pp::Var data_var = gsc::ConvertValueToPpVar(data);
+  std::thread(&ProcessMessageFromUi, data_var, message_from_ui_handler_,
               request_handling_mutex_)
       .detach();
   return true;

--- a/example_cpp_smart_card_client_app/src/ui_bridge.h
+++ b/example_cpp_smart_card_client_app/src/ui_bridge.h
@@ -24,6 +24,7 @@
 #include <google_smart_card_common/messaging/typed_message_listener.h>
 #include <google_smart_card_common/messaging/typed_message_router.h>
 #include <google_smart_card_common/thread_safe_unique_ptr.h>
+#include <google_smart_card_common/value.h>
 
 namespace smart_card_client {
 
@@ -68,7 +69,7 @@ class UiBridge final : public google_smart_card::TypedMessageListener {
 
   // google_smart_card::TypedMessageListener:
   std::string GetListenedMessageType() const override;
-  bool OnTypedMessageReceived(const pp::Var& data) override;
+  bool OnTypedMessageReceived(google_smart_card::Value data) override;
 
  private:
   struct AttachedState {

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
@@ -35,6 +35,8 @@
 #include <google_smart_card_common/pp_var_utils/struct_converter.h>
 #include <google_smart_card_common/requesting/remote_call_message.h>
 #include <google_smart_card_common/unique_ptr_utils.h>
+#include <google_smart_card_common/value.h>
+#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
 
 #include "client_request_processor.h"
 
@@ -122,11 +124,13 @@ std::string PcscLiteServerClientsManager::CreateHandlerMessageListener::
 }
 
 bool PcscLiteServerClientsManager::CreateHandlerMessageListener::
-    OnTypedMessageReceived(const pp::Var& data) {
+    OnTypedMessageReceived(Value data) {
+  // TODO: Parse `Value` directly instead of transforming into `pp::Var`.
+  const pp::Var data_var = ConvertValueToPpVar(data);
   CreateHandlerMessageData message_data;
   std::string error_message;
   if (!StructConverter<CreateHandlerMessageData>::ConvertFromVar(
-          data, &message_data, &error_message)) {
+          data_var, &message_data, &error_message)) {
     GOOGLE_SMART_CARD_LOG_FATAL
         << kLoggingPrefix << "Failed to parse "
         << "client handler creation message: " << error_message;
@@ -149,11 +153,13 @@ std::string PcscLiteServerClientsManager::DeleteHandlerMessageListener ::
 }
 
 bool PcscLiteServerClientsManager::DeleteHandlerMessageListener ::
-    OnTypedMessageReceived(const pp::Var& data) {
+    OnTypedMessageReceived(Value data) {
+  // TODO: Parse `Value` directly instead of transforming into `pp::Var`.
+  const pp::Var data_var = ConvertValueToPpVar(data);
   DeleteHandlerMessageData message_data;
   std::string error_message;
   if (!StructConverter<DeleteHandlerMessageData>::ConvertFromVar(
-          data, &message_data, &error_message)) {
+          data_var, &message_data, &error_message)) {
     GOOGLE_SMART_CARD_LOG_FATAL
         << kLoggingPrefix << "Failed to parse "
         << "client handler deletion message: " << error_message;

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h
@@ -40,6 +40,7 @@
 #include <google_smart_card_common/requesting/js_request_receiver.h>
 #include <google_smart_card_common/requesting/request_handler.h>
 #include <google_smart_card_common/requesting/request_receiver.h>
+#include <google_smart_card_common/value.h>
 
 #include "client_request_processor.h"
 
@@ -108,7 +109,7 @@ class PcscLiteServerClientsManager final {
 
     // TypedMessageListener:
     std::string GetListenedMessageType() const override;
-    bool OnTypedMessageReceived(const pp::Var& data) override;
+    bool OnTypedMessageReceived(Value data) override;
 
    private:
     PcscLiteServerClientsManager* clients_manager_;
@@ -126,7 +127,7 @@ class PcscLiteServerClientsManager final {
 
     // TypedMessageListener:
     std::string GetListenedMessageType() const override;
-    bool OnTypedMessageReceived(const pp::Var& data) override;
+    bool OnTypedMessageReceived(Value data) override;
 
    private:
     PcscLiteServerClientsManager* clients_manager_;


### PR DESCRIPTION
Change the typed_message_listener.h and all child classes to use the
Value class in the interface, rather than using the Native Client
specific pp::Var.

As an additional outcome, the implementation of the
typed_message_router.cc file becomes completely free of pp::Var usages
as well.

This commit contributes to the goal of making most of the //common/cpp
library be toolchain-agnostic and support WebAssembly (as tracked
by #185).