### PR TITLE
Temporarily disable tests that fail in Emscripten

### DIFF
--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_router_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_router_unittest.cc
@@ -130,7 +130,13 @@ TEST(MessagingTypedMessageRouterTest, Basic) {
       MakeTypedMessageValue(kSampleType1, MakeSampleData(7))));
 }
 
-TEST(MessagingTypedMessageRouterTest, MultiThreading) {
+#ifdef __EMSCRIPTEN__
+// TODO(#185): Crashes in Emscripten due to out-of-memory.
+#define MAYBE_MultiThreading DISABLED_MultiThreading
+#else
+#define MAYBE_MultiThreading MultiThreading
+#endif
+TEST(MessagingTypedMessageRouterTest, MAYBE_MultiThreading) {
   const int kIterationCount = 100 * 1000;
 
   TypedMessageRouter router;

--- a/common/cpp/src/google_smart_card_common/requesting/async_requests_storage_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/async_requests_storage_unittest.cc
@@ -85,7 +85,13 @@ TEST(RequestingAsyncRequestsStorageTest, Basic) {
   EXPECT_FALSE(storage.Pop(request_4_id));
 }
 
-TEST(RequestingAsyncRequestsStorageTest, MultiThreading) {
+#ifdef __EMSCRIPTEN__
+// TODO(#185): Crashes in Emscripten due to out-of-memory.
+#define MAYBE_MultiThreading DISABLED_MultiThreading
+#else
+#define MAYBE_MultiThreading MultiThreading
+#endif
+TEST(RequestingAsyncRequestsStorageTest, MAYBE_MultiThreading) {
   const int kThreadCount = 10;
   const int kIterationCount = 10 * 1000;
 


### PR DESCRIPTION
Disable the following tests that are currently failing in Emscripten
builds:
* RequestingAsyncRequestsStorageTest.MultiThreading;
* MessagingTypedMessageRouterTest.MultiThreading.

Both tests are related to threading; they're failing due to
out-of-memory (due to hitting the default memory limit when allocating
memory for each thread). Naively increasing the limit doesn't help - the
tests begin to crash with more mysterious errors. Therefore fixing these
tests will require separate later investigation (tracked by #185).