### PR TITLE
Use "-pthread" for GoogleTest builds in Emscripten

### DIFF
--- a/third_party/googletest/webport/build/Makefile
+++ b/third_party/googletest/webport/build/Makefile
@@ -78,7 +78,13 @@ endif
 #   the compilation according to prepared scripts.
 #
 # Explanation of parameters to cmake:
-# B: build directory.
+# E env: Wraps the further second cmake call into the "env" tool that allows to
+#   specify environment variables.
+# CXXFLAGS: Enables Emscripten Pthreads support (despite that it's not used by
+#   GoogleTest itself due to the other parameter below, Emscripten requires this
+#   flag to be set if a library is linked later with other files that have it).
+# LDFLAGS: Enables Emscripten Pthreads support.
+# B: Build directory.
 # CMAKE_BUILD_TYPE: Specify debug/release build.
 # gtest_disable_pthreads: Disables pthreads-based functionality in GoogleTest
 #   that doesn't behave well under Emscripten (it deadlocks on startup).
@@ -86,6 +92,10 @@ $(ARTIFACTS_LIBS) &:
 	rm -rf out-artifacts
 	mkdir out-artifacts
 	emcmake \
+		cmake \
+		-E env \
+		CXXFLAGS="-pthread" \
+		LDFLAGS="-pthread" \
 		cmake \
 		../../src \
 		-B out-artifacts \

--- a/third_party/googletest/webport/build/Makefile
+++ b/third_party/googletest/webport/build/Makefile
@@ -78,7 +78,7 @@ endif
 #   the compilation according to prepared scripts.
 #
 # Explanation of parameters to cmake:
-# E env: Wraps the further second cmake call into the "env" tool that allows to
+# E env: Wraps the succeeding cmake call into the "env" tool that allows to
 #   specify environment variables.
 # CXXFLAGS: Enables Emscripten Pthreads support (despite that it's not used by
 #   GoogleTest itself due to the other parameter below, Emscripten requires this


### PR DESCRIPTION
Add the "-pthread" flag when compiling and linking the GoogleTest static
libraries in Emscripten builds.

Meanwhile Pthreads aren't actually used by GoogleTest itself (due to the
"gtest_disable_pthreads" parameter that we specify), it's still necessary
because we use "-pthread" when compiling other libraries and source
files, and Emscripten seems to require this flag to be used consistently
everywhere.

This is a preparatory fix for introducing Emscripten builds of unit
tests, as tracked by #177.