### PR TITLE
Tighten compilation flags in Emscripten builds

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -70,6 +70,7 @@ CXXFLAGS := \
 	-I$(ROOT_SOURCES_PATH)/ \
 	-pedantic \
 	-Wall \
+	-Werror \
 	-Wextra \
 	-std=gnu++11 \
 

--- a/common/cpp/src/google_smart_card_common/logging/logging.cc
+++ b/common/cpp/src/google_smart_card_common/logging/logging.cc
@@ -32,11 +32,13 @@ namespace google_smart_card {
 
 namespace {
 
+#ifdef __native_client__
 constexpr char kTypeMessageKey[] = "type";
 constexpr char kMessageType[] = "log_message";
 constexpr char kDataMessageKey[] = "data";
 constexpr char kDataLogLevelMessageKey[] = "log_level";
 constexpr char kDataTextMessageKey[] = "text";
+#endif  // __native_client__
 
 bool ShouldLogWithSeverity(LogSeverity severity) {
 #ifdef NDEBUG

--- a/common/cpp/src/google_smart_card_common/value_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_unittest.cc
@@ -77,7 +77,7 @@ TEST(ValueTest, Integer64BitMax) {
   EXPECT_FALSE(value.is_dictionary());
   EXPECT_FALSE(value.is_array());
   EXPECT_EQ(value.GetInteger(), integer_value);
-  EXPECT_DOUBLE_EQ(value.GetFloat(), integer_value);
+  EXPECT_DOUBLE_EQ(value.GetFloat(), static_cast<double>(integer_value));
 }
 
 TEST(ValueTest, Integer64BitMin) {

--- a/common/integration_testing/build/Makefile
+++ b/common/integration_testing/build/Makefile
@@ -34,6 +34,7 @@ CXXFLAGS := \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-pedantic \
 	-Wall \
+	-Werror \
 	-Wextra \
 	-std=gnu++11 \
 

--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -82,8 +82,10 @@ ifeq ($(CONFIG),Release)
 #
 # Explanation:
 # O3: Enable advanced optimizations.
+# NDEBUG: Disable debug-only functionality (assertions, etc.).
 EMSCRIPTEN_FLAGS += \
   -O3 \
+  -DNDEBUG \
 
 else ifeq ($(CONFIG),Debug)
 

--- a/common/tests_runner/build.mk
+++ b/common/tests_runner/build.mk
@@ -97,6 +97,7 @@ CPPFLAGS := \
 	-pedantic \
 	-std=gnu++11 \
 	-Wall \
+	-Werror \
 	-Wextra \
 	-Wno-zero-length-array \
 	$(ADDITIONAL_TEST_CPPFLAGS)

--- a/example_cpp_smart_card_client_app/build/integration_tests/Makefile
+++ b/example_cpp_smart_card_client_app/build/integration_tests/Makefile
@@ -63,6 +63,7 @@ CPPFLAGS := \
 	-pedantic \
 	-std=gnu++11 \
 	-Wall \
+	-Werror \
 	-Wextra \
 	-Wno-zero-length-array \
 

--- a/example_cpp_smart_card_client_app/build/nacl_module/Makefile
+++ b/example_cpp_smart_card_client_app/build/nacl_module/Makefile
@@ -58,6 +58,7 @@ CPPFLAGS := \
 	-I$(PCSC_LITE_CLIENT_INCLUDE_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-Wall \
+	-Werror \
 	-Wextra \
 	-Wno-zero-length-array \
 	-pedantic \

--- a/smart_card_connector_app/build/nacl_module/Makefile
+++ b/smart_card_connector_app/build/nacl_module/Makefile
@@ -66,6 +66,7 @@ CXXFLAGS := \
 	-I$(PCSC_LITE_SERVER_INCLUDE_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-Wall \
+	-Werror \
 	-Wextra \
 	-Wno-zero-length-array \
 	-pedantic \

--- a/third_party/libusb/naclport/build/Makefile
+++ b/third_party/libusb/naclport/build/Makefile
@@ -56,6 +56,7 @@ CPPFLAGS := \
 	-I$(LIBUSB_SOURCES_PATH)/libusb \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-Wall \
+	-Werror \
 	-Wextra \
 	-Wno-sign-compare \
 

--- a/third_party/pcsc-lite/naclport/common/build/Makefile
+++ b/third_party/pcsc-lite/naclport/common/build/Makefile
@@ -49,6 +49,7 @@ CXXFLAGS := \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-pedantic \
 	-Wall \
+	-Werror \
 	-Wextra \
 	-Wno-zero-length-array \
 	-std=gnu++11 \


### PR DESCRIPTION
* Add "-Werror" - i.e., treat warnings as compilation errors. (To note,
  in Native Client builds this has always been enabled by NaCl's
  toolchain.)
* Enable "NDEBUG" preprocessor definition in Release builds, in order to
  disable debug-only assertions and debug value output. (In NaCl builds
  this has already been enabled.)
* Fix a few warnings detected by Emscripten's clang compiler:
* * logging.cc:35:16: error: unused variable 'kTypeMessageKey'
* * logging.cc:36:16: error: unused variable 'kMessageType'
* * logging.cc:37:16: error: unused variable 'kDataMessageKey'
* * logging.cc:38:16: error: unused variable 'kDataLogLevelMessageKey'
* * logging.cc:39:16: error: unused variable 'kDataTextMessageKey'
* * value_unittest.cc:80:38: error: implicit conversion from 'const int64_t'
    (aka 'const long long') to 'double' changes value.

This is an improvement for the Emscripten/WebAssembly build
infrastructure that is tracked by #177.