### PR TITLE
Build //common NaCl-specific files only under NaCl

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -28,7 +28,6 @@ ROOT_SOURCES_SUBDIR := google_smart_card_common
 SOURCES_PATH := $(ROOT_SOURCES_PATH)/$(ROOT_SOURCES_SUBDIR)
 
 SOURCES := \
-	$(SOURCES_PATH)/external_logs_printer.cc \
 	$(SOURCES_PATH)/formatting.cc \
 	$(SOURCES_PATH)/logging/function_call_tracer.cc \
 	$(SOURCES_PATH)/logging/hex_dumping.cc \
@@ -37,25 +36,35 @@ SOURCES := \
 	$(SOURCES_PATH)/messaging/typed_message.cc \
 	$(SOURCES_PATH)/messaging/typed_message_router.cc \
 	$(SOURCES_PATH)/multi_string.cc \
-	$(SOURCES_PATH)/nacl_io_utils.cc \
 	$(SOURCES_PATH)/numeric_conversions.cc \
+	$(SOURCES_PATH)/value.cc \
+	$(SOURCES_PATH)/value_conversion.cc \
+	$(SOURCES_PATH)/value_debug_dumping.cc \
+
+ifeq ($(TOOLCHAIN),pnacl)
+
+SOURCES += \
+	$(SOURCES_PATH)/nacl_io_utils.cc \
 	$(SOURCES_PATH)/pp_var_utils/construction.cc \
 	$(SOURCES_PATH)/pp_var_utils/copying.cc \
 	$(SOURCES_PATH)/pp_var_utils/debug_dump.cc \
 	$(SOURCES_PATH)/pp_var_utils/extraction.cc \
 	$(SOURCES_PATH)/pp_var_utils/operations.cc \
-	$(SOURCES_PATH)/requesting/js_requester.cc \
+	$(SOURCES_PATH)/value_nacl_pp_var_conversion.cc \
+
+# TODO(#185): Migrate these to support the Emscripten toolchain as well.
+SOURCES += \
+	$(SOURCES_PATH)/external_logs_printer.cc \
 	$(SOURCES_PATH)/requesting/js_request_receiver.cc \
+	$(SOURCES_PATH)/requesting/js_requester.cc \
 	$(SOURCES_PATH)/requesting/remote_call_adaptor.cc \
 	$(SOURCES_PATH)/requesting/remote_call_message.cc \
-	$(SOURCES_PATH)/requesting/requester.cc \
-	$(SOURCES_PATH)/requesting/requester_message.cc \
 	$(SOURCES_PATH)/requesting/request_receiver.cc \
 	$(SOURCES_PATH)/requesting/request_result.cc \
-	$(SOURCES_PATH)/value.cc \
-	$(SOURCES_PATH)/value_conversion.cc \
-	$(SOURCES_PATH)/value_debug_dumping.cc \
-	$(SOURCES_PATH)/value_nacl_pp_var_conversion.cc \
+	$(SOURCES_PATH)/requesting/requester.cc \
+	$(SOURCES_PATH)/requesting/requester_message.cc \
+
+endif
 
 CXXFLAGS := \
 	-I$(ROOT_SOURCES_PATH)/ \

--- a/common/cpp/build/tests/Makefile
+++ b/common/cpp/build/tests/Makefile
@@ -43,15 +43,24 @@ TEST_SOURCES := \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/logging/hex_dumping_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/messaging/typed_message_router_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/numeric_conversions_unittest.cc \
+	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_conversion_unittest.cc \
+	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_debug_dumping_unittest.cc \
+	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_unittest.cc \
+
+ifeq ($(TOOLCHAIN),pnacl)
+
+TEST_SOURCES += \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/pp_var_utils/construction_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/pp_var_utils/enum_converter_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/pp_var_utils/struct_converter_unittest.cc \
+	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_nacl_pp_var_conversion_unittest.cc \
+
+# TODO(#185): Migrate these to support the Emscripten toolchain as well.
+TEST_SOURCES += \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/requesting/async_request_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/requesting/async_requests_storage_unittest.cc \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_conversion_unittest.cc \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_debug_dumping_unittest.cc \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_nacl_pp_var_conversion_unittest.cc \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_unittest.cc \
+
+endif
 
 ADDITIONAL_TEST_CPPFLAGS := \
 	-I$(TEST_SOURCES_PATH) \

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_router_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_router_unittest.cc
@@ -24,7 +24,6 @@
 #include <google_smart_card_common/formatting.h>
 #include <google_smart_card_common/messaging/typed_message.h>
 #include <google_smart_card_common/messaging/typed_message_listener.h>
-#include <google_smart_card_common/pp_var_utils/extraction.h>
 #include <google_smart_card_common/value.h>
 #include <google_smart_card_common/value_conversion.h>
 

--- a/common/cpp/src/google_smart_card_common/nacl_io_utils.h
+++ b/common/cpp/src/google_smart_card_common/nacl_io_utils.h
@@ -15,6 +15,10 @@
 #ifndef GOOGLE_SMART_CARD_COMMON_NACL_IO_UTILS_H_
 #define GOOGLE_SMART_CARD_COMMON_NACL_IO_UTILS_H_
 
+#ifndef __native_client__
+#error "This file should only be used in Native Client builds"
+#endif  // __native_client__
+
 #include <ppapi/cpp/instance.h>
 
 namespace google_smart_card {

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/construction.h
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/construction.h
@@ -18,6 +18,10 @@
 #ifndef GOOGLE_SMART_CARD_COMMON_PP_VAR_UTILS_CONSTRUCTION_H_
 #define GOOGLE_SMART_CARD_COMMON_PP_VAR_UTILS_CONSTRUCTION_H_
 
+#ifndef __native_client__
+#error "This file should only be used in Native Client builds"
+#endif  // __native_client__
+
 #include <stdint.h>
 
 #include <string>

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/copying.h
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/copying.h
@@ -24,6 +24,10 @@
 #ifndef GOOGLE_SMART_CARD_COMMON_PP_VAR_UTILS_COPYING_H_
 #define GOOGLE_SMART_CARD_COMMON_PP_VAR_UTILS_COPYING_H_
 
+#ifndef __native_client__
+#error "This file should only be used in Native Client builds"
+#endif  // __native_client__
+
 #include <stdint.h>
 
 #include <string>

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/debug_dump.h
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/debug_dump.h
@@ -18,6 +18,10 @@
 #ifndef GOOGLE_SMART_CARD_COMMON_PP_VAR_UTILS_DEBUG_DUMP_H_
 #define GOOGLE_SMART_CARD_COMMON_PP_VAR_UTILS_DEBUG_DUMP_H_
 
+#ifndef __native_client__
+#error "This file should only be used in Native Client builds"
+#endif  // __native_client__
+
 #include <string>
 
 #include <ppapi/cpp/var.h>

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/extraction.h
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/extraction.h
@@ -22,6 +22,10 @@
 #ifndef GOOGLE_SMART_CARD_COMMON_PP_VAR_UTILS_EXTRACTION_H_
 #define GOOGLE_SMART_CARD_COMMON_PP_VAR_UTILS_EXTRACTION_H_
 
+#ifndef __native_client__
+#error "This file should only be used in Native Client builds"
+#endif  // __native_client__
+
 #include <inttypes.h>
 #include <stdint.h>
 

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/operations.h
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/operations.h
@@ -18,6 +18,10 @@
 #ifndef GOOGLE_SMART_CARD_COMMON_PP_VAR_UTILS_OPERATIONS_H_
 #define GOOGLE_SMART_CARD_COMMON_PP_VAR_UTILS_OPERATIONS_H_
 
+#ifndef __native_client__
+#error "This file should only be used in Native Client builds"
+#endif  // __native_client__
+
 #include <stdint.h>
 
 #include <string>

--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h
@@ -18,6 +18,10 @@
 #ifndef GOOGLE_SMART_CARD_COMMON_VALUE_NACL_PP_VAR_CONVERSION_H_
 #define GOOGLE_SMART_CARD_COMMON_VALUE_NACL_PP_VAR_CONVERSION_H_
 
+#ifndef __native_client__
+#error "This file should only be used in Native Client builds"
+#endif  // __native_client__
+
 #include <string>
 
 #include <ppapi/cpp/var.h>


### PR DESCRIPTION
This fixes the makefiles in //common/cpp to exclude source files from
compilation in case the toolchain is non Native Client and the files
can only be compiled under the Native Client.

This fixes the Emscripten/WebAssembly builds of //common/cpp (as tracked
by #177). Note that there are two groups of excluded files currently:
those that provide NaCl-specific capabilities, and those that aren't
migrated to support Emscripten yet. The latter ones will be gradually
migrated and reenabled in follow-ups.