### PR TITLE
Migrate request_handler.h to Value

### DIFF
--- a/common/cpp/src/google_smart_card_common/requesting/request_handler.h
+++ b/common/cpp/src/google_smart_card_common/requesting/request_handler.h
@@ -15,9 +15,8 @@
 #ifndef GOOGLE_SMART_CARD_COMMON_REQUESTING_REQUEST_HANDLER_H_
 #define GOOGLE_SMART_CARD_COMMON_REQUESTING_REQUEST_HANDLER_H_
 
-#include <ppapi/cpp/var.h>
-
 #include <google_smart_card_common/requesting/request_receiver.h>
+#include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
 
@@ -36,13 +35,12 @@ class RequestHandler {
   // callback that can be used to send the request results back.
   //
   // Note that, generally speaking, this function should not block for a very
-  // long periods of time (and probably not do any waiting on the incoming
+  // long period of time (and probably not do any waiting on the incoming
   // Pepper messages at all), as the request receiver calls this method
   // synchronously and, depending on the type of channel it uses, may lead to
   // freezes and deadlocks.
   virtual void HandleRequest(
-      const pp::Var& payload,
-      RequestReceiver::ResultCallback result_callback) = 0;
+      Value payload, RequestReceiver::ResultCallback result_callback) = 0;
 };
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/requesting/request_receiver.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/request_receiver.cc
@@ -18,6 +18,7 @@
 
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/requesting/request_handler.h>
+#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
 
 namespace google_smart_card {
 
@@ -33,7 +34,9 @@ std::string RequestReceiver::name() const { return name_; }
 
 void RequestReceiver::HandleRequest(RequestId request_id,
                                     const pp::Var& payload) {
-  handler_->HandleRequest(payload, MakeResultCallback(request_id));
+  // TODO(#185): Directly receive `Value` instead of converting from `pp::Var`.
+  handler_->HandleRequest(ConvertPpVarToValueOrDie(payload),
+                          MakeResultCallback(request_id));
 }
 
 RequestReceiver::ResultCallbackImpl::ResultCallbackImpl(

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.cc
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.cc
@@ -33,6 +33,7 @@
 #include <google_smart_card_common/requesting/request_result.h>
 #include <google_smart_card_common/unique_ptr_utils.h>
 #include <google_smart_card_common/value.h>
+#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
 #include <google_smart_card_integration_testing/integration_test_helper.h>
 
 namespace google_smart_card {
@@ -86,13 +87,15 @@ void IntegrationTestService::Deactivate() {
 }
 
 void IntegrationTestService::HandleRequest(
-    const pp::Var& payload, RequestReceiver::ResultCallback result_callback) {
+    Value payload, RequestReceiver::ResultCallback result_callback) {
+  // TODO(#185): Parse `Value` directly, instead of converting into `pp::Var`.
+  const pp::Var payload_var = ConvertValueToPpVar(payload);
   std::string method_name;
   pp::VarArray method_arguments;
-  if (!ParseRemoteCallRequestPayload(payload, &method_name,
+  if (!ParseRemoteCallRequestPayload(payload_var, &method_name,
                                      &method_arguments)) {
     GOOGLE_SMART_CARD_LOG_FATAL << "Cannot parse call parameters from "
-                                << DumpVar(payload);
+                                << DumpVar(payload_var);
   }
   if (method_name == "SetUp") {
     std::string helper_name;

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
@@ -26,6 +26,7 @@
 
 #include <google_smart_card_common/messaging/typed_message_listener.h>
 #include <google_smart_card_common/requesting/js_request_receiver.h>
+#include <google_smart_card_common/value.h>
 #include <google_smart_card_integration_testing/integration_test_helper.h>
 
 namespace google_smart_card {
@@ -45,31 +46,27 @@ class IntegrationTestService final : public RequestHandler {
 
   // Starts listening for incoming requests and translating them into commands
   // for test helpers.
-  void Activate(
-      pp::Instance* pp_instance,
-      pp::Core* pp_core,
-      TypedMessageRouter* typed_message_router);
+  void Activate(pp::Instance* pp_instance, pp::Core* pp_core,
+                TypedMessageRouter* typed_message_router);
   // Tears down all previously set up helpers and stops listening for incoming
   // requests.
   void Deactivate();
 
   // RequestHandler:
-  void HandleRequest(
-      const pp::Var& payload,
-      RequestReceiver::ResultCallback result_callback) override;
+  void HandleRequest(Value payload,
+                     RequestReceiver::ResultCallback result_callback) override;
 
  private:
   IntegrationTestService();
   ~IntegrationTestService();
 
   IntegrationTestHelper* FindHelperByName(const std::string& name);
-  void SetUpHelper(
-      const std::string& helper_name, const pp::Var& data_for_helper);
+  void SetUpHelper(const std::string& helper_name,
+                   const pp::Var& data_for_helper);
   void TearDownAllHelpers();
-  void SendMessageToHelper(
-      const std::string& helper_name,
-      const pp::Var& message_for_helper,
-      RequestReceiver::ResultCallback result_callback);
+  void SendMessageToHelper(const std::string& helper_name,
+                           const pp::Var& message_for_helper,
+                           RequestReceiver::ResultCallback result_callback);
 
   pp::Instance* pp_instance_ = nullptr;
   pp::Core* pp_core_ = nullptr;

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
@@ -201,12 +201,13 @@ void ApiBridge::StopPinRequest(const StopPinRequestOptions& options) {
 }
 
 void ApiBridge::HandleRequest(
-    const pp::Var& payload,
-    gsc::RequestReceiver::ResultCallback result_callback) {
+    gsc::Value payload, gsc::RequestReceiver::ResultCallback result_callback) {
+  // TODO: Parse `Value` directly instead of transforming into `pp::Var`.
+  const pp::Var payload_var = gsc::ConvertValueToPpVar(payload);
   std::string function_name;
   pp::VarArray arguments;
-  GOOGLE_SMART_CARD_CHECK(
-      gsc::ParseRemoteCallRequestPayload(payload, &function_name, &arguments));
+  GOOGLE_SMART_CARD_CHECK(gsc::ParseRemoteCallRequestPayload(
+      payload_var, &function_name, &arguments));
   if (function_name == kHandleCertificatesRequestFunctionName) {
     HandleCertificatesRequest(arguments, result_callback);
   } else if (function_name == kHandleSignatureRequestFunctionName) {

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
@@ -138,7 +138,7 @@ class ApiBridge final : public google_smart_card::RequestHandler {
 
  private:
   // google_smart_card::RequestHandler:
-  void HandleRequest(const pp::Var& payload,
+  void HandleRequest(google_smart_card::Value payload,
                      google_smart_card::RequestReceiver::ResultCallback
                          result_callback) override;
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
@@ -30,6 +30,8 @@
 #include <sstream>
 #include <utility>
 
+#include <ppapi/cpp/var.h>
+
 #include <google_smart_card_common/formatting.h>
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/pp_var_utils/struct_converter.h>
@@ -215,10 +217,12 @@ PcscLiteServerClientsManager::Handler::~Handler() {
 }
 
 void PcscLiteServerClientsManager::Handler::HandleRequest(
-    const pp::Var& payload, RequestReceiver::ResultCallback result_callback) {
+    Value payload, RequestReceiver::ResultCallback result_callback) {
+  // TODO: Parse `Value` directly instead of transforming into `pp::Var`.
+  const pp::Var payload_var = ConvertValueToPpVar(payload);
   std::string function_name;
   pp::VarArray arguments;
-  if (!ParseRemoteCallRequestPayload(payload, &function_name, &arguments)) {
+  if (!ParseRemoteCallRequestPayload(payload_var, &function_name, &arguments)) {
     result_callback(GenericRequestResult::CreateFailed(
         "Failed to parse remote call request payload"));
     return;

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h
@@ -33,7 +33,6 @@
 #include <unordered_map>
 
 #include <ppapi/cpp/instance.h>
-#include <ppapi/cpp/var.h>
 
 #include <google_smart_card_common/messaging/typed_message_listener.h>
 #include <google_smart_card_common/messaging/typed_message_router.h>
@@ -149,7 +148,7 @@ class PcscLiteServerClientsManager final {
 
     // RequestHandler:
     void HandleRequest(
-        const pp::Var& payload,
+        Value payload,
         RequestReceiver::ResultCallback result_callback) override;
 
    private:


### PR DESCRIPTION
Change the request_handler.h header and all related code to use the
toolchain-independent Value class instead of the Native Client specific
pp::Var class.

This commit contributes to the goal of making most of the //common/cpp
library be toolchain-agnostic and support WebAssembly (as tracked
by #185).