### PR TITLE
Introduce interface for toolchain-specific C++ ops

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -47,6 +47,7 @@ SOURCES := \
 ifeq ($(TOOLCHAIN),pnacl)
 
 SOURCES += \
+	$(SOURCES_PATH)/global_context_impl_nacl.cc \
 	$(SOURCES_PATH)/nacl_io_utils.cc \
 	$(SOURCES_PATH)/pp_var_utils/construction.cc \
 	$(SOURCES_PATH)/pp_var_utils/copying.cc \
@@ -67,6 +68,7 @@ SOURCES += \
 else ifeq ($(TOOLCHAIN),emscripten)
 
 SOURCES += \
+	$(SOURCES_PATH)/global_context_impl_emscripten.cc \
 	$(SOURCES_PATH)/value_emscripten_val_conversion.cc \
 
 endif

--- a/common/cpp/src/google_smart_card_common/global_context.h
+++ b/common/cpp/src/google_smart_card_common/global_context.h
@@ -35,6 +35,10 @@ class GlobalContext {
   // Returns whether the current thread is the main event loop thread. Is
   // intended to be used to avoid blocking/deadlocking the main thread.
   virtual bool IsMainEventLoopThread() const = 0;
+
+  // Disables communication with the JavaScript side. All calls to
+  // `PostMessageToJs()` after this point will return `false`.
+  virtual void DisableJsCommunication() = 0;
 };
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/global_context.h
+++ b/common/cpp/src/google_smart_card_common/global_context.h
@@ -1,0 +1,42 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_SMART_CARD_COMMON_GLOBAL_CONTEXT_H_
+#define GOOGLE_SMART_CARD_COMMON_GLOBAL_CONTEXT_H_
+
+#include <google_smart_card_common/value.h>
+
+namespace google_smart_card {
+
+// Global context is an interface that abstracts away webport-specific
+// operations.
+//
+// The implementation of this class is required to be thread-safe.
+class GlobalContext {
+ public:
+  virtual ~GlobalContext() = default;
+
+  // Sends the given message to the JavaScript side. Returns whether the message
+  // was sent successfully (note that the status doesn't tell anything about the
+  // result of the message handling on the JS side).
+  virtual bool PostMessageToJs(const Value& message) = 0;
+
+  // Returns whether the current thread is the main event loop thread. Is
+  // intended to be used to avoid blocking/deadlocking the main thread.
+  virtual bool IsMainEventLoopThread() const = 0;
+};
+
+}  // namespace google_smart_card
+
+#endif  // GOOGLE_SMART_CARD_COMMON_GLOBAL_CONTEXT_H_

--- a/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.cc
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.cc
@@ -1,0 +1,50 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google_smart_card_common/global_context_impl_emscripten.h>
+
+#include <mutex>
+#include <thread>
+
+#include <emscripten/val.h>
+
+#include <google_smart_card_common/value.h>
+#include <google_smart_card_common/value_emscripten_val_conversion.h>
+
+namespace google_smart_card {
+
+GlobalContextImplEmscripten::GlobalContextImplEmscripten(
+    std::thread::id main_thread_id, emscripten::val post_message_callback)
+    : main_thread_id_(main_thread_id),
+      post_message_callback_(post_message_callback) {}
+
+GlobalContextImplEmscripten::~GlobalContextImplEmscripten() = default;
+
+void GlobalContextImplEmscripten::DetachFromPostMessage() {
+  const std::unique_lock<std::mutex> lock(mutex_);
+  post_message_callback_ = emscripten::val::undefined();
+}
+
+bool GlobalContextImplEmscripten::PostMessageToJs(const Value& message) {
+  const std::unique_lock<std::mutex> lock(mutex_);
+  if (post_message_callback_.isUndefined()) return false;
+  post_message_callback_(ConvertValueToEmscriptenVal(message));
+  return true;
+}
+
+bool GlobalContextImplEmscripten::IsMainEventLoopThread() const {
+  return std::this_thread::get_id() == main_thread_id_;
+}
+
+}  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.cc
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.cc
@@ -31,11 +31,6 @@ GlobalContextImplEmscripten::GlobalContextImplEmscripten(
 
 GlobalContextImplEmscripten::~GlobalContextImplEmscripten() = default;
 
-void GlobalContextImplEmscripten::DetachFromPostMessage() {
-  const std::unique_lock<std::mutex> lock(mutex_);
-  post_message_callback_ = emscripten::val::undefined();
-}
-
 bool GlobalContextImplEmscripten::PostMessageToJs(const Value& message) {
   // Converting the value before entering the mutex, in order to minimize the
   // time spent under the lock.
@@ -49,6 +44,11 @@ bool GlobalContextImplEmscripten::PostMessageToJs(const Value& message) {
 
 bool GlobalContextImplEmscripten::IsMainEventLoopThread() const {
   return std::this_thread::get_id() == main_thread_id_;
+}
+
+void GlobalContextImplEmscripten::DisableJsCommunication() {
+  const std::unique_lock<std::mutex> lock(mutex_);
+  post_message_callback_ = emscripten::val::undefined();
 }
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.cc
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.cc
@@ -37,9 +37,13 @@ void GlobalContextImplEmscripten::DetachFromPostMessage() {
 }
 
 bool GlobalContextImplEmscripten::PostMessageToJs(const Value& message) {
+  // Converting the value before entering the mutex, in order to minimize the
+  // time spent under the lock.
+  const emscripten::val val = ConvertValueToEmscriptenVal(message);
+
   const std::unique_lock<std::mutex> lock(mutex_);
   if (post_message_callback_.isUndefined()) return false;
-  post_message_callback_(ConvertValueToEmscriptenVal(message));
+  post_message_callback_(val);
   return true;
 }
 

--- a/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.h
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.h
@@ -52,6 +52,8 @@ class GlobalContextImplEmscripten final : public GlobalContext {
 
  private:
   const std::thread::id main_thread_id_;
+
+  // The mutex that protects access to `post_message_callback_`.
   std::mutex mutex_;
   emscripten::val post_message_callback_;
 };

--- a/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.h
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.h
@@ -1,0 +1,61 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_SMART_CARD_COMMON_GLOBAL_CONTEXT_IMPL_EMSCRIPTEN_H_
+#define GOOGLE_SMART_CARD_COMMON_GLOBAL_CONTEXT_IMPL_EMSCRIPTEN_H_
+
+#ifndef __EMSCRIPTEN__
+#error "This file should only be used in Emscripten builds"
+#endif  // __EMSCRIPTEN__
+
+#include <mutex>
+#include <thread>
+
+#include <emscripten/val.h>
+
+#include <google_smart_card_common/global_context.h>
+#include <google_smart_card_common/value.h>
+
+namespace google_smart_card {
+
+// Implementation of the GlobalContext interface for the Emscripten
+// (WebAssembly) environment.
+class GlobalContextImplEmscripten final : public GlobalContext {
+ public:
+  // `post_message_callback` - JavaScript callback that will be called for
+  // posting a message.
+  GlobalContextImplEmscripten(std::thread::id main_thread_id,
+                              emscripten::val post_message_callback);
+  GlobalContextImplEmscripten(const GlobalContextImplEmscripten&) = delete;
+  GlobalContextImplEmscripten& operator=(const GlobalContextImplEmscripten&) =
+      delete;
+  ~GlobalContextImplEmscripten() override;
+
+  // Disables posting new messages to JS. All calls to `PostMessageToJs()` after
+  // this point will return `false`.
+  void DetachFromPostMessage();
+
+  // GlobalContext:
+  bool PostMessageToJs(const Value& message) override;
+  bool IsMainEventLoopThread() const override;
+
+ private:
+  const std::thread::id main_thread_id_;
+  std::mutex mutex_;
+  emscripten::val post_message_callback_;
+};
+
+}  // namespace google_smart_card
+
+#endif  // GOOGLE_SMART_CARD_COMMON_GLOBAL_CONTEXT_IMPL_EMSCRIPTEN_H_

--- a/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.h
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.h
@@ -42,13 +42,10 @@ class GlobalContextImplEmscripten final : public GlobalContext {
       delete;
   ~GlobalContextImplEmscripten() override;
 
-  // Disables posting new messages to JS. All calls to `PostMessageToJs()` after
-  // this point will return `false`.
-  void DetachFromPostMessage();
-
   // GlobalContext:
   bool PostMessageToJs(const Value& message) override;
   bool IsMainEventLoopThread() const override;
+  void DisableJsCommunication() override;
 
  private:
   const std::thread::id main_thread_id_;

--- a/common/cpp/src/google_smart_card_common/global_context_impl_nacl.cc
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_nacl.cc
@@ -1,0 +1,49 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google_smart_card_common/global_context_impl_nacl.h>
+
+#include <mutex>
+
+#include <ppapi/cpp/core.h>
+#include <ppapi/cpp/instance.h>
+
+#include <google_smart_card_common/value.h>
+#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
+
+namespace google_smart_card {
+
+GlobalContextImplNacl::GlobalContextImplNacl(pp::Core* pp_core,
+                                             pp::Instance* pp_instance)
+    : pp_core_(pp_core), pp_instance_(pp_instance) {}
+
+GlobalContextImplNacl::~GlobalContextImplNacl() = default;
+
+void GlobalContextImplNacl::DetachFromPpInstance() {
+  const std::unique_lock<std::mutex> lock(mutex_);
+  pp_instance_ = nullptr;
+}
+
+bool GlobalContextImplNacl::PostMessageToJs(const Value& message) {
+  const std::unique_lock<std::mutex> lock(mutex_);
+  if (!pp_instance_) return false;
+  pp_instance_->PostMessage(ConvertValueToPpVar(message));
+  return true;
+}
+
+bool GlobalContextImplNacl::IsMainEventLoopThread() const {
+  return pp_core_->IsMainThread();
+}
+
+}  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/global_context_impl_nacl.cc
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_nacl.cc
@@ -31,11 +31,6 @@ GlobalContextImplNacl::GlobalContextImplNacl(pp::Core* pp_core,
 
 GlobalContextImplNacl::~GlobalContextImplNacl() = default;
 
-void GlobalContextImplNacl::DetachFromPpInstance() {
-  const std::unique_lock<std::mutex> lock(mutex_);
-  pp_instance_ = nullptr;
-}
-
 bool GlobalContextImplNacl::PostMessageToJs(const Value& message) {
   // Converting the value before entering the mutex, in order to minimize the
   // time spent under the lock.
@@ -49,6 +44,11 @@ bool GlobalContextImplNacl::PostMessageToJs(const Value& message) {
 
 bool GlobalContextImplNacl::IsMainEventLoopThread() const {
   return pp_core_->IsMainThread();
+}
+
+void GlobalContextImplNacl::DisableJsCommunication() {
+  const std::unique_lock<std::mutex> lock(mutex_);
+  pp_instance_ = nullptr;
 }
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/global_context_impl_nacl.cc
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_nacl.cc
@@ -18,6 +18,7 @@
 
 #include <ppapi/cpp/core.h>
 #include <ppapi/cpp/instance.h>
+#include <ppapi/cpp/var.h>
 
 #include <google_smart_card_common/value.h>
 #include <google_smart_card_common/value_nacl_pp_var_conversion.h>
@@ -36,9 +37,13 @@ void GlobalContextImplNacl::DetachFromPpInstance() {
 }
 
 bool GlobalContextImplNacl::PostMessageToJs(const Value& message) {
+  // Converting the value before entering the mutex, in order to minimize the
+  // time spent under the lock.
+  const pp::Var var = ConvertValueToPpVar(message);
+
   const std::unique_lock<std::mutex> lock(mutex_);
   if (!pp_instance_) return false;
-  pp_instance_->PostMessage(ConvertValueToPpVar(message));
+  pp_instance_->PostMessage(var);
   return true;
 }
 

--- a/common/cpp/src/google_smart_card_common/global_context_impl_nacl.h
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_nacl.h
@@ -38,13 +38,10 @@ class GlobalContextImplNacl final : public GlobalContext {
   GlobalContextImplNacl& operator=(const GlobalContextImplNacl&) = delete;
   ~GlobalContextImplNacl() override;
 
-  // Disables posting new messages to JS. All calls to `PostMessageToJs()` after
-  // this point will return `false`.
-  void DetachFromPpInstance();
-
   // GlobalContext:
   bool PostMessageToJs(const Value& message) override;
   bool IsMainEventLoopThread() const override;
+  void DisableJsCommunication() override;
 
  private:
   pp::Core* const pp_core_;

--- a/common/cpp/src/google_smart_card_common/global_context_impl_nacl.h
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_nacl.h
@@ -48,6 +48,8 @@ class GlobalContextImplNacl final : public GlobalContext {
 
  private:
   pp::Core* const pp_core_;
+
+  // The mutex that protects access to `pp_instance_`.
   std::mutex mutex_;
   pp::Instance* pp_instance_;
 };

--- a/common/cpp/src/google_smart_card_common/global_context_impl_nacl.h
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_nacl.h
@@ -1,0 +1,57 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_SMART_CARD_COMMON_GLOBAL_CONTEXT_IMPL_NACL_H_
+#define GOOGLE_SMART_CARD_COMMON_GLOBAL_CONTEXT_IMPL_NACL_H_
+
+#ifndef __native_client__
+#error "This file should only be used in Native Client builds"
+#endif  // __native_client__
+
+#include <mutex>
+
+#include <ppapi/cpp/core.h>
+#include <ppapi/cpp/instance.h>
+
+#include <google_smart_card_common/global_context.h>
+#include <google_smart_card_common/value.h>
+
+namespace google_smart_card {
+
+// Implementation of the GlobalContext interface for the Native Client
+// environment.
+class GlobalContextImplNacl final : public GlobalContext {
+ public:
+  GlobalContextImplNacl(pp::Core* pp_core, pp::Instance* pp_instance);
+  GlobalContextImplNacl(const GlobalContextImplNacl&) = delete;
+  GlobalContextImplNacl& operator=(const GlobalContextImplNacl&) = delete;
+  ~GlobalContextImplNacl() override;
+
+  // Disables posting new messages to JS. All calls to `PostMessageToJs()` after
+  // this point will return `false`.
+  void DetachFromPpInstance();
+
+  // GlobalContext:
+  bool PostMessageToJs(const Value& message) override;
+  bool IsMainEventLoopThread() const override;
+
+ private:
+  pp::Core* const pp_core_;
+  std::mutex mutex_;
+  pp::Instance* pp_instance_;
+};
+
+}  // namespace google_smart_card
+
+#endif  // GOOGLE_SMART_CARD_COMMON_GLOBAL_CONTEXT_IMPL_NACL_H_


### PR DESCRIPTION
Introduce a GlobalContext interface that abstracts away some of the
differences between Native Client and Emscripten, such as different ways
of sending messages to JavaScript.

This commit provides implementations of this interface for both Native
Client and Emscripten. Currently both the interface and the
implementations are unused; follow-up commits will migrate the existing
codebase in //common/cpp to use this interface instead of various
NaCl-specific delegates (contributing to the goal of making most of the
//common/cpp library be toolchain-independent, as tracked by #185).