### PR TITLE
Add conversion from std::vector to Value

### DIFF
--- a/common/cpp/src/google_smart_card_common/value_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion.cc
@@ -58,6 +58,9 @@ bool ConvertIntegerFromValue(Value value, const char* type_name, T* number,
 
 namespace internal {
 
+const char kErrorToArrayValueConversion[] =
+    "Cannot convert item #%d to value: %s";
+
 EnumToValueConverter::EnumToValueConverter(int64_t enum_to_convert)
     : enum_to_convert_(enum_to_convert) {}
 

--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -25,27 +25,31 @@
 //   special case that an integer can be converted from a floating-point
 //   `Value`, in case it's within the range of precisely representable numbers);
 // * `double`;
-// * `std::string`.
+// * `std::string`;
+// * `std::vector` of any supported type (note: there's also a special case that
+//    `std::vector<uint8_t>` can be converted from a binary value).
 //
 // The same helpers can also be enabled for custom types:
 // * a custom enum can be registered via the `EnumValueDescriptor` class for
 //   conversion to/from a string `Value`;
 // * a custom struct can be registered via the `StructValueDescriptor` class for
 //   conversion to/from a dictionary `Value`.
-//
-// TODO: Add support for std::vector.
 
 #ifndef GOOGLE_SMART_CARD_COMMON_VALUE_CONVERSION_H_
 #define GOOGLE_SMART_CARD_COMMON_VALUE_CONVERSION_H_
 
 #include <stdint.h>
 
+#include <memory>
 #include <string>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
+#include <google_smart_card_common/formatting.h>
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/optional.h>
+#include <google_smart_card_common/unique_ptr_utils.h>
 #include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
@@ -53,6 +57,8 @@ namespace google_smart_card {
 ///////////// Internal helpers ///////////////////
 
 namespace internal {
+
+extern const char kErrorToArrayValueConversion[];
 
 // Visitor of enum type's items that converts a C++ enum value into a string
 // `Value`, by finding the corresponding item among visited ones. This is a
@@ -497,6 +503,26 @@ typename std::enable_if<std::is_class<T>::value, bool>::type ConvertToValue(
           .GetDescription();
   return converter.TakeConvertedValue(description.type_name(), value,
                                       error_message);
+}
+
+// Converts from a vector of items of a supported type into an array `Value`.
+template <typename T>
+bool ConvertToValue(std::vector<T> objects, Value* value,
+                    std::string* error_message = nullptr) {
+  std::vector<std::unique_ptr<Value>> converted_items(objects.size());
+  std::string local_error_message;
+  for (size_t i = 0; i < objects.size(); ++i) {
+    converted_items[i] = MakeUnique<Value>();
+    if (!ConvertToValue(std::move(objects[i]), converted_items[i].get(),
+                        &local_error_message)) {
+      FormatPrintfTemplateAndSet(
+          error_message, internal::kErrorToArrayValueConversion,
+          static_cast<int>(i), local_error_message.c_str());
+      return false;
+    }
+  }
+  *value = Value(std::move(converted_items));
+  return true;
 }
 
 // Synonym to other `ConvertToValue()` overloads, but immediately crashes the


### PR DESCRIPTION
Implement the ConvertToValue() helper for the std::vector<> input type,
with recursively applying the same ConvertToValue() transform to each
item.

This extends the set of helpers for converting between Value instances
and C/C++ objects, paving the way for migrating the rest of //common/cpp
library to become toolchain-independent (as tracked by #185).