### PR TITLE
Implement C++ unit test runner for Emscripten

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -85,7 +85,7 @@ $(foreach src,$(SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
 $(eval $(call LIB_RULE,$(TARGET),$(SOURCES)))
 
 
-test::
+test:: all
 	+$(MAKE) --directory tests run_test
 
 tests_clean::

--- a/common/cpp/build/tests/Makefile
+++ b/common/cpp/build/tests/Makefile
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#
 # Makefile for the C++ library tests.
 #
-# The tests are executed through the separate tests runner, and therefore its
-# makefile has to be used - with our specific options plugged into it through a
-# bunch of make variables.
-#
+# The makefile is based on the helper definitions provided by
+# "cpp_unit_test_runner".
 
 include ../../../cpp_unit_test_runner/include.mk
 

--- a/common/cpp/build/tests/Makefile
+++ b/common/cpp/build/tests/Makefile
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 #
 # Makefile for the C++ library tests.
 #
@@ -21,46 +20,46 @@
 # bunch of make variables.
 #
 
+include ../../../cpp_unit_test_runner/include.mk
 
-ADDITIONAL_TEST_LIBS_PREFIX := \
-	google_smart_card_common \
+ROOT_SOURCES_PATH := ../../src
+ROOT_SOURCES_SUBDIR := google_smart_card_common
+SOURCES_PATH := $(ROOT_SOURCES_PATH)/$(ROOT_SOURCES_SUBDIR)
 
-ADDITIONAL_TEST_LIBS_SUFFIX := \
-	nacl_io \
-
-
-ADDITIONAL_TEST_DEPS = \
-	nacl_io \
-	google_smart_card_common:.. \
-
-
-TEST_SOURCES_PATH := ../../src
-
-TEST_SOURCES_SUBDIR := google_smart_card_common
-
-TEST_SOURCES := \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/formatting_unittest.cc \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/logging/hex_dumping_unittest.cc \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/messaging/typed_message_router_unittest.cc \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/numeric_conversions_unittest.cc \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/requesting/async_request_unittest.cc \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/requesting/async_requests_storage_unittest.cc \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_conversion_unittest.cc \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_debug_dumping_unittest.cc \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_unittest.cc \
+SOURCES := \
+	$(SOURCES_PATH)/formatting_unittest.cc \
+	$(SOURCES_PATH)/logging/hex_dumping_unittest.cc \
+	$(SOURCES_PATH)/messaging/typed_message_router_unittest.cc \
+	$(SOURCES_PATH)/numeric_conversions_unittest.cc \
+	$(SOURCES_PATH)/requesting/async_request_unittest.cc \
+	$(SOURCES_PATH)/requesting/async_requests_storage_unittest.cc \
+	$(SOURCES_PATH)/value_conversion_unittest.cc \
+	$(SOURCES_PATH)/value_debug_dumping_unittest.cc \
+	$(SOURCES_PATH)/value_unittest.cc \
 
 ifeq ($(TOOLCHAIN),pnacl)
 
-TEST_SOURCES += \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/pp_var_utils/construction_unittest.cc \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/pp_var_utils/enum_converter_unittest.cc \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/pp_var_utils/struct_converter_unittest.cc \
-	$(TEST_SOURCES_PATH)/$(TEST_SOURCES_SUBDIR)/value_nacl_pp_var_conversion_unittest.cc \
+SOURCES += \
+	$(SOURCES_PATH)/pp_var_utils/construction_unittest.cc \
+	$(SOURCES_PATH)/pp_var_utils/enum_converter_unittest.cc \
+	$(SOURCES_PATH)/pp_var_utils/struct_converter_unittest.cc \
+	$(SOURCES_PATH)/value_nacl_pp_var_conversion_unittest.cc \
 
 endif
 
-ADDITIONAL_TEST_CPPFLAGS := \
-	-I$(TEST_SOURCES_PATH) \
+CXXFLAGS := \
+	-I$(ROOT_SOURCES_PATH)/ \
+	-pedantic \
+	-Wall \
+	-Werror \
+	-Wextra \
+	-std=gnu++11 \
+	$(TEST_ADDITIONAL_CXXFLAGS) \
 
+LIBS := \
+	google_smart_card_common \
 
-include ../../../tests_runner/build.mk
+$(foreach src,$(SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
+
+$(eval $(call LINK_EXECUTABLE_RULE,$(SOURCES) $(TEST_RUNNER_SOURCES),\
+	$(LIBS) $(TEST_RUNNER_LIBS),$(TEST_RUNNER_DEPS),$(TEST_ADDITIONAL_LDFLAGS)))

--- a/common/cpp_unit_test_runner/include.mk
+++ b/common/cpp_unit_test_runner/include.mk
@@ -1,0 +1,54 @@
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file provides helper definitions for building and running C++ unit tests,
+# written using the GoogleTest framework.
+
+# The resulting target name. Note that this string is also hardcoded in some of
+# the toolchain-specific files pulled in below.
+TARGET := cpp_unit_test_runner
+
+include $(dir $(lastword $(MAKEFILE_LIST)))/../make/common.mk
+include $(ROOT_PATH)/common/make/executable_building.mk
+
+# Common documentation for definitions provided by this file (they are
+# implemented in toolchain-specific .mk files, but share the same interface):
+#
+# * TEST_ADDITIONAL_CXXFLAGS:
+#   Additional flags to be specified when compiling test files.
+#
+# * TEST_RUNNER_SOURCES:
+#   Test runner's own C/C++ sources to be linked into the resulting executable.
+#
+# * TEST_RUNNER_LIBS:
+#   Test runner's own static libraries to be linked into the resulting
+#   executable.
+#
+# * TEST_RUNNER_DEPS:
+#   Test runner's own dependencies that need to be added as prerequisites for
+#   the linking of the resulting executable.
+#
+# * run_test:
+#   A target that executes the tests.
+
+.PHONY: run_test
+
+# Load the toolchain-specific file.
+ifeq ($(TOOLCHAIN),emscripten)
+include $(ROOT_PATH)/common/cpp_unit_test_runner/src/build_emscripten.mk
+else ifeq ($(TOOLCHAIN),pnacl)
+include $(ROOT_PATH)/common/cpp_unit_test_runner/src/build_nacl.mk
+else
+$(error Unknown TOOLCHAIN "$(TOOLCHAIN)".)
+endif

--- a/common/cpp_unit_test_runner/include.mk
+++ b/common/cpp_unit_test_runner/include.mk
@@ -28,6 +28,9 @@ include $(ROOT_PATH)/common/make/executable_building.mk
 # * TEST_ADDITIONAL_CXXFLAGS:
 #   Additional flags to be specified when compiling test files.
 #
+# * TEST_ADDITIONAL_LDFLAGS:
+#   Additional flags to be specified when linking the resulting executable.
+#
 # * TEST_RUNNER_SOURCES:
 #   Test runner's own C/C++ sources to be linked into the resulting executable.
 #

--- a/common/cpp_unit_test_runner/src/build_emscripten.mk
+++ b/common/cpp_unit_test_runner/src/build_emscripten.mk
@@ -1,0 +1,74 @@
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains the implementation of the ../include.mk interface that
+# builds the C++ unit test runner using the Emscripten toolchain.
+
+# Flags passed to the Emscripten compiler/linker tools in test builds.
+#
+# Explanation:
+# MODULARIZE: Disable putting the Emscripten module JavaScript loading code into
+#   a factory function, so that the test runner module is loaded automatically
+#   on startup.
+TEST_ADDITIONAL_EMSCRIPTEN_FLAGS := \
+	-s MODULARIZE=0 \
+
+# Documented at ../include.mk.
+TEST_ADDITIONAL_CXXFLAGS := \
+	$(TEST_ADDITIONAL_EMSCRIPTEN_FLAGS) \
+	-I$(ROOT_PATH)/third_party/googletest/src/googlemock/include \
+	-I$(ROOT_PATH)/third_party/googletest/src/googletest/include \
+
+# Documented at ../include.mk.
+TEST_ADDITIONAL_LDFLAGS := \
+	$(TEST_ADDITIONAL_EMSCRIPTEN_FLAGS) \
+
+# Documented at ../include.mk.
+TEST_RUNNER_SOURCES :=
+
+# Documented at ../include.mk.
+TEST_RUNNER_LIBS := \
+	gtest_main \
+	gmock \
+	gtest \
+
+# Documented at ../include.mk.
+TEST_RUNNER_DEPS := \
+
+# Rules for building GoogleTest static libraries.
+
+GOOGLETEST_LIBS := \
+	$(LIB_DIR)/libgmock.a \
+	$(LIB_DIR)/libgmock_main.a \
+	$(LIB_DIR)/libgtest.a \
+	$(LIB_DIR)/libgtest_main.a \
+
+$(GOOGLETEST_LIBS) &:
+	$(MAKE) -C $(ROOT_PATH)/third_party/googletest/webport/build
+
+# Documented at ../include.mk.
+#
+# Implementation notes:
+# The execution is performed via Node.js.
+#
+# Explanation of arguments:
+# DISPLAY: Workaround against "Permission denied" Node.js issue.
+# experimental-wasm-threads, experimental-wasm-bulk-memory: Needed for Pthreads
+#   (multi-threading) support.
+run_test: all
+	DISPLAY= \
+		node \
+		--experimental-wasm-threads \
+		--experimental-wasm-bulk-memory \
+		$(OUT_DIR_PATH)/$(TARGET).js

--- a/common/cpp_unit_test_runner/src/build_emscripten.mk
+++ b/common/cpp_unit_test_runner/src/build_emscripten.mk
@@ -24,26 +24,26 @@
 TEST_ADDITIONAL_EMSCRIPTEN_FLAGS := \
 	-s MODULARIZE=0 \
 
-# Documented at ../include.mk.
+# Documented in ../include.mk.
 TEST_ADDITIONAL_CXXFLAGS := \
 	$(TEST_ADDITIONAL_EMSCRIPTEN_FLAGS) \
 	-I$(ROOT_PATH)/third_party/googletest/src/googlemock/include \
 	-I$(ROOT_PATH)/third_party/googletest/src/googletest/include \
 
-# Documented at ../include.mk.
+# Documented in ../include.mk.
 TEST_ADDITIONAL_LDFLAGS := \
 	$(TEST_ADDITIONAL_EMSCRIPTEN_FLAGS) \
 
-# Documented at ../include.mk.
+# Documented in ../include.mk.
 TEST_RUNNER_SOURCES :=
 
-# Documented at ../include.mk.
+# Documented in ../include.mk.
 TEST_RUNNER_LIBS := \
 	gtest_main \
 	gmock \
 	gtest \
 
-# Documented at ../include.mk.
+# Documented in ../include.mk.
 TEST_RUNNER_DEPS := \
 
 # Rules for building GoogleTest static libraries.
@@ -57,7 +57,7 @@ GOOGLETEST_LIBS := \
 $(GOOGLETEST_LIBS) &:
 	$(MAKE) -C $(ROOT_PATH)/third_party/googletest/webport/build
 
-# Documented at ../include.mk.
+# Documented in ../include.mk.
 #
 # Implementation notes:
 # The execution is performed via Node.js.

--- a/common/cpp_unit_test_runner/src/build_nacl.mk
+++ b/common/cpp_unit_test_runner/src/build_nacl.mk
@@ -1,0 +1,83 @@
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains the implementation of the ../include.mk interface that
+# builds the C++ unit test runner using the Native Client toolchain.
+
+# Documented at ../include.mk.
+TEST_ADDITIONAL_CXXFLAGS :=
+# Documented at ../include.mk.
+TEST_ADDITIONAL_LDFLAGS :=
+
+# Path to the test runner's own source files.
+TEST_RUNNER_SOURCES_DIR := $(ROOT_PATH)/common/cpp_unit_test_runner/src
+# Documented at ../include.mk.
+TEST_RUNNER_SOURCES := \
+	$(TEST_RUNNER_SOURCES_DIR)/entry_point_nacl.cc \
+
+# C++ flags to be used when compiling the test runner's own C++ source files.
+TEST_RUNNER_CXXFLAGS := \
+	-pedantic \
+	-Wall \
+	-Werror \
+	-Wextra \
+	-std=gnu++11 \
+
+# Add rules for compiling the test runner's own C++ source files.
+$(foreach src,$(TEST_RUNNER_SOURCES),\
+	$(eval $(call COMPILE_RULE,$(src),$(TEST_RUNNER_CXXFLAGS))))
+
+# Documented at ../include.mk.
+TEST_RUNNER_LIBS := \
+	gmock \
+	gtest \
+	ppapi_simple_cpp \
+	$(DEFAULT_NACL_LIBS) \
+	nacl_io \
+
+# Documented at ../include.mk.
+TEST_RUNNER_DEPS := \
+	ppapi_simple_cpp \
+	nacl_io \
+
+# Rules for building the test runner's own dependencies.
+$(eval $(call DEPEND_RULE,nacl_io))
+$(eval $(call DEPEND_RULE,ppapi_simple_cpp))
+
+# Rules for copying the test runner's own static files:
+
+TEST_RUNNER_STATIC_FILES := \
+	$(NACL_SDK_ROOT)/getting_started/part2/common.js \
+	$(TEST_RUNNER_SOURCES_DIR)/index_nacl.html \
+
+$(foreach static_file,$(TEST_RUNNER_STATIC_FILES),\
+	$(eval $(call COPY_TO_OUT_DIR_RULE,$(static_file))))
+
+# Documented at ../include.mk.
+#
+# Implementation notes:
+# The tests are executed by starting a Chrome instance with the test runner's
+# HTML page. A web server is additionally started that serves the page and the
+# NaCl module's files.
+#
+# Note: The recipe uses variables that are defined by the NaCl's makefiles.
+run_test: all
+	$(RUN_PY) \
+		-C $(OUT_DIR_PATH) \
+		-P "index_nacl.html?tc=$(TOOLCHAIN)&config=$(CONFIG)" \
+		$(addprefix -E ,$(CHROME_ENV)) \
+		-- \
+		"$(CHROME_PATH)" \
+		$(CHROME_ARGS) \
+		--register-pepper-plugins="$(PPAPI_DEBUG),$(PPAPI_RELEASE)" \

--- a/common/cpp_unit_test_runner/src/build_nacl.mk
+++ b/common/cpp_unit_test_runner/src/build_nacl.mk
@@ -15,14 +15,14 @@
 # This file contains the implementation of the ../include.mk interface that
 # builds the C++ unit test runner using the Native Client toolchain.
 
-# Documented at ../include.mk.
+# Documented in ../include.mk.
 TEST_ADDITIONAL_CXXFLAGS :=
-# Documented at ../include.mk.
+# Documented in ../include.mk.
 TEST_ADDITIONAL_LDFLAGS :=
 
 # Path to the test runner's own source files.
 TEST_RUNNER_SOURCES_DIR := $(ROOT_PATH)/common/cpp_unit_test_runner/src
-# Documented at ../include.mk.
+# Documented in ../include.mk.
 TEST_RUNNER_SOURCES := \
 	$(TEST_RUNNER_SOURCES_DIR)/entry_point_nacl.cc \
 
@@ -38,7 +38,7 @@ TEST_RUNNER_CXXFLAGS := \
 $(foreach src,$(TEST_RUNNER_SOURCES),\
 	$(eval $(call COMPILE_RULE,$(src),$(TEST_RUNNER_CXXFLAGS))))
 
-# Documented at ../include.mk.
+# Documented in ../include.mk.
 TEST_RUNNER_LIBS := \
 	gmock \
 	gtest \
@@ -46,7 +46,7 @@ TEST_RUNNER_LIBS := \
 	$(DEFAULT_NACL_LIBS) \
 	nacl_io \
 
-# Documented at ../include.mk.
+# Documented in ../include.mk.
 TEST_RUNNER_DEPS := \
 	ppapi_simple_cpp \
 	nacl_io \
@@ -64,7 +64,7 @@ TEST_RUNNER_STATIC_FILES := \
 $(foreach static_file,$(TEST_RUNNER_STATIC_FILES),\
 	$(eval $(call COPY_TO_OUT_DIR_RULE,$(static_file))))
 
-# Documented at ../include.mk.
+# Documented in ../include.mk.
 #
 # Implementation notes:
 # The tests are executed by starting a Chrome instance with the test runner's

--- a/common/cpp_unit_test_runner/src/entry_point_nacl.cc
+++ b/common/cpp_unit_test_runner/src/entry_point_nacl.cc
@@ -65,8 +65,7 @@ class GTestEventListener final : public testing::EmptyTestEventListener {
     message.Set("ok", !test_info.result()->Failed());
     PostMessage(message);
 
-    if (test_info.result()->Failed())
-      ++failed_test_count_;
+    if (test_info.result()->Failed()) ++failed_test_count_;
     current_test_case_name_.clear();
     current_test_name_.clear();
   }

--- a/common/cpp_unit_test_runner/src/index_nacl.html
+++ b/common/cpp_unit_test_runner/src/index_nacl.html
@@ -116,7 +116,7 @@ limitations under the License.
     }
   </script>
 </head>
-<body data-attrs="PS_EXIT_MESSAGE=testend" data-name="tests_runner" data-tools="pnacl" data-configs="Debug Release" data-path="." data-width="0" data-height="0">
+<body data-attrs="PS_EXIT_MESSAGE=testend" data-name="cpp_unit_test_runner" data-tools="pnacl" data-configs="Debug Release" data-path="." data-width="0" data-height="0">
   <h1>NaCl code Tests</h1>
   <div id="listener"></div>
   <h2>NaCl module: <code id="statusField">Initializing</code>.</h2>

--- a/third_party/libusb/naclport/build/tests/Makefile
+++ b/third_party/libusb/naclport/build/tests/Makefile
@@ -14,38 +14,35 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-
-#
 # Makefile for the libusb NaCl port library tests.
 #
-# The tests are executed through the separate tests runner, and therefore its
-# makefile has to be used - with our specific options plugged into it through a
-# bunch of make variables.
-#
+# The makefile is based on the helper definitions provided by
+# "cpp_unit_test_runner".
 
+include ../../../../../common/cpp_unit_test_runner/include.mk
 
-ADDITIONAL_TEST_LIBS_PREFIX := \
+SOURCES_PATH := ../../src
+
+SOURCES := \
+	$(SOURCES_PATH)/libusb_over_chrome_usb_unittest.cc \
+
+CXXFLAGS := \
+	-I$(SOURCES_PATH) \
+	-I$(NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH)/google_smart_card_libusb/libusb-1.0 \
+	-I$(ROOT_PATH)/common/cpp/src \
+	-pedantic \
+	-Wall \
+	-Werror \
+	-Wextra \
+	-Wno-zero-length-array \
+	-std=gnu++11 \
+	$(TEST_ADDITIONAL_CXXFLAGS) \
+
+LIBS := \
 	google_smart_card_libusb \
 	google_smart_card_common \
 
-ADDITIONAL_TEST_LIBS_SUFFIX := \
-	nacl_io \
+$(foreach src,$(SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
 
-
-ADDITIONAL_TEST_DEPS = \
-	nacl_io \
-	google_smart_card_libusb:.. \
-
-
-TEST_SOURCES_PATH := ../../src
-
-TEST_SOURCES := \
-	$(TEST_SOURCES_PATH)/libusb_over_chrome_usb_unittest.cc \
-
-ADDITIONAL_TEST_CPPFLAGS = \
-	-I$(TEST_SOURCES_PATH) \
-	-I$(NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH)/google_smart_card_libusb/libusb-1.0 \
-	-I$(ROOT_PATH)/common/cpp/src \
-
-
-include ../../../../../common/tests_runner/build.mk
+$(eval $(call LINK_EXECUTABLE_RULE,$(SOURCES) $(TEST_RUNNER_SOURCES),\
+	$(LIBS) $(TEST_RUNNER_LIBS),$(TEST_RUNNER_DEPS),$(TEST_ADDITIONAL_LDFLAGS)))


### PR DESCRIPTION
This commit adds the support of building and running C++ unit tests in
Emscripten builds.

In order to achieve this, there's also a refactoring made that
simplifies how the tests' makefiles are organized and allows to abstract
away differences between Native Client and Emscripten.

This is an improvement for the Emscripten/WebAssembly build
infrastructure that is tracked by #177.