### PR TITLE
Migrate async_request.h and related to Value

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -37,6 +37,9 @@ SOURCES := \
 	$(SOURCES_PATH)/messaging/typed_message_router.cc \
 	$(SOURCES_PATH)/multi_string.cc \
 	$(SOURCES_PATH)/numeric_conversions.cc \
+	$(SOURCES_PATH)/requesting/request_result.cc \
+	$(SOURCES_PATH)/requesting/requester.cc \
+	$(SOURCES_PATH)/requesting/requester_message.cc \
 	$(SOURCES_PATH)/value.cc \
 	$(SOURCES_PATH)/value_conversion.cc \
 	$(SOURCES_PATH)/value_debug_dumping.cc \
@@ -60,9 +63,6 @@ SOURCES += \
 	$(SOURCES_PATH)/requesting/remote_call_adaptor.cc \
 	$(SOURCES_PATH)/requesting/remote_call_message.cc \
 	$(SOURCES_PATH)/requesting/request_receiver.cc \
-	$(SOURCES_PATH)/requesting/request_result.cc \
-	$(SOURCES_PATH)/requesting/requester.cc \
-	$(SOURCES_PATH)/requesting/requester_message.cc \
 
 endif
 

--- a/common/cpp/build/tests/Makefile
+++ b/common/cpp/build/tests/Makefile
@@ -43,6 +43,8 @@ TEST_SOURCES := \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/logging/hex_dumping_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/messaging/typed_message_router_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/numeric_conversions_unittest.cc \
+	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/requesting/async_request_unittest.cc \
+	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/requesting/async_requests_storage_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_conversion_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_debug_dumping_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_unittest.cc \
@@ -54,11 +56,6 @@ TEST_SOURCES += \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/pp_var_utils/enum_converter_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/pp_var_utils/struct_converter_unittest.cc \
 	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_nacl_pp_var_conversion_unittest.cc \
-
-# TODO(#185): Migrate these to support the Emscripten toolchain as well.
-TEST_SOURCES += \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/requesting/async_request_unittest.cc \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/requesting/async_requests_storage_unittest.cc \
 
 endif
 

--- a/common/cpp/src/google_smart_card_common/requesting/async_request.h
+++ b/common/cpp/src/google_smart_card_common/requesting/async_request.h
@@ -24,10 +24,9 @@
 #include <string>
 #include <utility>
 
-#include <ppapi/cpp/var.h>
-
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/requesting/request_result.h>
+#include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
 
@@ -40,7 +39,7 @@ template <typename PayloadType>
 using AsyncRequestCallback =
     std::function<void(RequestResult<PayloadType> request_result)>;
 
-using GenericAsyncRequestCallback = AsyncRequestCallback<pp::Var>;
+using GenericAsyncRequestCallback = AsyncRequestCallback<Value>;
 
 // This class contains the internal state of an asynchronous request.
 //
@@ -78,7 +77,7 @@ class AsyncRequestState final {
   std::atomic_flag is_callback_call_started_ = ATOMIC_FLAG_INIT;
 };
 
-using GenericAsyncRequestState = AsyncRequestState<pp::Var>;
+using GenericAsyncRequestState = AsyncRequestState<Value>;
 
 // This class contains the interface of an asynchronous request that is exposed
 // to consumers.
@@ -120,7 +119,7 @@ class AsyncRequest final {
   std::shared_ptr<AsyncRequestState<PayloadType>> state_;
 };
 
-using GenericAsyncRequest = AsyncRequest<pp::Var>;
+using GenericAsyncRequest = AsyncRequest<Value>;
 
 }  // namespace google_smart_card
 

--- a/common/cpp/src/google_smart_card_common/requesting/async_request_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/async_request_unittest.cc
@@ -22,8 +22,8 @@
 
 #include <gtest/gtest.h>
 
-#include <google_smart_card_common/pp_var_utils/extraction.h>
 #include <google_smart_card_common/requesting/request_result.h>
+#include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
 
@@ -57,16 +57,18 @@ TEST(RequestingAsyncRequestTest, AsyncRequestStateBasic) {
 
   // The first set of the request result is successful and triggers the callback
   const int kValue = 123;
-  ASSERT_TRUE(
-      request_state.SetResult(GenericRequestResult::CreateSuccessful(kValue)));
+  ASSERT_TRUE(request_state.SetResult(
+      GenericRequestResult::CreateSuccessful(Value(kValue))));
   ASSERT_EQ(1, callback.call_count());
-  EXPECT_EQ(kValue, VarAs<int>(callback.request_result().payload()));
+  ASSERT_TRUE(callback.request_result().payload().is_integer());
+  EXPECT_EQ(callback.request_result().payload().GetInteger(), kValue);
 
   // The subsequent set of the request result does not change the stored value
   // and does not trigger the callback
   ASSERT_FALSE(request_state.SetResult(GenericRequestResult::CreateFailed("")));
   ASSERT_EQ(1, callback.call_count());
-  EXPECT_EQ(kValue, VarAs<int>(callback.request_result().payload()));
+  ASSERT_TRUE(callback.request_result().payload().is_integer());
+  EXPECT_EQ(callback.request_result().payload().GetInteger(), kValue);
 }
 
 TEST(RequestingAsyncRequestTest, AsyncRequestStateMultiThreading) {

--- a/common/cpp/src/google_smart_card_common/requesting/async_requests_storage.h
+++ b/common/cpp/src/google_smart_card_common/requesting/async_requests_storage.h
@@ -20,11 +20,10 @@
 #include <unordered_map>
 #include <vector>
 
-#include <ppapi/cpp/var.h>
-
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/requesting/async_request.h>
 #include <google_smart_card_common/requesting/request_id.h>
+#include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
 
@@ -94,7 +93,7 @@ class AsyncRequestsStorage final {
       state_map_;
 };
 
-using GenericAsyncRequestsStorage = AsyncRequestsStorage<pp::Var>;
+using GenericAsyncRequestsStorage = AsyncRequestsStorage<Value>;
 
 }  // namespace google_smart_card
 

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.h
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.h
@@ -26,6 +26,7 @@
 #include <google_smart_card_common/requesting/async_request.h>
 #include <google_smart_card_common/requesting/request_result.h>
 #include <google_smart_card_common/requesting/requester.h>
+#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
 
 namespace google_smart_card {
 
@@ -74,8 +75,10 @@ class RemoteCallAdaptor final {
       *error_message = generic_request_result.error_message();
       return false;
     }
+    // TODO(#185): Parse `Value` diectly, without converting to `pp::Var`.
+    pp::Var payload_var = ConvertValueToPpVar(generic_request_result.payload());
     pp::VarArray var_array;
-    if (!VarAs(generic_request_result.payload(), &var_array, error_message)) {
+    if (!VarAs(payload_var, &var_array, error_message)) {
       GOOGLE_SMART_CARD_LOG_FATAL << "Failed to extract the response "
                                   << "payload items: " << *error_message;
     }

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.cc
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.cc
@@ -20,6 +20,7 @@
 #include <google_smart_card_common/requesting/request_result.h>
 #include <google_smart_card_common/unique_ptr_utils.h>
 #include <google_smart_card_common/value.h>
+#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
 
 namespace smart_card_client {
 
@@ -33,8 +34,10 @@ constexpr char kPinMessageKey[] = "pin";
 void ExtractPinRequestResult(
     const google_smart_card::GenericRequestResult& request_result,
     std::string* pin) {
+  // TODO: Parse `Value` directly, without converting into `pp::Var`.
   const pp::VarDictionary result_var =
-      google_smart_card::VarAs<pp::VarDictionary>(request_result.payload());
+      google_smart_card::VarAs<pp::VarDictionary>(
+          google_smart_card::ConvertValueToPpVar(request_result.payload()));
 
   google_smart_card::VarDictValuesExtractor extractor(result_var);
   extractor.Extract(kPinMessageKey, pin);

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.cc
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.cc
@@ -34,7 +34,7 @@ constexpr char kPinMessageKey[] = "pin";
 void ExtractPinRequestResult(
     const google_smart_card::GenericRequestResult& request_result,
     std::string* pin) {
-  // TODO: Parse `Value` directly, without converting into `pp::Var`.
+  // TODO(#220): Parse `Value` directly, without converting into `pp::Var`.
   const pp::VarDictionary result_var =
       google_smart_card::VarAs<pp::VarDictionary>(
           google_smart_card::ConvertValueToPpVar(request_result.payload()));

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
@@ -60,7 +60,7 @@ void ProcessCertificatesRequest(
       locked_certificates_request_handler = certificates_request_handler.lock();
   GOOGLE_SMART_CARD_CHECK(locked_certificates_request_handler);
   if (locked_certificates_request_handler->HandleRequest(&certificates)) {
-    // TODO: Build `Value` directly, without converting from `pp::Var`.
+    // TODO(#220): Build `Value` directly, without converting from `pp::Var`.
     result_callback(gsc::GenericRequestResult::CreateSuccessful(
         gsc::ConvertPpVarToValueOrDie(gsc::MakeVarArray(certificates))));
   } else {
@@ -84,7 +84,7 @@ void ProcessSignatureRequest(
   GOOGLE_SMART_CARD_CHECK(locked_signature_request_handler);
   if (locked_signature_request_handler->HandleRequest(signature_request,
                                                       &signature)) {
-    // TODO: Build `Value` directly, without converting from `pp::Var`.
+    // TODO(#220): Build `Value` directly, without converting from `pp::Var`.
     result_callback(gsc::GenericRequestResult::CreateSuccessful(
         gsc::ConvertPpVarToValueOrDie(gsc::MakeVarArray(signature))));
   } else {
@@ -153,7 +153,7 @@ bool ApiBridge::RequestPin(const RequestPinOptions& options, std::string* pin) {
     tracer.LogExit();
     return false;
   }
-  // TODO: Parse `Value` directly, rather than convert into `pp::Var`.
+  // TODO(#220): Parse `Value` directly, rather than convert into `pp::Var`.
   const pp::Var payload_var =
       gsc::ConvertValueToPpVar(generic_request_result.payload());
   // Note: Cannot use RemoteCallAdaptor::ExtractResultPayload(), since the API

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
@@ -30,6 +30,7 @@
 #include <google_smart_card_common/requesting/request_receiver.h>
 #include <google_smart_card_common/requesting/request_result.h>
 #include <google_smart_card_common/unique_ptr_utils.h>
+#include <google_smart_card_common/value.h>
 #include <google_smart_card_integration_testing/integration_test_helper.h>
 #include <google_smart_card_integration_testing/integration_test_service.h>
 
@@ -73,7 +74,7 @@ void SetCertificatesOnBackgroundThread(
   if (!locked_api_bridge)
     GOOGLE_SMART_CARD_LOG_FATAL << "ApiBridge already destroyed";
   locked_api_bridge->SetCertificates(certificates);
-  result_callback(gsc::GenericRequestResult::CreateSuccessful(pp::Var()));
+  result_callback(gsc::GenericRequestResult::CreateSuccessful(gsc::Value()));
 }
 
 }  // namespace

--- a/third_party/libusb/naclport/src/libusb_over_chrome_usb.cc
+++ b/third_party/libusb/naclport/src/libusb_over_chrome_usb.cc
@@ -1070,7 +1070,7 @@ LibusbOverChromeUsb::SyncTransferHelper::WaitForCompletion() {
     context_->WaitAndProcessOutputSyncTransferReceivedResult(
         async_request_state_);
   }
-  return result_;
+  return std::move(result_);
 }
 
 libusb_context* LibusbOverChromeUsb::SubstituteDefaultContextIfNull(

--- a/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.cc
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.cc
@@ -41,6 +41,7 @@
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/multi_string.h>
 #include <google_smart_card_common/pp_var_utils/extraction.h>
+#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
 #include <google_smart_card_pcsc_lite_common/scard_structs_serialization.h>
 
 namespace google_smart_card {
@@ -148,9 +149,12 @@ LONG ExtractRequestResultsAndCode(
     return SCARD_F_INTERNAL_ERROR;
   }
 
+  // TODO: Parse `Value` directly, instead of converting to `pp::Var`.
+  pp::Var payload_var = ConvertValueToPpVar(generic_request_result.payload());
+
   std::string error_message;
   pp::VarArray var_array;
-  if (!VarAs(generic_request_result.payload(), &var_array, &error_message)) {
+  if (!VarAs(payload_var, &var_array, &error_message)) {
     GOOGLE_SMART_CARD_LOG_FATAL << logging_prefix << "Failed to extract the "
                                 << "response payload items: " << error_message;
   }

--- a/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.cc
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.cc
@@ -149,7 +149,7 @@ LONG ExtractRequestResultsAndCode(
     return SCARD_F_INTERNAL_ERROR;
   }
 
-  // TODO: Parse `Value` directly, instead of converting to `pp::Var`.
+  // TODO(#220): Parse `Value` directly, instead of converting to `pp::Var`.
   pp::Var payload_var = ConvertValueToPpVar(generic_request_result.payload());
 
   std::string error_message;

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.cc
@@ -49,7 +49,7 @@ namespace {
 
 template <typename... Args>
 GenericRequestResult ReturnValues(const Args&... args) {
-  // TODO: Build `Value` directly, without converting from `pp::Var`.
+  // TODO(#220): Build `Value` directly, without converting from `pp::Var`.
   return GenericRequestResult::CreateSuccessful(
       ConvertPpVarToValueOrDie(MakeVarArray(args...)));
 }


### PR DESCRIPTION
Change async_request.h, async_requests_storage.h, request_result.h
to use the toolchain-independent Value class intead of Native Client
specific pp::Var class in most places. As an additional bonus, the
request_result.cc, requester.cc, requester_message.cc files became
completely free of NaCl-specific definitions as well.

Besides the mechanical replacement, there's a bit of refactoring due to
using std::move() instead of the previously used copying in related
classes. The background here is that the NaCl's pp::Var class was
copyable (with ref-counting), meanwhile the new Value class is only
moveable.

This commit contributes to the goal of making most of the //common/cpp
library be toolchain-agnostic and support WebAssembly (as tracked
by #185).