### PR TITLE
Add conversion from Emscripten's val into Value

### DIFF
--- a/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.cc
@@ -35,7 +35,7 @@ namespace google_smart_card {
 
 namespace {
 
-constexpr char kErrorWrongType[] = "Error converting: unsupported type \"%s\"";
+constexpr char kErrorWrongType[] = "Conversion error: unsupported type \"%s\"";
 
 emscripten::val CreateIntegerVal(int64_t integer) {
   // `emscripten::val` doesn't support direct conversion from `int64_t`, so

--- a/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.cc
@@ -19,16 +19,23 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <emscripten/val.h>
+#include <emscripten/wire.h>
 
+#include <google_smart_card_common/formatting.h>
 #include <google_smart_card_common/logging/logging.h>
+#include <google_smart_card_common/optional.h>
+#include <google_smart_card_common/unique_ptr_utils.h>
 #include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
 
 namespace {
+
+constexpr char kErrorWrongType[] = "Error converting: unsupported type \"%s\"";
 
 emscripten::val CreateIntegerVal(int64_t integer) {
   // `emscripten::val` doesn't support direct conversion from `int64_t`, so
@@ -37,6 +44,7 @@ emscripten::val CreateIntegerVal(int64_t integer) {
       integer <= std::numeric_limits<int>::max()) {
     return emscripten::val(static_cast<int>(integer));
   }
+  // TODO(#217): Forbid conversions that lose precision.
   return emscripten::val(static_cast<double>(integer));
 }
 
@@ -66,6 +74,87 @@ emscripten::val CreateArrayVal(const Value::ArrayStorage& array) {
   return emscripten::val::array(converted_items);
 }
 
+bool IsEmcriptenValInstanceof(const emscripten::val& val,
+                              const char* type_name) {
+  // clang-format incorrectly adds a space after "instanceof".
+  // clang-format off
+  return val.instanceof(emscripten::val::global(type_name));
+  // clang-format on
+}
+
+Value CreateValueFromNumberVal(const emscripten::val& val) {
+  // Convert the number as `int`, in case it's an integer that fits into `int`.
+  // Note that `emscripten::val` doesn't support direct conversions into
+  // `int64_t`.
+  // TODO(#217): Avoid conversions from imprecise numbers into integers.
+  if (emscripten::val::global("Number").call<bool>("isInteger", val) &&
+      val <= emscripten::val(std::numeric_limits<int>::max()) &&
+      val >= emscripten::val(std::numeric_limits<int>::min()))
+    return Value(val.as<int>());
+  // The number is fractional or too big - therefore convert it into `double`.
+  return Value(val.as<double>());
+}
+
+Value CreateValueFromArrayBufferVal(const emscripten::val& val) {
+  const emscripten::val source_uint8_array =
+      emscripten::val::global("Uint8Array").new_(val);
+  std::vector<uint8_t> bytes(source_uint8_array["length"].as<int>());
+  if (!bytes.empty()) {
+    // Copy the array buffer in an effective way: create a typed array that
+    // points to the `std::vector` allocated above, and fill it with contents of
+    // `source_uint8_array` by a single call. This should be much faster than
+    // accessing each byte one-by-one via operator[].
+    const emscripten::val target_uint8_array = emscripten::val(
+        emscripten::typed_memory_view(bytes.size(), bytes.data()));
+    target_uint8_array.call<void>("set", source_uint8_array);
+  }
+  return Value(std::move(bytes));
+}
+
+optional<Value> CreateValueFromArrayLikeVal(const emscripten::val& val,
+                                            std::string* error_message) {
+  const size_t size = val["length"].as<size_t>();
+  std::vector<std::unique_ptr<Value>> converted_items(size);
+  std::string local_error_message;
+  for (size_t index = 0; index < size; ++index) {
+    optional<Value> converted_item =
+        ConvertEmscriptenValToValue(val[index], &local_error_message);
+    if (!converted_item) {
+      FormatPrintfTemplateAndSet(
+          error_message, "Error converting array item #%d: %s",
+          static_cast<int>(index), local_error_message.c_str());
+      return {};
+    }
+    converted_items[index] = MakeUnique<Value>(std::move(*converted_item));
+  }
+  return Value(std::move(converted_items));
+}
+
+optional<Value> CreateValueFromObjectVal(const emscripten::val& val,
+                                         std::string* error_message) {
+  const emscripten::val keys =
+      emscripten::val::global("Object").call<emscripten::val>("keys", val);
+  const size_t keys_size = keys["length"].as<size_t>();
+  std::string local_error_message;
+  Value value(Value::Type::kDictionary);
+  for (size_t index = 0; index < keys_size; ++index) {
+    const emscripten::val item_key = keys[index];
+    const emscripten::val item_value = val[item_key];
+    GOOGLE_SMART_CARD_CHECK(item_key.isString());
+    const std::string key = item_key.as<std::string>();
+    optional<Value> converted_item_value =
+        ConvertEmscriptenValToValue(item_value, &local_error_message);
+    if (!converted_item_value) {
+      FormatPrintfTemplateAndSet(error_message,
+                                 "Error converting object property \"%s\": %s",
+                                 key.c_str(), local_error_message.c_str());
+      return {};
+    }
+    value.SetDictionaryItem(key, std::move(*converted_item_value));
+  }
+  return std::move(value);
+}
+
 }  // namespace
 
 emscripten::val ConvertValueToEmscriptenVal(const Value& value) {
@@ -88,6 +177,44 @@ emscripten::val ConvertValueToEmscriptenVal(const Value& value) {
       return CreateArrayVal(value.GetArray());
   }
   GOOGLE_SMART_CARD_NOTREACHED;
+}
+
+optional<Value> ConvertEmscriptenValToValue(const emscripten::val& val,
+                                            std::string* error_message) {
+  if (val.isUndefined() || val.isNull()) return Value();
+  if (val.isTrue()) return Value(true);
+  if (val.isFalse()) return Value(false);
+  if (val.isNumber()) return CreateValueFromNumberVal(val);
+  if (val.isString()) return Value(val.as<std::string>());
+  if (val.isArray()) return CreateValueFromArrayLikeVal(val, error_message);
+  if (IsEmcriptenValInstanceof(val, "DataView")) {
+    FormatPrintfTemplateAndSet(error_message, kErrorWrongType, "DataView");
+    return {};
+  }
+  if (IsEmcriptenValInstanceof(val, "ArrayBuffer"))
+    return CreateValueFromArrayBufferVal(val);
+  if (emscripten::val::global("ArrayBuffer").call<bool>("isView", val)) {
+    // Note that `ArrayBuffer.isView()` returns true for all TypedArray objects,
+    // but also for `DataView` objects that aren't iterable and therefore have
+    // to be excluded above.
+    return CreateValueFromArrayLikeVal(val, error_message);
+  }
+  const std::string val_typeof = val.typeOf().as<std::string>();
+  if (val_typeof == "object")
+    return CreateValueFromObjectVal(val, error_message);
+  // There's no easy way to stringify an arbitrary JavaScript value (e.g.,
+  // calling "String()" might raise an exception), therefore simply use the
+  // result of "typeof".
+  FormatPrintfTemplateAndSet(error_message, kErrorWrongType,
+                             val_typeof.c_str());
+  return {};
+}
+
+Value ConvertEmscriptenValToValueOrDie(const emscripten::val& val) {
+  std::string error_message;
+  optional<Value> value = ConvertEmscriptenValToValue(val, &error_message);
+  if (!value) GOOGLE_SMART_CARD_LOG_FATAL << error_message;
+  return std::move(*value);
 }
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.h
@@ -22,14 +22,28 @@
 #error "This file should only be used in Emscripten builds"
 #endif  // __EMSCRIPTEN__
 
+#include <string>
+
 #include <emscripten/val.h>
 
+#include <google_smart_card_common/optional.h>
 #include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
 
 // Converts the given `Value` into a `emscripten::val`.
 emscripten::val ConvertValueToEmscriptenVal(const Value& value);
+
+// Converts the given `emscripten::val` into a `Value`.
+//
+// When the conversion isn't possible (e.g., when the passed variable is a
+// function), returns a null optional and, if provided, sets `*error_message`.
+optional<Value> ConvertEmscriptenValToValue(
+    const emscripten::val& val, std::string* error_message = nullptr);
+
+// Same as `ConvertEmscriptenValToValue()`, but immediately crashes the program
+// if the conversion fails.
+Value ConvertEmscriptenValToValueOrDie(const emscripten::val& val);
 
 }  // namespace google_smart_card
 

--- a/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion_unittest.cc
@@ -358,7 +358,7 @@ TEST(ValueEmscriptenValConversion, FunctionEmscriptenVal) {
     emscripten::val val = emscripten::val::global("String");
     std::string error_message;
     EXPECT_FALSE(ConvertEmscriptenValToValue(val, &error_message));
-    EXPECT_EQ(error_message, "Error converting: unsupported type \"function\"");
+    EXPECT_EQ(error_message, "Conversion error: unsupported type \"function\"");
   }
 
   {
@@ -412,7 +412,7 @@ TEST(ValueEmscriptenValConversion, ArrayEmscriptenValWithBadItem) {
     std::string error_message;
     EXPECT_FALSE(ConvertEmscriptenValToValue(inner_array_val, &error_message));
     EXPECT_EQ(error_message,
-              "Error converting array item #0: Error converting: unsupported "
+              "Error converting array item #0: Conversion error: unsupported "
               "type \"function\"");
   }
 
@@ -421,7 +421,7 @@ TEST(ValueEmscriptenValConversion, ArrayEmscriptenValWithBadItem) {
     EXPECT_FALSE(ConvertEmscriptenValToValue(array_val, &error_message));
     EXPECT_EQ(error_message,
               "Error converting array item #1: Error converting array item #0: "
-              "Error converting: unsupported type \"function\"");
+              "Conversion error: unsupported type \"function\"");
   }
 }
 
@@ -463,7 +463,7 @@ TEST(ValueEmscriptenValConversion, DataViewEmscriptenVal) {
   {
     std::string error_message;
     EXPECT_FALSE(ConvertEmscriptenValToValue(val, &error_message));
-    EXPECT_EQ(error_message, "Error converting: unsupported type \"DataView\"");
+    EXPECT_EQ(error_message, "Conversion error: unsupported type \"DataView\"");
   }
 }
 
@@ -518,8 +518,8 @@ TEST(ValueEmscriptenValConversion, ObjectEmscriptenValWithBadItem) {
     std::string error_message;
     EXPECT_FALSE(ConvertEmscriptenValToValue(inner_object_val, &error_message));
     EXPECT_EQ(error_message,
-              "Error converting object property \"someInnerKey\": Error "
-              "converting: unsupported type \"function\"");
+              "Error converting object property \"someInnerKey\": Conversion "
+              "error: unsupported type \"function\"");
   }
 
   {
@@ -527,7 +527,7 @@ TEST(ValueEmscriptenValConversion, ObjectEmscriptenValWithBadItem) {
     EXPECT_FALSE(ConvertEmscriptenValToValue(object_val, &error_message));
     EXPECT_EQ(error_message,
               "Error converting object property \"someKey\": Error converting "
-              "object property \"someInnerKey\": Error converting: unsupported "
+              "object property \"someInnerKey\": Conversion error: unsupported "
               "type \"function\"");
   }
 }

--- a/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion_unittest.cc
@@ -208,4 +208,360 @@ TEST(ValueEmscriptenValConversion, ArrayValue) {
   }
 }
 
+TEST(ValueEmscriptenValConversion, UndefinedEmscriptenVal) {
+  std::string error_message;
+  const optional<Value> value =
+      ConvertEmscriptenValToValue(emscripten::val::undefined(), &error_message);
+  EXPECT_TRUE(error_message.empty());
+  ASSERT_TRUE(value);
+  EXPECT_TRUE(value->is_null());
+}
+
+TEST(ValueEmscriptenValConversion, NullEmscriptenVal) {
+  std::string error_message;
+  const optional<Value> value =
+      ConvertEmscriptenValToValue(emscripten::val::null(), &error_message);
+  EXPECT_TRUE(error_message.empty());
+  ASSERT_TRUE(value);
+  EXPECT_TRUE(value->is_null());
+}
+
+TEST(ValueEmscriptenValConversion, BooleanEmscriptenVal) {
+  {
+    constexpr bool kBoolean = false;
+    std::string error_message;
+    const optional<Value> value =
+        ConvertEmscriptenValToValue(emscripten::val(kBoolean), &error_message);
+    EXPECT_TRUE(error_message.empty());
+    ASSERT_TRUE(value);
+    ASSERT_TRUE(value->is_boolean());
+    EXPECT_EQ(value->GetBoolean(), kBoolean);
+  }
+
+  {
+    constexpr bool kBoolean = true;
+    std::string error_message;
+    const optional<Value> value =
+        ConvertEmscriptenValToValue(emscripten::val(kBoolean), &error_message);
+    EXPECT_TRUE(error_message.empty());
+    ASSERT_TRUE(value);
+    ASSERT_TRUE(value->is_boolean());
+    EXPECT_EQ(value->GetBoolean(), kBoolean);
+  }
+}
+
+TEST(ValueEmscriptenValConversion, IntegerNumberEmscriptenVal) {
+  {
+    constexpr int kNumber = 123;
+    std::string error_message;
+    const optional<Value> value =
+        ConvertEmscriptenValToValue(emscripten::val(kNumber), &error_message);
+    EXPECT_TRUE(error_message.empty());
+    ASSERT_TRUE(value);
+    ASSERT_TRUE(value->is_integer());
+    EXPECT_EQ(value->GetInteger(), kNumber);
+  }
+
+  {
+    // This is a big number that is guaranteed to fit into `int` and into the
+    // range of precisely representable JavaScript numbers.
+    constexpr int kBig =
+        sizeof(int) < 4 ? std::numeric_limits<int>::max() : (1 << 30);
+    const optional<Value> value =
+        ConvertEmscriptenValToValue(emscripten::val(kBig));
+    ASSERT_TRUE(value);
+    ASSERT_TRUE(value->is_integer());
+    EXPECT_EQ(value->GetInteger(), kBig);
+  }
+
+  {
+    constexpr int64_t kInt64Max = std::numeric_limits<int64_t>::max();
+    const optional<Value> value = ConvertEmscriptenValToValue(
+        emscripten::val(static_cast<double>(kInt64Max)));
+    ASSERT_TRUE(value);
+    ASSERT_TRUE(value->is_float());
+    EXPECT_DOUBLE_EQ(value->GetFloat(), static_cast<double>(kInt64Max));
+  }
+}
+
+TEST(ValueEmscriptenValConversion, FloatNumberEmscriptenVal) {
+  {
+    constexpr double kFractional = 123.456;
+    std::string error_message;
+    const optional<Value> value = ConvertEmscriptenValToValue(
+        emscripten::val(kFractional), &error_message);
+    EXPECT_TRUE(error_message.empty());
+    ASSERT_TRUE(value);
+    ASSERT_TRUE(value->is_float());
+    EXPECT_DOUBLE_EQ(value->GetFloat(), kFractional);
+  }
+
+  {
+    constexpr double kHuge = 1E100;
+    const optional<Value> value =
+        ConvertEmscriptenValToValue(emscripten::val(kHuge));
+    ASSERT_TRUE(value);
+    ASSERT_TRUE(value->is_float());
+    EXPECT_DOUBLE_EQ(value->GetFloat(), kHuge);
+  }
+}
+
+TEST(ValueEmscriptenValConversion, StringEmscriptenVal) {
+  {
+    constexpr char kEmpty[] = "";
+    std::string error_message;
+    const optional<Value> value =
+        ConvertEmscriptenValToValue(emscripten::val(kEmpty), &error_message);
+    EXPECT_TRUE(error_message.empty());
+    ASSERT_TRUE(value);
+    ASSERT_TRUE(value->is_string());
+    EXPECT_EQ(value->GetString(), kEmpty);
+  }
+
+  {
+    constexpr char kFoo[] = "foo";
+    const optional<Value> value =
+        ConvertEmscriptenValToValue(emscripten::val(kFoo));
+    ASSERT_TRUE(value);
+    ASSERT_TRUE(value->is_string());
+    EXPECT_EQ(value->GetString(), kFoo);
+  }
+}
+
+TEST(ValueEmscriptenValConversion, ArrayBufferEmscriptenVal) {
+  {
+    std::string error_message;
+    const optional<Value> value = ConvertEmscriptenValToValue(
+        emscripten::val::global("ArrayBuffer").new_(), &error_message);
+    EXPECT_TRUE(error_message.empty());
+    ASSERT_TRUE(value);
+    ASSERT_TRUE(value->is_binary());
+    EXPECT_TRUE(value->GetBinary().empty());
+  }
+
+  {
+    const std::vector<uint8_t> kBytes = {1, 2, 3};
+    const emscripten::val uint8_array_val =
+        emscripten::val::global("Uint8Array")
+            .call<emscripten::val>("from", emscripten::val::array(kBytes));
+    emscripten::val array_buffer_val = uint8_array_val["buffer"];
+
+    const optional<Value> value = ConvertEmscriptenValToValue(array_buffer_val);
+    ASSERT_TRUE(value);
+    ASSERT_TRUE(value->is_binary());
+    EXPECT_EQ(value->GetBinary(), kBytes);
+  }
+}
+
+TEST(ValueEmscriptenValConversion, FunctionEmscriptenVal) {
+  {
+    emscripten::val val = emscripten::val::global("String");
+    std::string error_message;
+    EXPECT_FALSE(ConvertEmscriptenValToValue(val, &error_message));
+    EXPECT_EQ(error_message, "Error converting: unsupported type \"function\"");
+  }
+
+  {
+    emscripten::val val = emscripten::val::global("parseInt");
+    EXPECT_FALSE(ConvertEmscriptenValToValue(val));
+  }
+}
+
+TEST(ValueEmscriptenValConversion, ArrayEmscriptenVal) {
+  {
+    std::string error_message;
+    const optional<Value> value =
+        ConvertEmscriptenValToValue(emscripten::val::array(), &error_message);
+    EXPECT_TRUE(error_message.empty());
+    ASSERT_TRUE(value);
+    ASSERT_TRUE(value->is_array());
+    EXPECT_TRUE(value->GetArray().empty());
+  }
+
+  {
+    emscripten::val val = emscripten::val::global("JSON").call<emscripten::val>(
+        "parse", std::string("[[null, 123]]"));
+
+    std::string error_message;
+    const optional<Value> value =
+        ConvertEmscriptenValToValue(val, &error_message);
+    EXPECT_TRUE(error_message.empty());
+    ASSERT_TRUE(value);
+    ASSERT_TRUE(value->is_array());
+    ASSERT_EQ(value->GetArray().size(), 1U);
+    const Value& inner_value = *value->GetArray()[0];
+    ASSERT_TRUE(inner_value.is_array());
+    ASSERT_EQ(inner_value.GetArray().size(), 2U);
+    EXPECT_TRUE(inner_value.GetArray()[0]->is_null());
+    ASSERT_TRUE(inner_value.GetArray()[1]->is_integer());
+    EXPECT_EQ(inner_value.GetArray()[1]->GetInteger(), 123);
+  }
+}
+
+TEST(ValueEmscriptenValConversion, ArrayEmscriptenValWithBadItem) {
+  emscripten::val inner_array_val = emscripten::val::array();  // [<function>]
+  inner_array_val.set(0, emscripten::val::global("parseInt"));
+  emscripten::val array_val = emscripten::val::array();  // [null, [<function>]]
+  array_val.set(0, emscripten::val::null());
+  array_val.set(1, inner_array_val);
+
+  EXPECT_FALSE(ConvertEmscriptenValToValue(inner_array_val));
+  EXPECT_FALSE(ConvertEmscriptenValToValue(array_val));
+
+  {
+    std::string error_message;
+    EXPECT_FALSE(ConvertEmscriptenValToValue(inner_array_val, &error_message));
+    EXPECT_EQ(error_message,
+              "Error converting array item #0: Error converting: unsupported "
+              "type \"function\"");
+  }
+
+  {
+    std::string error_message;
+    EXPECT_FALSE(ConvertEmscriptenValToValue(array_val, &error_message));
+    EXPECT_EQ(error_message,
+              "Error converting array item #1: Error converting array item #0: "
+              "Error converting: unsupported type \"function\"");
+  }
+}
+
+TEST(ValueEmscriptenValConversion, Uint8ArrayEmscriptenVal) {
+  {
+    std::string error_message;
+    const optional<Value> value = ConvertEmscriptenValToValue(
+        emscripten::val::global("Uint8Array").new_(), &error_message);
+    EXPECT_TRUE(error_message.empty());
+    ASSERT_TRUE(value);
+    ASSERT_TRUE(value->is_array());
+    EXPECT_TRUE(value->GetArray().empty());
+  }
+
+  {
+    const std::vector<uint8_t> kBytes = {1, 2, 255};
+    emscripten::val val = emscripten::val::global("Uint8Array")
+                              .new_(emscripten::val::array(kBytes));
+
+    const optional<Value> value = ConvertEmscriptenValToValue(val);
+    ASSERT_TRUE(value);
+    ASSERT_TRUE(value->is_array());
+    ASSERT_EQ(value->GetArray().size(), kBytes.size());
+    for (size_t i = 0; i < kBytes.size(); ++i) {
+      const Value& item = *value->GetArray()[i];
+      ASSERT_TRUE(item.is_integer());
+      EXPECT_EQ(item.GetInteger(), kBytes[i]);
+    }
+  }
+}
+
+TEST(ValueEmscriptenValConversion, DataViewEmscriptenVal) {
+  const emscripten::val val =
+      emscripten::val::global("DataView")
+          .new_(emscripten::val::global("ArrayBuffer").new_());
+
+  EXPECT_FALSE(ConvertEmscriptenValToValue(val));
+
+  {
+    std::string error_message;
+    EXPECT_FALSE(ConvertEmscriptenValToValue(val, &error_message));
+    EXPECT_EQ(error_message, "Error converting: unsupported type \"DataView\"");
+  }
+}
+
+TEST(ValueEmscriptenValConversion, ObjectEmscriptenVal) {
+  {
+    std::string error_message;
+    const optional<Value> value =
+        ConvertEmscriptenValToValue(emscripten::val::object(), &error_message);
+    EXPECT_TRUE(error_message.empty());
+    ASSERT_TRUE(value);
+    ASSERT_TRUE(value->is_dictionary());
+    EXPECT_TRUE(value->GetDictionary().empty());
+  }
+
+  {
+    emscripten::val val = emscripten::val::global("JSON").call<emscripten::val>(
+        "parse", std::string(R"({"xyz": {"foo": null, "bar": 123}})"));
+
+    const optional<Value> value = ConvertEmscriptenValToValue(val);
+    ASSERT_TRUE(value);
+    ASSERT_TRUE(value->is_dictionary());
+    EXPECT_EQ(value->GetDictionary().size(), 1U);
+    const auto xyz_iter = value->GetDictionary().find("xyz");
+    ASSERT_NE(xyz_iter, value->GetDictionary().end());
+    const Value& inner_value = *xyz_iter->second;
+    ASSERT_TRUE(inner_value.is_dictionary());
+    EXPECT_EQ(inner_value.GetDictionary().size(), 2U);
+    const auto foo_iter = inner_value.GetDictionary().find("foo");
+    ASSERT_NE(foo_iter, inner_value.GetDictionary().end());
+    const Value& foo_item_value = *foo_iter->second;
+    EXPECT_TRUE(foo_item_value.is_null());
+    const auto bar_iter = inner_value.GetDictionary().find("bar");
+    ASSERT_NE(bar_iter, inner_value.GetDictionary().end());
+    const Value& bar_item_value = *bar_iter->second;
+    ASSERT_TRUE(bar_item_value.is_integer());
+    EXPECT_EQ(bar_item_value.GetInteger(), 123);
+  }
+}
+
+TEST(ValueEmscriptenValConversion, ObjectEmscriptenValWithBadItem) {
+  emscripten::val inner_object_val =
+      emscripten::val::object();  // {"someInnerKey": <function>}
+  inner_object_val.set("someInnerKey", emscripten::val::global("parseInt"));
+  emscripten::val object_val =
+      emscripten::val::object();  // {"someKey": {"someInnerKey": <function>}}
+  object_val.set("someKey", inner_object_val);
+
+  EXPECT_FALSE(ConvertEmscriptenValToValue(inner_object_val));
+  EXPECT_FALSE(ConvertEmscriptenValToValue(object_val));
+
+  {
+    std::string error_message;
+    EXPECT_FALSE(ConvertEmscriptenValToValue(inner_object_val, &error_message));
+    EXPECT_EQ(error_message,
+              "Error converting object property \"someInnerKey\": Error "
+              "converting: unsupported type \"function\"");
+  }
+
+  {
+    std::string error_message;
+    EXPECT_FALSE(ConvertEmscriptenValToValue(object_val, &error_message));
+    EXPECT_EQ(error_message,
+              "Error converting object property \"someKey\": Error converting "
+              "object property \"someInnerKey\": Error converting: unsupported "
+              "type \"function\"");
+  }
+}
+
+// Test that `ConvertEmscriptenValToValueOrDie()` succeeds on supported inputs.
+// As death tests aren't supported, we don't test failure scenarios.
+TEST(ValueEmscriptenValConversion, EmscriptenValOrDie) {
+  {
+    constexpr bool kBoolean = false;
+    const Value value =
+        ConvertEmscriptenValToValueOrDie(emscripten::val(kBoolean));
+    ASSERT_TRUE(value.is_boolean());
+    EXPECT_EQ(value.GetBoolean(), kBoolean);
+  }
+
+  {
+    const int kInteger = 123;
+    const Value value =
+        ConvertEmscriptenValToValueOrDie(emscripten::val(kInteger));
+    ASSERT_TRUE(value.is_integer());
+    EXPECT_EQ(value.GetInteger(), kInteger);
+  }
+
+  {
+    emscripten::val object_val = emscripten::val::object();
+    object_val.set("foo", emscripten::val::null());
+
+    const Value value = ConvertEmscriptenValToValueOrDie(object_val);
+    ASSERT_TRUE(value.is_dictionary());
+    EXPECT_EQ(value.GetDictionary().size(), 1U);
+    const Value* foo_value = value.GetDictionaryItem("foo");
+    ASSERT_TRUE(foo_value);
+    EXPECT_TRUE(foo_value->is_null());
+  }
+}
+
 }  // namespace google_smart_card


### PR DESCRIPTION
Implement helper functions that transform an Emscripten Embind's
emscripten::val object into a Value object.

This will be used in follow-ups in order to receive messages from
JavaScript in Emscripten/WebAssembly builds, with the messages
handling code being toolchain-independent, contributing to the goal
of making most of the //common/cpp library be toolchain-independent
(as tracked by #185).