### PR TITLE
Substitute ArrayBuffer in cross-extension messages

### DIFF
--- a/common/js/src/container-helpers-unittest.js
+++ b/common/js/src/container-helpers-unittest.js
@@ -21,11 +21,10 @@ goog.setTestOnly();
 
 goog.scope(function() {
 
-/** @const */
-var GSC = GoogleSmartCard;
-
-/** @const */
-var buildObjectFromMap = GSC.ContainerHelpers.buildObjectFromMap;
+const GSC = GoogleSmartCard;
+const buildObjectFromMap = GSC.ContainerHelpers.buildObjectFromMap;
+const substituteArrayBuffersRecursively =
+    GSC.ContainerHelpers.substituteArrayBuffersRecursively;
 
 goog.exportSymbol('testBuildObjectFromMap', function() {
   assertObjectEquals(buildObjectFromMap(new Map), {});
@@ -45,6 +44,43 @@ goog.exportSymbol('testBuildObjectFromMap', function() {
   assertThrows(function() {
     buildObjectFromMap(new Map([[{}, 'value']]));
   });
+});
+
+goog.exportSymbol('testSubstituteArrayBuffersRecursively', function() {
+  const buffer12 = (new Uint8Array([1, 2])).buffer;
+
+  assertObjectEquals(substituteArrayBuffersRecursively(new ArrayBuffer(0)), []);
+  assertObjectEquals(
+      substituteArrayBuffersRecursively(new ArrayBuffer(3)), [0, 0, 0]);
+  assertObjectEquals(substituteArrayBuffersRecursively(buffer12), [1, 2]);
+
+  assertEquals(substituteArrayBuffersRecursively(undefined), undefined);
+  assertEquals(substituteArrayBuffersRecursively(null), null);
+  assertEquals(substituteArrayBuffersRecursively(false), false);
+  assertEquals(substituteArrayBuffersRecursively(true), true);
+  assertEquals(substituteArrayBuffersRecursively(123), 123);
+  assertEquals(substituteArrayBuffersRecursively('foo'), 'foo');
+
+  assertObjectEquals(substituteArrayBuffersRecursively([]), []);
+  assertObjectEquals(substituteArrayBuffersRecursively([-1, 1000]), [-1, 1000]);
+  assertObjectEquals(
+      substituteArrayBuffersRecursively(['a', buffer12]), ['a', [1, 2]]);
+  assertObjectEquals(
+      substituteArrayBuffersRecursively([[buffer12]]), [[[1, 2]]]);
+
+  assertObjectEquals(substituteArrayBuffersRecursively({}), {});
+  assertObjectEquals(
+      substituteArrayBuffersRecursively({foo: {bar: 1, baz: null}}),
+      {foo: {bar: 1, baz: null}});
+  assertObjectEquals(
+      substituteArrayBuffersRecursively({foo: buffer12}), {foo: [1, 2]});
+
+  const uint8Array = new Uint8Array([1, 2, 255]);
+  assertEquals(substituteArrayBuffersRecursively(uint8Array), uint8Array);
+
+  // A function/class isn't a sensible input, but verify such cases anyway.
+  assertEquals(substituteArrayBuffersRecursively(parseInt), parseInt);
+  assertEquals(substituteArrayBuffersRecursively(Array), Array);
 });
 
 });  // goog.scope

--- a/common/js/src/container-helpers.js
+++ b/common/js/src/container-helpers.js
@@ -17,6 +17,7 @@
 goog.provide('GoogleSmartCard.ContainerHelpers');
 
 goog.require('GoogleSmartCard.Logging');
+goog.require('goog.object');
 
 goog.scope(function() {
 
@@ -38,6 +39,31 @@ GSC.ContainerHelpers.buildObjectFromMap = function(map) {
     obj[key] = value;
   }
   return obj;
+};
+
+/**
+ * Recursively visits the given value and replaces all ArrayBuffer objects with
+ * their Array views of bytes. Returns the resulting value after substitutions.
+ * @param {?} value
+ * @return {?}
+ */
+GSC.ContainerHelpers.substituteArrayBuffersRecursively = function(value) {
+  const substituteArrayBuffersRecursively =
+      GSC.ContainerHelpers.substituteArrayBuffersRecursively;
+  if (value instanceof ArrayBuffer) {
+    // Convert the array buffer into an array of bytes.
+    return Array.from(new Uint8Array(value));
+  }
+  if (goog.isArray(value)) {
+    // Recursively process array items.
+    return value.map(substituteArrayBuffersRecursively);
+  }
+  if (goog.isObject(value) && !goog.isFunction(value) &&
+      !ArrayBuffer.isView(value)) {
+    // This is a dictionary-like object; process it recursively.
+    return goog.object.map(value, substituteArrayBuffersRecursively);
+  }
+  return value;
 };
 
 });  // goog.scope

--- a/common/js/src/messaging/port-message-channel-unittest.js
+++ b/common/js/src/messaging/port-message-channel-unittest.js
@@ -169,6 +169,28 @@ goog.exportSymbol('testPortMessageChannelMessageSending', function() {
   return testCasePromiseResolver.promise;
 });
 
+
+// Test that array buffers in sent messages are substituted with byte arrays.
+goog.exportSymbol('testPortMessageChannelArrayBufferSending', function() {
+  const MESSAGE_TYPE = 'foo';
+  const MESSAGE_DATA = {x: (new Uint8Array([1, 255])).buffer};
+  const EXPECTED_TRANSMITTED_DATA = {x: [1, 255]};
+  const EXPECTED_TRANSMITTED_MESSAGE = new TypedMessage(
+      MESSAGE_TYPE, EXPECTED_TRANSMITTED_DATA);
+
+  const mockPort = new GSC.MockPort('mock port');
+  mockPort.postMessage(new goog.testing.mockmatchers.ObjectEquals(
+      EXPECTED_TRANSMITTED_MESSAGE.makeMessage())).$once();
+  mockPort.postMessage.$replay();
+
+  const portMessageChannel = new GSC.PortMessageChannel(
+      mockPort.getFakePort());
+  portMessageChannel.send(MESSAGE_TYPE, MESSAGE_DATA);
+  mockPort.postMessage.$verify();
+
+  mockPort.dispose();
+});
+
 // Test that the port message channel passes the messages received from the port
 // to the correct services with preserving the relative order.
 goog.exportSymbol('testPortMessageChannelMessageReceiving', function() {

--- a/common/js/src/messaging/port-message-channel-unittest.js
+++ b/common/js/src/messaging/port-message-channel-unittest.js
@@ -169,7 +169,6 @@ goog.exportSymbol('testPortMessageChannelMessageSending', function() {
   return testCasePromiseResolver.promise;
 });
 
-
 // Test that array buffers in sent messages are substituted with byte arrays.
 goog.exportSymbol('testPortMessageChannelArrayBufferSending', function() {
   const MESSAGE_TYPE = 'foo';

--- a/common/js/src/messaging/port-message-channel.js
+++ b/common/js/src/messaging/port-message-channel.js
@@ -23,6 +23,7 @@
 
 goog.provide('GoogleSmartCard.PortMessageChannel');
 
+goog.require('GoogleSmartCard.ContainerHelpers');
 goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.MessageChannelPinging.PingResponder');
@@ -106,7 +107,10 @@ PortMessageChannel.prototype.send = function(serviceName, payload) {
   GSC.Logging.checkWithLogger(this.logger, goog.isObject(payload));
   goog.asserts.assertObject(payload);
 
-  var typedMessage = new GSC.TypedMessage(serviceName, payload);
+  const normalizedPayload =
+      GSC.ContainerHelpers.substituteArrayBuffersRecursively(payload);
+
+  var typedMessage = new GSC.TypedMessage(serviceName, normalizedPayload);
   var message = typedMessage.makeMessage();
   this.logger.finest('Posting a message: ' + GSC.DebugDump.debugDump(message));
 

--- a/common/js/src/messaging/port-message-channel.js
+++ b/common/js/src/messaging/port-message-channel.js
@@ -110,8 +110,8 @@ PortMessageChannel.prototype.send = function(serviceName, payload) {
   const normalizedPayload =
       GSC.ContainerHelpers.substituteArrayBuffersRecursively(payload);
 
-  var typedMessage = new GSC.TypedMessage(serviceName, normalizedPayload);
-  var message = typedMessage.makeMessage();
+  const typedMessage = new GSC.TypedMessage(serviceName, normalizedPayload);
+  const message = typedMessage.makeMessage();
   this.logger.finest('Posting a message: ' + GSC.DebugDump.debugDump(message));
 
   if (this.isDisposed()) {


### PR DESCRIPTION
Replace ArrayBuffer's with byte Array's when sending cross-extension
messages.

The background for this change is that Chrome Extension APIs don't
support sending ArrayBuffer's inside messages from one extension/app to
another. Currently the code in this project never attempts to do that,
but the refactoring proposed in #222 will start putting ArrayBuffer's
into the sent messages. Therefore the current commit anticipates this
upcoming change and adds an automatic conversion that will prevent data
loss in cross-extension messages.