### PR TITLE
Introduce "make run_test" for running tests

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -86,7 +86,7 @@ $(eval $(call LIB_RULE,$(TARGET),$(SOURCES)))
 
 
 test::
-	+$(MAKE) --directory tests run
+	+$(MAKE) --directory tests run_test
 
 tests_clean::
 	+$(MAKE) --directory tests clean

--- a/common/cpp/build/tests/.gitignore
+++ b/common/cpp/build/tests/.gitignore
@@ -1,2 +1,3 @@
 /out/
 /pnacl/
+/user-data-dir/

--- a/common/js/build/Makefile
+++ b/common/js/build/Makefile
@@ -17,7 +17,7 @@ all:
 
 
 test::
-	+$(MAKE) --directory unittests run
+	+$(MAKE) --directory unittests run_test
 
 tests_clean::
 	+$(MAKE) --directory unittests clean

--- a/common/make/js_building_common.mk
+++ b/common/make/js_building_common.mk
@@ -232,7 +232,7 @@ endef
 #
 # Macro rule that compiles the resulting JavaScript file with unit tests (see
 # also the BUILD_TESTING_JS_SCRIPT macro rule), creates HTML file with unit
-# tests runner, and adds run target that executes the unit tests.
+# tests runner, and adds run_test target that executes the unit tests.
 #
 # Arguments:
 #    $1: Paths to the directories with the source JavaScript files (it should
@@ -249,7 +249,7 @@ $(OUT_DIR_PATH)/index.html: $(OUT_DIR_PATH)
 
 generate_out: $(OUT_DIR_PATH)/index.html
 
-run: all
+run_test: all
 	$(CHROME_ENV) $(CHROME_PATH) $(OUT_DIR_PATH)/index.html $(CHROME_ARGS) \
 		--user-data-dir=$(OUT_DIR_ROOT_PATH)/temp_chrome_profile
 

--- a/common/tests_runner/build.mk
+++ b/common/tests_runner/build.mk
@@ -148,7 +148,7 @@ $(foreach static_file,$(TESTS_RUNNER_STATIC_FILES),$(eval $(call COPY_TO_OUT_DIR
 # and the NaCl module's files. The user-data-dir, which is passed to Chrome for
 # storing data, is cleared before each run to prevent state leakage.
 #
-# Note: The recipe uses variables that are defined by the NaCl's makefiles.
+# Note: The recipe uses variables that are defined by NaCl's makefiles.
 run_test: all
 	rm -rf user-data-dir
 	$(RUN_PY) \

--- a/common/tests_runner/build.mk
+++ b/common/tests_runner/build.mk
@@ -154,8 +154,8 @@ run_test: all
 	$(RUN_PY) \
 		-C $(OUT_DIR_PATH) \
 		-P "index.html?tc=$(TOOLCHAIN)&config=$(CONFIG)" \
-	  $(addprefix -E ,$(CHROME_ENV)) \
-	  -- \
-	  "$(CHROME_PATH)" \
-	  $(CHROME_ARGS) \
-	  --register-pepper-plugins="$(PPAPI_DEBUG),$(PPAPI_RELEASE)" \
+		$(addprefix -E ,$(CHROME_ENV)) \
+		-- \
+		"$(CHROME_PATH)" \
+		$(CHROME_ARGS) \
+		--register-pepper-plugins="$(PPAPI_DEBUG),$(PPAPI_RELEASE)" \

--- a/example_cpp_smart_card_client_app/build/Makefile
+++ b/example_cpp_smart_card_client_app/build/Makefile
@@ -75,7 +75,7 @@ $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/built_in_pin_dialog/built-in-
 # Rules for building and running tests and for cleaning test build files.
 
 test::
-	+$(MAKE) --directory integration_tests run
+	+$(MAKE) --directory integration_tests run_test
 
 tests_clean::
 	+$(MAKE) --directory integration_tests clean

--- a/example_cpp_smart_card_client_app/build/integration_tests/.gitignore
+++ b/example_cpp_smart_card_client_app/build/integration_tests/.gitignore
@@ -1,3 +1,4 @@
 /js_build/
 /out/
 /pnacl/
+/user-data-dir/

--- a/example_cpp_smart_card_client_app/build/integration_tests/Makefile
+++ b/example_cpp_smart_card_client_app/build/integration_tests/Makefile
@@ -21,8 +21,6 @@ TARGET := integration_tests
 
 include ../../../common/make/common.mk
 
-PAGE := $(OUT_DIR_PATH)/index.html
-
 include $(COMMON_DIR_PATH)/make/js_building_common.mk
 include $(COMMON_DIR_PATH)/make/executable_building.mk
 include $(COMMON_DIR_PATH)/cpp/include.mk
@@ -76,14 +74,21 @@ $(eval $(call BUILD_TESTING_JS_SCRIPT,tests.js,$(JS_COMPILER_INPUT_PATHS)))
 
 $(OUT_DIR_PATH)/index.html: $(OUT_DIR_PATH)
 	@echo "<script src='tests.js'></script>" > $(OUT_DIR_PATH)/index.html
+all: $(OUT_DIR_PATH)/index.html
 
-
+# Target that executes the tests by starting a Chrome instance with the test
+# runner's HTML page. A web server is additionally started that serves the page
+# and the NaCl module's files. The user-data-dir, which is passed to Chrome for
+# storing data, is cleared before each run to prevent state leakage.
 #
-# Hack: change CURDIR to the out directory, so that the "run" target starts
-# Chrome with the correct working directory, and re-adjust path to the loaded
-# page accordingly.
-#
-
-CURDIR := $(OUT_DIR_PATH)
-
-PAGE := index.html
+# Note: The recipe uses variables that are defined by the NaCl's makefiles.
+run_test: all
+	rm -rf user-data-dir
+	$(RUN_PY) \
+		-C $(OUT_DIR_PATH) \
+		-P "index.html?tc=$(TOOLCHAIN)&config=$(CONFIG)" \
+	  $(addprefix -E ,$(CHROME_ENV)) \
+	  -- \
+	  "$(CHROME_PATH)" \
+	  $(CHROME_ARGS) \
+	  --register-pepper-plugins="$(PPAPI_DEBUG),$(PPAPI_RELEASE)" \

--- a/example_cpp_smart_card_client_app/build/integration_tests/Makefile
+++ b/example_cpp_smart_card_client_app/build/integration_tests/Makefile
@@ -87,8 +87,8 @@ run_test: all
 	$(RUN_PY) \
 		-C $(OUT_DIR_PATH) \
 		-P "index.html?tc=$(TOOLCHAIN)&config=$(CONFIG)" \
-	  $(addprefix -E ,$(CHROME_ENV)) \
-	  -- \
-	  "$(CHROME_PATH)" \
-	  $(CHROME_ARGS) \
-	  --register-pepper-plugins="$(PPAPI_DEBUG),$(PPAPI_RELEASE)" \
+		$(addprefix -E ,$(CHROME_ENV)) \
+		-- \
+		"$(CHROME_PATH)" \
+		$(CHROME_ARGS) \
+		--register-pepper-plugins="$(PPAPI_DEBUG),$(PPAPI_RELEASE)" \

--- a/example_cpp_smart_card_client_app/build/integration_tests/Makefile
+++ b/example_cpp_smart_card_client_app/build/integration_tests/Makefile
@@ -81,7 +81,7 @@ all: $(OUT_DIR_PATH)/index.html
 # and the NaCl module's files. The user-data-dir, which is passed to Chrome for
 # storing data, is cleared before each run to prevent state leakage.
 #
-# Note: The recipe uses variables that are defined by the NaCl's makefiles.
+# Note: The recipe uses variables that are defined by NaCl's makefiles.
 run_test: all
 	rm -rf user-data-dir
 	$(RUN_PY) \

--- a/third_party/libusb/naclport/build/Makefile
+++ b/third_party/libusb/naclport/build/Makefile
@@ -79,8 +79,8 @@ $(eval $(call NACL_LIBRARY_HEADERS_INSTALLATION_RULE,$(INSTALLING_HEADERS)))
 
 
 test::
-	+$(MAKE) --directory tests run
-	+$(MAKE) --directory js_unittests run
+	+$(MAKE) --directory tests run_test
+	+$(MAKE) --directory js_unittests run_test
 
 tests_clean::
 	+$(MAKE) --directory tests clean

--- a/third_party/libusb/naclport/build/tests/.gitignore
+++ b/third_party/libusb/naclport/build/tests/.gitignore
@@ -1,2 +1,3 @@
 /out/
 /pnacl/
+/user-data-dir/

--- a/third_party/pcsc-lite/naclport/server_clients_management/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server_clients_management/build/Makefile
@@ -92,7 +92,7 @@ $(eval $(call NACL_LIBRARY_HEADERS_INSTALLATION_RULE,$(INSTALLING_HEADERS)))
 
 
 test::
-	+$(MAKE) --directory js_unittests run
+	+$(MAKE) --directory js_unittests run_test
 
 tests_clean::
 	+$(MAKE) --directory js_unittests clean


### PR DESCRIPTION
Rename the existing "run" makefile target into "run_test", in order to
avoid clashing with the Native Client's definition of the "run" target.

Previously we were intentionally using this clash in order to reduce
amount of boilerplate needed for running tests, but that came with the
price of doing some nontrivial hacks (like changing the current
directory CURDIR back and forth). This commit gets rids of these hacks
and makes tests' makefiles slightly simpler, which will also simplify
the upcoming Emscripten test runner implementation.

This is a preparatory fix for introducing Emscripten builds of unit
tests, as tracked by #177.