### PR TITLE
Migrate requester_message.h to Value

### DIFF
--- a/common/cpp/src/google_smart_card_common/requesting/requester_message.h
+++ b/common/cpp/src/google_smart_card_common/requesting/requester_message.h
@@ -67,7 +67,7 @@ struct RequestMessageData {
   // messages (see `ResponseMessageData`) with the requests.
   //
   // Note that this field must be unique among all requests with the same
-  // `name`; in general, requests with different `name` can use overlapping IDs.
+  // `name`. Requests with different `name` can use overlapping IDs.
   RequestId request_id;
   // The request payload, represented as a generic `Value` object. Contents of
   // this field are specific to a particular type of request.

--- a/common/cpp/src/google_smart_card_common/requesting/requester_message.h
+++ b/common/cpp/src/google_smart_card_common/requesting/requester_message.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file contains various types and functions for creating and parsing
-// messages for requests and for request responses.
+// This file contains helper definitions for request messages and for request
+// response messages.
 //
 // See google_smart_card_common/messaging/typed_message.h file for the
 // description of notion of "message type" and "message data".
@@ -27,10 +27,9 @@
 
 #include <string>
 
-#include <ppapi/cpp/var.h>
-
 #include <google_smart_card_common/requesting/request_id.h>
 #include <google_smart_card_common/requesting/request_result.h>
+#include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
 
@@ -42,29 +41,59 @@ std::string GetRequestMessageType(const std::string& name);
 // the specified name.
 std::string GetResponseMessageType(const std::string& name);
 
-// Constructs message data that contains the request data.
-pp::Var MakeRequestMessageData(RequestId request_id, const pp::Var& payload);
-
-// Constructs message data that contains the response data.
+// Represents the contents of the `TypedMessage::data` field for "request"
+// messages.
 //
-// Note that the if the response has the RequestResultStatus::kCanceled state,
-// then for simplicity reasons it will be serialized as a failed response.
-pp::Var MakeResponseMessageData(RequestId request_id,
-                                const GenericRequestResult& request_result);
+// Example usage scenario: Suppose the C++ code wants to make a "say_hello"
+// request to the JavaScript side. In that case, the C++ code would generate a
+// typed message with the following contents:
+//   type = "say_hello::request"
+//   data = serialized RequestMessageData structure with the following fields:
+//     request_id = 123
+//     payload = "Hello request from C++"
+// This typed message would then be sent to the JS side, which, would respond
+// with a typed message like this:
+//   type = "say_hello::response"
+//   data = serialized ResponseMessageData structure with the following fields:
+//     request_id = 123
+//     payload = "Hello response from JS"
+struct RequestMessageData {
+  // Unique identifier of the request; is used in order to correlate response
+  // messages (see `ResponseMessageData`) with the requests.
+  //
+  // Note that this field must be unique among all requests with the same
+  // `name`; in general, requests with different `name` can use overlapping IDs.
+  RequestId request_id;
+  // The request payload, represented as a generic `Value` object. Contents of
+  // this field are specific to a particular type of request.
+  Value payload;
+};
 
-// Parses the request message data, extracting the request identifier and the
-// request data from it.
-bool ParseRequestMessageData(const pp::Var& message_data, RequestId* request_id,
-                             pp::Var* payload);
-
-// Parses the request response message data, extracting the request identifier
-// and the request result information from it.
+// Represents the contents of the `TypedMessage::data` field for "response"
+// messages.
 //
-// Note that the only possible result states returned are
-// RequestResultStatus::kSucceeded and RequestResultStatus::kFailed.
-bool ParseResponseMessageData(const pp::Var& message_data,
-                              RequestId* request_id,
-                              GenericRequestResult* request_result);
+// See the documentation above for more details.
+struct ResponseMessageData {
+  // Converts the `GenericRequestResult` object into `ResponseMessageData`.
+  static ResponseMessageData CreateFromRequestResult(
+      RequestId request_id, GenericRequestResult request_result);
+  // Creates a `GenericRequestResult` object from the `payload`/`error_message`
+  // fields. Returns false in case |this| is invalid (it's expected that exactly
+  // one of {`payload`, `error_message`} are non-empty).
+  // Note: this is a destructive operation - the fields are moved into the
+  // resulting object.
+  bool ExtractRequestResult(GenericRequestResult* request_result);
+
+  // Identifier of the request. Should be equal to the
+  // `RequestMessageData::request_id` field of the correspond request.
+  RequestId request_id = -1;
+  // The response payload, represented as a generic `Value` object, or a null in
+  // case the request failed. Contents of the value stored here are specific to
+  // a particular type of request.
+  optional<Value> payload;
+  // The error message, in case the request failed, or a null otherwise.
+  optional<std::string> error_message;
+};
 
 }  // namespace google_smart_card
 

--- a/common/cpp/src/google_smart_card_common/requesting/requester_message.h
+++ b/common/cpp/src/google_smart_card_common/requesting/requester_message.h
@@ -45,18 +45,23 @@ std::string GetResponseMessageType(const std::string& name);
 // messages.
 //
 // Example usage scenario: Suppose the C++ code wants to make a "say_hello"
-// request to the JavaScript side. In that case, the C++ code would generate a
-// typed message with the following contents:
-//   type = "say_hello::request"
-//   data = serialized RequestMessageData structure with the following fields:
-//     request_id = 123
-//     payload = "Hello request from C++"
-// This typed message would then be sent to the JS side, which, would respond
-// with a typed message like this:
-//   type = "say_hello::response"
-//   data = serialized ResponseMessageData structure with the following fields:
-//     request_id = 123
-//     payload = "Hello response from JS"
+// request to the JavaScript side. The simplified code would look like this:
+//   RequestMessageData message_data;
+//   message_data.request_id = 123;
+//   message_data.payload = Valie("Hello request from C++");
+//   TypedMessage typed_message;
+//   typed_message.type = GetRequestMessageType("say_hello");
+//   typed_message.data = ConvertToValueOrDie(std::move(message_data));
+//   SendMessageToJs(typed_message);
+// The received response would be a typed message that is equivalent to the one
+// produced by this sample code:
+//   ResponseMessageData response_message_data;
+//   response_message_data.request_id = 123;
+//   response_message_data.payload = Valie("Hello response from JS");
+//   TypedMessage response_typed_message;
+//   response_typed_message.type = GetResponseMessageType("say_hello");
+//   response_typed_message.data = ConvertToValueOrDie(
+//       std::move(response_message_data));
 struct RequestMessageData {
   // Unique identifier of the request; is used in order to correlate response
   // messages (see `ResponseMessageData`) with the requests.
@@ -87,11 +92,11 @@ struct ResponseMessageData {
   // Identifier of the request. Should be equal to the
   // `RequestMessageData::request_id` field of the correspond request.
   RequestId request_id = -1;
-  // The response payload, represented as a generic `Value` object, or a null in
+  // The response payload, represented as a generic `Value` object, or null in
   // case the request failed. Contents of the value stored here are specific to
   // a particular type of request.
   optional<Value> payload;
-  // The error message, in case the request failed, or a null otherwise.
+  // The error message, in case the request failed, or null otherwise.
   optional<std::string> error_message;
 };
 


### PR DESCRIPTION
Change the requester_message.h header to use the toolchain-independent
Value class instead of Native Client specific pp::Var class. Besides the
mechanical replacement, this commit introduces dedicated structs for the
"request"/"response" messages, since it makes the interface more concise
and allows to reuse automatic to/from Value conversion helpers.

This commit contributes to the goal of making most of the //common/cpp
library be toolchain-agnostic and support WebAssembly (as tracked
by #185).