### PR TITLE
Register enums/structs in to/from Value conversion

### DIFF
--- a/common/cpp/src/google_smart_card_common/external_logs_printer.cc
+++ b/common/cpp/src/google_smart_card_common/external_logs_printer.cc
@@ -23,6 +23,7 @@
 #include <google_smart_card_common/messaging/typed_message_listener.h>
 #include <google_smart_card_common/pp_var_utils/struct_converter.h>
 #include <google_smart_card_common/value.h>
+#include <google_smart_card_common/value_conversion.h>
 #include <google_smart_card_common/value_nacl_pp_var_conversion.h>
 
 namespace google_smart_card {
@@ -43,6 +44,14 @@ void PrintExternalLogMessage(const ExternalLogMessageData& message_data) {
 }
 
 }  // namespace
+
+template <>
+StructValueDescriptor<ExternalLogMessageData>::Description
+StructValueDescriptor<ExternalLogMessageData>::GetDescription() {
+  return Describe("ExternalLogMessageData")
+      .WithField(&ExternalLogMessageData::formatted_log_message,
+                 "formatted_log_message");
+}
 
 template <>
 constexpr const char*

--- a/common/cpp/src/google_smart_card_common/external_logs_printer.cc
+++ b/common/cpp/src/google_smart_card_common/external_logs_printer.cc
@@ -48,6 +48,8 @@ void PrintExternalLogMessage(const ExternalLogMessageData& message_data) {
 template <>
 StructValueDescriptor<ExternalLogMessageData>::Description
 StructValueDescriptor<ExternalLogMessageData>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names in
+  // //common/js/src/logging/log-buffer-forwarder.js.
   return Describe("ExternalLogMessageData")
       .WithField(&ExternalLogMessageData::formatted_log_message,
                  "formatted_log_message");

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message.cc
@@ -22,6 +22,8 @@ namespace google_smart_card {
 template <>
 StructValueDescriptor<TypedMessage>::Description
 StructValueDescriptor<TypedMessage>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the keys in
+  // //common/js/src/messaging/typed-message.js.
   return Describe("TypedMessage")
       .WithField(&TypedMessage::type, "type")
       .WithField(&TypedMessage::data, "data");

--- a/common/cpp/src/google_smart_card_common/requesting/requester_message.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/requester_message.cc
@@ -43,6 +43,8 @@ std::string GetResponseMessageType(const std::string& name) {
 template <>
 StructValueDescriptor<RequestMessageData>::Description
 StructValueDescriptor<RequestMessageData>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the keys in
+  // //common/js/src/requesting/requester-message.js.
   return Describe("RequestMessageData")
       .WithField(&RequestMessageData::request_id, "request_id")
       .WithField(&RequestMessageData::payload, "payload");
@@ -51,6 +53,8 @@ StructValueDescriptor<RequestMessageData>::GetDescription() {
 template <>
 StructValueDescriptor<ResponseMessageData>::Description
 StructValueDescriptor<ResponseMessageData>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the keys in
+  // //common/js/src/requesting/requester-message.js.
   return Describe("ResponseMessageData")
       .WithField(&ResponseMessageData::request_id, "request_id")
       .WithField(&ResponseMessageData::payload, "payload")

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.cc
@@ -42,6 +42,8 @@ using StopPinRequestOptionsConverter =
 template <>
 EnumValueDescriptor<ccp::Algorithm>::Description
 EnumValueDescriptor<ccp::Algorithm>::GetDescription() {
+  // Note: Strings passed to WithItem() below must match the enum names in the
+  // chrome.certificateProvider API.
   return Describe("chrome_certificate_provider::Algorithm")
       .WithItem(ccp::Algorithm::kRsassaPkcs1v15Md5Sha1,
                 "RSASSA_PKCS1_v1_5_MD5_SHA1")
@@ -75,6 +77,8 @@ void AlgorithmConverter::VisitCorrespondingPairs(Callback callback) {
 template <>
 EnumValueDescriptor<ccp::Error>::Description
 EnumValueDescriptor<ccp::Error>::GetDescription() {
+  // Note: Strings passed to WithItem() below must match the enum names in the
+  // chrome.certificateProvider API.
   return Describe("chrome_certificate_provider::Error")
       .WithItem(ccp::Error::kGeneral, "GENERAL_ERROR");
 }
@@ -95,6 +99,8 @@ void ErrorConverter::VisitCorrespondingPairs(Callback callback) {
 template <>
 EnumValueDescriptor<ccp::PinRequestType>::Description
 EnumValueDescriptor<ccp::PinRequestType>::GetDescription() {
+  // Note: Strings passed to WithItem() below must match the enum names in the
+  // chrome.certificateProvider API.
   return Describe("chrome_certificate_provider::PinRequestType")
       .WithItem(ccp::PinRequestType::kPin, "PIN")
       .WithItem(ccp::PinRequestType::kPuk, "PUK");
@@ -117,6 +123,8 @@ void PinRequestTypeConverter::VisitCorrespondingPairs(Callback callback) {
 template <>
 EnumValueDescriptor<ccp::PinRequestErrorType>::Description
 EnumValueDescriptor<ccp::PinRequestErrorType>::GetDescription() {
+  // Note: Strings passed to WithItem() below must match the enum names in the
+  // chrome.certificateProvider API.
   return Describe("chrome_certificate_provider::PinRequestErrorType")
       .WithItem(ccp::PinRequestErrorType::kInvalidPin, "INVALID_PIN")
       .WithItem(ccp::PinRequestErrorType::kInvalidPuk, "INVALID_PUK")
@@ -145,6 +153,8 @@ void PinRequestErrorTypeConverter::VisitCorrespondingPairs(Callback callback) {
 template <>
 StructValueDescriptor<ccp::ClientCertificateInfo>::Description
 StructValueDescriptor<ccp::ClientCertificateInfo>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names in
+  // bridge-backend.js.
   return Describe("chrome_certificate_provider::ClientCertificateInfo")
       .WithField(&ccp::ClientCertificateInfo::certificate, "certificate")
       .WithField(&ccp::ClientCertificateInfo::supported_algorithms,
@@ -169,6 +179,8 @@ void ClientCertificateInfoConverter::VisitFields(
 template <>
 StructValueDescriptor<ccp::SetCertificatesDetails>::Description
 StructValueDescriptor<ccp::SetCertificatesDetails>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names in
+  // the chrome.certificateProvider API.
   return Describe("chrome_certificate_provider::SetCertificatesDetails")
       .WithField(&ccp::SetCertificatesDetails::certificates_request_id,
                  "certificatesRequestId")
@@ -196,6 +208,8 @@ void SetCertificatesDetailsConverter::VisitFields(
 template <>
 StructValueDescriptor<ccp::SignatureRequest>::Description
 StructValueDescriptor<ccp::SignatureRequest>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names in
+  // the chrome.certificateProvider API.
   return Describe("chrome_certificate_provider::SignatureRequest")
       .WithField(&ccp::SignatureRequest::sign_request_id, "signRequestId")
       .WithField(&ccp::SignatureRequest::input, "input")
@@ -225,6 +239,8 @@ void SignatureRequestConverter::VisitFields(const ccp::SignatureRequest& value,
 template <>
 StructValueDescriptor<ccp::RequestPinOptions>::Description
 StructValueDescriptor<ccp::RequestPinOptions>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names in
+  // the chrome.certificateProvider API.
   return Describe("chrome_certificate_provider::RequestPinOptions")
       .WithField(&ccp::RequestPinOptions::sign_request_id, "signRequestId")
       .WithField(&ccp::RequestPinOptions::request_type, "requestType")
@@ -252,6 +268,8 @@ void RequestPinOptionsConverter::VisitFields(
 template <>
 StructValueDescriptor<ccp::RequestPinResults>::Description
 StructValueDescriptor<ccp::RequestPinResults>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names in
+  // the chrome.certificateProvider API.
   return Describe("chrome_certificate_provider::RequestPinResults")
       .WithField(&ccp::RequestPinResults::user_input, "userInput");
 }
@@ -273,6 +291,8 @@ void RequestPinResultsConverter::VisitFields(
 template <>
 StructValueDescriptor<ccp::StopPinRequestOptions>::Description
 StructValueDescriptor<ccp::StopPinRequestOptions>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names in
+  // the chrome.certificateProvider API.
   return Describe("chrome_certificate_provider::StopPinRequestOptions")
       .WithField(&ccp::StopPinRequestOptions::sign_request_id, "signRequestId")
       .WithField(&ccp::StopPinRequestOptions::error_type, "errorType");

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.cc
@@ -16,6 +16,7 @@
 
 #include <google_smart_card_common/pp_var_utils/enum_converter.h>
 #include <google_smart_card_common/pp_var_utils/struct_converter.h>
+#include <google_smart_card_common/value_conversion.h>
 
 namespace scc = smart_card_client;
 namespace ccp = scc::chrome_certificate_provider;
@@ -38,6 +39,21 @@ using RequestPinResultsConverter = StructConverter<ccp::RequestPinResults>;
 using StopPinRequestOptionsConverter =
     StructConverter<ccp::StopPinRequestOptions>;
 
+template <>
+EnumValueDescriptor<ccp::Algorithm>::Description
+EnumValueDescriptor<ccp::Algorithm>::GetDescription() {
+  return Describe("chrome_certificate_provider::Algorithm")
+      .WithItem(ccp::Algorithm::kRsassaPkcs1v15Md5Sha1,
+                "RSASSA_PKCS1_v1_5_MD5_SHA1")
+      .WithItem(ccp::Algorithm::kRsassaPkcs1v15Sha1, "RSASSA_PKCS1_v1_5_SHA1")
+      .WithItem(ccp::Algorithm::kRsassaPkcs1v15Sha256,
+                "RSASSA_PKCS1_v1_5_SHA256")
+      .WithItem(ccp::Algorithm::kRsassaPkcs1v15Sha384,
+                "RSASSA_PKCS1_v1_5_SHA384")
+      .WithItem(ccp::Algorithm::kRsassaPkcs1v15Sha512,
+                "RSASSA_PKCS1_v1_5_SHA512");
+}
+
 // static
 template <>
 constexpr const char* AlgorithmConverter::GetEnumTypeName() {
@@ -56,6 +72,13 @@ void AlgorithmConverter::VisitCorrespondingPairs(Callback callback) {
   callback(ccp::Algorithm::kRsassaPkcs1v15Sha512, "RSASSA_PKCS1_v1_5_SHA512");
 }
 
+template <>
+EnumValueDescriptor<ccp::Error>::Description
+EnumValueDescriptor<ccp::Error>::GetDescription() {
+  return Describe("chrome_certificate_provider::Error")
+      .WithItem(ccp::Error::kGeneral, "GENERAL_ERROR");
+}
+
 // static
 template <>
 constexpr const char* ErrorConverter::GetEnumTypeName() {
@@ -67,6 +90,14 @@ template <>
 template <typename Callback>
 void ErrorConverter::VisitCorrespondingPairs(Callback callback) {
   callback(ccp::Error::kGeneral, "GENERAL_ERROR");
+}
+
+template <>
+EnumValueDescriptor<ccp::PinRequestType>::Description
+EnumValueDescriptor<ccp::PinRequestType>::GetDescription() {
+  return Describe("chrome_certificate_provider::PinRequestType")
+      .WithItem(ccp::PinRequestType::kPin, "PIN")
+      .WithItem(ccp::PinRequestType::kPuk, "PUK");
 }
 
 // static
@@ -81,6 +112,17 @@ template <typename Callback>
 void PinRequestTypeConverter::VisitCorrespondingPairs(Callback callback) {
   callback(ccp::PinRequestType::kPin, "PIN");
   callback(ccp::PinRequestType::kPuk, "PUK");
+}
+
+template <>
+EnumValueDescriptor<ccp::PinRequestErrorType>::Description
+EnumValueDescriptor<ccp::PinRequestErrorType>::GetDescription() {
+  return Describe("chrome_certificate_provider::PinRequestErrorType")
+      .WithItem(ccp::PinRequestErrorType::kInvalidPin, "INVALID_PIN")
+      .WithItem(ccp::PinRequestErrorType::kInvalidPuk, "INVALID_PUK")
+      .WithItem(ccp::PinRequestErrorType::kMaxAttemptsExceeded,
+                "MAX_ATTEMPTS_EXCEEDED")
+      .WithItem(ccp::PinRequestErrorType::kUnknownError, "UNKNOWN_ERROR");
 }
 
 // static
@@ -100,6 +142,15 @@ void PinRequestErrorTypeConverter::VisitCorrespondingPairs(Callback callback) {
   callback(ccp::PinRequestErrorType::kUnknownError, "UNKNOWN_ERROR");
 }
 
+template <>
+StructValueDescriptor<ccp::ClientCertificateInfo>::Description
+StructValueDescriptor<ccp::ClientCertificateInfo>::GetDescription() {
+  return Describe("chrome_certificate_provider::ClientCertificateInfo")
+      .WithField(&ccp::ClientCertificateInfo::certificate, "certificate")
+      .WithField(&ccp::ClientCertificateInfo::supported_algorithms,
+                 "supportedAlgorithms");
+}
+
 // static
 template <>
 constexpr const char* ClientCertificateInfoConverter::GetStructTypeName() {
@@ -113,6 +164,17 @@ void ClientCertificateInfoConverter::VisitFields(
     const ccp::ClientCertificateInfo& value, Callback callback) {
   callback(&value.certificate, "certificate");
   callback(&value.supported_algorithms, "supportedAlgorithms");
+}
+
+template <>
+StructValueDescriptor<ccp::SetCertificatesDetails>::Description
+StructValueDescriptor<ccp::SetCertificatesDetails>::GetDescription() {
+  return Describe("chrome_certificate_provider::SetCertificatesDetails")
+      .WithField(&ccp::SetCertificatesDetails::certificates_request_id,
+                 "certificatesRequestId")
+      .WithField(&ccp::SetCertificatesDetails::error, "error")
+      .WithField(&ccp::SetCertificatesDetails::client_certificates,
+                 "clientCertificates");
 }
 
 // static
@@ -129,6 +191,17 @@ void SetCertificatesDetailsConverter::VisitFields(
   callback(&value.certificates_request_id, "certificatesRequestId");
   callback(&value.error, "error");
   callback(&value.client_certificates, "clientCertificates");
+}
+
+template <>
+StructValueDescriptor<ccp::SignatureRequest>::Description
+StructValueDescriptor<ccp::SignatureRequest>::GetDescription() {
+  return Describe("chrome_certificate_provider::SignatureRequest")
+      .WithField(&ccp::SignatureRequest::sign_request_id, "signRequestId")
+      .WithField(&ccp::SignatureRequest::input, "input")
+      .WithField(&ccp::SignatureRequest::digest, "digest")
+      .WithField(&ccp::SignatureRequest::algorithm, "algorithm")
+      .WithField(&ccp::SignatureRequest::certificate, "certificate");
 }
 
 // static
@@ -149,6 +222,16 @@ void SignatureRequestConverter::VisitFields(const ccp::SignatureRequest& value,
   callback(&value.certificate, "certificate");
 }
 
+template <>
+StructValueDescriptor<ccp::RequestPinOptions>::Description
+StructValueDescriptor<ccp::RequestPinOptions>::GetDescription() {
+  return Describe("chrome_certificate_provider::RequestPinOptions")
+      .WithField(&ccp::RequestPinOptions::sign_request_id, "signRequestId")
+      .WithField(&ccp::RequestPinOptions::request_type, "requestType")
+      .WithField(&ccp::RequestPinOptions::error_type, "errorType")
+      .WithField(&ccp::RequestPinOptions::attempts_left, "attemptsLeft");
+}
+
 // static
 template <>
 constexpr const char* RequestPinOptionsConverter::GetStructTypeName() {
@@ -166,6 +249,13 @@ void RequestPinOptionsConverter::VisitFields(
   callback(&value.attempts_left, "attemptsLeft");
 }
 
+template <>
+StructValueDescriptor<ccp::RequestPinResults>::Description
+StructValueDescriptor<ccp::RequestPinResults>::GetDescription() {
+  return Describe("chrome_certificate_provider::RequestPinResults")
+      .WithField(&ccp::RequestPinResults::user_input, "userInput");
+}
+
 // static
 template <>
 constexpr const char* RequestPinResultsConverter::GetStructTypeName() {
@@ -178,6 +268,14 @@ template <typename Callback>
 void RequestPinResultsConverter::VisitFields(
     const ccp::RequestPinResults& value, Callback callback) {
   callback(&value.user_input, "userInput");
+}
+
+template <>
+StructValueDescriptor<ccp::StopPinRequestOptions>::Description
+StructValueDescriptor<ccp::StopPinRequestOptions>::GetDescription() {
+  return Describe("chrome_certificate_provider::StopPinRequestOptions")
+      .WithField(&ccp::StopPinRequestOptions::sign_request_id, "signRequestId")
+      .WithField(&ccp::StopPinRequestOptions::error_type, "errorType");
 }
 
 // static

--- a/third_party/libusb/naclport/src/chrome_usb/types.cc
+++ b/third_party/libusb/naclport/src/chrome_usb/types.cc
@@ -104,6 +104,8 @@ bool ControlTransferInfo::operator==(const ControlTransferInfo& other) const {
 template <>
 EnumValueDescriptor<Direction>::Description
 EnumValueDescriptor<Direction>::GetDescription() {
+  // Note: Strings passed to WithItem() below must match the enum names in the
+  // chrome.usb API.
   return Describe("chrome_usb::Direction")
       .WithItem(Direction::kIn, "in")
       .WithItem(Direction::kOut, "out");
@@ -126,6 +128,8 @@ void DirectionConverter::VisitCorrespondingPairs(Callback callback) {
 template <>
 StructValueDescriptor<Device>::Description
 StructValueDescriptor<Device>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names in
+  // the chrome.usb API.
   return Describe("chrome_usb::Device")
       .WithField(&Device::device, "device")
       .WithField(&Device::vendor_id, "vendorId")
@@ -158,6 +162,8 @@ void DeviceConverter::VisitFields(const Device& value, Callback callback) {
 template <>
 StructValueDescriptor<ConnectionHandle>::Description
 StructValueDescriptor<ConnectionHandle>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names in
+  // the chrome.usb API.
   return Describe("chrome_usb::ConnectionHandle")
       .WithField(&ConnectionHandle::handle, "handle")
       .WithField(&ConnectionHandle::vendor_id, "vendorId")
@@ -183,6 +189,8 @@ void ConnectionHandleConverter::VisitFields(const ConnectionHandle& value,
 template <>
 EnumValueDescriptor<EndpointDescriptorType>::Description
 EnumValueDescriptor<EndpointDescriptorType>::GetDescription() {
+  // Note: Strings passed to WithItem() below must match the enum names in the
+  // chrome.usb API.
   return Describe("chrome_usb::EndpointDescriptorType")
       .WithItem(EndpointDescriptorType::kControl, "control")
       .WithItem(EndpointDescriptorType::kInterrupt, "interrupt")
@@ -210,6 +218,8 @@ void EndpointDescriptorTypeConverter::VisitCorrespondingPairs(
 template <>
 EnumValueDescriptor<EndpointDescriptorSynchronization>::Description
 EnumValueDescriptor<EndpointDescriptorSynchronization>::GetDescription() {
+  // Note: Strings passed to WithItem() below must match the enum names in the
+  // chrome.usb API.
   return Describe("chrome_usb::EndpointDescriptorSynchronization")
       .WithItem(EndpointDescriptorSynchronization::kAsynchronous,
                 "asynchronous")
@@ -237,6 +247,8 @@ void EndpointDescriptorSynchronizationConverter::VisitCorrespondingPairs(
 template <>
 EnumValueDescriptor<EndpointDescriptorUsage>::Description
 EnumValueDescriptor<EndpointDescriptorUsage>::GetDescription() {
+  // Note: Strings passed to WithItem() below must match the enum names in the
+  // chrome.usb API.
   return Describe("chrome_usb::EndpointDescriptorUsage")
       .WithItem(EndpointDescriptorUsage::kData, "data")
       .WithItem(EndpointDescriptorUsage::kFeedback, "feedback")
@@ -266,6 +278,8 @@ void EndpointDescriptorUsageConverter::VisitCorrespondingPairs(
 template <>
 StructValueDescriptor<EndpointDescriptor>::Description
 StructValueDescriptor<EndpointDescriptor>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names in
+  // the chrome.usb API.
   return Describe("chrome_usb::EndpointDescriptor")
       .WithField(&EndpointDescriptor::address, "address")
       .WithField(&EndpointDescriptor::type, "type")
@@ -301,6 +315,8 @@ void EndpointDescriptorConverter::VisitFields(const EndpointDescriptor& value,
 template <>
 StructValueDescriptor<InterfaceDescriptor>::Description
 StructValueDescriptor<InterfaceDescriptor>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names in
+  // the chrome.usb API.
   return Describe("chrome_usb::InterfaceDescriptor")
       .WithField(&InterfaceDescriptor::interface_number, "interfaceNumber")
       .WithField(&InterfaceDescriptor::alternate_setting, "alternateSetting")
@@ -336,6 +352,8 @@ void InterfaceDescriptorConverter::VisitFields(const InterfaceDescriptor& value,
 template <>
 StructValueDescriptor<ConfigDescriptor>::Description
 StructValueDescriptor<ConfigDescriptor>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names in
+  // the chrome.usb API.
   return Describe("chrome_usb::ConfigDescriptor")
       .WithField(&ConfigDescriptor::active, "active")
       .WithField(&ConfigDescriptor::configuration_value, "configurationValue")
@@ -371,6 +389,8 @@ void ConfigDescriptorConverter::VisitFields(const ConfigDescriptor& value,
 template <>
 StructValueDescriptor<GenericTransferInfo>::Description
 StructValueDescriptor<GenericTransferInfo>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names in
+  // the chrome.usb API.
   return Describe("chrome_usb::GenericTransferInfo")
       .WithField(&GenericTransferInfo::direction, "direction")
       .WithField(&GenericTransferInfo::endpoint, "endpoint")
@@ -400,6 +420,8 @@ void GenericTransferInfoConverter::VisitFields(const GenericTransferInfo& value,
 template <>
 EnumValueDescriptor<ControlTransferInfoRecipient>::Description
 EnumValueDescriptor<ControlTransferInfoRecipient>::GetDescription() {
+  // Note: Strings passed to WithItem() below must match the enum names in the
+  // chrome.usb API.
   return Describe("chrome_usb::ControlTransferInfoRecipient")
       .WithItem(ControlTransferInfoRecipient::kDevice, "device")
       .WithItem(ControlTransferInfoRecipient::kInterface, "interface")
@@ -427,6 +449,8 @@ void ControlTransferInfoRecipientConverter::VisitCorrespondingPairs(
 template <>
 EnumValueDescriptor<ControlTransferInfoRequestType>::Description
 EnumValueDescriptor<ControlTransferInfoRequestType>::GetDescription() {
+  // Note: Strings passed to WithItem() below must match the enum names in the
+  // chrome.usb API.
   return Describe("chrome_usb::ControlTransferInfoRequestType")
       .WithItem(ControlTransferInfoRequestType::kStandard, "standard")
       .WithItem(ControlTransferInfoRequestType::kClass, "class")
@@ -455,6 +479,8 @@ void ControlTransferInfoRequestTypeConverter::VisitCorrespondingPairs(
 template <>
 StructValueDescriptor<ControlTransferInfo>::Description
 StructValueDescriptor<ControlTransferInfo>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names in
+  // the chrome.usb API.
   return Describe("chrome_usb::ControlTransferInfo")
       .WithField(&ControlTransferInfo::direction, "direction")
       .WithField(&ControlTransferInfo::recipient, "recipient")
@@ -492,6 +518,8 @@ void ControlTransferInfoConverter::VisitFields(const ControlTransferInfo& value,
 template <>
 StructValueDescriptor<TransferResultInfo>::Description
 StructValueDescriptor<TransferResultInfo>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names in
+  // the chrome.usb API.
   return Describe("chrome_usb::TransferResultInfo")
       .WithField(&TransferResultInfo::result_code, "resultCode")
       .WithField(&TransferResultInfo::data, "data");
@@ -515,6 +543,8 @@ void TransferResultInfoConverter::VisitFields(const TransferResultInfo& value,
 template <>
 StructValueDescriptor<DeviceFilter>::Description
 StructValueDescriptor<DeviceFilter>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names in
+  // the chrome.usb API.
   return Describe("chrome_usb::DeviceFilter")
       .WithField(&DeviceFilter::vendor_id, "vendorId")
       .WithField(&DeviceFilter::product_id, "productId")
@@ -544,6 +574,8 @@ void DeviceFilterConverter::VisitFields(const DeviceFilter& value,
 template <>
 StructValueDescriptor<GetDevicesOptions>::Description
 StructValueDescriptor<GetDevicesOptions>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names in
+  // the chrome.usb API.
   return Describe("chrome_usb::GetDevicesOptions")
       .WithField(&GetDevicesOptions::filters, "filters");
 }
@@ -565,6 +597,8 @@ void GetDevicesOptionsConverter::VisitFields(const GetDevicesOptions& value,
 template <>
 StructValueDescriptor<GetUserSelectedDevicesOptions>::Description
 StructValueDescriptor<GetUserSelectedDevicesOptions>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names in
+  // the chrome.usb API.
   return Describe("chrome_usb::GetUserSelectedDevicesOptions")
       .WithField(&GetUserSelectedDevicesOptions::filters, "filters");
 }

--- a/third_party/libusb/naclport/src/chrome_usb/types.cc
+++ b/third_party/libusb/naclport/src/chrome_usb/types.cc
@@ -18,6 +18,7 @@
 
 #include <google_smart_card_common/pp_var_utils/enum_converter.h>
 #include <google_smart_card_common/pp_var_utils/struct_converter.h>
+#include <google_smart_card_common/value_conversion.h>
 
 namespace google_smart_card {
 
@@ -79,16 +80,6 @@ using GetDevicesOptionsConverter = StructConverter<GetDevicesOptions>;
 using GetUserSelectedDevicesOptionsConverter =
     StructConverter<GetUserSelectedDevicesOptions>;
 
-namespace {
-
-bool IsSameOptionalArrayBuffer(const optional<pp::VarArrayBuffer>& lhs,
-                               const optional<pp::VarArrayBuffer>& rhs) {
-  if (!lhs || !rhs) return lhs == rhs;
-  return VarAs<std::vector<uint8_t>>(*lhs) == VarAs<std::vector<uint8_t>>(*rhs);
-}
-
-}  // namespace
-
 bool Device::operator==(const Device& other) const {
   return device == other.device && vendor_id == other.vendor_id &&
          product_id == other.product_id && version == other.version &&
@@ -106,9 +97,16 @@ bool ControlTransferInfo::operator==(const ControlTransferInfo& other) const {
   return direction == other.direction && recipient == other.recipient &&
          request_type == other.request_type && request == other.request &&
          value == other.value && index == other.index &&
-         length == other.length &&
-         IsSameOptionalArrayBuffer(data, other.data) &&
+         length == other.length && data == other.data &&
          timeout == other.timeout;
+}
+
+template <>
+EnumValueDescriptor<Direction>::Description
+EnumValueDescriptor<Direction>::GetDescription() {
+  return Describe("chrome_usb::Direction")
+      .WithItem(Direction::kIn, "in")
+      .WithItem(Direction::kOut, "out");
 }
 
 // static
@@ -123,6 +121,19 @@ template <typename Callback>
 void DirectionConverter::VisitCorrespondingPairs(Callback callback) {
   callback(Direction::kIn, "in");
   callback(Direction::kOut, "out");
+}
+
+template <>
+StructValueDescriptor<Device>::Description
+StructValueDescriptor<Device>::GetDescription() {
+  return Describe("chrome_usb::Device")
+      .WithField(&Device::device, "device")
+      .WithField(&Device::vendor_id, "vendorId")
+      .WithField(&Device::product_id, "productId")
+      .WithField(&Device::version, "version")
+      .WithField(&Device::product_name, "productName")
+      .WithField(&Device::manufacturer_name, "manufacturerName")
+      .WithField(&Device::serial_number, "serialNumber");
 }
 
 // static
@@ -144,6 +155,15 @@ void DeviceConverter::VisitFields(const Device& value, Callback callback) {
   callback(&value.serial_number, "serialNumber");
 }
 
+template <>
+StructValueDescriptor<ConnectionHandle>::Description
+StructValueDescriptor<ConnectionHandle>::GetDescription() {
+  return Describe("chrome_usb::ConnectionHandle")
+      .WithField(&ConnectionHandle::handle, "handle")
+      .WithField(&ConnectionHandle::vendor_id, "vendorId")
+      .WithField(&ConnectionHandle::product_id, "productId");
+}
+
 // static
 template <>
 constexpr const char* ConnectionHandleConverter::GetStructTypeName() {
@@ -158,6 +178,16 @@ void ConnectionHandleConverter::VisitFields(const ConnectionHandle& value,
   callback(&value.handle, "handle");
   callback(&value.vendor_id, "vendorId");
   callback(&value.product_id, "productId");
+}
+
+template <>
+EnumValueDescriptor<EndpointDescriptorType>::Description
+EnumValueDescriptor<EndpointDescriptorType>::GetDescription() {
+  return Describe("chrome_usb::EndpointDescriptorType")
+      .WithItem(EndpointDescriptorType::kControl, "control")
+      .WithItem(EndpointDescriptorType::kInterrupt, "interrupt")
+      .WithItem(EndpointDescriptorType::kIsochronous, "isochronous")
+      .WithItem(EndpointDescriptorType::kBulk, "bulk");
 }
 
 // static
@@ -177,6 +207,16 @@ void EndpointDescriptorTypeConverter::VisitCorrespondingPairs(
   callback(EndpointDescriptorType::kBulk, "bulk");
 }
 
+template <>
+EnumValueDescriptor<EndpointDescriptorSynchronization>::Description
+EnumValueDescriptor<EndpointDescriptorSynchronization>::GetDescription() {
+  return Describe("chrome_usb::EndpointDescriptorSynchronization")
+      .WithItem(EndpointDescriptorSynchronization::kAsynchronous,
+                "asynchronous")
+      .WithItem(EndpointDescriptorSynchronization::kAdaptive, "adaptive")
+      .WithItem(EndpointDescriptorSynchronization::kSynchronous, "synchronous");
+}
+
 // static
 template <>
 constexpr const char*
@@ -192,6 +232,17 @@ void EndpointDescriptorSynchronizationConverter::VisitCorrespondingPairs(
   callback(EndpointDescriptorSynchronization::kAsynchronous, "asynchronous");
   callback(EndpointDescriptorSynchronization::kAdaptive, "adaptive");
   callback(EndpointDescriptorSynchronization::kSynchronous, "synchronous");
+}
+
+template <>
+EnumValueDescriptor<EndpointDescriptorUsage>::Description
+EnumValueDescriptor<EndpointDescriptorUsage>::GetDescription() {
+  return Describe("chrome_usb::EndpointDescriptorUsage")
+      .WithItem(EndpointDescriptorUsage::kData, "data")
+      .WithItem(EndpointDescriptorUsage::kFeedback, "feedback")
+      .WithItem(EndpointDescriptorUsage::kExplicitFeedback, "explicitFeedback")
+      .WithItem(EndpointDescriptorUsage::kPeriodic, "periodic")
+      .WithItem(EndpointDescriptorUsage::kNotification, "notification");
 }
 
 // static
@@ -210,6 +261,20 @@ void EndpointDescriptorUsageConverter::VisitCorrespondingPairs(
   callback(EndpointDescriptorUsage::kExplicitFeedback, "explicitFeedback");
   callback(EndpointDescriptorUsage::kPeriodic, "periodic");
   callback(EndpointDescriptorUsage::kNotification, "notification");
+}
+
+template <>
+StructValueDescriptor<EndpointDescriptor>::Description
+StructValueDescriptor<EndpointDescriptor>::GetDescription() {
+  return Describe("chrome_usb::EndpointDescriptor")
+      .WithField(&EndpointDescriptor::address, "address")
+      .WithField(&EndpointDescriptor::type, "type")
+      .WithField(&EndpointDescriptor::direction, "direction")
+      .WithField(&EndpointDescriptor::maximum_packet_size, "maximumPacketSize")
+      .WithField(&EndpointDescriptor::synchronization, "synchronization")
+      .WithField(&EndpointDescriptor::usage, "usage")
+      .WithField(&EndpointDescriptor::polling_interval, "pollingInterval")
+      .WithField(&EndpointDescriptor::extra_data, "extra_data");
 }
 
 // static
@@ -233,6 +298,20 @@ void EndpointDescriptorConverter::VisitFields(const EndpointDescriptor& value,
   callback(&value.extra_data, "extra_data");
 }
 
+template <>
+StructValueDescriptor<InterfaceDescriptor>::Description
+StructValueDescriptor<InterfaceDescriptor>::GetDescription() {
+  return Describe("chrome_usb::InterfaceDescriptor")
+      .WithField(&InterfaceDescriptor::interface_number, "interfaceNumber")
+      .WithField(&InterfaceDescriptor::alternate_setting, "alternateSetting")
+      .WithField(&InterfaceDescriptor::interface_class, "interfaceClass")
+      .WithField(&InterfaceDescriptor::interface_subclass, "interfaceSubclass")
+      .WithField(&InterfaceDescriptor::interface_protocol, "interfaceProtocol")
+      .WithField(&InterfaceDescriptor::description, "description")
+      .WithField(&InterfaceDescriptor::endpoints, "endpoints")
+      .WithField(&InterfaceDescriptor::extra_data, "extra_data");
+}
+
 // static
 template <>
 constexpr const char* InterfaceDescriptorConverter::GetStructTypeName() {
@@ -252,6 +331,20 @@ void InterfaceDescriptorConverter::VisitFields(const InterfaceDescriptor& value,
   callback(&value.description, "description");
   callback(&value.endpoints, "endpoints");
   callback(&value.extra_data, "extra_data");
+}
+
+template <>
+StructValueDescriptor<ConfigDescriptor>::Description
+StructValueDescriptor<ConfigDescriptor>::GetDescription() {
+  return Describe("chrome_usb::ConfigDescriptor")
+      .WithField(&ConfigDescriptor::active, "active")
+      .WithField(&ConfigDescriptor::configuration_value, "configurationValue")
+      .WithField(&ConfigDescriptor::description, "description")
+      .WithField(&ConfigDescriptor::self_powered, "selfPowered")
+      .WithField(&ConfigDescriptor::remote_wakeup, "remoteWakeup")
+      .WithField(&ConfigDescriptor::max_power, "maxPower")
+      .WithField(&ConfigDescriptor::interfaces, "interfaces")
+      .WithField(&ConfigDescriptor::extra_data, "extra_data");
 }
 
 // static
@@ -275,6 +368,17 @@ void ConfigDescriptorConverter::VisitFields(const ConfigDescriptor& value,
   callback(&value.extra_data, "extra_data");
 }
 
+template <>
+StructValueDescriptor<GenericTransferInfo>::Description
+StructValueDescriptor<GenericTransferInfo>::GetDescription() {
+  return Describe("chrome_usb::GenericTransferInfo")
+      .WithField(&GenericTransferInfo::direction, "direction")
+      .WithField(&GenericTransferInfo::endpoint, "endpoint")
+      .WithField(&GenericTransferInfo::length, "length")
+      .WithField(&GenericTransferInfo::data, "data")
+      .WithField(&GenericTransferInfo::timeout, "timeout");
+}
+
 // static
 template <>
 constexpr const char* GenericTransferInfoConverter::GetStructTypeName() {
@@ -291,6 +395,16 @@ void GenericTransferInfoConverter::VisitFields(const GenericTransferInfo& value,
   callback(&value.length, "length");
   callback(&value.data, "data");
   callback(&value.timeout, "timeout");
+}
+
+template <>
+EnumValueDescriptor<ControlTransferInfoRecipient>::Description
+EnumValueDescriptor<ControlTransferInfoRecipient>::GetDescription() {
+  return Describe("chrome_usb::ControlTransferInfoRecipient")
+      .WithItem(ControlTransferInfoRecipient::kDevice, "device")
+      .WithItem(ControlTransferInfoRecipient::kInterface, "interface")
+      .WithItem(ControlTransferInfoRecipient::kEndpoint, "endpoint")
+      .WithItem(ControlTransferInfoRecipient::kOther, "other");
 }
 
 // static
@@ -310,6 +424,16 @@ void ControlTransferInfoRecipientConverter::VisitCorrespondingPairs(
   callback(ControlTransferInfoRecipient::kOther, "other");
 }
 
+template <>
+EnumValueDescriptor<ControlTransferInfoRequestType>::Description
+EnumValueDescriptor<ControlTransferInfoRequestType>::GetDescription() {
+  return Describe("chrome_usb::ControlTransferInfoRequestType")
+      .WithItem(ControlTransferInfoRequestType::kStandard, "standard")
+      .WithItem(ControlTransferInfoRequestType::kClass, "class")
+      .WithItem(ControlTransferInfoRequestType::kVendor, "vendor")
+      .WithItem(ControlTransferInfoRequestType::kReserved, "reserved");
+}
+
 // static
 template <>
 constexpr const char*
@@ -326,6 +450,21 @@ void ControlTransferInfoRequestTypeConverter::VisitCorrespondingPairs(
   callback(ControlTransferInfoRequestType::kClass, "class");
   callback(ControlTransferInfoRequestType::kVendor, "vendor");
   callback(ControlTransferInfoRequestType::kReserved, "reserved");
+}
+
+template <>
+StructValueDescriptor<ControlTransferInfo>::Description
+StructValueDescriptor<ControlTransferInfo>::GetDescription() {
+  return Describe("chrome_usb::ControlTransferInfo")
+      .WithField(&ControlTransferInfo::direction, "direction")
+      .WithField(&ControlTransferInfo::recipient, "recipient")
+      .WithField(&ControlTransferInfo::request_type, "requestType")
+      .WithField(&ControlTransferInfo::request, "request")
+      .WithField(&ControlTransferInfo::value, "value")
+      .WithField(&ControlTransferInfo::index, "index")
+      .WithField(&ControlTransferInfo::length, "length")
+      .WithField(&ControlTransferInfo::data, "data")
+      .WithField(&ControlTransferInfo::timeout, "timeout");
 }
 
 // static
@@ -350,6 +489,14 @@ void ControlTransferInfoConverter::VisitFields(const ControlTransferInfo& value,
   callback(&value.timeout, "timeout");
 }
 
+template <>
+StructValueDescriptor<TransferResultInfo>::Description
+StructValueDescriptor<TransferResultInfo>::GetDescription() {
+  return Describe("chrome_usb::TransferResultInfo")
+      .WithField(&TransferResultInfo::result_code, "resultCode")
+      .WithField(&TransferResultInfo::data, "data");
+}
+
 // static
 template <>
 constexpr const char* TransferResultInfoConverter::GetStructTypeName() {
@@ -363,6 +510,17 @@ void TransferResultInfoConverter::VisitFields(const TransferResultInfo& value,
                                               Callback callback) {
   callback(&value.result_code, "resultCode");
   callback(&value.data, "data");
+}
+
+template <>
+StructValueDescriptor<DeviceFilter>::Description
+StructValueDescriptor<DeviceFilter>::GetDescription() {
+  return Describe("chrome_usb::DeviceFilter")
+      .WithField(&DeviceFilter::vendor_id, "vendorId")
+      .WithField(&DeviceFilter::product_id, "productId")
+      .WithField(&DeviceFilter::interface_class, "interfaceClass")
+      .WithField(&DeviceFilter::interface_subclass, "interfaceSubclass")
+      .WithField(&DeviceFilter::interface_protocol, "interfaceProtocol");
 }
 
 // static
@@ -383,6 +541,13 @@ void DeviceFilterConverter::VisitFields(const DeviceFilter& value,
   callback(&value.interface_protocol, "interfaceProtocol");
 }
 
+template <>
+StructValueDescriptor<GetDevicesOptions>::Description
+StructValueDescriptor<GetDevicesOptions>::GetDescription() {
+  return Describe("chrome_usb::GetDevicesOptions")
+      .WithField(&GetDevicesOptions::filters, "filters");
+}
+
 // static
 template <>
 constexpr const char* GetDevicesOptionsConverter::GetStructTypeName() {
@@ -395,6 +560,13 @@ template <typename Callback>
 void GetDevicesOptionsConverter::VisitFields(const GetDevicesOptions& value,
                                              Callback callback) {
   callback(&value.filters, "filters");
+}
+
+template <>
+StructValueDescriptor<GetUserSelectedDevicesOptions>::Description
+StructValueDescriptor<GetUserSelectedDevicesOptions>::GetDescription() {
+  return Describe("chrome_usb::GetUserSelectedDevicesOptions")
+      .WithField(&GetUserSelectedDevicesOptions::filters, "filters");
 }
 
 // static

--- a/third_party/libusb/naclport/src/chrome_usb/types.h
+++ b/third_party/libusb/naclport/src/chrome_usb/types.h
@@ -40,7 +40,6 @@
 #include <vector>
 
 #include <ppapi/cpp/var.h>
-#include <ppapi/cpp/var_array_buffer.h>
 
 #include <google_smart_card_common/optional.h>
 #include <google_smart_card_common/pp_var_utils/construction.h>
@@ -111,7 +110,7 @@ struct EndpointDescriptor {
   optional<EndpointDescriptorSynchronization> synchronization;
   optional<EndpointDescriptorUsage> usage;
   optional<int64_t> polling_interval;
-  pp::VarArrayBuffer extra_data;
+  std::vector<uint8_t> extra_data;
 };
 
 struct InterfaceDescriptor {
@@ -122,7 +121,7 @@ struct InterfaceDescriptor {
   int64_t interface_protocol;
   optional<std::string> description;
   std::vector<EndpointDescriptor> endpoints;
-  pp::VarArrayBuffer extra_data;
+  std::vector<uint8_t> extra_data;
 };
 
 struct ConfigDescriptor {
@@ -133,14 +132,14 @@ struct ConfigDescriptor {
   bool remote_wakeup;
   int64_t max_power;
   std::vector<InterfaceDescriptor> interfaces;
-  pp::VarArrayBuffer extra_data;
+  std::vector<uint8_t> extra_data;
 };
 
 struct GenericTransferInfo {
   Direction direction;
   int64_t endpoint;
   optional<int64_t> length;
-  optional<pp::VarArrayBuffer> data;
+  optional<std::vector<uint8_t>> data;
   optional<int64_t> timeout;
 };
 
@@ -168,13 +167,13 @@ struct ControlTransferInfo {
   int64_t value;
   int64_t index;
   optional<int64_t> length;
-  optional<pp::VarArrayBuffer> data;
+  optional<std::vector<uint8_t>> data;
   optional<int64_t> timeout;
 };
 
 struct TransferResultInfo {
   optional<int64_t> result_code;
-  optional<pp::VarArrayBuffer> data;
+  optional<std::vector<uint8_t>> data;
 };
 
 constexpr int64_t kTransferResultInfoSuccessResultCode = 0;

--- a/third_party/libusb/naclport/src/libusb_over_chrome_usb_unittest.cc
+++ b/third_party/libusb/naclport/src/libusb_over_chrome_usb_unittest.cc
@@ -26,6 +26,7 @@
 #include <map>
 #include <memory>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include <gmock/gmock.h>
@@ -33,7 +34,6 @@
 #include <libusb.h>
 
 #include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/pp_var_utils/construction.h>
 #include <google_smart_card_common/requesting/request_result.h>
 
 #include "chrome_usb/api_bridge_interface.h"
@@ -495,10 +495,9 @@ class LibusbOverChromeUsbTransfersTest
     transfer_info.request = kTransferRequestField;
     transfer_info.value = kTransferValueField;
     transfer_info.index = transfer_index;
-    const std::vector<uint8_t> data =
-        GenerateTransferData(transfer_index, is_output);
+    std::vector<uint8_t> data = GenerateTransferData(transfer_index, is_output);
     if (is_output)
-      transfer_info.data = MakeVarArrayBuffer(data);
+      transfer_info.data = std::move(data);
     else
       transfer_info.length = data.size();
     transfer_info.timeout = kTransferTimeout;
@@ -527,10 +526,8 @@ class LibusbOverChromeUsbTransfersTest
     if (!IsTransferToFinishUnsuccessfully(transfer_index)) {
       result.result_info.result_code =
           chrome_usb::kTransferResultInfoSuccessResultCode;
-      if (!is_output) {
-        result.result_info.data =
-            MakeVarArrayBuffer(GenerateTransferData(transfer_index, false));
-      }
+      if (!is_output)
+        result.result_info.data = GenerateTransferData(transfer_index, false);
     }
     return RequestResult<chrome_usb::TransferResult>::CreateSuccessful(result);
   }

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.cc
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.cc
@@ -48,6 +48,9 @@ std::vector<uint8_t> GetSCardReaderStateAtr(
 template <>
 StructValueDescriptor<InboundSCardReaderState>::Description
 StructValueDescriptor<InboundSCardReaderState>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names of
+  // SCARD_READERSTATE_IN in
+  // //third_party/pcsc-lite/naclport/js_client/src/api.js.
   return Describe("SCARD_READERSTATE_inbound")
       .WithField(&InboundSCardReaderState::reader_name, "reader_name")
       .WithField(&InboundSCardReaderState::user_data, "user_data")
@@ -74,6 +77,9 @@ void StructConverter<InboundSCardReaderState>::VisitFields(
 template <>
 StructValueDescriptor<OutboundSCardReaderState>::Description
 StructValueDescriptor<OutboundSCardReaderState>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names of
+  // SCARD_READERSTATE_OUT in
+  // //third_party/pcsc-lite/naclport/js_client/src/api.js.
   return Describe("SCARD_READERSTATE_outbound")
       .WithField(&OutboundSCardReaderState::reader_name, "reader_name")
       .WithField(&OutboundSCardReaderState::user_data, "user_data")
@@ -104,6 +110,8 @@ void StructConverter<OutboundSCardReaderState>::VisitFields(
 template <>
 StructValueDescriptor<SCardIoRequest>::Description
 StructValueDescriptor<SCardIoRequest>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the property names of
+  // SCARD_IO_REQUEST in //third_party/pcsc-lite/naclport/js_client/src/api.js.
   return Describe("SCARD_IO_REQUEST")
       .WithField(&SCardIoRequest::protocol, "protocol");
 }

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.cc
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.cc
@@ -28,6 +28,7 @@
 #include <cstring>
 
 #include <google_smart_card_common/pp_var_utils/struct_converter.h>
+#include <google_smart_card_common/value_conversion.h>
 
 namespace google_smart_card {
 
@@ -44,6 +45,15 @@ std::vector<uint8_t> GetSCardReaderStateAtr(
 
 }  // namespace
 
+template <>
+StructValueDescriptor<InboundSCardReaderState>::Description
+StructValueDescriptor<InboundSCardReaderState>::GetDescription() {
+  return Describe("SCARD_READERSTATE_inbound")
+      .WithField(&InboundSCardReaderState::reader_name, "reader_name")
+      .WithField(&InboundSCardReaderState::user_data, "user_data")
+      .WithField(&InboundSCardReaderState::current_state, "current_state");
+}
+
 // static
 template <>
 constexpr const char*
@@ -59,6 +69,17 @@ void StructConverter<InboundSCardReaderState>::VisitFields(
   callback(&value.reader_name, "reader_name");
   callback(&value.user_data, "user_data");
   callback(&value.current_state, "current_state");
+}
+
+template <>
+StructValueDescriptor<OutboundSCardReaderState>::Description
+StructValueDescriptor<OutboundSCardReaderState>::GetDescription() {
+  return Describe("SCARD_READERSTATE_outbound")
+      .WithField(&OutboundSCardReaderState::reader_name, "reader_name")
+      .WithField(&OutboundSCardReaderState::user_data, "user_data")
+      .WithField(&OutboundSCardReaderState::current_state, "current_state")
+      .WithField(&OutboundSCardReaderState::event_state, "event_state")
+      .WithField(&OutboundSCardReaderState::atr, "atr");
 }
 
 // static
@@ -78,6 +99,13 @@ void StructConverter<OutboundSCardReaderState>::VisitFields(
   callback(&value.current_state, "current_state");
   callback(&value.event_state, "event_state");
   callback(&value.atr, "atr");
+}
+
+template <>
+StructValueDescriptor<SCardIoRequest>::Description
+StructValueDescriptor<SCardIoRequest>::GetDescription() {
+  return Describe("SCARD_IO_REQUEST")
+      .WithField(&SCardIoRequest::protocol, "protocol");
 }
 
 // static

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
@@ -36,6 +36,7 @@
 #include <google_smart_card_common/requesting/remote_call_message.h>
 #include <google_smart_card_common/unique_ptr_utils.h>
 #include <google_smart_card_common/value.h>
+#include <google_smart_card_common/value_conversion.h>
 #include <google_smart_card_common/value_nacl_pp_var_conversion.h>
 
 #include "client_request_processor.h"
@@ -64,6 +65,14 @@ struct DeleteHandlerMessageData {
 }  // namespace
 
 template <>
+StructValueDescriptor<CreateHandlerMessageData>::Description
+StructValueDescriptor<CreateHandlerMessageData>::GetDescription() {
+  return Describe("CreateHandlerMessageData")
+      .WithField(&CreateHandlerMessageData::handler_id, "handler_id")
+      .WithField(&CreateHandlerMessageData::client_app_id, "client_app_id");
+}
+
+template <>
 constexpr const char*
 StructConverter<CreateHandlerMessageData>::GetStructTypeName() {
   return "CreateHandlerMessageData";
@@ -75,6 +84,13 @@ void StructConverter<CreateHandlerMessageData>::VisitFields(
     const CreateHandlerMessageData& value, Callback callback) {
   callback(&value.handler_id, "handler_id");
   callback(&value.client_app_id, "client_app_id");
+}
+
+template <>
+StructValueDescriptor<DeleteHandlerMessageData>::Description
+StructValueDescriptor<DeleteHandlerMessageData>::GetDescription() {
+  return Describe("DeleteHandlerMessageData")
+      .WithField(&DeleteHandlerMessageData::handler_id, "handler_id");
 }
 
 template <>

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
@@ -67,6 +67,8 @@ struct DeleteHandlerMessageData {
 template <>
 StructValueDescriptor<CreateHandlerMessageData>::Description
 StructValueDescriptor<CreateHandlerMessageData>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the keys in
+  // //third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js.
   return Describe("CreateHandlerMessageData")
       .WithField(&CreateHandlerMessageData::handler_id, "handler_id")
       .WithField(&CreateHandlerMessageData::client_app_id, "client_app_id");


### PR DESCRIPTION
Add helper definitions that allow conversions to/from Value objects for
every relevant enum/struct in this project (i.e., for every enum/struct
that currently support conversions to/from Native Client pp::Var objects).

This paves the way for continuing the //common/cpp WebAssembly migration
effort (as tracked by #185) without breaking the compilation of the
whole project. Specifically, some upcoming commits will change the way
how outgoing request parameters are serialized before being sent to the
JavaScript side: they'll be converted into Value instead of pp::Var.

Note that the current commit still keeps the old pp::Var conversion
helpers: those will be cleaned up in later follow-ups once they become
unused.

The commit also introduces behavior change: some of the struct fields
are switched to use std::vector<uint8_t>, which, starting from #222,
will make them be serialized into JavaScript ArrayBuffer instead of
bytes Array. It's expected to be a non-breaking change, thanks to #226.