### PR TITLE
Convert vector<uint8_t> into binary/ArrayBuffer

### DIFF
--- a/common/cpp/src/google_smart_card_common/pp_var_utils/construction.cc
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/construction.cc
@@ -66,6 +66,10 @@ pp::Var MakeVar(const std::string& value) {
   return value;
 }
 
+pp::Var MakeVar(const std::vector<uint8_t>& value) {
+  return MakeVarArrayBuffer(value);
+}
+
 std::string CleanupStringForVar(const std::string& string) {
   const char kPlaceholder = '_';
   std::string result = string;

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/construction.h
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/construction.h
@@ -85,6 +85,9 @@ inline pp::Var MakeVar(const std::vector<T>& value) {
   return result;
 }
 
+// Creates an array buffer.
+pp::Var MakeVar(const std::vector<uint8_t>& value);
+
 // Returns a string in which all characters that cannot be represented in a
 // Pepper value are replaced with a placeholder.
 std::string CleanupStringForVar(const std::string& string);

--- a/common/cpp/src/google_smart_card_common/value_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion.cc
@@ -228,6 +228,12 @@ bool ConvertToValue(const char* characters, Value* value,
   return true;
 }
 
+bool ConvertToValue(std::vector<uint8_t> bytes, Value* value,
+                    std::string* /*error_message*/) {
+  *value = Value(std::move(bytes));
+  return true;
+}
+
 bool ConvertFromValue(Value value, bool* boolean, std::string* error_message) {
   if (value.is_boolean()) {
     *boolean = value.GetBoolean();

--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -27,7 +27,8 @@
 // * `double`;
 // * `std::string`;
 // * `std::vector` of any supported type (note: there's also a special case that
-//    `std::vector<uint8_t>` can be converted from a binary value).
+//    `std::vector<uint8_t>` is converted to/from a binary `Value` and can
+//    additionally be converted from an array `Value`).
 //
 // The same helpers can also be enabled for custom types:
 // * a custom enum can be registered via the `EnumValueDescriptor` class for
@@ -527,6 +528,11 @@ bool ConvertToValue(std::vector<T> objects, Value* value,
   *value = Value(std::move(converted_items));
   return true;
 }
+
+// Converts a vector of bytes into a binary `Value`. (Note: This is unlike all
+// other types of `std::vector`, which are converted to an array `Value`.)
+bool ConvertToValue(std::vector<uint8_t> bytes, Value* value,
+                    std::string* error_message = nullptr);
 
 // Synonym to other `ConvertToValue()` overloads, but immediately crashes the
 // program if the conversion fails.

--- a/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
@@ -1375,6 +1375,14 @@ TEST(ValueConversion, VectorToValue) {
   }
 
   {
+    const std::vector<uint8_t> kBytes = {1, 2, 255};
+    Value value;
+    EXPECT_TRUE(ConvertToValue(kBytes, &value));
+    ASSERT_TRUE(value.is_binary());
+    EXPECT_EQ(value.GetBinary(), kBytes);
+  }
+
+  {
     const std::vector<SomeEnum> kEnums = {SomeEnum::kSecond, SomeEnum::kFirst};
     Value value;
     EXPECT_TRUE(ConvertToValue(kEnums, &value));

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
@@ -86,7 +86,7 @@ void ProcessSignatureRequest(
                                                       &signature)) {
     // TODO(#220): Build `Value` directly, without converting from `pp::Var`.
     result_callback(gsc::GenericRequestResult::CreateSuccessful(
-        gsc::ConvertPpVarToValueOrDie(gsc::MakeVarArray(signature))));
+        gsc::ConvertPpVarToValueOrDie(gsc::MakeVarArrayBuffer(signature))));
   } else {
     result_callback(gsc::GenericRequestResult::CreateFailed("Failure"));
   }

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
@@ -422,7 +422,7 @@ Backend.prototype.processSignatureRequest_ = function(request) {
       remoteCallMessage.makeRequestPayload());
   promise.then(function(results) {
     GSC.Logging.checkWithLogger(this.logger, results.length == 1);
-    const signature = normalizeSignature(results[0]);
+    const signature = results[0];
     this.logger.info(
         'Responding to the signature request with the created signature: ' +
         GSC.DebugDump.debugDump(signature));
@@ -488,7 +488,7 @@ Backend.prototype.processSignDigestRequest_ = function(
       remoteCallMessage.makeRequestPayload());
   promise.then(function(results) {
     GSC.Logging.checkWithLogger(this.logger, results.length == 1);
-    const signature = normalizeSignature(results[0]);
+    const signature = results[0];
     this.logger.info(
         'Responding to the digest sign request with the created signature: ' +
         GSC.DebugDump.debugDump(signature));
@@ -539,8 +539,7 @@ function transformFunctionArguments(functionName, functionArguments) {
  */
 function createClientCertificateInfo(naclCertificateInfo) {
   return {
-    certificateChain: [
-        (new Uint8Array(naclCertificateInfo['certificate'])).buffer],
+    certificateChain: [naclCertificateInfo['certificate']],
     supportedAlgorithms: naclCertificateInfo['supportedAlgorithms']
   };
 }
@@ -551,7 +550,7 @@ function createClientCertificateInfo(naclCertificateInfo) {
  */
 function createCertificateInfo(naclCertificateInfo) {
   return {
-    certificate: (new Uint8Array(naclCertificateInfo['certificate'])).buffer,
+    certificate: naclCertificateInfo['certificate'],
     supportedHashes: goog.array.map(
       naclCertificateInfo['supportedAlgorithms'], getHashFromAlgorithm)
   };
@@ -581,14 +580,6 @@ function getHashFromAlgorithm(algorithm) {
   }
   GSC.Logging.fail(`Unknown algorithm ${algorithm}`);
   return chrome.certificateProvider.Hash.SHA1;
-}
-
-/**
- * @param {!Array.<number>} signature
- * @return !ArrayBuffer
- */
-function normalizeSignature(signature) {
-  return (new Uint8Array(signature)).buffer;
 }
 
 });  // goog.scope


### PR DESCRIPTION
Change the vector-to-Value and the [obsolete, NaCl-specific]
vector-to-pp::Var conversion implementations to have a special
treatment for the "std::vector<uint8_t>" input type: convert it into a
binary/ArrayBuffer object, instead of the normal conversion into an
array with numbers.

This suits several purposes:
1. Allow seamless transformations in case the ArrayBuffer is really
   required on the receiver side - for example, when calling an
   Extensions API that uses an ArrayBuffer parameter.
2. Avoid introducing a special C++ type that would behave like an
   std::vector<uint8_t>, but denote "convert me into ArrayBuffer,
   unlike any real std::vector". (Note that previously, before we
   started working on WebAssembly, the pp::VarArrayBuffer type
   was suiting that purpose.)
3. Increase the performance (as a single binary object uses O(1)
   allocations, meanwhile an array object uses O(n) ones).