### PR TITLE
Add conversion from Value to std::vector

### DIFF
--- a/common/cpp/src/google_smart_card_common/value.cc
+++ b/common/cpp/src/google_smart_card_common/value.cc
@@ -129,6 +129,11 @@ const Value::BinaryStorage& Value::GetBinary() const {
   return binary_value_;
 }
 
+Value::BinaryStorage& Value::GetBinary() {
+  GOOGLE_SMART_CARD_CHECK(is_binary());
+  return binary_value_;
+}
+
 const Value::DictionaryStorage& Value::GetDictionary() const {
   GOOGLE_SMART_CARD_CHECK(is_dictionary());
   return dictionary_value_;
@@ -140,6 +145,11 @@ Value::DictionaryStorage& Value::GetDictionary() {
 }
 
 const Value::ArrayStorage& Value::GetArray() const {
+  GOOGLE_SMART_CARD_CHECK(is_array());
+  return array_value_;
+}
+
+Value::ArrayStorage& Value::GetArray() {
   GOOGLE_SMART_CARD_CHECK(is_array());
   return array_value_;
 }

--- a/common/cpp/src/google_smart_card_common/value.h
+++ b/common/cpp/src/google_smart_card_common/value.h
@@ -98,9 +98,11 @@ class Value final {
   double GetFloat() const;
   const std::string& GetString() const;
   const BinaryStorage& GetBinary() const;
+  BinaryStorage& GetBinary();
   const DictionaryStorage& GetDictionary() const;
   DictionaryStorage& GetDictionary();
   const ArrayStorage& GetArray() const;
+  ArrayStorage& GetArray();
 
   // Returns null when the key isn't present.
   const Value* GetDictionaryItem(const std::string& key) const;

--- a/common/cpp/src/google_smart_card_common/value_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion.cc
@@ -305,7 +305,7 @@ bool ConvertFromValue(Value value, std::vector<uint8_t>* bytes,
                       std::string* error_message) {
   if (value.is_binary()) {
     // This is a special case that is the reason why the standard
-    // array-to-vector template is overloaded by our function.
+    // array-to-vector template is overloaded by this function.
     *bytes = std::move(value.GetBinary());
     return true;
   }

--- a/common/cpp/src/google_smart_card_common/value_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion.cc
@@ -31,8 +31,6 @@ namespace google_smart_card {
 
 namespace {
 
-constexpr char kErrorWrongType[] = "Expected value of type %s, instead got: %s";
-
 template <typename T>
 bool ConvertIntegerFromValue(Value value, const char* type_name, T* number,
                              std::string* error_message) {
@@ -46,9 +44,9 @@ bool ConvertIntegerFromValue(Value value, const char* type_name, T* number,
     if (!CastDoubleToInt64(value.GetFloat(), &int64_number, error_message))
       return false;
   } else {
-    FormatPrintfTemplateAndSet(error_message, kErrorWrongType,
-                               Value::kIntegerTypeTitle,
-                               DebugDumpValueSanitized(value).c_str());
+    FormatPrintfTemplateAndSet(
+        error_message, internal::kErrorWrongTypeValueConversion,
+        Value::kIntegerTypeTitle, DebugDumpValueSanitized(value).c_str());
     return false;
   }
   return CastInteger(int64_number, type_name, number, error_message);
@@ -58,6 +56,10 @@ bool ConvertIntegerFromValue(Value value, const char* type_name, T* number,
 
 namespace internal {
 
+const char kErrorWrongTypeValueConversion[] =
+    "Expected value of type %s, instead got: %s";
+const char kErrorFromArrayValueConversion[] =
+    "Cannot convert item #%d from value: %s";
 const char kErrorToArrayValueConversion[] =
     "Cannot convert item #%d to value: %s";
 
@@ -231,9 +233,9 @@ bool ConvertFromValue(Value value, bool* boolean, std::string* error_message) {
     *boolean = value.GetBoolean();
     return true;
   }
-  FormatPrintfTemplateAndSet(error_message, kErrorWrongType,
-                             Value::kBooleanTypeTitle,
-                             DebugDumpValueSanitized(value).c_str());
+  FormatPrintfTemplateAndSet(
+      error_message, internal::kErrorWrongTypeValueConversion,
+      Value::kBooleanTypeTitle, DebugDumpValueSanitized(value).c_str());
   return false;
 }
 
@@ -279,7 +281,7 @@ bool ConvertFromValue(Value value, double* number, std::string* error_message) {
     return true;
   }
   FormatPrintfTemplateAndSet(
-      error_message, kErrorWrongType,
+      error_message, internal::kErrorWrongTypeValueConversion,
       FormatPrintfTemplate("%s or %s", Value::kIntegerTypeTitle,
                            Value::kFloatTypeTitle)
           .c_str(),
@@ -293,10 +295,34 @@ bool ConvertFromValue(Value value, std::string* characters,
     *characters = value.GetString();
     return true;
   }
-  FormatPrintfTemplateAndSet(error_message, kErrorWrongType,
-                             Value::kStringTypeTitle,
-                             DebugDumpValueSanitized(value).c_str());
+  FormatPrintfTemplateAndSet(
+      error_message, internal::kErrorWrongTypeValueConversion,
+      Value::kStringTypeTitle, DebugDumpValueSanitized(value).c_str());
   return false;
+}
+
+bool ConvertFromValue(Value value, std::vector<uint8_t>* bytes,
+                      std::string* error_message) {
+  if (value.is_binary()) {
+    // This is a special case that is the reason why the standard
+    // array-to-vector template is overloaded by our function.
+    *bytes = std::move(value.GetBinary());
+    return true;
+  }
+  if (!value.is_array()) {
+    // Note: We're creating the error message here rather than letting the
+    // template call below do that, because we want to mention that the binary
+    // value type would be allowed as well.
+    FormatPrintfTemplateAndSet(
+        error_message, internal::kErrorWrongTypeValueConversion,
+        FormatPrintfTemplate("%s or %s", Value::kArrayTypeTitle,
+                             Value::kBinaryTypeTitle)
+            .c_str(),
+        DebugDumpValueSanitized(value).c_str());
+    return false;
+  }
+  // Delegate to the standard array-to-vector template implementation.
+  return ConvertFromValue<uint8_t>(std::move(value), bytes, error_message);
 }
 
 }  // namespace google_smart_card


### PR DESCRIPTION
Implement the ConvertFromValue() helper for the std::vector<> output
type, with recursively applying the same ConvertFromValue() transform
to each array item.

This extends the set of helpers for converting between Value instances
and C/C++ objects, paving the way for migrating the rest of //common/cpp
library to become toolchain-independent (as tracked by #185).