### PR TITLE
Fix errors in the example app built-in PIN dialog

### DIFF
--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog.css
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog.css
@@ -46,7 +46,7 @@ body {
 }
 
 #cancel::after {
-  content: "__MSG_pbuiltInPinDialogCancel__";
+  content: "__MSG_builtInPinDialogCancel__";
 }
 
 

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.cc
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.cc
@@ -60,7 +60,8 @@ void BuiltInPinDialogServer::Detach() { js_requester_.Detach(); }
 
 bool BuiltInPinDialogServer::RequestPin(std::string* pin) {
   const google_smart_card::GenericRequestResult request_result =
-      js_requester_.PerformSyncRequest(/*payload=*/google_smart_card::Value());
+      js_requester_.PerformSyncRequest(/*payload=*/google_smart_card::Value(
+          google_smart_card::Value::Type::kDictionary));
   if (!request_result.is_successful()) return false;
   ExtractPinRequestResult(request_result, pin);
   return true;


### PR DESCRIPTION
1. The dialog not being displayed, due to incorrectly sending a null
   value instead of an empty dictionary value when making a C++-to-JS
   request. (The error introduced in #209.)
2. Fix the "Cancel" button title not being correctly loaded, due to a
   typo in the localized message name (introduced back in #113).