### PR TITLE
Fix test compilation

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -113,6 +113,7 @@ INSTALLING_HEADERS := \
 	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):unique_ptr_utils.h \
 	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):value.h \
 	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):value_conversion.h \
+	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):value_debug_dumping.h \
 	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):value_nacl_pp_var_conversion.h \
 
 $(eval $(call NACL_LIBRARY_HEADERS_INSTALLATION_RULE,$(INSTALLING_HEADERS)))

--- a/common/integration_testing/build/Makefile
+++ b/common/integration_testing/build/Makefile
@@ -16,7 +16,7 @@ TARGET := google_smart_card_integration_testing
 
 include ../../make/common.mk
 
-include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
+include $(COMMON_DIR_PATH)/make/executable_building.mk
 
 include ../include.mk
 

--- a/common/integration_testing/dependency.mk
+++ b/common/integration_testing/dependency.mk
@@ -17,8 +17,8 @@
 # Including of this file creates a NaCl module building dependency on this
 # library.
 #
-# /common/make/common.mk, /common/make/binary_executable_building.mk and
-# include.mk must be included before including this file.
+# /common/make/common.mk, /common/make/executable_building.mk and include.mk
+# must be included before including this file.
 #
 
 

--- a/common/integration_testing/include.mk
+++ b/common/integration_testing/include.mk
@@ -16,7 +16,7 @@
 #
 # This file contains helper definitions for using this library.
 #
-# /common/make/common.mk and /common/make/binary_executable_building.mk must be
+# /common/make/common.mk and /common/make/executable_building.mk must be
 # included before including this file.
 #
 

--- a/common/tests_runner/build.mk
+++ b/common/tests_runner/build.mk
@@ -31,7 +31,7 @@ include $(TESTS_RUNNER_DIR)/../make/common.mk
 
 PAGE := $(OUT_DIR_PATH)/index.html
 
-include $(COMMON_DIR_PATH)/make/binary_executable_building.mk
+include $(COMMON_DIR_PATH)/make/executable_building.mk
 
 
 #

--- a/test-all.sh
+++ b/test-all.sh
@@ -29,6 +29,7 @@ set -eu
 TEST_DIRS="
   common/cpp/build
   common/js/build
+  example_cpp_smart_card_client_app/build
   third_party/libusb/naclport/build
   third_party/pcsc-lite/naclport/server_clients_management/build"
 


### PR DESCRIPTION
Fix several issues with tests compilation:
* //common/integration_testing/ and //common/tests-runner/ build
  scripts were pointing to a non-existing .mk file (since #204);
* //common/integration_testing/ C++ code wasn't updated to use Value
  instead of pp::Var (since #196);
* //common/cpp/ build scripts weren't installing value_debug_dumping.h
  into a public header location, which made it impossible to use it in
  tests (originally forgotten in #189);
* //test-all.sh wasn't updated to include the new
  //example_cpp_smart_card_client_app/build/integration_tests/ target.