### PR TITLE
Migrate [js_]requester.h to Value

### DIFF
--- a/common/cpp/src/google_smart_card_common/requesting/js_requester.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/js_requester.cc
@@ -75,15 +75,15 @@ void JsRequester::Detach() {
   Requester::Detach();
 }
 
-void JsRequester::StartAsyncRequest(const pp::Var& payload,
+void JsRequester::StartAsyncRequest(Value payload,
                                     GenericAsyncRequestCallback callback,
                                     GenericAsyncRequest* async_request) {
   RequestId request_id;
-  *async_request = CreateAsyncRequest(payload, callback, &request_id);
+  *async_request = CreateAsyncRequest(callback, &request_id);
 
   RequestMessageData message_data;
   message_data.request_id = request_id;
-  message_data.payload = ConvertPpVarToValueOrDie(payload);
+  message_data.payload = std::move(payload);
   TypedMessage typed_message;
   typed_message.type = GetRequestMessageType(name());
   typed_message.data = ConvertToValueOrDie(std::move(message_data));
@@ -97,9 +97,9 @@ void JsRequester::StartAsyncRequest(const pp::Var& payload,
   }
 }
 
-GenericRequestResult JsRequester::PerformSyncRequest(const pp::Var& payload) {
+GenericRequestResult JsRequester::PerformSyncRequest(Value payload) {
   GOOGLE_SMART_CARD_CHECK(!IsMainPpThread());
-  return Requester::PerformSyncRequest(payload);
+  return Requester::PerformSyncRequest(std::move(payload));
 }
 
 std::string JsRequester::GetListenedMessageType() const {

--- a/common/cpp/src/google_smart_card_common/requesting/js_requester.h
+++ b/common/cpp/src/google_smart_card_common/requesting/js_requester.h
@@ -91,15 +91,14 @@ class JsRequester final : public Requester, public TypedMessageListener {
 
   // Requester implementation
   void Detach() override;
-  void StartAsyncRequest(const pp::Var& payload,
-                         GenericAsyncRequestCallback callback,
+  void StartAsyncRequest(Value payload, GenericAsyncRequestCallback callback,
                          GenericAsyncRequest* async_request) override;
   // Requester implementation override
   //
   // Note that it is asserted that this method is called not from the main
   // Pepper thread (as in that case waiting would block the message loop and
   // result in deadlock).
-  GenericRequestResult PerformSyncRequest(const pp::Var& payload) override;
+  GenericRequestResult PerformSyncRequest(Value payload) override;
 
  private:
   // TypedMessageListener implementation

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.cc
@@ -19,6 +19,7 @@
 #include <ppapi/cpp/var_dictionary.h>
 
 #include <google_smart_card_common/requesting/remote_call_message.h>
+#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
 
 namespace google_smart_card {
 
@@ -31,23 +32,28 @@ RemoteCallAdaptor::~RemoteCallAdaptor() = default;
 
 GenericRequestResult RemoteCallAdaptor::PerformSyncRequest(
     const std::string& function_name, const pp::VarArray& converted_arguments) {
-  return requester_->PerformSyncRequest(
-      MakeRemoteCallRequestPayload(function_name, converted_arguments));
+  // TODO(#185): Create `Value` directly, without converting from `pp::Var`.
+  return requester_->PerformSyncRequest(ConvertPpVarToValueOrDie(
+      MakeRemoteCallRequestPayload(function_name, converted_arguments)));
 }
 
 GenericAsyncRequest RemoteCallAdaptor::StartAsyncRequest(
     const std::string& function_name, const pp::VarArray& converted_arguments,
     GenericAsyncRequestCallback callback) {
+  // TODO(#185): Create `Value` directly, without converting from `pp::Var`.
   return requester_->StartAsyncRequest(
-      MakeRemoteCallRequestPayload(function_name, converted_arguments),
+      ConvertPpVarToValueOrDie(
+          MakeRemoteCallRequestPayload(function_name, converted_arguments)),
       callback);
 }
 
 void RemoteCallAdaptor::StartAsyncRequest(
     const std::string& function_name, const pp::VarArray& converted_arguments,
     GenericAsyncRequestCallback callback, GenericAsyncRequest* async_request) {
+  // TODO(#185): Create `Value` directly, without converting from `pp::Var`.
   requester_->StartAsyncRequest(
-      MakeRemoteCallRequestPayload(function_name, converted_arguments),
+      ConvertPpVarToValueOrDie(
+          MakeRemoteCallRequestPayload(function_name, converted_arguments)),
       callback, async_request);
 }
 

--- a/common/cpp/src/google_smart_card_common/requesting/requester.h
+++ b/common/cpp/src/google_smart_card_common/requesting/requester.h
@@ -17,12 +17,11 @@
 
 #include <string>
 
-#include <ppapi/cpp/var.h>
-
 #include <google_smart_card_common/requesting/async_request.h>
 #include <google_smart_card_common/requesting/async_requests_storage.h>
 #include <google_smart_card_common/requesting/request_id.h>
 #include <google_smart_card_common/requesting/request_result.h>
+#include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
 
@@ -69,7 +68,7 @@ class Requester {
   // Note: It's also possible that the callback is executed synchronously during
   // this method call (e.g. when a fatal error occurred that prevents the
   // implementation from starting the asynchronous request).
-  GenericAsyncRequest StartAsyncRequest(const pp::Var& payload,
+  GenericAsyncRequest StartAsyncRequest(Value payload,
                                         GenericAsyncRequestCallback callback);
 
   // Starts an asynchronous request with the given payload and the given
@@ -87,7 +86,7 @@ class Requester {
   // Note: It's also possible that the callback is executed synchronously during
   // this method call (e.g. when a fatal error occurred that prevents the
   // implementation from starting the asynchronous request).
-  virtual void StartAsyncRequest(const pp::Var& payload,
+  virtual void StartAsyncRequest(Value payload,
                                  GenericAsyncRequestCallback callback,
                                  GenericAsyncRequest* async_request) = 0;
 
@@ -96,14 +95,13 @@ class Requester {
   //
   // It's guaranteed that the returned result cannot have the
   // RequestResultStatus::kCanceled state.
-  virtual GenericRequestResult PerformSyncRequest(const pp::Var& payload);
+  virtual GenericRequestResult PerformSyncRequest(Value payload);
 
  protected:
   // Creates and stores internally a new asynchronous request state, returning
   // its public proxy object (GenericAsyncRequest object) and its generated
   // request identifier.
-  GenericAsyncRequest CreateAsyncRequest(const pp::Var& payload,
-                                         GenericAsyncRequestCallback callback,
+  GenericAsyncRequest CreateAsyncRequest(GenericAsyncRequestCallback callback,
                                          RequestId* request_id);
 
   // Finds the request state by the specified request identifier and sets its

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.cc
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.cc
@@ -19,6 +19,7 @@
 #include <google_smart_card_common/pp_var_utils/extraction.h>
 #include <google_smart_card_common/requesting/request_result.h>
 #include <google_smart_card_common/unique_ptr_utils.h>
+#include <google_smart_card_common/value.h>
 
 namespace smart_card_client {
 
@@ -56,7 +57,7 @@ void BuiltInPinDialogServer::Detach() { js_requester_.Detach(); }
 
 bool BuiltInPinDialogServer::RequestPin(std::string* pin) {
   const google_smart_card::GenericRequestResult request_result =
-      js_requester_.PerformSyncRequest(pp::VarDictionary());
+      js_requester_.PerformSyncRequest(/*payload=*/google_smart_card::Value());
   if (!request_result.is_successful()) return false;
   ExtractPinRequestResult(request_result, pin);
   return true;


### PR DESCRIPTION
Change requester.h and js_requester.h headers and the corresponding
implementation .cc files to use the toolchain-independent Value
class intead of Native Client specific pp::Var class in most places.
The only left place is the delegate for sending messages to JS, which
will be refactored separately.

This commit contributes to the goal of making most of the //common/cpp
library be toolchain-agnostic and support WebAssembly (as tracked
by #185).