### PR TITLE
Switch C++ sources format to Chromium code style

### DIFF
--- a/common/cpp/src/google_smart_card_common/external_logs_printer.cc
+++ b/common/cpp/src/google_smart_card_common/external_logs_printer.cc
@@ -64,7 +64,8 @@ StructConverter<ExternalLogMessageData>::GetStructTypeName() {
 template <>
 template <typename Callback>
 void StructConverter<ExternalLogMessageData>::VisitFields(
-    const ExternalLogMessageData& value, Callback callback) {
+    const ExternalLogMessageData& value,
+    Callback callback) {
   callback(&value.formatted_log_message, "formatted_log_message");
 }
 

--- a/common/cpp/src/google_smart_card_common/formatting.cc
+++ b/common/cpp/src/google_smart_card_common/formatting.cc
@@ -49,9 +49,11 @@ std::string FormatPrintfTemplate(const char* format, va_list var_args) {
   }
 }
 
-void FormatPrintfTemplateAndSet(std::string* output_string, const char* format,
+void FormatPrintfTemplateAndSet(std::string* output_string,
+                                const char* format,
                                 ...) {
-  if (!output_string) return;
+  if (!output_string)
+    return;
   va_list var_args;
   va_start(var_args, format);
   *output_string = FormatPrintfTemplate(format, var_args);

--- a/common/cpp/src/google_smart_card_common/formatting.h
+++ b/common/cpp/src/google_smart_card_common/formatting.h
@@ -29,7 +29,8 @@ std::string FormatPrintfTemplate(const char* format, va_list var_args);
 
 // Same as `FormatPrintfTemplate()`, but stores the result in `output_string`.
 // Does nothing if `output_string` is null.
-void FormatPrintfTemplateAndSet(std::string* output_string, const char* format,
+void FormatPrintfTemplateAndSet(std::string* output_string,
+                                const char* format,
                                 ...) __attribute__((format(__printf__, 2, 3)));
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.cc
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.cc
@@ -25,7 +25,8 @@
 namespace google_smart_card {
 
 GlobalContextImplEmscripten::GlobalContextImplEmscripten(
-    std::thread::id main_thread_id, emscripten::val post_message_callback)
+    std::thread::id main_thread_id,
+    emscripten::val post_message_callback)
     : main_thread_id_(main_thread_id),
       post_message_callback_(post_message_callback) {}
 
@@ -37,7 +38,8 @@ bool GlobalContextImplEmscripten::PostMessageToJs(const Value& message) {
   const emscripten::val val = ConvertValueToEmscriptenVal(message);
 
   const std::unique_lock<std::mutex> lock(mutex_);
-  if (post_message_callback_.isUndefined()) return false;
+  if (post_message_callback_.isUndefined())
+    return false;
   post_message_callback_(val);
   return true;
 }

--- a/common/cpp/src/google_smart_card_common/global_context_impl_nacl.cc
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_nacl.cc
@@ -37,7 +37,8 @@ bool GlobalContextImplNacl::PostMessageToJs(const Value& message) {
   const pp::Var var = ConvertValueToPpVar(message);
 
   const std::unique_lock<std::mutex> lock(mutex_);
-  if (!pp_instance_) return false;
+  if (!pp_instance_)
+    return false;
   pp_instance_->PostMessage(var);
   return true;
 }

--- a/common/cpp/src/google_smart_card_common/logging/function_call_tracer.cc
+++ b/common/cpp/src/google_smart_card_common/logging/function_call_tracer.cc
@@ -48,9 +48,11 @@ void FunctionCallTracer::LogEntrance() const {
 
 void FunctionCallTracer::LogExit() const {
   std::string results_part;
-  if (dumped_return_value_) results_part = *dumped_return_value_;
+  if (dumped_return_value_)
+    results_part = *dumped_return_value_;
   if (!returned_args_.empty()) {
-    if (!results_part.empty()) results_part += ", ";
+    if (!results_part.empty())
+      results_part += ", ";
     results_part += DumpArgs(returned_args_);
   }
 
@@ -60,7 +62,8 @@ void FunctionCallTracer::LogExit() const {
 }
 
 FunctionCallTracer::ArgNameWithValue::ArgNameWithValue(
-    const std::string& name, const std::string& dumped_value)
+    const std::string& name,
+    const std::string& dumped_value)
     : name(name), dumped_value(dumped_value) {}
 
 // static
@@ -68,7 +71,8 @@ std::string FunctionCallTracer::DumpArgs(
     const std::vector<ArgNameWithValue>& args) {
   std::string result;
   for (const auto& arg : args) {
-    if (!result.empty()) result += ", ";
+    if (!result.empty())
+      result += ", ";
     result += arg.name;
     result += "=";
     result += arg.dumped_value;

--- a/common/cpp/src/google_smart_card_common/logging/hex_dumping.cc
+++ b/common/cpp/src/google_smart_card_common/logging/hex_dumping.cc
@@ -37,7 +37,8 @@ std::string HexDumpIntegerWithExactBitLength(T value, int bit_length) {
   // representation), and then the adjustment of the negative numbers is made
   // when necessary (if the original bit length was smaller than 64).
   uint64_t value_to_dump = static_cast<uint64_t>(value);
-  if (value < 0 && bit_length < 64) value_to_dump += 1ULL << bit_length;
+  if (value < 0 && bit_length < 64)
+    value_to_dump += 1ULL << bit_length;
 
   std::ostringstream stream;
   stream.setf(std::ios::uppercase);
@@ -96,7 +97,8 @@ std::string HexDumpOctlet(uint64_t value) {
 }
 
 std::string HexDumpPointer(const void* value) {
-  if (!value) return "NULL";
+  if (!value)
+    return "NULL";
   return HexDumpInteger(reinterpret_cast<uintptr_t>(value));
 }
 
@@ -109,18 +111,21 @@ std::string HexDumpUnknownSizeInteger(uint64_t value) {
 }
 
 std::string HexDumpBytes(const void* begin, int64_t size) {
-  if (size) GOOGLE_SMART_CARD_CHECK(begin);
+  if (size)
+    GOOGLE_SMART_CARD_CHECK(begin);
   const uint8_t* const begin_casted = static_cast<const uint8_t*>(begin);
   std::string result;
   for (int64_t index = 0; index < size; ++index) {
-    if (index) result += ' ';
+    if (index)
+      result += ' ';
     result += HexDumpByte(begin_casted[index]);
   }
   return result;
 }
 
 std::string HexDumpBytes(const std::vector<uint8_t>& bytes) {
-  if (bytes.empty()) return "";
+  if (bytes.empty())
+    return "";
   return HexDumpBytes(&bytes[0], bytes.size());
 }
 

--- a/common/cpp/src/google_smart_card_common/logging/hex_dumping.h
+++ b/common/cpp/src/google_smart_card_common/logging/hex_dumping.h
@@ -69,8 +69,9 @@ std::string HexDumpPointer(const void* value);
 //
 
 template <typename T>
-inline typename std::enable_if<
-    sizeof(T) == sizeof(int8_t) && std::is_signed<T>::value, std::string>::type
+inline typename std::enable_if<sizeof(T) == sizeof(int8_t) &&
+                                   std::is_signed<T>::value,
+                               std::string>::type
 HexDumpInteger(T value) {
   return HexDumpByte(static_cast<int8_t>(value));
 }
@@ -84,8 +85,9 @@ HexDumpInteger(T value) {
 }
 
 template <typename T>
-inline typename std::enable_if<
-    sizeof(T) == sizeof(int16_t) && std::is_signed<T>::value, std::string>::type
+inline typename std::enable_if<sizeof(T) == sizeof(int16_t) &&
+                                   std::is_signed<T>::value,
+                               std::string>::type
 HexDumpInteger(T value) {
   return HexDumpDoublet(static_cast<int16_t>(value));
 }
@@ -99,8 +101,9 @@ HexDumpInteger(T value) {
 }
 
 template <typename T>
-inline typename std::enable_if<
-    sizeof(T) == sizeof(int32_t) && std::is_signed<T>::value, std::string>::type
+inline typename std::enable_if<sizeof(T) == sizeof(int32_t) &&
+                                   std::is_signed<T>::value,
+                               std::string>::type
 HexDumpInteger(T value) {
   return HexDumpQuadlet(static_cast<int32_t>(value));
 }
@@ -114,8 +117,9 @@ HexDumpInteger(T value) {
 }
 
 template <typename T>
-inline typename std::enable_if<
-    sizeof(T) == sizeof(int64_t) && std::is_signed<T>::value, std::string>::type
+inline typename std::enable_if<sizeof(T) == sizeof(int64_t) &&
+                                   std::is_signed<T>::value,
+                               std::string>::type
 HexDumpInteger(T value) {
   return HexDumpOctlet(static_cast<int64_t>(value));
 }

--- a/common/cpp/src/google_smart_card_common/logging/logging.cc
+++ b/common/cpp/src/google_smart_card_common/logging/logging.cc
@@ -132,7 +132,8 @@ void EmitLogMessageToJavaScript(LogSeverity severity,
     for (const std::pair<PP_Instance, pp::Instance*>& instance_map_item :
          pp_instance_map) {
       pp::Instance* const instance = instance_map_item.second;
-      if (instance) instance->PostMessage(message);
+      if (instance)
+        instance->PostMessage(message);
     }
   }
 }
@@ -166,10 +167,13 @@ LogMessage::~LogMessage() {
   }
 }
 
-std::ostringstream& LogMessage::stream() { return stream_; }
+std::ostringstream& LogMessage::stream() {
+  return stream_;
+}
 
 std::string MakeCheckFailedMessage(const std::string& stringified_condition,
-                                   const std::string& file, int line,
+                                   const std::string& file,
+                                   int line,
                                    const std::string& function) {
   std::ostringstream stream;
   stream << "Check \"" << stringified_condition << "\" failed. File \"" << file
@@ -177,7 +181,8 @@ std::string MakeCheckFailedMessage(const std::string& stringified_condition,
   return stream.str();
 }
 
-std::string MakeNotreachedHitMessage(const std::string& file, int line,
+std::string MakeNotreachedHitMessage(const std::string& file,
+                                     int line,
                                      const std::string& function) {
   std::ostringstream stream;
   stream << "NOTREACHED hit at file \"" << file << "\", line " << line

--- a/common/cpp/src/google_smart_card_common/logging/logging.h
+++ b/common/cpp/src/google_smart_card_common/logging/logging.h
@@ -53,10 +53,12 @@ class LogMessage final {
 };
 
 std::string MakeCheckFailedMessage(const std::string& stringified_condition,
-                                   const std::string& file, int line,
+                                   const std::string& file,
+                                   int line,
                                    const std::string& function);
 
-std::string MakeNotreachedHitMessage(const std::string& file, int line,
+std::string MakeNotreachedHitMessage(const std::string& file,
+                                     int line,
                                      const std::string& function);
 
 #define GOOGLE_SMART_CARD_INTERNAL_LOGGING_WITH_SEVERITY(severity) \

--- a/common/cpp/src/google_smart_card_common/logging/mask_dumping.h
+++ b/common/cpp/src/google_smart_card_common/logging/mask_dumping.h
@@ -35,19 +35,24 @@ struct MaskOptionValueWithName {
 
 template <typename T, typename... Args>
 inline std::string DumpMask(
-    T value, const std::vector<MaskOptionValueWithName<T>>& options) {
+    T value,
+    const std::vector<MaskOptionValueWithName<T>>& options) {
   std::string result;
   for (const auto& option : options) {
-    if (!(value & option.value)) continue;
-    if (!result.empty()) result += '|';
+    if (!(value & option.value))
+      continue;
+    if (!result.empty())
+      result += '|';
     result += option.name;
     value &= ~option.value;
   }
   if (value) {
-    if (!result.empty()) result += '|';
+    if (!result.empty())
+      result += '|';
     result += HexDumpInteger(value);
   }
-  if (result.empty()) return "0";
+  if (result.empty())
+    return "0";
   return result;
 }
 

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_router.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_router.cc
@@ -76,7 +76,8 @@ TypedMessageListener* TypedMessageRouter::FindListenerByType(
   const std::unique_lock<std::mutex> lock(mutex_);
 
   const auto route_map_iter = route_map_.find(message_type);
-  if (route_map_iter == route_map_.end()) return nullptr;
+  if (route_map_iter == route_map_.end())
+    return nullptr;
   return route_map_iter->second;
 }
 

--- a/common/cpp/src/google_smart_card_common/multi_string.cc
+++ b/common/cpp/src/google_smart_card_common/multi_string.cc
@@ -21,7 +21,8 @@ namespace google_smart_card {
 namespace {
 
 std::vector<std::string> ExtractMultiStringElements(
-    const char* multi_string, const char** multi_string_end) {
+    const char* multi_string,
+    const char** multi_string_end) {
   std::vector<std::string> result;
   const char* current_begin = multi_string;
   while (*current_begin != '\0') {

--- a/common/cpp/src/google_smart_card_common/numeric_conversions.cc
+++ b/common/cpp/src/google_smart_card_common/numeric_conversions.cc
@@ -28,7 +28,8 @@ constexpr int64_t kDoubleExactRangeMin =
 
 }  // namespace internal
 
-bool CastDoubleToInt64(double value, int64_t* result,
+bool CastDoubleToInt64(double value,
+                       int64_t* result,
                        std::string* error_message) {
   if (!(internal::kDoubleExactRangeMin <= value &&
         value <= internal::kDoubleExactRangeMax)) {

--- a/common/cpp/src/google_smart_card_common/numeric_conversions.h
+++ b/common/cpp/src/google_smart_card_common/numeric_conversions.h
@@ -44,14 +44,16 @@ extern const int64_t kDoubleExactRangeMin;
 // Performs safe cast of double value into a 64-bit integer value (fails if the
 // value is outside the range of integers that can be represented by the double
 // type exactly).
-bool CastDoubleToInt64(double value, int64_t* result,
+bool CastDoubleToInt64(double value,
+                       int64_t* result,
                        std::string* error_message = nullptr);
 
 namespace internal {
 
 template <typename T>
 inline int GetIntegerSign(T value) {
-  if (!value) return 0;
+  if (!value)
+    return 0;
   return value > 0 ? +1 : -1;
 }
 
@@ -72,18 +74,21 @@ inline int CompareIntegers(T1 value_1, T2 value_2) {
   // numbers.
   const int sign_1 = internal::GetIntegerSign(value_1);
   const int sign_2 = internal::GetIntegerSign(value_2);
-  if (sign_1 != sign_2) return sign_1 < sign_2 ? -1 : +1;
+  if (sign_1 != sign_2)
+    return sign_1 < sign_2 ? -1 : +1;
   using CommonType = typename std::common_type<T1, T2>::type;
   const CommonType promoted_value_1 = static_cast<CommonType>(value_1);
   const CommonType promoted_value_2 = static_cast<CommonType>(value_2);
-  if (promoted_value_1 == promoted_value_2) return 0;
+  if (promoted_value_1 == promoted_value_2)
+    return 0;
   return promoted_value_1 < promoted_value_2 ? -1 : +1;
 }
 
 // Performs safe cast of an integer value into another integer value, possibly
 // of different type (fails if the value is outside the target type range).
 template <typename SourceType, typename TargetType>
-inline bool CastInteger(SourceType source_value, const char* target_type_name,
+inline bool CastInteger(SourceType source_value,
+                        const char* target_type_name,
                         TargetType* target_value,
                         std::string* error_message = nullptr) {
   static_assert(std::is_integral<SourceType>::value,
@@ -112,7 +117,8 @@ inline bool CastInteger(SourceType source_value, const char* target_type_name,
 // is outside the range of integers that can be represented by the double type
 // exactly).
 template <typename T>
-inline bool CastIntegerToDouble(T value, double* result,
+inline bool CastIntegerToDouble(T value,
+                                double* result,
                                 std::string* error_message) {
   if (CompareIntegers(internal::kDoubleExactRangeMin, value) <= 0 &&
       CompareIntegers(internal::kDoubleExactRangeMax, value) >= 0) {

--- a/common/cpp/src/google_smart_card_common/numeric_conversions_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/numeric_conversions_unittest.cc
@@ -93,7 +93,8 @@ TEST_F(NumericConversionsDoubleCastingTest, ValuesOutsideDoubleExactRange) {
 class NumericConversionsIntegerCastingTest : public ::testing::Test {
  protected:
   template <typename TargetIntegerType>
-  void TestCasting(int64_t value, const char* type_name,
+  void TestCasting(int64_t value,
+                   const char* type_name,
                    bool expected_success) const {
     TargetIntegerType result_value;
     std::string error_message;

--- a/common/cpp/src/google_smart_card_common/optional.h
+++ b/common/cpp/src/google_smart_card_common/optional.h
@@ -83,14 +83,16 @@ class optional final {
   void reset() { storage_.reset(); }
 
   bool operator<(const optional& other) const {
-    if (!*this || !other) return !*this && other;
+    if (!*this || !other)
+      return !*this && other;
     return value() < other.value();
   }
 
   bool operator>(const optional& other) const { return other < *this; }
 
   bool operator==(const optional& other) const {
-    if (!*this || !other) return !*this == !other;
+    if (!*this || !other)
+      return !*this == !other;
     return value() == other.value();
   }
 

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/construction.cc
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/construction.cc
@@ -51,15 +51,25 @@ bool IsStringValidForVar(const std::string& string) {
 
 }  // namespace
 
-pp::Var MakeVar(unsigned value) { return MakeVarFromInteger(value); }
+pp::Var MakeVar(unsigned value) {
+  return MakeVarFromInteger(value);
+}
 
-pp::Var MakeVar(long value) { return MakeVarFromInteger(value); }
+pp::Var MakeVar(long value) {
+  return MakeVarFromInteger(value);
+}
 
-pp::Var MakeVar(unsigned long value) { return MakeVarFromInteger(value); }
+pp::Var MakeVar(unsigned long value) {
+  return MakeVarFromInteger(value);
+}
 
-pp::Var MakeVar(int64_t value) { return MakeVarFromInteger(value); }
+pp::Var MakeVar(int64_t value) {
+  return MakeVarFromInteger(value);
+}
 
-pp::Var MakeVar(uint64_t value) { return MakeVarFromInteger(value); }
+pp::Var MakeVar(uint64_t value) {
+  return MakeVarFromInteger(value);
+}
 
 pp::Var MakeVar(const std::string& value) {
   GOOGLE_SMART_CARD_CHECK(IsStringValidForVar(value));
@@ -79,7 +89,8 @@ std::string CleanupStringForVar(const std::string& string) {
 }
 
 pp::VarArrayBuffer MakeVarArrayBuffer(const std::vector<uint8_t>& data) {
-  if (data.empty()) return pp::VarArrayBuffer();
+  if (data.empty())
+    return pp::VarArrayBuffer();
   return MakeVarArrayBuffer(&data[0], data.size());
 }
 

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/construction.h
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/construction.h
@@ -72,7 +72,8 @@ pp::Var MakeVar(const std::string& value);
 
 template <typename T>
 inline pp::Var MakeVar(const optional<T>& value) {
-  if (!value) return pp::Var();
+  if (!value)
+    return pp::Var();
   return MakeVar(*value);
 }
 
@@ -106,8 +107,10 @@ inline void FillVarArray(pp::VarArray* /*var*/,
                          uint32_t /*current_item_index*/) {}
 
 template <typename Arg, typename... Args>
-inline void FillVarArray(pp::VarArray* var, uint32_t current_item_index,
-                         const Arg& arg, const Args&... args) {
+inline void FillVarArray(pp::VarArray* var,
+                         uint32_t current_item_index,
+                         const Arg& arg,
+                         const Args&... args) {
   GOOGLE_SMART_CARD_CHECK(var->Set(current_item_index, MakeVar(arg)));
   FillVarArray(var, current_item_index + 1, args...);
 }

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/copying.cc
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/copying.cc
@@ -59,27 +59,38 @@ pp::VarDictionary CopyVarDictUpToDepth(const pp::VarDictionary& var,
 
 pp::Var CopyVarUpToDepth(const pp::Var& var, int depth) {
   GOOGLE_SMART_CARD_CHECK(depth >= 0);
-  if (!depth) return var;
-  if (var.is_undefined()) return pp::Var();
-  if (var.is_null()) return pp::Var::Null();
-  if (var.is_bool()) return var.AsBool();
-  if (var.is_string()) return var.AsString();
+  if (!depth)
+    return var;
+  if (var.is_undefined())
+    return pp::Var();
+  if (var.is_null())
+    return pp::Var::Null();
+  if (var.is_bool())
+    return var.AsBool();
+  if (var.is_string())
+    return var.AsString();
   if (var.is_object())
     GOOGLE_SMART_CARD_LOG_FATAL << "Cannot copy object Pepper value";
-  if (var.is_array()) return CopyVarArrayUpToDepth(pp::VarArray(var), depth);
+  if (var.is_array())
+    return CopyVarArrayUpToDepth(pp::VarArray(var), depth);
   if (var.is_dictionary())
     return CopyVarDictUpToDepth(pp::VarDictionary(var), depth);
   if (var.is_resource())
     GOOGLE_SMART_CARD_LOG_FATAL << "Cannot copy resource Pepper value";
-  if (var.is_int()) return var.AsInt();
-  if (var.is_double()) return var.AsDouble();
-  if (var.is_array_buffer()) return CopyVarArrayBuffer(pp::VarArrayBuffer(var));
+  if (var.is_int())
+    return var.AsInt();
+  if (var.is_double())
+    return var.AsDouble();
+  if (var.is_array_buffer())
+    return CopyVarArrayBuffer(pp::VarArrayBuffer(var));
   GOOGLE_SMART_CARD_NOTREACHED;
 }
 
 }  // namespace
 
-pp::Var ShallowCopyVar(const pp::Var& var) { return CopyVarUpToDepth(var, 1); }
+pp::Var ShallowCopyVar(const pp::Var& var) {
+  return CopyVarUpToDepth(var, 1);
+}
 
 pp::VarArray ShallowCopyVar(const pp::VarArray& var) {
   return CopyVarArrayUpToDepth(var, 1);

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/debug_dump.cc
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/debug_dump.cc
@@ -39,23 +39,36 @@ const char kRealJsTypeTitle[] = "Real";
 const char kArrayBufferJsTypeTitle[] = "ArrayBuffer";
 
 std::string GetVarTypeTitle(const pp::Var& var) {
-  if (var.is_undefined()) return kUndefinedJsTypeTitle;
-  if (var.is_null()) return kNullJsTypeTitle;
-  if (var.is_bool()) return kBooleanJsTypeTitle;
-  if (var.is_string()) return kStringJsTypeTitle;
-  if (var.is_object()) return kObjectJsTypeTitle;
-  if (var.is_array()) return kArrayJsTypeTitle;
-  if (var.is_dictionary()) return kDictionaryJsTypeTitle;
-  if (var.is_resource()) return kResourceJsTypeTitle;
-  if (var.is_int()) return kIntegerJsTypeTitle;
-  if (var.is_double()) return kRealJsTypeTitle;
-  if (var.is_array_buffer()) return kArrayBufferJsTypeTitle;
+  if (var.is_undefined())
+    return kUndefinedJsTypeTitle;
+  if (var.is_null())
+    return kNullJsTypeTitle;
+  if (var.is_bool())
+    return kBooleanJsTypeTitle;
+  if (var.is_string())
+    return kStringJsTypeTitle;
+  if (var.is_object())
+    return kObjectJsTypeTitle;
+  if (var.is_array())
+    return kArrayJsTypeTitle;
+  if (var.is_dictionary())
+    return kDictionaryJsTypeTitle;
+  if (var.is_resource())
+    return kResourceJsTypeTitle;
+  if (var.is_int())
+    return kIntegerJsTypeTitle;
+  if (var.is_double())
+    return kRealJsTypeTitle;
+  if (var.is_array_buffer())
+    return kArrayBufferJsTypeTitle;
   GOOGLE_SMART_CARD_NOTREACHED;
 }
 
 namespace {
 
-std::string DumpBoolValue(bool value) { return value ? "true" : "false"; }
+std::string DumpBoolValue(bool value) {
+  return value ? "true" : "false";
+}
 
 std::string DumpStringValue(const std::string& value) {
   return '"' + value + '"';
@@ -64,7 +77,8 @@ std::string DumpStringValue(const std::string& value) {
 std::string DumpVarArrayValue(const pp::VarArray& var) {
   std::string result = "[";
   for (uint32_t index = 0; index < var.GetLength(); ++index) {
-    if (index > 0) result += ", ";
+    if (index > 0)
+      result += ", ";
     result += DumpVar(var.Get(index));
   }
   result += "]";
@@ -75,7 +89,8 @@ std::string DumpVarDictValue(const pp::VarDictionary& var) {
   std::string result = "{";
   const pp::VarArray keys = var.GetKeys();
   for (uint32_t index = 0; index < keys.GetLength(); ++index) {
-    if (index > 0) result += ", ";
+    if (index > 0)
+      result += ", ";
     const pp::Var key = keys.Get(index);
     GOOGLE_SMART_CARD_CHECK(key.is_string());
     result += DumpStringValue(key.AsString()) + ": " + DumpVar(var.Get(key));
@@ -88,7 +103,8 @@ std::string DumpVarArrayBufferValue(pp::VarArrayBuffer var) {
   const uint8_t* const data = static_cast<const uint8_t*>(var.Map());
   std::string result = std::string(kArrayBufferJsTypeTitle) + "[";
   for (uint32_t offset = 0; offset < var.ByteLength(); ++offset) {
-    if (offset > 0) result += ", ";
+    if (offset > 0)
+      result += ", ";
     result += HexDumpByte(data[offset]);
   }
   result += "]";
@@ -107,17 +123,26 @@ std::string DebugDumpVar(const pp::Var& var) {
 }
 
 std::string DumpVar(const pp::Var& var) {
-  if (var.is_undefined()) return kUndefinedJsTypeTitle;
-  if (var.is_null()) return kNullJsTypeTitle;
-  if (var.is_bool()) return DumpBoolValue(var.AsBool());
-  if (var.is_string()) return DumpStringValue(var.AsString());
-  if (var.is_object()) return std::string(kObjectJsTypeTitle) + "<...>";
-  if (var.is_array()) return DumpVarArrayValue(pp::VarArray(var));
-  if (var.is_dictionary()) return DumpVarDictValue(pp::VarDictionary(var));
-  if (var.is_resource()) return std::string(kResourceJsTypeTitle) + "<...>";
+  if (var.is_undefined())
+    return kUndefinedJsTypeTitle;
+  if (var.is_null())
+    return kNullJsTypeTitle;
+  if (var.is_bool())
+    return DumpBoolValue(var.AsBool());
+  if (var.is_string())
+    return DumpStringValue(var.AsString());
+  if (var.is_object())
+    return std::string(kObjectJsTypeTitle) + "<...>";
+  if (var.is_array())
+    return DumpVarArrayValue(pp::VarArray(var));
+  if (var.is_dictionary())
+    return DumpVarDictValue(pp::VarDictionary(var));
+  if (var.is_resource())
+    return std::string(kResourceJsTypeTitle) + "<...>";
   if (var.is_int())
     return HexDumpUnknownSizeInteger(static_cast<int64_t>(var.AsInt()));
-  if (var.is_double()) return std::to_string(var.AsDouble());
+  if (var.is_double())
+    return std::to_string(var.AsDouble());
   if (var.is_array_buffer())
     return DumpVarArrayBufferValue(pp::VarArrayBuffer(var));
   GOOGLE_SMART_CARD_NOTREACHED;

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/enum_converter.h
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/enum_converter.h
@@ -77,7 +77,8 @@ class EnumConverter final {
   //
   // Fails if the Pepper value has unexpected type, or if the value is not
   // corresponding to any C/C++ enum value.
-  static bool ConvertFromVar(const pp::Var& var, EnumType* result,
+  static bool ConvertFromVar(const pp::Var& var,
+                             EnumType* result,
                              std::string* error_message) {
     GOOGLE_SMART_CARD_CHECK(result);
     GOOGLE_SMART_CARD_CHECK(error_message);

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/extraction.cc
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/extraction.cc
@@ -26,7 +26,9 @@ constexpr char kErrorWrongType[] =
     "Expected a value of type \"%s\", instead got: %s";
 
 template <typename T>
-bool VarAsInteger(const pp::Var& var, const char* type_name, T* result,
+bool VarAsInteger(const pp::Var& var,
+                  const char* type_name,
+                  T* result,
                   std::string* error_message) {
   int64_t integer;
   if (var.is_int()) {
@@ -80,14 +82,16 @@ bool VarAs(const pp::Var& var, long* result, std::string* error_message) {
   return VarAsInteger(var, "long", result, error_message);
 }
 
-bool VarAs(const pp::Var& var, unsigned long* result,
+bool VarAs(const pp::Var& var,
+           unsigned long* result,
            std::string* error_message) {
   return VarAsInteger(var, "unsigned long", result, error_message);
 }
 
 bool VarAs(const pp::Var& var, float* result, std::string* error_message) {
   double double_value;
-  if (!VarAs(var, &double_value, error_message)) return false;
+  if (!VarAs(var, &double_value, error_message))
+    return false;
   *result = static_cast<float>(double_value);
   return true;
 }
@@ -112,7 +116,8 @@ bool VarAs(const pp::Var& var, bool* result, std::string* error_message) {
   return true;
 }
 
-bool VarAs(const pp::Var& var, std::string* result,
+bool VarAs(const pp::Var& var,
+           std::string* result,
            std::string* error_message) {
   if (!var.is_string()) {
     *error_message = FormatPrintfTemplate(kErrorWrongType, kStringJsTypeTitle,
@@ -123,13 +128,15 @@ bool VarAs(const pp::Var& var, std::string* result,
   return true;
 }
 
-bool VarAs(const pp::Var& var, pp::Var* result,
+bool VarAs(const pp::Var& var,
+           pp::Var* result,
            std::string* /*error_message*/) {
   *result = var;
   return true;
 }
 
-bool VarAs(const pp::Var& var, pp::VarArray* result,
+bool VarAs(const pp::Var& var,
+           pp::VarArray* result,
            std::string* error_message) {
   if (!var.is_array()) {
     *error_message = FormatPrintfTemplate(kErrorWrongType, kArrayJsTypeTitle,
@@ -140,7 +147,8 @@ bool VarAs(const pp::Var& var, pp::VarArray* result,
   return true;
 }
 
-bool VarAs(const pp::Var& var, pp::VarArrayBuffer* result,
+bool VarAs(const pp::Var& var,
+           pp::VarArrayBuffer* result,
            std::string* error_message) {
   if (!var.is_array_buffer()) {
     *error_message = FormatPrintfTemplate(
@@ -151,7 +159,8 @@ bool VarAs(const pp::Var& var, pp::VarArrayBuffer* result,
   return true;
 }
 
-bool VarAs(const pp::Var& var, pp::VarDictionary* result,
+bool VarAs(const pp::Var& var,
+           pp::VarDictionary* result,
            std::string* error_message) {
   if (!var.is_dictionary()) {
     *error_message = FormatPrintfTemplate(
@@ -162,7 +171,8 @@ bool VarAs(const pp::Var& var, pp::VarDictionary* result,
   return true;
 }
 
-bool VarAs(const pp::Var& var, pp::Var::Null* /*result*/,
+bool VarAs(const pp::Var& var,
+           pp::Var::Null* /*result*/,
            std::string* error_message) {
   if (!var.is_null()) {
     *error_message = FormatPrintfTemplate(kErrorWrongType, kNullJsTypeTitle,
@@ -193,8 +203,10 @@ int GetVarArraySize(const pp::VarArray& var) {
   return static_cast<int>(var.GetLength());
 }
 
-bool GetVarDictValue(const pp::VarDictionary& var, const std::string& key,
-                     pp::Var* result, std::string* error_message) {
+bool GetVarDictValue(const pp::VarDictionary& var,
+                     const std::string& key,
+                     pp::Var* result,
+                     std::string* error_message) {
   if (!var.HasKey(key)) {
     *error_message =
         FormatPrintfTemplate("The dictionary has no key \"%s\"", key.c_str());
@@ -229,11 +241,13 @@ bool VarDictValuesExtractor::GetSuccess(std::string* error_message) const {
 
 bool VarDictValuesExtractor::GetSuccessWithNoExtraKeysAllowed(
     std::string* error_message) const {
-  if (!GetSuccess(error_message)) return false;
+  if (!GetSuccess(error_message))
+    return false;
   if (!not_requested_keys_.empty()) {
     std::string unexpected_keys_dump;
     for (const std::string& key : not_requested_keys_) {
-      if (!unexpected_keys_dump.empty()) unexpected_keys_dump += ", ";
+      if (!unexpected_keys_dump.empty())
+        unexpected_keys_dump += ", ";
       unexpected_keys_dump += '"' + key + '"';
     }
     *error_message =
@@ -246,7 +260,8 @@ bool VarDictValuesExtractor::GetSuccessWithNoExtraKeysAllowed(
 
 void VarDictValuesExtractor::CheckSuccess() const {
   std::string error_message;
-  if (!GetSuccess(&error_message)) GOOGLE_SMART_CARD_LOG_FATAL << error_message;
+  if (!GetSuccess(&error_message))
+    GOOGLE_SMART_CARD_LOG_FATAL << error_message;
 }
 
 void VarDictValuesExtractor::CheckSuccessWithNoExtraKeysAllowed() const {
@@ -260,7 +275,8 @@ void VarDictValuesExtractor::AddRequestedKey(const std::string& key) {
 }
 
 void VarDictValuesExtractor::ProcessFailedExtraction(
-    const std::string& key, const std::string& extraction_error_message) {
+    const std::string& key,
+    const std::string& extraction_error_message) {
   if (failed_) {
     // We could concatenate all occurred errors, but storing of the first error
     // only should be enough.

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/extraction.h
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/extraction.h
@@ -80,7 +80,8 @@ bool VarAs(const pp::Var& var, uint64_t* result, std::string* error_message);
 
 bool VarAs(const pp::Var& var, long* result, std::string* error_message);
 
-bool VarAs(const pp::Var& var, unsigned long* result,
+bool VarAs(const pp::Var& var,
+           unsigned long* result,
            std::string* error_message);
 
 bool VarAs(const pp::Var& var, float* result, std::string* error_message);
@@ -93,27 +94,33 @@ bool VarAs(const pp::Var& var, std::string* result, std::string* error_message);
 
 bool VarAs(const pp::Var& var, pp::Var* result, std::string* error_message);
 
-bool VarAs(const pp::Var& var, pp::VarArray* result,
+bool VarAs(const pp::Var& var,
+           pp::VarArray* result,
            std::string* error_message);
 
-bool VarAs(const pp::Var& var, pp::VarArrayBuffer* result,
+bool VarAs(const pp::Var& var,
+           pp::VarArrayBuffer* result,
            std::string* error_message);
 
-bool VarAs(const pp::Var& var, pp::VarDictionary* result,
+bool VarAs(const pp::Var& var,
+           pp::VarDictionary* result,
            std::string* error_message);
 
-bool VarAs(const pp::Var& var, pp::Var::Null* result,
+bool VarAs(const pp::Var& var,
+           pp::Var::Null* result,
            std::string* error_message);
 
 template <typename T>
-inline bool VarAs(const pp::Var& var, optional<T>* result,
+inline bool VarAs(const pp::Var& var,
+                  optional<T>* result,
                   std::string* error_message) {
   if (var.is_undefined() || var.is_null()) {
     result->reset();
     return true;
   }
   T result_value;
-  if (!VarAs(var, &result_value, error_message)) return false;
+  if (!VarAs(var, &result_value, error_message))
+    return false;
   *result = result_value;
   return true;
 }
@@ -137,10 +144,12 @@ inline bool GetVarArrayItemsVector(const pp::VarArray& var,
 }
 
 template <typename T>
-inline bool VarAsVarArrayAsVector(const pp::Var& var, std::vector<T>* result,
+inline bool VarAsVarArrayAsVector(const pp::Var& var,
+                                  std::vector<T>* result,
                                   std::string* error_message) {
   pp::VarArray var_array;
-  if (!VarAs(var, &var_array, error_message)) return false;
+  if (!VarAs(var, &var_array, error_message))
+    return false;
   return GetVarArrayItemsVector(var_array, result, error_message);
 }
 
@@ -163,13 +172,15 @@ inline bool VarAsVarArrayBufferAsUint8Vector(const pp::Var& var,
 }  // namespace internal
 
 template <typename T>
-inline bool VarAs(const pp::Var& var, std::vector<T>* result,
+inline bool VarAs(const pp::Var& var,
+                  std::vector<T>* result,
                   std::string* error_message) {
   return internal::VarAsVarArrayAsVector(var, result, error_message);
 }
 
 template <>
-inline bool VarAs(const pp::Var& var, std::vector<uint8_t>* result,
+inline bool VarAs(const pp::Var& var,
+                  std::vector<uint8_t>* result,
                   std::string* error_message) {
   return internal::VarAsVarArrayAsVector(var, result, error_message) ||
          internal::VarAsVarArrayBufferAsUint8Vector(var, result, error_message);
@@ -197,8 +208,10 @@ int GetVarArraySize(const pp::VarArray& var);
 // Extracts the value from the Pepper dictionary by the given key.
 //
 // Returns false (and sets error_message) if the requested key is not present.
-bool GetVarDictValue(const pp::VarDictionary& var, const std::string& key,
-                     pp::Var* result, std::string* error_message);
+bool GetVarDictValue(const pp::VarDictionary& var,
+                     const std::string& key,
+                     pp::Var* result,
+                     std::string* error_message);
 
 // Extracts the value from the dictionary by the given key.
 //
@@ -214,7 +227,8 @@ pp::Var GetVarDictValue(const pp::VarDictionary& var, const std::string& key);
 // if the value conversion didn't succeed.
 template <typename T>
 inline bool GetVarDictValueAs(const pp::VarDictionary& var,
-                              const std::string& key, T* result,
+                              const std::string& key,
+                              T* result,
                               std::string* error_message) {
   pp::Var value_var;
   if (!GetVarDictValue(var, key, &value_var, error_message)) {
@@ -245,7 +259,8 @@ inline T GetVarDictValueAs(const pp::VarDictionary& var,
 
 namespace internal {
 
-inline bool IsVarArraySizeValid(const pp::VarArray& var, size_t expected_size,
+inline bool IsVarArraySizeValid(const pp::VarArray& var,
+                                size_t expected_size,
                                 std::string* error_message) {
   if (var.GetLength() != expected_size) {
     *error_message = FormatPrintfTemplate(
@@ -267,7 +282,8 @@ inline bool TryGetVarArrayItemsInternal(const pp::VarArray& /*var*/,
 template <typename Arg, typename... Args>
 inline bool TryGetVarArrayItemsInternal(const pp::VarArray& var,
                                         uint32_t current_item_index,
-                                        std::string* error_message, Arg* arg,
+                                        std::string* error_message,
+                                        Arg* arg,
                                         Args*... args) {
   if (!VarAs(var.Get(current_item_index), arg, error_message)) {
     *error_message = FormatPrintfTemplate(
@@ -285,7 +301,8 @@ inline bool TryGetVarArrayItemsInternal(const pp::VarArray& var,
 // if some value conversion didn't succeed.
 template <typename... Args>
 inline bool TryGetVarArrayItems(const pp::VarArray& var,
-                                std::string* error_message, Args*... args) {
+                                std::string* error_message,
+                                Args*... args) {
   return internal::IsVarArraySizeValid(var, sizeof...(Args), error_message) &&
          TryGetVarArrayItemsInternal(var, 0, error_message, args...);
 }

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/operations.cc
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/operations.cc
@@ -16,7 +16,8 @@
 
 namespace google_smart_card {
 
-pp::VarArray SliceVarArray(const pp::VarArray& var, uint32_t begin_index,
+pp::VarArray SliceVarArray(const pp::VarArray& var,
+                           uint32_t begin_index,
                            uint32_t count) {
   GOOGLE_SMART_CARD_CHECK(begin_index + count <= var.GetLength());
   pp::VarArray result;

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/operations.h
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/operations.h
@@ -47,7 +47,8 @@ inline void SetVarArrayItem(pp::VarArray* var, size_t index, const T& value) {
 // Returns a sub-array of the given Pepper array.
 //
 // Asserts the validity of the specified indices.
-pp::VarArray SliceVarArray(const pp::VarArray& var, uint32_t begin_index,
+pp::VarArray SliceVarArray(const pp::VarArray& var,
+                           uint32_t begin_index,
                            uint32_t count);
 
 // Adds or updates the Pepper dictionary item.
@@ -56,7 +57,8 @@ pp::VarArray SliceVarArray(const pp::VarArray& var, uint32_t begin_index,
 // conversion of the passed value into the Pepper value (using the MakeVar
 // function in construction.h file).
 template <typename T>
-inline void SetVarDictValue(pp::VarDictionary* var, const std::string& key,
+inline void SetVarDictValue(pp::VarDictionary* var,
+                            const std::string& key,
                             const T& value) {
   GOOGLE_SMART_CARD_CHECK(var->Set(key, MakeVar(value)));
 }
@@ -68,7 +70,8 @@ inline void SetVarDictValue(pp::VarDictionary* var, const std::string& key,
 // conversion of the passed value into the Pepper value (using the MakeVar
 // function in construction.h file).
 template <typename T>
-inline void AddVarDictValue(pp::VarDictionary* var, const std::string& key,
+inline void AddVarDictValue(pp::VarDictionary* var,
+                            const std::string& key,
                             const T& value) {
   GOOGLE_SMART_CARD_CHECK(!var->HasKey(key));
   SetVarDictValue(var, key, value);

--- a/common/cpp/src/google_smart_card_common/pp_var_utils/struct_converter.h
+++ b/common/cpp/src/google_smart_card_common/pp_var_utils/struct_converter.h
@@ -59,12 +59,14 @@ class StructConverter final {
   // Fails if the Pepper value is not a dictionary, or if it contains some
   // unexpected extra keys, or if at least one key corresponding to a
   // non-optional field is missing.
-  static bool ConvertFromVar(const pp::Var& var, StructType* result,
+  static bool ConvertFromVar(const pp::Var& var,
+                             StructType* result,
                              std::string* error_message) {
     GOOGLE_SMART_CARD_CHECK(result);
     GOOGLE_SMART_CARD_CHECK(error_message);
     pp::VarDictionary var_dict;
-    if (!VarAs(var, &var_dict, error_message)) return false;
+    if (!VarAs(var, &var_dict, error_message))
+      return false;
     VarDictValuesExtractor extractor(var_dict);
     VisitFields(*result, FromVarConversionCallback(&extractor));
     return extractor.GetSuccessWithNoExtraKeysAllowed(error_message);
@@ -114,7 +116,8 @@ class StructConverter final {
     void operator()(const optional<FieldType>* field,
                     const std::string& field_name) {
       GOOGLE_SMART_CARD_CHECK(field);
-      if (*field) SetVarDictValue(target_var_, field_name, **field);
+      if (*field)
+        SetVarDictValue(target_var_, field_name, **field);
     }
 
    private:

--- a/common/cpp/src/google_smart_card_common/requesting/async_requests_storage.h
+++ b/common/cpp/src/google_smart_card_common/requesting/async_requests_storage.h
@@ -65,7 +65,8 @@ class AsyncRequestsStorage final {
     const std::unique_lock<std::mutex> lock(mutex_);
 
     const auto state_map_iter = state_map_.find(request_id);
-    if (state_map_iter == state_map_.end()) return nullptr;
+    if (state_map_iter == state_map_.end())
+      return nullptr;
     const std::shared_ptr<AsyncRequestState<PayloadType>> result =
         state_map_iter->second;
     state_map_.erase(state_map_iter);

--- a/common/cpp/src/google_smart_card_common/requesting/async_requests_storage_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/async_requests_storage_unittest.cc
@@ -107,7 +107,8 @@ TEST(RequestingAsyncRequestsStorageTest, MAYBE_MultiThreading) {
                 TestAsyncRequestCallback())));
       }
       if (thread_index % 2 == 0) {
-        for (auto request_id : request_ids) storage.Pop(request_id);
+        for (auto request_id : request_ids)
+          storage.Pop(request_id);
       } else {
         storage.PopAll();
       }

--- a/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.cc
@@ -50,12 +50,15 @@ JsRequestReceiver::JsRequestReceiver(const std::string& name,
   typed_message_router->AddRoute(this);
 }
 
-JsRequestReceiver::~JsRequestReceiver() { Detach(); }
+JsRequestReceiver::~JsRequestReceiver() {
+  Detach();
+}
 
 void JsRequestReceiver::Detach() {
   TypedMessageRouter* const typed_message_router =
       typed_message_router_.exchange(nullptr);
-  if (typed_message_router) typed_message_router->RemoveRoute(this);
+  if (typed_message_router)
+    typed_message_router->RemoveRoute(this);
 
   pp_delegate_.Reset();
 }

--- a/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.h
+++ b/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.h
@@ -77,7 +77,8 @@ class JsRequestReceiver final : public RequestReceiver,
   //
   // Adds a new route into the passed TypedMessageRouter for receiving the
   // requests messages.
-  JsRequestReceiver(const std::string& name, RequestHandler* request_handler,
+  JsRequestReceiver(const std::string& name,
+                    RequestHandler* request_handler,
                     TypedMessageRouter* typed_message_router,
                     std::unique_ptr<PpDelegate> pp_delegate);
 

--- a/common/cpp/src/google_smart_card_common/requesting/js_requester.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/js_requester.cc
@@ -63,12 +63,15 @@ JsRequester::JsRequester(const std::string& name,
   typed_message_router->AddRoute(this);
 }
 
-JsRequester::~JsRequester() { Detach(); }
+JsRequester::~JsRequester() {
+  Detach();
+}
 
 void JsRequester::Detach() {
   TypedMessageRouter* const typed_message_router =
       typed_message_router_.exchange(nullptr);
-  if (typed_message_router) typed_message_router->RemoveRoute(this);
+  if (typed_message_router)
+    typed_message_router->RemoveRoute(this);
 
   pp_delegate_.Reset();
 
@@ -119,7 +122,8 @@ bool JsRequester::OnTypedMessageReceived(Value data) {
 bool JsRequester::PostPpMessage(const pp::Var& message) {
   const ThreadSafeUniquePtr<PpDelegate>::Locked pp_delegate =
       pp_delegate_.Lock();
-  if (!pp_delegate) return false;
+  if (!pp_delegate)
+    return false;
   pp_delegate->PostMessage(message);
   return true;
 }

--- a/common/cpp/src/google_smart_card_common/requesting/js_requester.h
+++ b/common/cpp/src/google_smart_card_common/requesting/js_requester.h
@@ -81,7 +81,8 @@ class JsRequester final : public Requester, public TypedMessageListener {
   // Note that the passed TypedMessageRouter is allowed to be destroyed earlier
   // than the JsRequester object - but the Detach() method must be called before
   // destroying it.
-  JsRequester(const std::string& name, TypedMessageRouter* typed_message_router,
+  JsRequester(const std::string& name,
+              TypedMessageRouter* typed_message_router,
               std::unique_ptr<PpDelegate> pp_delegate);
 
   JsRequester(const JsRequester&) = delete;
@@ -91,7 +92,8 @@ class JsRequester final : public Requester, public TypedMessageListener {
 
   // Requester implementation
   void Detach() override;
-  void StartAsyncRequest(Value payload, GenericAsyncRequestCallback callback,
+  void StartAsyncRequest(Value payload,
+                         GenericAsyncRequestCallback callback,
                          GenericAsyncRequest* async_request) override;
   // Requester implementation override
   //

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.cc
@@ -31,14 +31,16 @@ RemoteCallAdaptor::RemoteCallAdaptor(Requester* requester)
 RemoteCallAdaptor::~RemoteCallAdaptor() = default;
 
 GenericRequestResult RemoteCallAdaptor::PerformSyncRequest(
-    const std::string& function_name, const pp::VarArray& converted_arguments) {
+    const std::string& function_name,
+    const pp::VarArray& converted_arguments) {
   // TODO(#185): Create `Value` directly, without converting from `pp::Var`.
   return requester_->PerformSyncRequest(ConvertPpVarToValueOrDie(
       MakeRemoteCallRequestPayload(function_name, converted_arguments)));
 }
 
 GenericAsyncRequest RemoteCallAdaptor::StartAsyncRequest(
-    const std::string& function_name, const pp::VarArray& converted_arguments,
+    const std::string& function_name,
+    const pp::VarArray& converted_arguments,
     GenericAsyncRequestCallback callback) {
   // TODO(#185): Create `Value` directly, without converting from `pp::Var`.
   return requester_->StartAsyncRequest(
@@ -48,8 +50,10 @@ GenericAsyncRequest RemoteCallAdaptor::StartAsyncRequest(
 }
 
 void RemoteCallAdaptor::StartAsyncRequest(
-    const std::string& function_name, const pp::VarArray& converted_arguments,
-    GenericAsyncRequestCallback callback, GenericAsyncRequest* async_request) {
+    const std::string& function_name,
+    const pp::VarArray& converted_arguments,
+    GenericAsyncRequestCallback callback,
+    GenericAsyncRequest* async_request) {
   // TODO(#185): Create `Value` directly, without converting from `pp::Var`.
   requester_->StartAsyncRequest(
       ConvertPpVarToValueOrDie(

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.h
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.h
@@ -60,7 +60,8 @@ class RemoteCallAdaptor final {
   template <typename... Args>
   void AsyncCall(GenericAsyncRequest* async_request,
                  GenericAsyncRequestCallback callback,
-                 const std::string& function_name, const Args&... args) {
+                 const std::string& function_name,
+                 const Args&... args) {
     StartAsyncRequest(function_name, ConvertRequestArguments(args...), callback,
                       async_request);
   }
@@ -68,7 +69,8 @@ class RemoteCallAdaptor final {
   template <typename... PayloadFields>
   static bool ExtractResultPayload(
       const GenericRequestResult& generic_request_result,
-      std::string* error_message, PayloadFields*... payload_fields) {
+      std::string* error_message,
+      PayloadFields*... payload_fields) {
     // TODO(emaxx): Probably add details about the function call into the error
     // messages?
     if (!generic_request_result.is_successful()) {

--- a/common/cpp/src/google_smart_card_common/requesting/request_handler.h
+++ b/common/cpp/src/google_smart_card_common/requesting/request_handler.h
@@ -40,7 +40,8 @@ class RequestHandler {
   // synchronously and, depending on the type of channel it uses, may lead to
   // freezes and deadlocks.
   virtual void HandleRequest(
-      Value payload, RequestReceiver::ResultCallback result_callback) = 0;
+      Value payload,
+      RequestReceiver::ResultCallback result_callback) = 0;
 };
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/requesting/request_receiver.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/request_receiver.cc
@@ -30,7 +30,9 @@ RequestReceiver::RequestReceiver(const std::string& name,
 
 RequestReceiver::~RequestReceiver() = default;
 
-std::string RequestReceiver::name() const { return name_; }
+std::string RequestReceiver::name() const {
+  return name_;
+}
 
 void RequestReceiver::HandleRequest(RequestId request_id,
                                     const pp::Var& payload) {
@@ -40,7 +42,8 @@ void RequestReceiver::HandleRequest(RequestId request_id,
 }
 
 RequestReceiver::ResultCallbackImpl::ResultCallbackImpl(
-    RequestId request_id, std::weak_ptr<RequestReceiver> request_receiver)
+    RequestId request_id,
+    std::weak_ptr<RequestReceiver> request_receiver)
     : request_id_(request_id), request_receiver_(request_receiver) {}
 
 RequestReceiver::ResultCallbackImpl::~ResultCallbackImpl() = default;

--- a/common/cpp/src/google_smart_card_common/requesting/requester.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/requester.cc
@@ -43,7 +43,8 @@ Requester::~Requester() {
 }
 
 GenericAsyncRequest Requester::StartAsyncRequest(
-    Value payload, GenericAsyncRequestCallback callback) {
+    Value payload,
+    GenericAsyncRequestCallback callback) {
   GenericAsyncRequest async_result;
   StartAsyncRequest(std::move(payload), callback, &async_result);
   return async_result;
@@ -70,7 +71,8 @@ GenericRequestResult Requester::PerformSyncRequest(Value payload) {
 }
 
 GenericAsyncRequest Requester::CreateAsyncRequest(
-    GenericAsyncRequestCallback callback, RequestId* request_id) {
+    GenericAsyncRequestCallback callback,
+    RequestId* request_id) {
   const auto async_request_state =
       std::make_shared<GenericAsyncRequestState>(callback);
   *request_id = async_requests_storage_.Push(async_request_state);
@@ -81,7 +83,8 @@ bool Requester::SetAsyncRequestResult(RequestId request_id,
                                       GenericRequestResult request_result) {
   const std::shared_ptr<GenericAsyncRequestState> async_request_state =
       async_requests_storage_.Pop(request_id);
-  if (!async_request_state) return false;
+  if (!async_request_state)
+    return false;
   async_request_state->SetResult(std::move(request_result));
   return true;
 }

--- a/common/cpp/src/google_smart_card_common/requesting/requester_message.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/requester_message.cc
@@ -63,7 +63,8 @@ StructValueDescriptor<ResponseMessageData>::GetDescription() {
 
 // static
 ResponseMessageData ResponseMessageData::CreateFromRequestResult(
-    RequestId request_id, GenericRequestResult request_result) {
+    RequestId request_id,
+    GenericRequestResult request_result) {
   ResponseMessageData message_data;
   message_data.request_id = request_id;
   switch (request_result.status()) {

--- a/common/cpp/src/google_smart_card_common/requesting/requester_message.h
+++ b/common/cpp/src/google_smart_card_common/requesting/requester_message.h
@@ -81,7 +81,8 @@ struct RequestMessageData {
 struct ResponseMessageData {
   // Converts the `GenericRequestResult` object into `ResponseMessageData`.
   static ResponseMessageData CreateFromRequestResult(
-      RequestId request_id, GenericRequestResult request_result);
+      RequestId request_id,
+      GenericRequestResult request_result);
   // Creates a `GenericRequestResult` object from the `payload`/`error_message`
   // fields. Returns false in case |this| is invalid (it's expected that exactly
   // one of {`payload`, `error_message`} are non-empty).

--- a/common/cpp/src/google_smart_card_common/value.cc
+++ b/common/cpp/src/google_smart_card_common/value.cc
@@ -92,7 +92,9 @@ Value::Value(DictionaryStorage dictionary_value)
 Value::Value(ArrayStorage array_value)
     : type_(Type::kArray), array_value_(std::move(array_value)) {}
 
-Value::Value(Value&& other) { MoveConstructFrom(std::move(other)); }
+Value::Value(Value&& other) {
+  MoveConstructFrom(std::move(other));
+}
 
 Value& Value::operator=(Value&& other) {
   if (this != &other) {
@@ -102,7 +104,9 @@ Value& Value::operator=(Value&& other) {
   return *this;
 }
 
-Value::~Value() { Destroy(); }
+Value::~Value() {
+  Destroy();
+}
 
 bool Value::GetBoolean() const {
   GOOGLE_SMART_CARD_CHECK(is_boolean());
@@ -157,7 +161,8 @@ Value::ArrayStorage& Value::GetArray() {
 const Value* Value::GetDictionaryItem(const std::string& key) const {
   GOOGLE_SMART_CARD_CHECK(is_dictionary());
   auto iter = dictionary_value_.find(key);
-  if (iter == dictionary_value_.end()) return nullptr;
+  if (iter == dictionary_value_.end())
+    return nullptr;
   return iter->second.get();
 }
 

--- a/common/cpp/src/google_smart_card_common/value_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion.cc
@@ -32,7 +32,9 @@ namespace google_smart_card {
 namespace {
 
 template <typename T>
-bool ConvertIntegerFromValue(Value value, const char* type_name, T* number,
+bool ConvertIntegerFromValue(Value value,
+                             const char* type_name,
+                             T* number,
                              std::string* error_message) {
   int64_t int64_number;
   if (value.is_integer()) {
@@ -70,7 +72,8 @@ EnumToValueConverter::~EnumToValueConverter() = default;
 
 void EnumToValueConverter::HandleItem(int64_t enum_item,
                                       const char* enum_item_name) {
-  if (converted_value_ || enum_to_convert_ != enum_item) return;
+  if (converted_value_ || enum_to_convert_ != enum_item)
+    return;
   converted_value_ = Value(enum_item_name);
 }
 
@@ -102,7 +105,8 @@ void EnumFromValueConverter::HandleItem(int64_t enum_item,
 }
 
 bool EnumFromValueConverter::GetConvertedEnum(
-    const char* type_name, int64_t* converted_enum,
+    const char* type_name,
+    int64_t* converted_enum,
     std::string* error_message) const {
   if (converted_enum_) {
     *converted_enum = *converted_enum_;
@@ -129,8 +133,10 @@ void StructToValueConverterBase::HandleFieldConversionError(
 }
 
 bool StructToValueConverterBase::FinishConversion(
-    const char* type_name, std::string* error_message) const {
-  if (succeeded_) return true;
+    const char* type_name,
+    std::string* error_message) const {
+  if (succeeded_)
+    return true;
   FormatPrintfTemplateAndSet(error_message,
                              "Cannot convert struct %s to value: %s", type_name,
                              inner_error_message_.c_str());
@@ -151,7 +157,8 @@ StructFromValueConverterBase::~StructFromValueConverterBase() = default;
 bool StructFromValueConverterBase::ExtractKey(const char* dictionary_key_name,
                                               bool is_required,
                                               Value* item_value) {
-  if (!succeeded_) return false;
+  if (!succeeded_)
+    return false;
   Value::DictionaryStorage& dict = value_to_convert_.GetDictionary();
   auto iter = dict.find(dictionary_key_name);
   if (iter != dict.end()) {
@@ -178,7 +185,8 @@ void StructFromValueConverterBase::HandleFieldConversionError(
 }
 
 bool StructFromValueConverterBase::FinishConversion(
-    const char* type_name, std::string* error_message) {
+    const char* type_name,
+    std::string* error_message) {
   if (succeeded_ && !value_to_convert_.GetDictionary().empty()) {
     succeeded_ = false;
     const std::string& first_unexpected_key =
@@ -186,7 +194,8 @@ bool StructFromValueConverterBase::FinishConversion(
     inner_error_message_ = FormatPrintfTemplate("Unexpected key \"%s\"",
                                                 first_unexpected_key.c_str());
   }
-  if (succeeded_) return true;
+  if (succeeded_)
+    return true;
   FormatPrintfTemplateAndSet(error_message,
                              "Cannot convert value to struct %s: %s", type_name,
                              inner_error_message_.c_str());
@@ -208,7 +217,8 @@ bool ConvertToValue(unsigned number, Value* value, std::string* error_message) {
   return true;
 }
 
-bool ConvertToValue(unsigned long number, Value* value,
+bool ConvertToValue(unsigned long number,
+                    Value* value,
                     std::string* error_message) {
   int64_t int64_number;
   if (!CastInteger(number, /*target_type_name=*/"int64_t", &int64_number,
@@ -221,14 +231,16 @@ bool ConvertToValue(unsigned long number, Value* value,
   return true;
 }
 
-bool ConvertToValue(const char* characters, Value* value,
+bool ConvertToValue(const char* characters,
+                    Value* value,
                     std::string* /*error_message*/) {
   GOOGLE_SMART_CARD_CHECK(characters);
   *value = Value(characters);
   return true;
 }
 
-bool ConvertToValue(std::vector<uint8_t> bytes, Value* value,
+bool ConvertToValue(std::vector<uint8_t> bytes,
+                    Value* value,
                     std::string* /*error_message*/) {
   *value = Value(std::move(bytes));
   return true;
@@ -250,7 +262,8 @@ bool ConvertFromValue(Value value, int* number, std::string* error_message) {
                                  error_message);
 }
 
-bool ConvertFromValue(Value value, unsigned* number,
+bool ConvertFromValue(Value value,
+                      unsigned* number,
                       std::string* error_message) {
   return ConvertIntegerFromValue(std::move(value), "unsigned", number,
                                  error_message);
@@ -261,19 +274,22 @@ bool ConvertFromValue(Value value, long* number, std::string* error_message) {
                                  error_message);
 }
 
-bool ConvertFromValue(Value value, unsigned long* number,
+bool ConvertFromValue(Value value,
+                      unsigned long* number,
                       std::string* error_message) {
   return ConvertIntegerFromValue(std::move(value), "unsigned long", number,
                                  error_message);
 }
 
-bool ConvertFromValue(Value value, uint8_t* number,
+bool ConvertFromValue(Value value,
+                      uint8_t* number,
                       std::string* error_message) {
   return ConvertIntegerFromValue(std::move(value), "uint8_t", number,
                                  error_message);
 }
 
-bool ConvertFromValue(Value value, int64_t* number,
+bool ConvertFromValue(Value value,
+                      int64_t* number,
                       std::string* error_message) {
   return ConvertIntegerFromValue(std::move(value), "int64_t", number,
                                  error_message);
@@ -295,7 +311,8 @@ bool ConvertFromValue(Value value, double* number, std::string* error_message) {
   return false;
 }
 
-bool ConvertFromValue(Value value, std::string* characters,
+bool ConvertFromValue(Value value,
+                      std::string* characters,
                       std::string* error_message) {
   if (value.is_string()) {
     *characters = value.GetString();
@@ -307,7 +324,8 @@ bool ConvertFromValue(Value value, std::string* characters,
   return false;
 }
 
-bool ConvertFromValue(Value value, std::vector<uint8_t>* bytes,
+bool ConvertFromValue(Value value,
+                      std::vector<uint8_t>* bytes,
                       std::string* error_message) {
   if (value.is_binary()) {
     // This is a special case that is the reason why the standard

--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -75,7 +75,8 @@ class EnumToValueConverter final {
   ~EnumToValueConverter();
 
   void HandleItem(int64_t enum_item, const char* enum_item_name);
-  bool TakeConvertedValue(const char* type_name, Value* converted_value,
+  bool TakeConvertedValue(const char* type_name,
+                          Value* converted_value,
                           std::string* error_message = nullptr);
 
  private:
@@ -94,7 +95,8 @@ class EnumFromValueConverter final {
   ~EnumFromValueConverter();
 
   void HandleItem(int64_t enum_item, const char* enum_item_name);
-  bool GetConvertedEnum(const char* type_name, int64_t* converted_enum,
+  bool GetConvertedEnum(const char* type_name,
+                        int64_t* converted_enum,
                         std::string* error_message) const;
 
  private:
@@ -150,9 +152,11 @@ class StructToValueConverter final : public StructToValueConverterBase {
     ConvertFieldToValue(std::move(*field), dictionary_key_name);
   }
 
-  bool TakeConvertedValue(const char* type_name, Value* converted_value,
+  bool TakeConvertedValue(const char* type_name,
+                          Value* converted_value,
                           std::string* error_message = nullptr) {
-    if (!FinishConversion(type_name, error_message)) return false;
+    if (!FinishConversion(type_name, error_message))
+      return false;
     *converted_value = std::move(converted_value_);
     return true;
   }
@@ -175,7 +179,8 @@ class StructFromValueConverterBase {
       delete;
   ~StructFromValueConverterBase();
 
-  bool ExtractKey(const char* dictionary_key_name, bool is_required,
+  bool ExtractKey(const char* dictionary_key_name,
+                  bool is_required,
                   Value* item_value);
   void HandleFieldConversionError(const char* dictionary_key_name);
   bool FinishConversion(const char* type_name,
@@ -218,16 +223,19 @@ class StructFromValueConverter final : public StructFromValueConverterBase {
                           &field.value());
   }
 
-  bool TakeConvertedObject(const char* type_name, T* converted_object,
+  bool TakeConvertedObject(const char* type_name,
+                           T* converted_object,
                            std::string* error_message = nullptr) {
-    if (!FinishConversion(type_name, error_message)) return false;
+    if (!FinishConversion(type_name, error_message))
+      return false;
     *converted_object = std::move(converted_object_);
     return true;
   }
 
  private:
   template <typename FieldT>
-  void ConvertFieldFromValue(const char* dictionary_key_name, Value item_value,
+  void ConvertFieldFromValue(const char* dictionary_key_name,
+                             Value item_value,
                              FieldT* converted_field);
 
   T converted_object_;
@@ -412,59 +420,70 @@ class StructValueDescriptor {
 // and the last one isn't useful in this context (as helpers in this file are
 // about converting between a `Value` and a non-`Value` object).
 
-inline bool ConvertToValue(Value source_value, Value* target_value,
+inline bool ConvertToValue(Value source_value,
+                           Value* target_value,
                            std::string* /*error_message*/ = nullptr) {
   *target_value = std::move(source_value);
   return true;
 }
 
-inline bool ConvertToValue(bool boolean, Value* value,
+inline bool ConvertToValue(bool boolean,
+                           Value* value,
                            std::string* /*error_message*/ = nullptr) {
   *value = Value(boolean);
   return true;
 }
 
-inline bool ConvertToValue(int number, Value* value,
+inline bool ConvertToValue(int number,
+                           Value* value,
                            std::string* /*error_message*/ = nullptr) {
   *value = Value(number);
   return true;
 }
 
-bool ConvertToValue(unsigned number, Value* value,
+bool ConvertToValue(unsigned number,
+                    Value* value,
                     std::string* error_message = nullptr);
 
-inline bool ConvertToValue(long number, Value* value,
+inline bool ConvertToValue(long number,
+                           Value* value,
                            std::string* /*error_message*/ = nullptr) {
   *value = Value(static_cast<int64_t>(number));
   return true;
 }
 
-bool ConvertToValue(unsigned long number, Value* value,
+bool ConvertToValue(unsigned long number,
+                    Value* value,
                     std::string* error_message = nullptr);
 
-inline bool ConvertToValue(uint8_t number, Value* value,
+inline bool ConvertToValue(uint8_t number,
+                           Value* value,
                            std::string* /*error_message*/ = nullptr) {
   *value = Value(number);
   return true;
 }
 
-inline bool ConvertToValue(int64_t number, Value* value,
+inline bool ConvertToValue(int64_t number,
+                           Value* value,
                            std::string* /*error_message*/ = nullptr) {
   *value = Value(number);
   return true;
 }
 
-inline bool ConvertToValue(double number, Value* value,
+inline bool ConvertToValue(double number,
+                           Value* value,
                            std::string* /*error_message*/ = nullptr) {
   *value = Value(number);
   return true;
 }
 
 // Note: `characters` must be non-null.
-bool ConvertToValue(const char* characters, Value* value,
+bool ConvertToValue(const char* characters,
+                    Value* value,
                     std::string* error_message = nullptr);
 
-inline bool ConvertToValue(std::string characters, Value* value,
+inline bool ConvertToValue(std::string characters,
+                           Value* value,
                            std::string* /*error_message*/ = nullptr) {
   *value = Value(std::move(characters));
   return true;
@@ -472,7 +491,8 @@ inline bool ConvertToValue(std::string characters, Value* value,
 
 // Forbid conversion of pointers other than `const char*`. Without this deleted
 // overload, the `bool`-argument overload would be silently picked up.
-bool ConvertToValue(const void* pointer_value, Value* value,
+bool ConvertToValue(const void* pointer_value,
+                    Value* value,
                     std::string* error_message = nullptr) = delete;
 
 // Converts from an enum into a string `Value`. The enum type has to be
@@ -483,7 +503,9 @@ bool ConvertToValue(const void* pointer_value, Value* value,
 // in this file.
 template <typename T>
 typename std::enable_if<std::is_enum<T>::value, bool>::type ConvertToValue(
-    T enum_value, Value* value, std::string* error_message = nullptr) {
+    T enum_value,
+    Value* value,
+    std::string* error_message = nullptr) {
   internal::EnumToValueConverter converter(static_cast<int64_t>(enum_value));
   const auto& description =
       EnumValueDescriptor<T>(&converter, /*from_value_converter=*/nullptr)
@@ -499,8 +521,8 @@ typename std::enable_if<std::is_enum<T>::value, bool>::type ConvertToValue(
 // overload resolution, so that unrelated types will use other functions
 // declared in this file.
 template <typename T>
-typename std::enable_if<std::is_class<T>::value, bool>::type ConvertToValue(
-    T object, Value* value, std::string* error_message = nullptr) {
+typename std::enable_if<std::is_class<T>::value, bool>::type
+ConvertToValue(T object, Value* value, std::string* error_message = nullptr) {
   internal::StructToValueConverter<T> converter(std::move(object));
   const auto& description =
       StructValueDescriptor<T>(&converter, /*from_value_converter=*/nullptr)
@@ -511,7 +533,8 @@ typename std::enable_if<std::is_class<T>::value, bool>::type ConvertToValue(
 
 // Converts from a vector of items of a supported type into an array `Value`.
 template <typename T>
-bool ConvertToValue(std::vector<T> objects, Value* value,
+bool ConvertToValue(std::vector<T> objects,
+                    Value* value,
                     std::string* error_message = nullptr) {
   std::vector<std::unique_ptr<Value>> converted_items(objects.size());
   std::string local_error_message;
@@ -531,7 +554,8 @@ bool ConvertToValue(std::vector<T> objects, Value* value,
 
 // Converts a vector of bytes into a binary `Value`. (Note: This is unlike all
 // other types of `std::vector`, which are converted to an array `Value`.)
-bool ConvertToValue(std::vector<uint8_t> bytes, Value* value,
+bool ConvertToValue(std::vector<uint8_t> bytes,
+                    Value* value,
                     std::string* error_message = nullptr);
 
 // Synonym to other `ConvertToValue()` overloads, but immediately crashes the
@@ -549,29 +573,39 @@ Value ConvertToValueOrDie(T object) {
 
 // Group of overloads that perform trivial conversions from `Value`.
 
-inline bool ConvertFromValue(Value source_value, Value* target_value,
+inline bool ConvertFromValue(Value source_value,
+                             Value* target_value,
                              std::string* /*error_message*/ = nullptr) {
   *target_value = std::move(source_value);
   return true;
 }
 
-bool ConvertFromValue(Value value, bool* boolean,
+bool ConvertFromValue(Value value,
+                      bool* boolean,
                       std::string* error_message = nullptr);
-bool ConvertFromValue(Value value, int* number,
+bool ConvertFromValue(Value value,
+                      int* number,
                       std::string* error_message = nullptr);
-bool ConvertFromValue(Value value, unsigned* number,
+bool ConvertFromValue(Value value,
+                      unsigned* number,
                       std::string* error_message = nullptr);
-bool ConvertFromValue(Value value, long* number,
+bool ConvertFromValue(Value value,
+                      long* number,
                       std::string* error_message = nullptr);
-bool ConvertFromValue(Value value, unsigned long* number,
+bool ConvertFromValue(Value value,
+                      unsigned long* number,
                       std::string* error_message = nullptr);
-bool ConvertFromValue(Value value, uint8_t* number,
+bool ConvertFromValue(Value value,
+                      uint8_t* number,
                       std::string* error_message = nullptr);
-bool ConvertFromValue(Value value, int64_t* number,
+bool ConvertFromValue(Value value,
+                      int64_t* number,
                       std::string* error_message = nullptr);
-bool ConvertFromValue(Value value, double* number,
+bool ConvertFromValue(Value value,
+                      double* number,
                       std::string* error_message = nullptr);
-bool ConvertFromValue(Value value, std::string* characters,
+bool ConvertFromValue(Value value,
+                      std::string* characters,
                       std::string* error_message = nullptr);
 
 // Converts from a string `Value` into an enum. The enum type has to be
@@ -582,7 +616,9 @@ bool ConvertFromValue(Value value, std::string* characters,
 // in this file.
 template <typename T>
 typename std::enable_if<std::is_enum<T>::value, bool>::type ConvertFromValue(
-    Value value, T* enum_value, std::string* error_message = nullptr) {
+    Value value,
+    T* enum_value,
+    std::string* error_message = nullptr) {
   internal::EnumFromValueConverter converter(std::move(value));
   const auto& description =
       EnumValueDescriptor<T>(/*from_value_converter=*/nullptr, &converter)
@@ -603,8 +639,8 @@ typename std::enable_if<std::is_enum<T>::value, bool>::type ConvertFromValue(
 // overload resolution, so that unrelated types will use other functions
 // declared in this file.
 template <typename T>
-typename std::enable_if<std::is_class<T>::value, bool>::type ConvertFromValue(
-    Value value, T* object, std::string* error_message = nullptr) {
+typename std::enable_if<std::is_class<T>::value, bool>::type
+ConvertFromValue(Value value, T* object, std::string* error_message = nullptr) {
   internal::StructFromValueConverter<T> converter(std::move(value));
   const auto& description =
       StructValueDescriptor<T>(/*to_value_converter=*/nullptr, &converter)
@@ -615,7 +651,8 @@ typename std::enable_if<std::is_class<T>::value, bool>::type ConvertFromValue(
 
 // Converts from an array `Value` into a vector of items of a supported type.
 template <typename T>
-bool ConvertFromValue(Value value, std::vector<T>* objects,
+bool ConvertFromValue(Value value,
+                      std::vector<T>* objects,
                       std::string* error_message = nullptr) {
   if (!value.is_array()) {
     FormatPrintfTemplateAndSet(
@@ -640,7 +677,8 @@ bool ConvertFromValue(Value value, std::vector<T>* objects,
 
 // Converts from an array or binary `Value` into a vector of bytes. (Note: The
 // difference to the template version above is the support of binary `Value`.)
-bool ConvertFromValue(Value value, std::vector<uint8_t>* bytes,
+bool ConvertFromValue(Value value,
+                      std::vector<uint8_t>* bytes,
                       std::string* error_message = nullptr);
 
 // Synonym to other `ConvertFromValue()` overloads, but immediately crashes the
@@ -664,8 +702,10 @@ namespace internal {
 template <typename T>
 template <typename FieldT>
 void StructToValueConverter<T>::ConvertFieldToValue(
-    FieldT field_value, const char* dictionary_key_name) {
-  if (!succeeded_) return;
+    FieldT field_value,
+    const char* dictionary_key_name) {
+  if (!succeeded_)
+    return;
   Value converted_field;
   if (ConvertToValue(std::move(field_value), &converted_field,
                      &inner_error_message_)) {
@@ -679,7 +719,8 @@ void StructToValueConverter<T>::ConvertFieldToValue(
 template <typename T>
 template <typename FieldT>
 void StructFromValueConverter<T>::ConvertFieldFromValue(
-    const char* dictionary_key_name, Value item_value,
+    const char* dictionary_key_name,
+    Value item_value,
     FieldT* converted_field) {
   if (!ConvertFromValue(std::move(item_value), converted_field,
                         &inner_error_message_))

--- a/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
@@ -1461,7 +1461,8 @@ TEST(ValueConversion, ValueToVector) {
   {
     const std::vector<int> kNumbers = {123, -1, 1024};
     std::vector<std::unique_ptr<Value>> items;
-    for (int number : kNumbers) items.push_back(MakeUnique<Value>(number));
+    for (int number : kNumbers)
+      items.push_back(MakeUnique<Value>(number));
     Value value(std::move(items));
 
     std::vector<int> converted;
@@ -1472,7 +1473,8 @@ TEST(ValueConversion, ValueToVector) {
   {
     const std::vector<uint8_t> kBytes = {1, 2, 255};
     std::vector<std::unique_ptr<Value>> items;
-    for (uint8_t byte : kBytes) items.push_back(MakeUnique<Value>(byte));
+    for (uint8_t byte : kBytes)
+      items.push_back(MakeUnique<Value>(byte));
     Value value(std::move(items));
 
     std::vector<uint8_t> converted;

--- a/common/cpp/src/google_smart_card_common/value_debug_dumping.cc
+++ b/common/cpp/src/google_smart_card_common/value_debug_dumping.cc
@@ -46,7 +46,9 @@ __attribute__((unused)) std::string GetValueTypeTitle(const Value& value) {
   GOOGLE_SMART_CARD_NOTREACHED;
 }
 
-std::string DebugDumpBoolean(bool value) { return value ? "true" : "false"; }
+std::string DebugDumpBoolean(bool value) {
+  return value ? "true" : "false";
+}
 
 std::string DebugDumpString(const std::string& value) {
   return '"' + value + '"';
@@ -55,7 +57,8 @@ std::string DebugDumpString(const std::string& value) {
 std::string DebugDumpArray(const Value::ArrayStorage& array_value) {
   std::string result = "[";
   for (size_t index = 0; index < array_value.size(); ++index) {
-    if (index > 0) result += ", ";
+    if (index > 0)
+      result += ", ";
     result += DebugDumpValueFull(*array_value[index]);
   }
   result += "]";
@@ -69,7 +72,8 @@ std::string DebugDumpDictionary(
   for (const auto& item : dictionary_value) {
     const std::string& item_key = item.first;
     const Value& item_value = *item.second;
-    if (!is_first_item) result += ", ";
+    if (!is_first_item)
+      result += ", ";
     is_first_item = false;
     result += DebugDumpString(item_key);
     result += ": ";
@@ -86,7 +90,8 @@ std::string DebugDumpBinary(const Value::BinaryStorage& binary_value) {
   // and for the sake of keeping the dumps easy to read.
   std::string result = std::string(Value::kBinaryTypeTitle) + "[";
   for (size_t offset = 0; offset < binary_value.size(); ++offset) {
-    if (offset > 0) result += ", ";
+    if (offset > 0)
+      result += ", ";
     result += HexDumpByte(binary_value[offset]);
   }
   result += "]";

--- a/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.cc
@@ -181,12 +181,18 @@ emscripten::val ConvertValueToEmscriptenVal(const Value& value) {
 
 optional<Value> ConvertEmscriptenValToValue(const emscripten::val& val,
                                             std::string* error_message) {
-  if (val.isUndefined() || val.isNull()) return Value();
-  if (val.isTrue()) return Value(true);
-  if (val.isFalse()) return Value(false);
-  if (val.isNumber()) return CreateValueFromNumberVal(val);
-  if (val.isString()) return Value(val.as<std::string>());
-  if (val.isArray()) return CreateValueFromArrayLikeVal(val, error_message);
+  if (val.isUndefined() || val.isNull())
+    return Value();
+  if (val.isTrue())
+    return Value(true);
+  if (val.isFalse())
+    return Value(false);
+  if (val.isNumber())
+    return CreateValueFromNumberVal(val);
+  if (val.isString())
+    return Value(val.as<std::string>());
+  if (val.isArray())
+    return CreateValueFromArrayLikeVal(val, error_message);
   if (IsEmcriptenValInstanceof(val, "DataView")) {
     FormatPrintfTemplateAndSet(error_message, kErrorWrongType, "DataView");
     return {};
@@ -213,7 +219,8 @@ optional<Value> ConvertEmscriptenValToValue(const emscripten::val& val,
 Value ConvertEmscriptenValToValueOrDie(const emscripten::val& val) {
   std::string error_message;
   optional<Value> value = ConvertEmscriptenValToValue(val, &error_message);
-  if (!value) GOOGLE_SMART_CARD_LOG_FATAL << error_message;
+  if (!value)
+    GOOGLE_SMART_CARD_LOG_FATAL << error_message;
   return std::move(*value);
 }
 

--- a/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.h
@@ -39,7 +39,8 @@ emscripten::val ConvertValueToEmscriptenVal(const Value& value);
 // When the conversion isn't possible (e.g., when the passed variable is a
 // function), returns a null optional and, if provided, sets `*error_message`.
 optional<Value> ConvertEmscriptenValToValue(
-    const emscripten::val& val, std::string* error_message = nullptr);
+    const emscripten::val& val,
+    std::string* error_message = nullptr);
 
 // Same as `ConvertEmscriptenValToValue()`, but immediately crashes the program
 // if the conversion fails.

--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.cc
@@ -153,9 +153,12 @@ pp::Var ConvertValueToPpVar(const Value& value) {
 
 optional<Value> ConvertPpVarToValue(const pp::Var& var,
                                     std::string* error_message) {
-  if (var.is_undefined() || var.is_null()) return Value();
-  if (var.is_bool()) return Value(var.AsBool());
-  if (var.is_string()) return Value(var.AsString());
+  if (var.is_undefined() || var.is_null())
+    return Value();
+  if (var.is_bool())
+    return Value(var.AsBool());
+  if (var.is_string())
+    return Value(var.AsString());
   if (var.is_object() || var.is_resource()) {
     FormatPrintfTemplateAndSet(error_message,
                                "Error converting: unsupported type \"%s\"",
@@ -168,8 +171,10 @@ optional<Value> ConvertPpVarToValue(const pp::Var& var,
     return CreateValueFromPpVarDictionary(pp::VarDictionary(var),
                                           error_message);
   }
-  if (var.is_int()) return Value(var.AsInt());
-  if (var.is_double()) return Value(var.AsDouble());
+  if (var.is_int())
+    return Value(var.AsInt());
+  if (var.is_double())
+    return Value(var.AsDouble());
   if (var.is_array_buffer())
     return CreateValueFromVarArrayBuffer(pp::VarArrayBuffer(var));
   GOOGLE_SMART_CARD_NOTREACHED;
@@ -178,7 +183,8 @@ optional<Value> ConvertPpVarToValue(const pp::Var& var,
 Value ConvertPpVarToValueOrDie(const pp::Var& var) {
   std::string error_message;
   optional<Value> value = ConvertPpVarToValue(var, &error_message);
-  if (!value) GOOGLE_SMART_CARD_LOG_FATAL << error_message;
+  if (!value)
+    GOOGLE_SMART_CARD_LOG_FATAL << error_message;
   return std::move(*value);
 }
 

--- a/common/cpp/src/google_smart_card_common/value_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_unittest.cc
@@ -342,7 +342,7 @@ TEST(ValueTest, MoveAssignmentToItself) {
   Value value("foo");
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wself-move"
-   value = std::move(value);
+  value = std::move(value);
 #pragma clang diagnostic pop
   ASSERT_TRUE(value.is_string());
   EXPECT_EQ(value.GetString(), "foo");

--- a/common/cpp_unit_test_runner/src/entry_point_nacl.cc
+++ b/common/cpp_unit_test_runner/src/entry_point_nacl.cc
@@ -65,7 +65,8 @@ class GTestEventListener final : public testing::EmptyTestEventListener {
     message.Set("ok", !test_info.result()->Failed());
     PostMessage(message);
 
-    if (test_info.result()->Failed()) ++failed_test_count_;
+    if (test_info.result()->Failed())
+      ++failed_test_count_;
     current_test_case_name_.clear();
     current_test_name_.clear();
   }

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h
@@ -48,11 +48,10 @@ class IntegrationTestHelper {
   virtual ~IntegrationTestHelper() = default;
 
   virtual std::string GetName() const = 0;
-  virtual void SetUp(
-      pp::Instance* /*pp_instance*/,
-      pp::Core* /*pp_core*/,
-      TypedMessageRouter* /*typed_message_router*/,
-      const pp::Var& /*data*/) {}
+  virtual void SetUp(pp::Instance* /*pp_instance*/,
+                     pp::Core* /*pp_core*/,
+                     TypedMessageRouter* /*typed_message_router*/,
+                     const pp::Var& /*data*/) {}
   virtual void TearDown() {}
   virtual void OnMessageFromJs(
       const pp::Var& data,

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.cc
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.cc
@@ -59,7 +59,8 @@ IntegrationTestHelper* IntegrationTestService::RegisterHelper(
 }
 
 void IntegrationTestService::Activate(
-    pp::Instance* pp_instance, pp::Core* pp_core,
+    pp::Instance* pp_instance,
+    pp::Core* pp_core,
     TypedMessageRouter* typed_message_router) {
   GOOGLE_SMART_CARD_CHECK(pp_instance);
   GOOGLE_SMART_CARD_CHECK(pp_core);
@@ -87,7 +88,8 @@ void IntegrationTestService::Deactivate() {
 }
 
 void IntegrationTestService::HandleRequest(
-    Value payload, RequestReceiver::ResultCallback result_callback) {
+    Value payload,
+    RequestReceiver::ResultCallback result_callback) {
   // TODO(#185): Parse `Value` directly, instead of converting into `pp::Var`.
   const pp::Var payload_var = ConvertValueToPpVar(payload);
   std::string method_name;
@@ -128,7 +130,8 @@ IntegrationTestService::~IntegrationTestService() = default;
 IntegrationTestHelper* IntegrationTestService::FindHelperByName(
     const std::string& name) {
   for (const auto& helper : helpers_) {
-    if (helper->GetName() == name) return helper.get();
+    if (helper->GetName() == name)
+      return helper.get();
   }
   return nullptr;
 }
@@ -136,22 +139,26 @@ IntegrationTestHelper* IntegrationTestService::FindHelperByName(
 void IntegrationTestService::SetUpHelper(const std::string& helper_name,
                                          const pp::Var& data_for_helper) {
   IntegrationTestHelper* helper = FindHelperByName(helper_name);
-  if (!helper) GOOGLE_SMART_CARD_LOG_FATAL << "Unknown helper " << helper_name;
+  if (!helper)
+    GOOGLE_SMART_CARD_LOG_FATAL << "Unknown helper " << helper_name;
   GOOGLE_SMART_CARD_CHECK(!set_up_helpers_.count(helper));
   set_up_helpers_.insert(helper);
   helper->SetUp(pp_instance_, pp_core_, typed_message_router_, data_for_helper);
 }
 
 void IntegrationTestService::TearDownAllHelpers() {
-  for (auto* helper : set_up_helpers_) helper->TearDown();
+  for (auto* helper : set_up_helpers_)
+    helper->TearDown();
   set_up_helpers_.clear();
 }
 
 void IntegrationTestService::SendMessageToHelper(
-    const std::string& helper_name, const pp::Var& message_for_helper,
+    const std::string& helper_name,
+    const pp::Var& message_for_helper,
     RequestReceiver::ResultCallback result_callback) {
   IntegrationTestHelper* helper = FindHelperByName(helper_name);
-  if (!helper) GOOGLE_SMART_CARD_LOG_FATAL << "Unknown helper " << helper_name;
+  if (!helper)
+    GOOGLE_SMART_CARD_LOG_FATAL << "Unknown helper " << helper_name;
   GOOGLE_SMART_CARD_CHECK(set_up_helpers_.count(helper));
   helper->OnMessageFromJs(message_for_helper, result_callback);
 }

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
@@ -46,7 +46,8 @@ class IntegrationTestService final : public RequestHandler {
 
   // Starts listening for incoming requests and translating them into commands
   // for test helpers.
-  void Activate(pp::Instance* pp_instance, pp::Core* pp_core,
+  void Activate(pp::Instance* pp_instance,
+                pp::Core* pp_core,
                 TypedMessageRouter* typed_message_router);
   // Tears down all previously set up helpers and stops listening for incoming
   // requests.

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.cc
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.cc
@@ -48,21 +48,27 @@ void ExtractPinRequestResult(
 
 BuiltInPinDialogServer::BuiltInPinDialogServer(
     google_smart_card::TypedMessageRouter* typed_message_router,
-    pp::Instance* pp_instance, pp::Core* pp_core)
-    : js_requester_(kRequesterName, typed_message_router,
-                    google_smart_card::MakeUnique<
-                        google_smart_card::JsRequester::PpDelegateImpl>(
-                        pp_instance, pp_core)) {}
+    pp::Instance* pp_instance,
+    pp::Core* pp_core)
+    : js_requester_(
+          kRequesterName,
+          typed_message_router,
+          google_smart_card::MakeUnique<
+              google_smart_card::JsRequester::PpDelegateImpl>(pp_instance,
+                                                              pp_core)) {}
 
 BuiltInPinDialogServer::~BuiltInPinDialogServer() = default;
 
-void BuiltInPinDialogServer::Detach() { js_requester_.Detach(); }
+void BuiltInPinDialogServer::Detach() {
+  js_requester_.Detach();
+}
 
 bool BuiltInPinDialogServer::RequestPin(std::string* pin) {
   const google_smart_card::GenericRequestResult request_result =
       js_requester_.PerformSyncRequest(/*payload=*/google_smart_card::Value(
           google_smart_card::Value::Type::kDictionary));
-  if (!request_result.is_successful()) return false;
+  if (!request_result.is_successful())
+    return false;
   ExtractPinRequestResult(request_result, pin);
   return true;
 }

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.h
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.h
@@ -45,7 +45,8 @@ class BuiltInPinDialogServer final {
   // into the specified TypedMessageRouter for receiving the request responses.
   BuiltInPinDialogServer(
       google_smart_card::TypedMessageRouter* typed_message_router,
-      pp::Instance* pp_instance, pp::Core* pp_core);
+      pp::Instance* pp_instance,
+      pp::Core* pp_core);
 
   BuiltInPinDialogServer(const BuiltInPinDialogServer&) = delete;
   BuiltInPinDialogServer& operator=(const BuiltInPinDialogServer&) = delete;

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
@@ -95,15 +95,19 @@ void ProcessSignatureRequest(
 }  // namespace
 
 ApiBridge::ApiBridge(gsc::TypedMessageRouter* typed_message_router,
-                     pp::Instance* pp_instance, pp::Core* pp_core,
+                     pp::Instance* pp_instance,
+                     pp::Core* pp_core,
                      std::shared_ptr<std::mutex> request_handling_mutex)
     : request_handling_mutex_(request_handling_mutex),
-      requester_(kRequesterName, typed_message_router,
+      requester_(kRequesterName,
+                 typed_message_router,
                  gsc::MakeUnique<gsc::JsRequester::PpDelegateImpl>(pp_instance,
                                                                    pp_core)),
       remote_call_adaptor_(&requester_),
       request_receiver_(new gsc::JsRequestReceiver(
-          kRequestReceiverName, this, typed_message_router,
+          kRequestReceiverName,
+          this,
+          typed_message_router,
           gsc::MakeUnique<gsc::JsRequestReceiver::PpDelegateImpl>(
               pp_instance))) {}
 
@@ -201,7 +205,8 @@ void ApiBridge::StopPinRequest(const StopPinRequestOptions& options) {
 }
 
 void ApiBridge::HandleRequest(
-    gsc::Value payload, gsc::RequestReceiver::ResultCallback result_callback) {
+    gsc::Value payload,
+    gsc::RequestReceiver::ResultCallback result_callback) {
   // TODO: Parse `Value` directly instead of transforming into `pp::Var`.
   const pp::Var payload_var = gsc::ConvertValueToPpVar(payload);
   std::string function_name;

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
@@ -93,7 +93,8 @@ class ApiBridge final : public google_smart_card::RequestHandler {
   // simultaneous execution of multiple requests: each next request will be
   // executed only once the previous one finishes.
   ApiBridge(google_smart_card::TypedMessageRouter* typed_message_router,
-            pp::Instance* pp_instance, pp::Core* pp_core,
+            pp::Instance* pp_instance,
+            pp::Core* pp_core,
             std::shared_ptr<std::mutex> request_handling_mutex);
 
   ApiBridge(const ApiBridge&) = delete;

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
@@ -83,7 +83,8 @@ class ApiBridgeIntegrationTestHelper final : public gsc::IntegrationTestHelper {
  public:
   // IntegrationTestHelper:
   std::string GetName() const override;
-  void SetUp(pp::Instance* pp_instance, pp::Core* pp_core,
+  void SetUp(pp::Instance* pp_instance,
+             pp::Core* pp_core,
              gsc::TypedMessageRouter* typed_message_router,
              const pp::Var& data) override;
   void TearDown() override;
@@ -108,8 +109,10 @@ std::string ApiBridgeIntegrationTestHelper::GetName() const {
 }
 
 void ApiBridgeIntegrationTestHelper::SetUp(
-    pp::Instance* pp_instance, pp::Core* pp_core,
-    gsc::TypedMessageRouter* typed_message_router, const pp::Var& /*data*/) {
+    pp::Instance* pp_instance,
+    pp::Core* pp_core,
+    gsc::TypedMessageRouter* typed_message_router,
+    const pp::Var& /*data*/) {
   api_bridge_ =
       std::make_shared<ApiBridge>(typed_message_router, pp_instance, pp_core,
                                   /*request_handling_mutex=*/nullptr);
@@ -121,7 +124,8 @@ void ApiBridgeIntegrationTestHelper::TearDown() {
 }
 
 void ApiBridgeIntegrationTestHelper::OnMessageFromJs(
-    const pp::Var& data, gsc::RequestReceiver::ResultCallback result_callback) {
+    const pp::Var& data,
+    gsc::RequestReceiver::ResultCallback result_callback) {
   std::string command;
   std::string error_message;
   if (!gsc::VarAs(data, &command, &error_message))

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.cc
@@ -171,7 +171,8 @@ constexpr const char* ClientCertificateInfoConverter::GetStructTypeName() {
 template <>
 template <typename Callback>
 void ClientCertificateInfoConverter::VisitFields(
-    const ccp::ClientCertificateInfo& value, Callback callback) {
+    const ccp::ClientCertificateInfo& value,
+    Callback callback) {
   callback(&value.certificate, "certificate");
   callback(&value.supported_algorithms, "supportedAlgorithms");
 }
@@ -199,7 +200,8 @@ constexpr const char* SetCertificatesDetailsConverter::GetStructTypeName() {
 template <>
 template <typename Callback>
 void SetCertificatesDetailsConverter::VisitFields(
-    const ccp::SetCertificatesDetails& value, Callback callback) {
+    const ccp::SetCertificatesDetails& value,
+    Callback callback) {
   callback(&value.certificates_request_id, "certificatesRequestId");
   callback(&value.error, "error");
   callback(&value.client_certificates, "clientCertificates");
@@ -258,7 +260,8 @@ constexpr const char* RequestPinOptionsConverter::GetStructTypeName() {
 template <>
 template <typename Callback>
 void RequestPinOptionsConverter::VisitFields(
-    const ccp::RequestPinOptions& value, Callback callback) {
+    const ccp::RequestPinOptions& value,
+    Callback callback) {
   callback(&value.sign_request_id, "signRequestId");
   callback(&value.request_type, "requestType");
   callback(&value.error_type, "errorType");
@@ -284,7 +287,8 @@ constexpr const char* RequestPinResultsConverter::GetStructTypeName() {
 template <>
 template <typename Callback>
 void RequestPinResultsConverter::VisitFields(
-    const ccp::RequestPinResults& value, Callback callback) {
+    const ccp::RequestPinResults& value,
+    Callback callback) {
   callback(&value.user_input, "userInput");
 }
 
@@ -308,7 +312,8 @@ constexpr const char* StopPinRequestOptionsConverter::GetStructTypeName() {
 template <>
 template <typename Callback>
 void StopPinRequestOptionsConverter::VisitFields(
-    const ccp::StopPinRequestOptions& value, Callback callback) {
+    const ccp::StopPinRequestOptions& value,
+    Callback callback) {
   callback(&value.sign_request_id, "signRequestId");
   callback(&value.error_type, "errorType");
 }
@@ -335,7 +340,8 @@ pp::Var MakeVar(Error value) {
   return gsc::ErrorConverter::ConvertToVar(value);
 }
 
-bool VarAs(const pp::Var& var, PinRequestType* result,
+bool VarAs(const pp::Var& var,
+           PinRequestType* result,
            std::string* error_message) {
   return gsc::PinRequestTypeConverter::ConvertFromVar(var, result,
                                                       error_message);
@@ -345,7 +351,8 @@ pp::Var MakeVar(PinRequestType value) {
   return gsc::PinRequestTypeConverter::ConvertToVar(value);
 }
 
-bool VarAs(const pp::Var& var, PinRequestErrorType* result,
+bool VarAs(const pp::Var& var,
+           PinRequestErrorType* result,
            std::string* error_message) {
   return gsc::PinRequestErrorTypeConverter::ConvertFromVar(var, result,
                                                            error_message);
@@ -355,7 +362,8 @@ pp::Var MakeVar(PinRequestErrorType value) {
   return gsc::PinRequestErrorTypeConverter::ConvertToVar(value);
 }
 
-bool VarAs(const pp::Var& var, ClientCertificateInfo* result,
+bool VarAs(const pp::Var& var,
+           ClientCertificateInfo* result,
            std::string* error_message) {
   return gsc::ClientCertificateInfoConverter::ConvertFromVar(var, result,
                                                              error_message);
@@ -365,7 +373,8 @@ pp::Var MakeVar(const ClientCertificateInfo& value) {
   return gsc::ClientCertificateInfoConverter::ConvertToVar(value);
 }
 
-bool VarAs(const pp::Var& var, SetCertificatesDetails* result,
+bool VarAs(const pp::Var& var,
+           SetCertificatesDetails* result,
            std::string* error_message) {
   return gsc::SetCertificatesDetailsConverter::ConvertFromVar(var, result,
                                                               error_message);
@@ -375,7 +384,8 @@ pp::Var MakeVar(const SetCertificatesDetails& value) {
   return gsc::SetCertificatesDetailsConverter::ConvertToVar(value);
 }
 
-bool VarAs(const pp::Var& var, SignatureRequest* result,
+bool VarAs(const pp::Var& var,
+           SignatureRequest* result,
            std::string* error_message) {
   return gsc::SignatureRequestConverter::ConvertFromVar(var, result,
                                                         error_message);
@@ -385,7 +395,8 @@ pp::Var MakeVar(const SignatureRequest& value) {
   return gsc::SignatureRequestConverter::ConvertToVar(value);
 }
 
-bool VarAs(const pp::Var& var, RequestPinOptions* result,
+bool VarAs(const pp::Var& var,
+           RequestPinOptions* result,
            std::string* error_message) {
   return gsc::RequestPinOptionsConverter::ConvertFromVar(var, result,
                                                          error_message);
@@ -395,7 +406,8 @@ pp::Var MakeVar(const RequestPinOptions& value) {
   return gsc::RequestPinOptionsConverter::ConvertToVar(value);
 }
 
-bool VarAs(const pp::Var& var, RequestPinResults* result,
+bool VarAs(const pp::Var& var,
+           RequestPinResults* result,
            std::string* error_message) {
   return gsc::RequestPinResultsConverter::ConvertFromVar(var, result,
                                                          error_message);
@@ -405,7 +417,8 @@ pp::Var MakeVar(const RequestPinResults& value) {
   return gsc::RequestPinResultsConverter::ConvertToVar(value);
 }
 
-bool VarAs(const pp::Var& var, StopPinRequestOptions* result,
+bool VarAs(const pp::Var& var,
+           StopPinRequestOptions* result,
            std::string* error_message) {
   return gsc::StopPinRequestOptionsConverter::ConvertFromVar(var, result,
                                                              error_message);

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.h
@@ -160,35 +160,43 @@ pp::Var MakeVar(Algorithm value);
 bool VarAs(const pp::Var& var, Error* result, std::string* error_message);
 pp::Var MakeVar(Error value);
 
-bool VarAs(const pp::Var& var, PinRequestType* result,
+bool VarAs(const pp::Var& var,
+           PinRequestType* result,
            std::string* error_message);
 pp::Var MakeVar(PinRequestType value);
 
-bool VarAs(const pp::Var& var, PinRequestErrorType* result,
+bool VarAs(const pp::Var& var,
+           PinRequestErrorType* result,
            std::string* error_message);
 pp::Var MakeVar(PinRequestErrorType value);
 
-bool VarAs(const pp::Var& var, ClientCertificateInfo* result,
+bool VarAs(const pp::Var& var,
+           ClientCertificateInfo* result,
            std::string* error_message);
 pp::Var MakeVar(const ClientCertificateInfo& value);
 
-bool VarAs(const pp::Var& var, SetCertificatesDetails* result,
+bool VarAs(const pp::Var& var,
+           SetCertificatesDetails* result,
            std::string* error_message);
 pp::Var MakeVar(const SetCertificatesDetails& value);
 
-bool VarAs(const pp::Var& var, SignatureRequest* result,
+bool VarAs(const pp::Var& var,
+           SignatureRequest* result,
            std::string* error_message);
 pp::Var MakeVar(const SignatureRequest& value);
 
-bool VarAs(const pp::Var& var, RequestPinOptions* result,
+bool VarAs(const pp::Var& var,
+           RequestPinOptions* result,
            std::string* error_message);
 pp::Var MakeVar(const RequestPinOptions& value);
 
-bool VarAs(const pp::Var& var, RequestPinResults* result,
+bool VarAs(const pp::Var& var,
+           RequestPinResults* result,
            std::string* error_message);
 pp::Var MakeVar(const RequestPinResults& value);
 
-bool VarAs(const pp::Var& var, StopPinRequestOptions* result,
+bool VarAs(const pp::Var& var,
+           StopPinRequestOptions* result,
            std::string* error_message);
 pp::Var MakeVar(const StopPinRequestOptions& value);
 

--- a/example_cpp_smart_card_client_app/src/pp_module.cc
+++ b/example_cpp_smart_card_client_app/src/pp_module.cc
@@ -139,20 +139,28 @@ class PpInstance final : public pp::Instance {
   explicit PpInstance(PP_Instance instance)
       : pp::Instance(instance),
         request_handling_mutex_(std::make_shared<std::mutex>()),
-        pcsc_lite_over_requester_global_(new gsc::PcscLiteOverRequesterGlobal(
-            &typed_message_router_, this, pp::Module::Get()->core())),
-        built_in_pin_dialog_server_(new BuiltInPinDialogServer(
-            &typed_message_router_, this, pp::Module::Get()->core())),
-        chrome_certificate_provider_api_bridge_(new ccp::ApiBridge(
-            &typed_message_router_, this, pp::Module::Get()->core(),
-            request_handling_mutex_)),
-        ui_bridge_(new UiBridge(&typed_message_router_, this,
+        pcsc_lite_over_requester_global_(
+            new gsc::PcscLiteOverRequesterGlobal(&typed_message_router_,
+                                                 this,
+                                                 pp::Module::Get()->core())),
+        built_in_pin_dialog_server_(
+            new BuiltInPinDialogServer(&typed_message_router_,
+                                       this,
+                                       pp::Module::Get()->core())),
+        chrome_certificate_provider_api_bridge_(
+            new ccp::ApiBridge(&typed_message_router_,
+                               this,
+                               pp::Module::Get()->core(),
+                               request_handling_mutex_)),
+        ui_bridge_(new UiBridge(&typed_message_router_,
+                                this,
                                 request_handling_mutex_)),
         certificates_request_handler_(new ClientCertificatesRequestHandler),
         signature_request_handler_(new ClientSignatureRequestHandler(
             chrome_certificate_provider_api_bridge_)),
-        message_from_ui_handler_(new ClientMessageFromUiHandler(
-            ui_bridge_, built_in_pin_dialog_server_)) {
+        message_from_ui_handler_(
+            new ClientMessageFromUiHandler(ui_bridge_,
+                                           built_in_pin_dialog_server_)) {
     chrome_certificate_provider_api_bridge_->SetCertificatesRequestHandler(
         certificates_request_handler_);
     chrome_certificate_provider_api_bridge_->SetSignatureRequestHandler(
@@ -393,7 +401,8 @@ class PpInstance final : public pp::Instance {
 
     void SendOutputMessageToUi(const std::string& text) {
       std::shared_ptr<UiBridge> locked_ui_bridge = ui_bridge_.lock();
-      if (!locked_ui_bridge) return;
+      if (!locked_ui_bridge)
+        return;
       locked_ui_bridge->SendMessageToUi(
           gsc::VarDictBuilder().Add("output_message", text).Result());
     }
@@ -485,6 +494,8 @@ namespace pp {
 
 // Entry point of the NaCl module, that is called by the NaCl framework when the
 // module is being loaded.
-Module* CreateModule() { return new scc::PpModule; }
+Module* CreateModule() {
+  return new scc::PpModule;
+}
 
 }  // namespace pp

--- a/example_cpp_smart_card_client_app/src/ui_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/ui_bridge.cc
@@ -71,13 +71,16 @@ UiBridge::UiBridge(gsc::TypedMessageRouter* typed_message_router,
   typed_message_router->AddRoute(this);
 }
 
-UiBridge::~UiBridge() { Detach(); }
+UiBridge::~UiBridge() {
+  Detach();
+}
 
 void UiBridge::Detach() {
   {
     const gsc::ThreadSafeUniquePtr<AttachedState>::Locked locked_state =
         attached_state_.Lock();
-    if (locked_state) locked_state->typed_message_router->RemoveRoute(this);
+    if (locked_state)
+      locked_state->typed_message_router->RemoveRoute(this);
   }
   attached_state_.Reset();
 }
@@ -86,7 +89,9 @@ void UiBridge::SetHandler(std::weak_ptr<MessageFromUiHandler> handler) {
   message_from_ui_handler_ = handler;
 }
 
-void UiBridge::RemoveHandler() { message_from_ui_handler_.reset(); }
+void UiBridge::RemoveHandler() {
+  message_from_ui_handler_.reset();
+}
 
 void UiBridge::SendMessageToUi(const pp::Var& message) {
   gsc::TypedMessage typed_message;
@@ -100,7 +105,8 @@ void UiBridge::SendMessageToUi(const pp::Var& message) {
       gsc::ConvertValueToPpVar(typed_message_value);
   const gsc::ThreadSafeUniquePtr<AttachedState>::Locked locked_state =
       attached_state_.Lock();
-  if (locked_state) locked_state->pp_instance->PostMessage(typed_message_var);
+  if (locked_state)
+    locked_state->pp_instance->PostMessage(typed_message_var);
 }
 
 std::string UiBridge::GetListenedMessageType() const {

--- a/format-code.sh
+++ b/format-code.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # This script formats the modified C++ files via clang-format according to the
-# Google C++ Style Guide.
+# Chromium C++ Style Guide.
 # Only files that are known to Git and belong to the diff of the "master" branch
 # are considered.
 #
@@ -36,4 +36,4 @@ FILES=$(git diff --name-only --diff-filter=d master -- "*.cc" "*.h")
 
 # Run clang-format on every found file.
 echo "${FILES}" | \
-  xargs clang-format -i --style=Google --sort-includes=false
+  xargs clang-format -i --style=Chromium --sort-includes=false

--- a/smart_card_connector_app/src/pp_module.cc
+++ b/smart_card_connector_app/src/pp_module.cc
@@ -50,8 +50,10 @@ class PpInstance final : public pp::Instance {
  public:
   explicit PpInstance(PP_Instance instance)
       : pp::Instance(instance),
-        libusb_over_chrome_usb_global_(new LibusbOverChromeUsbGlobal(
-            &typed_message_router_, this, pp::Module::Get()->core())),
+        libusb_over_chrome_usb_global_(
+            new LibusbOverChromeUsbGlobal(&typed_message_router_,
+                                          this,
+                                          pp::Module::Get()->core())),
         pcsc_lite_server_global_(new PcscLiteServerGlobal(this)) {
     typed_message_router_.AddRoute(&external_logs_printer_);
 
@@ -134,6 +136,8 @@ class PpModule final : public pp::Module {
 
 namespace pp {
 
-Module* CreateModule() { return new google_smart_card::PpModule; }
+Module* CreateModule() {
+  return new google_smart_card::PpModule;
+}
 
 }  // namespace pp

--- a/third_party/libusb/naclport/src/chrome_usb/api_bridge.cc
+++ b/third_party/libusb/naclport/src/chrome_usb/api_bridge.cc
@@ -32,7 +32,9 @@ ApiBridge::ApiBridge(std::unique_ptr<Requester> requester)
 
 ApiBridge::~ApiBridge() = default;
 
-void ApiBridge::Detach() { requester_->Detach(); }
+void ApiBridge::Detach() {
+  requester_->Detach();
+}
 
 RequestResult<GetDevicesResult> ApiBridge::GetDevices(
     const GetDevicesOptions& options) {
@@ -79,7 +81,8 @@ RequestResult<CloseDeviceResult> ApiBridge::CloseDevice(
 }
 
 RequestResult<SetConfigurationResult> ApiBridge::SetConfiguration(
-    const ConnectionHandle& connection_handle, int64_t configuration_value) {
+    const ConnectionHandle& connection_handle,
+    int64_t configuration_value) {
   const GenericRequestResult generic_request_result =
       remote_call_adaptor_.SyncCall("setConfiguration", connection_handle,
                                     configuration_value);
@@ -107,7 +110,8 @@ RequestResult<ListInterfacesResult> ApiBridge::ListInterfaces(
 }
 
 RequestResult<ClaimInterfaceResult> ApiBridge::ClaimInterface(
-    const ConnectionHandle& connection_handle, int64_t interface_number) {
+    const ConnectionHandle& connection_handle,
+    int64_t interface_number) {
   const GenericRequestResult generic_request_result =
       remote_call_adaptor_.SyncCall("claimInterface", connection_handle,
                                     interface_number);
@@ -117,7 +121,8 @@ RequestResult<ClaimInterfaceResult> ApiBridge::ClaimInterface(
 }
 
 RequestResult<ReleaseInterfaceResult> ApiBridge::ReleaseInterface(
-    const ConnectionHandle& connection_handle, int64_t interface_number) {
+    const ConnectionHandle& connection_handle,
+    int64_t interface_number) {
   const GenericRequestResult generic_request_result =
       remote_call_adaptor_.SyncCall("releaseInterface", connection_handle,
                                     interface_number);
@@ -157,7 +162,8 @@ void ApiBridge::AsyncBulkTransfer(const ConnectionHandle& connection_handle,
 
 void ApiBridge::AsyncInterruptTransfer(
     const ConnectionHandle& connection_handle,
-    const GenericTransferInfo& transfer_info, AsyncTransferCallback callback) {
+    const GenericTransferInfo& transfer_info,
+    AsyncTransferCallback callback) {
   remote_call_adaptor_.AsyncCall(WrapAsyncTransferCallback(callback),
                                  "interruptTransfer", connection_handle,
                                  transfer_info);

--- a/third_party/libusb/naclport/src/chrome_usb/api_bridge_interface.h
+++ b/third_party/libusb/naclport/src/chrome_usb/api_bridge_interface.h
@@ -58,10 +58,12 @@ class ApiBridgeInterface {
       const ConnectionHandle& connection_handle) = 0;
 
   virtual RequestResult<ClaimInterfaceResult> ClaimInterface(
-      const ConnectionHandle& connection_handle, int64_t interface_number) = 0;
+      const ConnectionHandle& connection_handle,
+      int64_t interface_number) = 0;
 
   virtual RequestResult<ReleaseInterfaceResult> ReleaseInterface(
-      const ConnectionHandle& connection_handle, int64_t interface_number) = 0;
+      const ConnectionHandle& connection_handle,
+      int64_t interface_number) = 0;
 
   virtual void AsyncControlTransfer(const ConnectionHandle& connection_handle,
                                     const ControlTransferInfo& transfer_info,

--- a/third_party/libusb/naclport/src/chrome_usb/types.cc
+++ b/third_party/libusb/naclport/src/chrome_usb/types.cc
@@ -614,7 +614,8 @@ GetUserSelectedDevicesOptionsConverter::GetStructTypeName() {
 template <>
 template <typename Callback>
 void GetUserSelectedDevicesOptionsConverter::VisitFields(
-    const GetUserSelectedDevicesOptions& value, Callback callback) {
+    const GetUserSelectedDevicesOptions& value,
+    Callback callback) {
   callback(&value.filters, "filters");
 }
 
@@ -636,7 +637,8 @@ pp::Var MakeVar(const Device& value) {
   return DeviceConverter::ConvertToVar(value);
 }
 
-bool VarAs(const pp::Var& var, ConnectionHandle* result,
+bool VarAs(const pp::Var& var,
+           ConnectionHandle* result,
            std::string* error_message) {
   return ConnectionHandleConverter::ConvertFromVar(var, result, error_message);
 }
@@ -645,7 +647,8 @@ pp::Var MakeVar(const ConnectionHandle& value) {
   return ConnectionHandleConverter::ConvertToVar(value);
 }
 
-bool VarAs(const pp::Var& var, EndpointDescriptorType* result,
+bool VarAs(const pp::Var& var,
+           EndpointDescriptorType* result,
            std::string* error_message) {
   return EndpointDescriptorTypeConverter::ConvertFromVar(var, result,
                                                          error_message);
@@ -655,7 +658,8 @@ pp::Var MakeVar(EndpointDescriptorType value) {
   return EndpointDescriptorTypeConverter::ConvertToVar(value);
 }
 
-bool VarAs(const pp::Var& var, EndpointDescriptorSynchronization* result,
+bool VarAs(const pp::Var& var,
+           EndpointDescriptorSynchronization* result,
            std::string* error_message) {
   return EndpointDescriptorSynchronizationConverter::ConvertFromVar(
       var, result, error_message);
@@ -665,7 +669,8 @@ pp::Var MakeVar(EndpointDescriptorSynchronization value) {
   return EndpointDescriptorSynchronizationConverter::ConvertToVar(value);
 }
 
-bool VarAs(const pp::Var& var, EndpointDescriptorUsage* result,
+bool VarAs(const pp::Var& var,
+           EndpointDescriptorUsage* result,
            std::string* error_message) {
   return EndpointDescriptorUsageConverter::ConvertFromVar(var, result,
                                                           error_message);
@@ -675,19 +680,22 @@ pp::Var MakeVar(EndpointDescriptorUsage value) {
   return EndpointDescriptorUsageConverter::ConvertToVar(value);
 }
 
-bool VarAs(const pp::Var& var, EndpointDescriptor* result,
+bool VarAs(const pp::Var& var,
+           EndpointDescriptor* result,
            std::string* error_message) {
   return EndpointDescriptorConverter::ConvertFromVar(var, result,
                                                      error_message);
 }
 
-bool VarAs(const pp::Var& var, InterfaceDescriptor* result,
+bool VarAs(const pp::Var& var,
+           InterfaceDescriptor* result,
            std::string* error_message) {
   return InterfaceDescriptorConverter::ConvertFromVar(var, result,
                                                       error_message);
 }
 
-bool VarAs(const pp::Var& var, ConfigDescriptor* result,
+bool VarAs(const pp::Var& var,
+           ConfigDescriptor* result,
            std::string* error_message) {
   return ConfigDescriptorConverter::ConvertFromVar(var, result, error_message);
 }
@@ -708,7 +716,8 @@ pp::Var MakeVar(const ControlTransferInfo& value) {
   return ControlTransferInfoConverter::ConvertToVar(value);
 }
 
-bool VarAs(const pp::Var& var, TransferResultInfo* result,
+bool VarAs(const pp::Var& var,
+           TransferResultInfo* result,
            std::string* error_message) {
   return TransferResultInfoConverter::ConvertFromVar(var, result,
                                                      error_message);

--- a/third_party/libusb/naclport/src/chrome_usb/types.h
+++ b/third_party/libusb/naclport/src/chrome_usb/types.h
@@ -209,33 +209,40 @@ bool VarAs(const pp::Var& var, Device* result, std::string* error_message);
 
 pp::Var MakeVar(const Device& value);
 
-bool VarAs(const pp::Var& var, ConnectionHandle* result,
+bool VarAs(const pp::Var& var,
+           ConnectionHandle* result,
            std::string* error_message);
 
 pp::Var MakeVar(const ConnectionHandle& value);
 
-bool VarAs(const pp::Var& var, EndpointDescriptorType* result,
+bool VarAs(const pp::Var& var,
+           EndpointDescriptorType* result,
            std::string* error_message);
 
 pp::Var MakeVar(EndpointDescriptorType value);
 
-bool VarAs(const pp::Var& var, EndpointDescriptorSynchronization* result,
+bool VarAs(const pp::Var& var,
+           EndpointDescriptorSynchronization* result,
            std::string* error_message);
 
 pp::Var MakeVar(EndpointDescriptorSynchronization value);
 
-bool VarAs(const pp::Var& var, EndpointDescriptorUsage* result,
+bool VarAs(const pp::Var& var,
+           EndpointDescriptorUsage* result,
            std::string* error_message);
 
 pp::Var MakeVar(EndpointDescriptorUsage value);
 
-bool VarAs(const pp::Var& var, EndpointDescriptor* result,
+bool VarAs(const pp::Var& var,
+           EndpointDescriptor* result,
            std::string* error_message);
 
-bool VarAs(const pp::Var& var, InterfaceDescriptor* result,
+bool VarAs(const pp::Var& var,
+           InterfaceDescriptor* result,
            std::string* error_message);
 
-bool VarAs(const pp::Var& var, ConfigDescriptor* result,
+bool VarAs(const pp::Var& var,
+           ConfigDescriptor* result,
            std::string* error_message);
 
 pp::Var MakeVar(const GenericTransferInfo& value);
@@ -246,7 +253,8 @@ pp::Var MakeVar(ControlTransferInfoRequestType value);
 
 pp::Var MakeVar(const ControlTransferInfo& value);
 
-bool VarAs(const pp::Var& var, TransferResultInfo* result,
+bool VarAs(const pp::Var& var,
+           TransferResultInfo* result,
            std::string* error_message);
 
 pp::Var MakeVar(const DeviceFilter& value);

--- a/third_party/libusb/naclport/src/google_smart_card_libusb/global.cc
+++ b/third_party/libusb/naclport/src/google_smart_card_libusb/global.cc
@@ -45,7 +45,8 @@ namespace google_smart_card {
 
 class LibusbOverChromeUsbGlobal::Impl final {
  public:
-  Impl(TypedMessageRouter* typed_message_router, pp::Instance* pp_instance,
+  Impl(TypedMessageRouter* typed_message_router,
+       pp::Instance* pp_instance,
        pp::Core* pp_core)
       : chrome_usb_api_bridge_(
             MakeRequester(typed_message_router, pp_instance, pp_core)),
@@ -61,13 +62,15 @@ class LibusbOverChromeUsbGlobal::Impl final {
   void Detach() { chrome_usb_api_bridge_.Detach(); }
 
   LibusbInterface* libusb() {
-    if (libusb_tracing_wrapper_) return libusb_tracing_wrapper_.get();
+    if (libusb_tracing_wrapper_)
+      return libusb_tracing_wrapper_.get();
     return &libusb_over_chrome_usb_;
   }
 
  private:
   static std::unique_ptr<Requester> MakeRequester(
-      TypedMessageRouter* typed_message_router, pp::Instance* pp_instance,
+      TypedMessageRouter* typed_message_router,
+      pp::Instance* pp_instance,
       pp::Core* pp_core) {
     return std::unique_ptr<Requester>(new JsRequester(
         chrome_usb::kApiBridgeRequesterName, typed_message_router,
@@ -80,7 +83,8 @@ class LibusbOverChromeUsbGlobal::Impl final {
 };
 
 LibusbOverChromeUsbGlobal::LibusbOverChromeUsbGlobal(
-    TypedMessageRouter* typed_message_router, pp::Instance* pp_instance,
+    TypedMessageRouter* typed_message_router,
+    pp::Instance* pp_instance,
     pp::Core* pp_core)
     : impl_(new Impl(typed_message_router, pp_instance, pp_core)) {
   GOOGLE_SMART_CARD_CHECK(!g_libusb);
@@ -92,7 +96,9 @@ LibusbOverChromeUsbGlobal::~LibusbOverChromeUsbGlobal() {
   g_libusb = nullptr;
 }
 
-void LibusbOverChromeUsbGlobal::Detach() { impl_->Detach(); }
+void LibusbOverChromeUsbGlobal::Detach() {
+  impl_->Detach();
+}
 
 }  // namespace google_smart_card
 
@@ -122,8 +128,9 @@ void LIBUSB_CALL libusb_unref_device(libusb_device* dev) {
   GetGlobalLibusb()->LibusbUnrefDevice(dev);
 }
 
-int LIBUSB_CALL libusb_get_active_config_descriptor(
-    libusb_device* dev, libusb_config_descriptor** config) {
+int LIBUSB_CALL
+libusb_get_active_config_descriptor(libusb_device* dev,
+                                    libusb_config_descriptor** config) {
   return GetGlobalLibusb()->LibusbGetActiveConfigDescriptor(dev, config);
 }
 
@@ -184,9 +191,12 @@ int LIBUSB_CALL libusb_reset_device(libusb_device_handle* dev) {
 }
 
 int LIBUSB_CALL libusb_control_transfer(libusb_device_handle* dev_handle,
-                                        uint8_t request_type, uint8_t bRequest,
-                                        uint16_t wValue, uint16_t wIndex,
-                                        unsigned char* data, uint16_t wLength,
+                                        uint8_t request_type,
+                                        uint8_t bRequest,
+                                        uint16_t wValue,
+                                        uint16_t wIndex,
+                                        unsigned char* data,
+                                        uint16_t wLength,
                                         unsigned int timeout) {
   return GetGlobalLibusb()->LibusbControlTransfer(dev_handle, request_type,
                                                   bRequest, wValue, wIndex,
@@ -195,15 +205,18 @@ int LIBUSB_CALL libusb_control_transfer(libusb_device_handle* dev_handle,
 
 int LIBUSB_CALL libusb_bulk_transfer(libusb_device_handle* dev_handle,
                                      unsigned char endpoint,
-                                     unsigned char* data, int length,
-                                     int* actual_length, unsigned int timeout) {
+                                     unsigned char* data,
+                                     int length,
+                                     int* actual_length,
+                                     unsigned int timeout) {
   return GetGlobalLibusb()->LibusbBulkTransfer(dev_handle, endpoint, data,
                                                length, actual_length, timeout);
 }
 
 int LIBUSB_CALL libusb_interrupt_transfer(libusb_device_handle* dev_handle,
                                           unsigned char endpoint,
-                                          unsigned char* data, int length,
+                                          unsigned char* data,
+                                          int length,
                                           int* actual_length,
                                           unsigned int timeout) {
   return GetGlobalLibusb()->LibusbInterruptTransfer(

--- a/third_party/libusb/naclport/src/google_smart_card_libusb/global.h
+++ b/third_party/libusb/naclport/src/google_smart_card_libusb/global.h
@@ -40,7 +40,8 @@ namespace google_smart_card {
 class LibusbOverChromeUsbGlobal final {
  public:
   LibusbOverChromeUsbGlobal(TypedMessageRouter* typed_message_router,
-                            pp::Instance* pp_instance, pp::Core* pp_core);
+                            pp::Instance* pp_instance,
+                            pp::Core* pp_core);
 
   LibusbOverChromeUsbGlobal(const LibusbOverChromeUsbGlobal&) = delete;
   LibusbOverChromeUsbGlobal& operator=(const LibusbOverChromeUsbGlobal&) =

--- a/third_party/libusb/naclport/src/libusb_interface.h
+++ b/third_party/libusb/naclport/src/libusb_interface.h
@@ -45,7 +45,8 @@ class LibusbInterface {
   virtual void LibusbUnrefDevice(libusb_device* dev) = 0;
 
   virtual int LibusbGetActiveConfigDescriptor(
-      libusb_device* dev, libusb_config_descriptor** config) = 0;
+      libusb_device* dev,
+      libusb_config_descriptor** config) = 0;
   virtual void LibusbFreeConfigDescriptor(libusb_config_descriptor* config) = 0;
 
   virtual int LibusbGetDeviceDescriptor(libusb_device* dev,
@@ -70,18 +71,25 @@ class LibusbInterface {
   virtual void LibusbFreeTransfer(libusb_transfer* transfer) = 0;
 
   virtual int LibusbControlTransfer(libusb_device_handle* dev,
-                                    uint8_t bmRequestType, uint8_t bRequest,
-                                    uint16_t wValue, uint16_t wIndex,
-                                    unsigned char* data, uint16_t wLength,
+                                    uint8_t bmRequestType,
+                                    uint8_t bRequest,
+                                    uint16_t wValue,
+                                    uint16_t wIndex,
+                                    unsigned char* data,
+                                    uint16_t wLength,
                                     unsigned timeout) = 0;
   virtual int LibusbBulkTransfer(libusb_device_handle* dev,
-                                 unsigned char endpoint, unsigned char* data,
-                                 int length, int* actual_length,
+                                 unsigned char endpoint,
+                                 unsigned char* data,
+                                 int length,
+                                 int* actual_length,
                                  unsigned timeout) = 0;
   virtual int LibusbInterruptTransfer(libusb_device_handle* dev,
                                       unsigned char endpoint,
-                                      unsigned char* data, int length,
-                                      int* actual_length, unsigned timeout) = 0;
+                                      unsigned char* data,
+                                      int length,
+                                      int* actual_length,
+                                      unsigned timeout) = 0;
 
   virtual int LibusbHandleEvents(libusb_context* ctx) = 0;
   virtual int LibusbHandleEventsCompleted(libusb_context* ctx,

--- a/third_party/libusb/naclport/src/libusb_opaque_types.cc
+++ b/third_party/libusb/naclport/src/libusb_opaque_types.cc
@@ -241,7 +241,8 @@ bool libusb_context::ExtractAsyncTransferStateUpdate(
 bool libusb_context::ExtractAsyncTransferStateCancellationUpdate(
     TransferAsyncRequestStatePtr* async_request_state,
     TransferRequestResult* result) {
-  if (transfers_to_cancel_.empty()) return false;
+  if (transfers_to_cancel_.empty())
+    return false;
 
   const auto iter = transfers_to_cancel_.begin();
   libusb_transfer* const transfer = *iter;
@@ -309,14 +310,16 @@ bool libusb_context::ExtractMatchingInputTransferResult(
     TransferRequestResult* result) {
   const auto iter =
       received_input_transfer_result_map_.find(transfer_destination);
-  if (iter == received_input_transfer_result_map_.end()) return false;
+  if (iter == received_input_transfer_result_map_.end())
+    return false;
   std::queue<TransferRequestResult>* results_queue = &iter->second;
 
   GOOGLE_SMART_CARD_CHECK(!results_queue->empty());
   *result = std::move(results_queue->front());
   results_queue->pop();
 
-  if (results_queue->empty()) received_input_transfer_result_map_.erase(iter);
+  if (results_queue->empty())
+    received_input_transfer_result_map_.erase(iter);
 
   return true;
 }
@@ -346,9 +349,13 @@ libusb_device::libusb_device(
   GOOGLE_SMART_CARD_CHECK(context);
 }
 
-libusb_device::~libusb_device() { GOOGLE_SMART_CARD_CHECK(!reference_count_); }
+libusb_device::~libusb_device() {
+  GOOGLE_SMART_CARD_CHECK(!reference_count_);
+}
 
-libusb_context* libusb_device::context() const { return context_; }
+libusb_context* libusb_device::context() const {
+  return context_;
+}
 
 const google_smart_card::chrome_usb::Device& libusb_device::chrome_usb_device()
     const {
@@ -363,7 +370,8 @@ void libusb_device::AddReference() {
 void libusb_device::RemoveReference() {
   const int new_reference_count = --reference_count_;
   GOOGLE_SMART_CARD_CHECK(new_reference_count >= 0);
-  if (!new_reference_count) delete this;
+  if (!new_reference_count)
+    delete this;
 }
 
 libusb_device_handle::libusb_device_handle(
@@ -376,9 +384,13 @@ libusb_device_handle::libusb_device_handle(
   device_->AddReference();
 }
 
-libusb_device_handle::~libusb_device_handle() { device_->RemoveReference(); }
+libusb_device_handle::~libusb_device_handle() {
+  device_->RemoveReference();
+}
 
-libusb_device* libusb_device_handle::device() const { return device_; }
+libusb_device* libusb_device_handle::device() const {
+  return device_;
+}
 
 libusb_context* libusb_device_handle::context() const {
   return device_->context();

--- a/third_party/libusb/naclport/src/libusb_over_chrome_usb.cc
+++ b/third_party/libusb/naclport/src/libusb_over_chrome_usb.cc
@@ -99,7 +99,8 @@ std::unique_ptr<uint8_t[]> CopyRawData(const uint8_t* data, size_t byte_count) {
 }
 
 std::unique_ptr<uint8_t[]> CopyRawData(const std::vector<uint8_t>& data) {
-  if (data.empty()) return nullptr;
+  if (data.empty())
+    return nullptr;
   return CopyRawData(&data[0], data.size());
 }
 
@@ -117,14 +118,16 @@ LibusbOverChromeUsb::~LibusbOverChromeUsb() = default;
 int LibusbOverChromeUsb::LibusbInit(libusb_context** ctx) {
   // If the default context was requested, nothing is done (it's always existing
   // and initialized as long as this class object is alive).
-  if (ctx) *ctx = contexts_storage_.CreateContext().get();
+  if (ctx)
+    *ctx = contexts_storage_.CreateContext().get();
   return LIBUSB_SUCCESS;
 }
 
 void LibusbOverChromeUsb::LibusbExit(libusb_context* ctx) {
   // If the default context deinitialization was requested, nothing is done
   // (it's always kept initialized as long as this class object is alive).
-  if (ctx) contexts_storage_.DestroyContext(ctx);
+  if (ctx)
+    contexts_storage_.DestroyContext(ctx);
 }
 
 ssize_t LibusbOverChromeUsb::LibusbGetDeviceList(libusb_context* ctx,
@@ -157,9 +160,11 @@ ssize_t LibusbOverChromeUsb::LibusbGetDeviceList(libusb_context* ctx,
 
 void LibusbOverChromeUsb::LibusbFreeDeviceList(libusb_device** list,
                                                int unref_devices) {
-  if (!list) return;
+  if (!list)
+    return;
   if (unref_devices) {
-    for (size_t index = 0; list[index]; ++index) LibusbUnrefDevice(list[index]);
+    for (size_t index = 0; list[index]; ++index)
+      LibusbUnrefDevice(list[index]);
   }
   delete[] list;
 }
@@ -349,7 +354,8 @@ void FillLibusbConfigDescriptor(
 }  // namespace
 
 int LibusbOverChromeUsb::LibusbGetActiveConfigDescriptor(
-    libusb_device* dev, libusb_config_descriptor** config) {
+    libusb_device* dev,
+    libusb_config_descriptor** config) {
   GOOGLE_SMART_CARD_CHECK(dev);
   GOOGLE_SMART_CARD_CHECK(config);
 
@@ -424,7 +430,8 @@ void DestroyLibusbConfigDescriptor(
 
 void LibusbOverChromeUsb::LibusbFreeConfigDescriptor(
     libusb_config_descriptor* config) {
-  if (!config) return;
+  if (!config)
+    return;
   DestroyLibusbConfigDescriptor(*config);
   delete config;
 }
@@ -482,7 +489,8 @@ void FillLibusbDeviceDescriptor(const chrome_usb::Device& chrome_usb_device,
 }  // namespace
 
 int LibusbOverChromeUsb::LibusbGetDeviceDescriptor(
-    libusb_device* dev, libusb_device_descriptor* desc) {
+    libusb_device* dev,
+    libusb_device_descriptor* desc) {
   GOOGLE_SMART_CARD_CHECK(dev);
   GOOGLE_SMART_CARD_CHECK(desc);
 
@@ -612,8 +620,13 @@ libusb_transfer* LibusbOverChromeUsb::LibusbAllocTransfer(int iso_packets) {
 namespace {
 
 bool CreateChromeUsbControlTransferInfo(
-    uint8_t request_type, uint8_t request, uint16_t value, uint16_t index,
-    unsigned char* data, uint16_t length, unsigned timeout,
+    uint8_t request_type,
+    uint8_t request,
+    uint16_t value,
+    uint16_t index,
+    unsigned char* data,
+    uint16_t length,
+    unsigned timeout,
     chrome_usb::ControlTransferInfo* result) {
   GOOGLE_SMART_CARD_CHECK(result);
 
@@ -665,7 +678,8 @@ bool CreateChromeUsbControlTransferInfo(
 
   result->index = libusb_le16_to_cpu(index);
 
-  if (result->direction == chrome_usb::Direction::kIn) result->length = length;
+  if (result->direction == chrome_usb::Direction::kIn)
+    result->length = length;
 
   if (result->direction == chrome_usb::Direction::kOut) {
     GOOGLE_SMART_CARD_CHECK(data);
@@ -678,7 +692,8 @@ bool CreateChromeUsbControlTransferInfo(
 }
 
 bool CreateChromeUsbControlTransferInfo(
-    libusb_transfer* transfer, chrome_usb::ControlTransferInfo* result) {
+    libusb_transfer* transfer,
+    chrome_usb::ControlTransferInfo* result) {
   GOOGLE_SMART_CARD_CHECK(transfer);
   GOOGLE_SMART_CARD_CHECK(transfer->type == LIBUSB_TRANSFER_TYPE_CONTROL);
   GOOGLE_SMART_CARD_CHECK(result);
@@ -705,7 +720,8 @@ bool CreateChromeUsbControlTransferInfo(
       libusb_control_transfer_get_setup(transfer);
 
   const uint16_t data_length = libusb_le16_to_cpu(control_setup->wLength);
-  if (data_length != transfer->length - LIBUSB_CONTROL_SETUP_SIZE) return false;
+  if (data_length != transfer->length - LIBUSB_CONTROL_SETUP_SIZE)
+    return false;
 
   return CreateChromeUsbControlTransferInfo(
       control_setup->bmRequestType, control_setup->bRequest,
@@ -716,8 +732,11 @@ bool CreateChromeUsbControlTransferInfo(
 }
 
 void CreateChromeUsbGenericTransferInfo(
-    unsigned char endpoint_address, unsigned char* data, int length,
-    unsigned timeout, chrome_usb::GenericTransferInfo* result) {
+    unsigned char endpoint_address,
+    unsigned char* data,
+    int length,
+    unsigned timeout,
+    chrome_usb::GenericTransferInfo* result) {
   GOOGLE_SMART_CARD_CHECK(result);
 
   result->direction =
@@ -727,7 +746,8 @@ void CreateChromeUsbGenericTransferInfo(
 
   result->endpoint = endpoint_address;
 
-  if (result->direction == chrome_usb::Direction::kIn) result->length = length;
+  if (result->direction == chrome_usb::Direction::kIn)
+    result->length = length;
 
   if (result->direction == chrome_usb::Direction::kOut) {
     GOOGLE_SMART_CARD_CHECK(data);
@@ -738,7 +758,8 @@ void CreateChromeUsbGenericTransferInfo(
 }
 
 void CreateChromeUsbGenericTransferInfo(
-    libusb_transfer* transfer, chrome_usb::GenericTransferInfo* result) {
+    libusb_transfer* transfer,
+    chrome_usb::GenericTransferInfo* result) {
   GOOGLE_SMART_CARD_CHECK(transfer);
   GOOGLE_SMART_CARD_CHECK(transfer->type == LIBUSB_TRANSFER_TYPE_BULK ||
                           transfer->type == LIBUSB_TRANSFER_TYPE_INTERRUPT);
@@ -865,7 +886,8 @@ int LibusbOverChromeUsb::LibusbCancelTransfer(libusb_transfer* transfer) {
 void LibusbOverChromeUsb::LibusbFreeTransfer(libusb_transfer* transfer) {
   GOOGLE_SMART_CARD_CHECK(transfer);
 
-  if (transfer->flags & LIBUSB_TRANSFER_FREE_BUFFER) ::free(transfer->buffer);
+  if (transfer->flags & LIBUSB_TRANSFER_FREE_BUFFER)
+    ::free(transfer->buffer);
   delete transfer;
 }
 
@@ -873,9 +895,12 @@ namespace {
 
 libusb_transfer_status FillLibusbTransferResult(
     const chrome_usb::TransferResultInfo& transfer_result_info,
-    bool is_short_not_ok, int data_length, unsigned char* data_buffer,
+    bool is_short_not_ok,
+    int data_length,
+    unsigned char* data_buffer,
     int* actual_length) {
-  if (!transfer_result_info.result_code) return LIBUSB_TRANSFER_ERROR;
+  if (!transfer_result_info.result_code)
+    return LIBUSB_TRANSFER_ERROR;
   if (*transfer_result_info.result_code !=
       chrome_usb::kTransferResultInfoSuccessResultCode) {
     return LIBUSB_TRANSFER_ERROR;
@@ -899,7 +924,8 @@ libusb_transfer_status FillLibusbTransferResult(
     actual_length_value = data_length;
   }
 
-  if (actual_length) *actual_length = actual_length_value;
+  if (actual_length)
+    *actual_length = actual_length_value;
 
   if (is_short_not_ok && actual_length_value < data_length)
     return LIBUSB_TRANSFER_ERROR;
@@ -920,10 +946,14 @@ int LibusbTransferStatusToLibusbErrorCode(
 
 }  // namespace
 
-int LibusbOverChromeUsb::LibusbControlTransfer(
-    libusb_device_handle* dev, uint8_t bmRequestType, uint8_t bRequest,
-    uint16_t wValue, uint16_t index, unsigned char* data, uint16_t wLength,
-    unsigned timeout) {
+int LibusbOverChromeUsb::LibusbControlTransfer(libusb_device_handle* dev,
+                                               uint8_t bmRequestType,
+                                               uint8_t bRequest,
+                                               uint16_t wValue,
+                                               uint16_t index,
+                                               unsigned char* data,
+                                               uint16_t wLength,
+                                               unsigned timeout) {
   GOOGLE_SMART_CARD_CHECK(dev);
 
   chrome_usb::ControlTransferInfo transfer_info;
@@ -954,13 +984,15 @@ int LibusbOverChromeUsb::LibusbControlTransfer(
   const int error_code =
       LibusbTransferStatusToLibusbErrorCode(FillLibusbTransferResult(
           result.payload().result_info, false, wLength, data, &actual_length));
-  if (error_code == LIBUSB_SUCCESS) return actual_length;
+  if (error_code == LIBUSB_SUCCESS)
+    return actual_length;
   return error_code;
 }
 
 int LibusbOverChromeUsb::LibusbBulkTransfer(libusb_device_handle* dev,
                                             unsigned char endpoint_address,
-                                            unsigned char* data, int length,
+                                            unsigned char* data,
+                                            int length,
                                             int* actual_length,
                                             unsigned timeout) {
   GOOGLE_SMART_CARD_CHECK(dev);
@@ -993,7 +1025,8 @@ int LibusbOverChromeUsb::LibusbBulkTransfer(libusb_device_handle* dev,
 int LibusbOverChromeUsb::LibusbInterruptTransfer(libusb_device_handle* dev,
                                                  unsigned char endpoint_address,
                                                  unsigned char* data,
-                                                 int length, int* actual_length,
+                                                 int length,
+                                                 int* actual_length,
                                                  unsigned timeout) {
   GOOGLE_SMART_CARD_CHECK(dev);
 
@@ -1073,15 +1106,18 @@ LibusbOverChromeUsb::SyncTransferHelper::WaitForCompletion() {
 
 libusb_context* LibusbOverChromeUsb::SubstituteDefaultContextIfNull(
     libusb_context* context_or_nullptr) const {
-  if (context_or_nullptr) return context_or_nullptr;
+  if (context_or_nullptr)
+    return context_or_nullptr;
   return default_context_.get();
 }
 
 libusb_context* LibusbOverChromeUsb::GetLibusbTransferContext(
     const libusb_transfer* transfer) const {
-  if (!transfer) return nullptr;
+  if (!transfer)
+    return nullptr;
   libusb_device_handle* const device_handle = transfer->dev_handle;
-  if (!device_handle) return nullptr;
+  if (!device_handle)
+    return nullptr;
   return device_handle->context();
 }
 

--- a/third_party/libusb/naclport/src/libusb_over_chrome_usb.h
+++ b/third_party/libusb/naclport/src/libusb_over_chrome_usb.h
@@ -65,7 +65,8 @@ class LibusbOverChromeUsb final : public LibusbInterface {
   libusb_device* LibusbRefDevice(libusb_device* dev) override;
   void LibusbUnrefDevice(libusb_device* dev) override;
   int LibusbGetActiveConfigDescriptor(
-      libusb_device* dev, libusb_config_descriptor** config) override;
+      libusb_device* dev,
+      libusb_config_descriptor** config) override;
   void LibusbFreeConfigDescriptor(libusb_config_descriptor* config) override;
   int LibusbGetDeviceDescriptor(libusb_device* dev,
                                 libusb_device_descriptor* desc) override;
@@ -82,16 +83,26 @@ class LibusbOverChromeUsb final : public LibusbInterface {
   int LibusbSubmitTransfer(libusb_transfer* transfer) override;
   int LibusbCancelTransfer(libusb_transfer* transfer) override;
   void LibusbFreeTransfer(libusb_transfer* transfer) override;
-  int LibusbControlTransfer(libusb_device_handle* dev, uint8_t bmRequestType,
-                            uint8_t bRequest, uint16_t wValue, uint16_t wIndex,
-                            unsigned char* data, uint16_t wLength,
+  int LibusbControlTransfer(libusb_device_handle* dev,
+                            uint8_t bmRequestType,
+                            uint8_t bRequest,
+                            uint16_t wValue,
+                            uint16_t wIndex,
+                            unsigned char* data,
+                            uint16_t wLength,
                             unsigned timeout) override;
-  int LibusbBulkTransfer(libusb_device_handle* dev, unsigned char endpoint,
-                         unsigned char* data, int length, int* actual_length,
+  int LibusbBulkTransfer(libusb_device_handle* dev,
+                         unsigned char endpoint,
+                         unsigned char* data,
+                         int length,
+                         int* actual_length,
                          unsigned timeout) override;
-  int LibusbInterruptTransfer(libusb_device_handle* dev, unsigned char endpoint,
-                              unsigned char* data, int length,
-                              int* actual_length, unsigned timeout) override;
+  int LibusbInterruptTransfer(libusb_device_handle* dev,
+                              unsigned char endpoint,
+                              unsigned char* data,
+                              int length,
+                              int* actual_length,
+                              unsigned timeout) override;
   int LibusbHandleEvents(libusb_context* ctx) override;
   int LibusbHandleEventsCompleted(libusb_context* ctx, int* completed) override;
 

--- a/third_party/libusb/naclport/src/libusb_over_chrome_usb_unittest.cc
+++ b/third_party/libusb/naclport/src/libusb_over_chrome_usb_unittest.cc
@@ -63,8 +63,9 @@ constexpr char kBoolValues[] = {false, true};
 
 class MockChromeUsbApiBridge final : public chrome_usb::ApiBridgeInterface {
  public:
-  MOCK_METHOD1(GetDevices, RequestResult<chrome_usb::GetDevicesResult>(
-                               const chrome_usb::GetDevicesOptions& options));
+  MOCK_METHOD1(GetDevices,
+               RequestResult<chrome_usb::GetDevicesResult>(
+                   const chrome_usb::GetDevicesOptions& options));
 
   MOCK_METHOD1(GetUserSelectedDevices,
                RequestResult<chrome_usb::GetUserSelectedDevicesResult>(
@@ -74,8 +75,9 @@ class MockChromeUsbApiBridge final : public chrome_usb::ApiBridgeInterface {
                RequestResult<chrome_usb::GetConfigurationsResult>(
                    const chrome_usb::Device& device));
 
-  MOCK_METHOD1(OpenDevice, RequestResult<chrome_usb::OpenDeviceResult>(
-                               const chrome_usb::Device& device));
+  MOCK_METHOD1(OpenDevice,
+               RequestResult<chrome_usb::OpenDeviceResult>(
+                   const chrome_usb::Device& device));
 
   MOCK_METHOD1(CloseDevice,
                RequestResult<chrome_usb::CloseDeviceResult>(
@@ -384,7 +386,8 @@ class LibusbOverChromeUsbTransfersTest
   }
 
   libusb_transfer* StartAsyncControlTransfer(
-      size_t transfer_index, bool is_output,
+      size_t transfer_index,
+      bool is_output,
       MockFunction<void(libusb_transfer_status)>* transfer_callback) {
     const std::vector<uint8_t> actual_data =
         GenerateTransferData(transfer_index, is_output);
@@ -419,14 +422,18 @@ class LibusbOverChromeUsbTransfersTest
   }
 
   void SetUpTransferCallbackMockExpectations(
-      size_t transfer_index, bool /*is_output*/, bool is_canceled,
+      size_t transfer_index,
+      bool /*is_output*/,
+      bool is_canceled,
       MockFunction<void(libusb_transfer_status)>* transfer_callback) {
     EXPECT_CALL(*transfer_callback,
                 Call(GetExpectedTransferStatus(transfer_index, is_canceled)));
   }
 
   void SetUpTransferCallbackMockExpectations(
-      size_t transfer_index, bool /*is_output*/, bool is_canceled,
+      size_t transfer_index,
+      bool /*is_output*/,
+      bool is_canceled,
       MockFunction<void(libusb_transfer_status)>* transfer_callback,
       int* completed) {
     EXPECT_CALL(*transfer_callback,
@@ -450,7 +457,8 @@ class LibusbOverChromeUsbTransfersTest
   class AsyncTransferCallbackWrapper {
    public:
     AsyncTransferCallbackWrapper(
-        LibusbOverChromeUsbTransfersTest* test_instance, size_t transfer_index,
+        LibusbOverChromeUsbTransfersTest* test_instance,
+        size_t transfer_index,
         bool is_output,
         MockFunction<void(libusb_transfer_status)>* transfer_callback)
         : test_instance_(test_instance),
@@ -484,7 +492,8 @@ class LibusbOverChromeUsbTransfersTest
   };
 
   chrome_usb::ControlTransferInfo GenerateControlTransferInfo(
-      size_t transfer_index, bool is_output) {
+      size_t transfer_index,
+      bool is_output) {
     chrome_usb::ControlTransferInfo transfer_info;
     transfer_info.direction =
         is_output ? chrome_usb::Direction::kOut : chrome_usb::Direction::kIn;
@@ -516,7 +525,8 @@ class LibusbOverChromeUsbTransfersTest
   }
 
   RequestResult<chrome_usb::TransferResult> GenerateTransferRequestResult(
-      size_t transfer_index, bool is_output) {
+      size_t transfer_index,
+      bool is_output) {
     if (IsTransferToFail(transfer_index)) {
       return RequestResult<chrome_usb::TransferResult>::CreateFailed(
           "fake failure");
@@ -533,7 +543,9 @@ class LibusbOverChromeUsbTransfersTest
   }
 
   void OnAsyncControlTransferFinished(
-      libusb_transfer* transfer, size_t transfer_index, bool is_output,
+      libusb_transfer* transfer,
+      size_t transfer_index,
+      bool is_output,
       MockFunction<void(libusb_transfer_status)>* transfer_callback) {
     if (transfer->status != LIBUSB_TRANSFER_CANCELLED) {
       EXPECT_EQ(GetExpectedTransferStatus(transfer_index, false),
@@ -559,8 +571,10 @@ class LibusbOverChromeUsbTransfersTest
 
   static libusb_transfer_status GetExpectedTransferStatus(size_t transfer_index,
                                                           bool is_canceled) {
-    if (is_canceled) return LIBUSB_TRANSFER_CANCELLED;
-    if (IsTransferToFail(transfer_index)) return LIBUSB_TRANSFER_ERROR;
+    if (is_canceled)
+      return LIBUSB_TRANSFER_CANCELLED;
+    if (IsTransferToFail(transfer_index))
+      return LIBUSB_TRANSFER_ERROR;
     if (IsTransferToFinishUnsuccessfully(transfer_index))
       return LIBUSB_TRANSFER_ERROR;
     return LIBUSB_TRANSFER_COMPLETED;
@@ -725,7 +739,8 @@ TEST_P(LibusbOverChromeUsbSingleTransferTest,
 }
 
 INSTANTIATE_TEST_CASE_P(
-    InputTransferTest, LibusbOverChromeUsbSingleTransferTest,
+    InputTransferTest,
+    LibusbOverChromeUsbSingleTransferTest,
     ::testing::Values(
         LibusbOverChromeUsbSingleTransferTestParam(
             LibusbOverChromeUsbSingleTransferTest::GetTransferIndexToSucceed(),
@@ -739,7 +754,8 @@ INSTANTIATE_TEST_CASE_P(
             false)));
 
 INSTANTIATE_TEST_CASE_P(
-    OutputTransferTest, LibusbOverChromeUsbSingleTransferTest,
+    OutputTransferTest,
+    LibusbOverChromeUsbSingleTransferTest,
     ::testing::Values(
         LibusbOverChromeUsbSingleTransferTestParam(
             LibusbOverChromeUsbSingleTransferTest::GetTransferIndexToSucceed(),
@@ -815,7 +831,8 @@ class LibusbOverChromeUsbAsyncTransfersMultiThreadingTest
   }
 
   bool WaitAndGetTransferInFlight(
-      size_t* transfer_index, bool* is_transfer_output,
+      size_t* transfer_index,
+      bool* is_transfer_output,
       std::function<void()>* chrome_usb_transfer_resolver) {
     std::unique_lock<std::mutex> lock(mutex_);
     for (;;) {
@@ -831,7 +848,8 @@ class LibusbOverChromeUsbAsyncTransfersMultiThreadingTest
         return true;
       }
 
-      if (chrome_usb_transfer_resolvers_.empty()) return false;
+      if (chrome_usb_transfer_resolvers_.empty())
+        return false;
 
       condition_.wait(lock);
     }

--- a/third_party/libusb/naclport/src/libusb_tracing_wrapper.cc
+++ b/third_party/libusb/naclport/src/libusb_tracing_wrapper.cc
@@ -50,11 +50,13 @@ std::string DebugDumpLibusbDevice(const libusb_device* device_list) {
 }
 
 std::string DebugDumpLibusbDeviceList(libusb_device* const* device_list) {
-  if (!device_list) return "<NULL>";
+  if (!device_list)
+    return "<NULL>";
   std::string result;
   for (libusb_device* const* current_device = device_list; *current_device;
        ++current_device) {
-    if (!result.empty()) result += ", ";
+    if (!result.empty())
+      result += ", ";
     result += DebugDumpLibusbDevice(*current_device);
   }
   return HexDumpPointer(device_list) + "([" + result + "])";
@@ -212,11 +214,14 @@ std::string DebugDumpLibusbEndpointDescriptor(
 }
 
 std::string DebugDumpLibusbEndpointDescriptorList(
-    const libusb_endpoint_descriptor* endpoint_descriptor_list, size_t size) {
-  if (!endpoint_descriptor_list) return "<NULL>";
+    const libusb_endpoint_descriptor* endpoint_descriptor_list,
+    size_t size) {
+  if (!endpoint_descriptor_list)
+    return "<NULL>";
   std::string result;
   for (size_t index = 0; index < size; ++index) {
-    if (!result.empty()) result += ", ";
+    if (!result.empty())
+      result += ", ";
     result +=
         DebugDumpLibusbEndpointDescriptor(endpoint_descriptor_list[index]);
   }
@@ -248,11 +253,14 @@ std::string DebugDumpLibusbInterfaceDescriptor(
 }
 
 std::string DebugDumpLibusbInterfaceDescriptorList(
-    const libusb_interface_descriptor* interface_descriptor_list, size_t size) {
-  if (!interface_descriptor_list) return "<NULL>";
+    const libusb_interface_descriptor* interface_descriptor_list,
+    size_t size) {
+  if (!interface_descriptor_list)
+    return "<NULL>";
   std::string result;
   for (size_t index = 0; index < size; ++index) {
-    if (!result.empty()) result += ", ";
+    if (!result.empty())
+      result += ", ";
     result +=
         DebugDumpLibusbInterfaceDescriptor(interface_descriptor_list[index]);
   }
@@ -268,10 +276,12 @@ std::string DebugDumpLibusbInterface(const libusb_interface& interface) {
 
 std::string DebugDumpLibusbInterfaceList(const libusb_interface* interface_list,
                                          size_t size) {
-  if (!interface_list) return "<NULL>";
+  if (!interface_list)
+    return "<NULL>";
   std::string result;
   for (size_t index = 0; index < size; ++index) {
-    if (!result.empty()) result += ", ";
+    if (!result.empty())
+      result += ", ";
     result += DebugDumpLibusbInterface(interface_list[index]);
   }
   return "[" + result + "]";
@@ -377,15 +387,19 @@ std::string DebugDumpLibusbControlSetupRequestType(uint8_t request_type) {
          DebugDumpLibusbEndpointDirection(request_type & kDirectionMask) + ")";
 }
 
-std::string DebugDumpInboundDataBuffer(const void* data, size_t size,
+std::string DebugDumpInboundDataBuffer(const void* data,
+                                       size_t size,
                                        bool is_input_data) {
-  if (is_input_data) return HexDumpPointer(data);
-  if (!data) return "<NULL>";
+  if (is_input_data)
+    return HexDumpPointer(data);
+  if (!data)
+    return "<NULL>";
   return HexDumpPointer(data) + "<" + HexDumpBytes(data, size) + ">";
 }
 
 std::string DebugDumpOutboundDataBuffer(const void* data, size_t size) {
-  if (!data) return "<NULL>";
+  if (!data)
+    return "<NULL>";
   return HexDumpPointer(data) + "<" + HexDumpBytes(data, size) + ">";
 }
 
@@ -436,7 +450,8 @@ std::string DebugDumpLibusbControlSetup(
 
 std::string DebugDumpLibusbTransfer(libusb_transfer* transfer,
                                     bool is_inbound_argument) {
-  if (!transfer) return "<NULL>";
+  if (!transfer)
+    return "<NULL>";
 
   const bool is_input_transfer =
       (transfer->endpoint & LIBUSB_ENDPOINT_DIR_MASK) == LIBUSB_ENDPOINT_IN;
@@ -495,7 +510,8 @@ class LibusbTransferTracingWrapper final {
   LibusbTransferTracingWrapper(const LibusbTransferTracingWrapper&) = delete;
 
   static libusb_transfer* CreateWrappedTransfer(
-      libusb_transfer* transfer, LibusbInterface* wrapped_libusb) {
+      libusb_transfer* transfer,
+      LibusbInterface* wrapped_libusb) {
     // Note: Here a manual memory management is used, as the only entity that
     // can own the created class instance is libusb_transfer, which can store
     // only the pointer to it.
@@ -572,7 +588,8 @@ int LibusbTracingWrapper::LibusbInit(libusb_context** ctx) {
 
   tracer.AddReturnValue(DebugDumpLibusbReturnCode(return_code));
   if (return_code == LIBUSB_SUCCESS) {
-    if (ctx) tracer.AddReturnedArg("*ctx", DebugDumpLibusbContext(*ctx));
+    if (ctx)
+      tracer.AddReturnedArg("*ctx", DebugDumpLibusbContext(*ctx));
   }
   tracer.LogExit();
   return return_code;
@@ -601,7 +618,8 @@ ssize_t LibusbTracingWrapper::LibusbGetDeviceList(libusb_context* ctx,
                             ? std::to_string(return_code)
                             : DebugDumpLibusbReturnCode(return_code));
   if (return_code >= 0) {
-    if (list) tracer.AddReturnedArg("*list", DebugDumpLibusbDeviceList(*list));
+    if (list)
+      tracer.AddReturnedArg("*list", DebugDumpLibusbDeviceList(*list));
   }
   tracer.LogExit();
   return return_code;
@@ -642,7 +660,8 @@ void LibusbTracingWrapper::LibusbUnrefDevice(libusb_device* dev) {
 }
 
 int LibusbTracingWrapper::LibusbGetActiveConfigDescriptor(
-    libusb_device* dev, libusb_config_descriptor** config) {
+    libusb_device* dev,
+    libusb_config_descriptor** config) {
   FunctionCallTracer tracer("libusb_get_active_config_descriptor",
                             kLoggingPrefix);
   tracer.AddPassedArg("dev", DebugDumpLibusbDevice(dev));
@@ -675,7 +694,8 @@ void LibusbTracingWrapper::LibusbFreeConfigDescriptor(
 }
 
 int LibusbTracingWrapper::LibusbGetDeviceDescriptor(
-    libusb_device* dev, libusb_device_descriptor* desc) {
+    libusb_device* dev,
+    libusb_device_descriptor* desc) {
   FunctionCallTracer tracer("libusb_get_device_descriptor", kLoggingPrefix);
   tracer.AddPassedArg("dev", DebugDumpLibusbDevice(dev));
   tracer.AddPassedArg("desc", HexDumpPointer(desc));
@@ -854,10 +874,14 @@ void LibusbTracingWrapper::LibusbFreeTransfer(libusb_transfer* transfer) {
   tracer.LogExit();
 }
 
-int LibusbTracingWrapper::LibusbControlTransfer(
-    libusb_device_handle* dev, uint8_t bmRequestType, uint8_t bRequest,
-    uint16_t wValue, uint16_t wIndex, unsigned char* data, uint16_t wLength,
-    unsigned timeout) {
+int LibusbTracingWrapper::LibusbControlTransfer(libusb_device_handle* dev,
+                                                uint8_t bmRequestType,
+                                                uint8_t bRequest,
+                                                uint16_t wValue,
+                                                uint16_t wIndex,
+                                                unsigned char* data,
+                                                uint16_t wLength,
+                                                unsigned timeout) {
   FunctionCallTracer tracer("libusb_control_transfer", kLoggingPrefix);
   tracer.AddPassedArg("dev", DebugDumpLibusbDeviceHandle(dev));
   tracer.AddPassedArg("bmRequestType",
@@ -891,7 +915,8 @@ int LibusbTracingWrapper::LibusbControlTransfer(
 
 int LibusbTracingWrapper::LibusbBulkTransfer(libusb_device_handle* dev,
                                              unsigned char endpoint,
-                                             unsigned char* data, int length,
+                                             unsigned char* data,
+                                             int length,
                                              int* actual_length,
                                              unsigned timeout) {
   FunctionCallTracer tracer("libusb_bulk_transfer", kLoggingPrefix);
@@ -922,9 +947,12 @@ int LibusbTracingWrapper::LibusbBulkTransfer(libusb_device_handle* dev,
   return return_code;
 }
 
-int LibusbTracingWrapper::LibusbInterruptTransfer(
-    libusb_device_handle* dev, unsigned char endpoint, unsigned char* data,
-    int length, int* actual_length, unsigned timeout) {
+int LibusbTracingWrapper::LibusbInterruptTransfer(libusb_device_handle* dev,
+                                                  unsigned char endpoint,
+                                                  unsigned char* data,
+                                                  int length,
+                                                  int* actual_length,
+                                                  unsigned timeout) {
   FunctionCallTracer tracer("libusb_interrupt_transfer", kLoggingPrefix);
   tracer.AddPassedArg("dev", DebugDumpLibusbDeviceHandle(dev));
   tracer.AddPassedArg("endpoint", DebugDumpLibusbEndpointAddress(endpoint));
@@ -981,7 +1009,8 @@ int LibusbTracingWrapper::LibusbHandleEventsCompleted(libusb_context* ctx,
 }
 
 void LibusbTracingWrapper::AddOriginalToWrappedTransferMapItem(
-    libusb_transfer* original_transfer, libusb_transfer* wrapped_transfer) {
+    libusb_transfer* original_transfer,
+    libusb_transfer* wrapped_transfer) {
   const std::unique_lock<std::mutex> lock(mutex_);
   // The mapping value under the original_transfer key, if previously existed,
   // is just overwritten here, because libusb API allows to re-use the same
@@ -993,7 +1022,8 @@ libusb_transfer* LibusbTracingWrapper::GetWrappedTransfer(
     libusb_transfer* original_transfer) const {
   const std::unique_lock<std::mutex> lock(mutex_);
   const auto iter = original_to_wrapped_transfer_map_.find(original_transfer);
-  if (iter == original_to_wrapped_transfer_map_.end()) return nullptr;
+  if (iter == original_to_wrapped_transfer_map_.end())
+    return nullptr;
   return iter->second;
 }
 

--- a/third_party/libusb/naclport/src/libusb_tracing_wrapper.h
+++ b/third_party/libusb/naclport/src/libusb_tracing_wrapper.h
@@ -46,7 +46,8 @@ class LibusbTracingWrapper : public LibusbInterface {
   libusb_device* LibusbRefDevice(libusb_device* dev) override;
   void LibusbUnrefDevice(libusb_device* dev) override;
   int LibusbGetActiveConfigDescriptor(
-      libusb_device* dev, libusb_config_descriptor** config) override;
+      libusb_device* dev,
+      libusb_config_descriptor** config) override;
   void LibusbFreeConfigDescriptor(libusb_config_descriptor* config) override;
   int LibusbGetDeviceDescriptor(libusb_device* dev,
                                 libusb_device_descriptor* desc) override;
@@ -63,16 +64,26 @@ class LibusbTracingWrapper : public LibusbInterface {
   int LibusbSubmitTransfer(libusb_transfer* transfer) override;
   int LibusbCancelTransfer(libusb_transfer* transfer) override;
   void LibusbFreeTransfer(libusb_transfer* transfer) override;
-  int LibusbControlTransfer(libusb_device_handle* dev, uint8_t bmRequestType,
-                            uint8_t bRequest, uint16_t wValue, uint16_t wIndex,
-                            unsigned char* data, uint16_t wLength,
+  int LibusbControlTransfer(libusb_device_handle* dev,
+                            uint8_t bmRequestType,
+                            uint8_t bRequest,
+                            uint16_t wValue,
+                            uint16_t wIndex,
+                            unsigned char* data,
+                            uint16_t wLength,
                             unsigned timeout) override;
-  int LibusbBulkTransfer(libusb_device_handle* dev, unsigned char endpoint,
-                         unsigned char* data, int length, int* actual_length,
+  int LibusbBulkTransfer(libusb_device_handle* dev,
+                         unsigned char endpoint,
+                         unsigned char* data,
+                         int length,
+                         int* actual_length,
                          unsigned timeout) override;
-  int LibusbInterruptTransfer(libusb_device_handle* dev, unsigned char endpoint,
-                              unsigned char* data, int length,
-                              int* actual_length, unsigned timeout) override;
+  int LibusbInterruptTransfer(libusb_device_handle* dev,
+                              unsigned char endpoint,
+                              unsigned char* data,
+                              int length,
+                              int* actual_length,
+                              unsigned timeout) override;
   int LibusbHandleEvents(libusb_context* ctx) override;
   int LibusbHandleEventsCompleted(libusb_context* ctx, int* completed) override;
 

--- a/third_party/libusb/naclport/src/usb_transfer_destination.cc
+++ b/third_party/libusb/naclport/src/usb_transfer_destination.cc
@@ -73,7 +73,8 @@ bool UsbTransferDestination::operator==(
 
 UsbTransferDestination::UsbTransferDestination(
     const chrome_usb::ConnectionHandle& connection_handle,
-    const chrome_usb::Direction& direction, optional<int64_t> endpoint,
+    const chrome_usb::Direction& direction,
+    optional<int64_t> endpoint,
     optional<chrome_usb::ControlTransferInfoRecipient>
         control_transfer_recipient,
     optional<chrome_usb::ControlTransferInfoRequestType>
@@ -94,8 +95,10 @@ namespace {
 
 template <typename T>
 int CompareValues(const T& lhs, const T& rhs) {
-  if (lhs < rhs) return -1;
-  if (lhs > rhs) return 1;
+  if (lhs < rhs)
+    return -1;
+  if (lhs > rhs)
+    return 1;
   return 0;
 }
 

--- a/third_party/libusb/naclport/src/usb_transfers_parameters_storage.cc
+++ b/third_party/libusb/naclport/src/usb_transfers_parameters_storage.cc
@@ -143,17 +143,22 @@ void UsbTransfersParametersStorage::RemoveByLibusbTransfer(
 }
 
 bool UsbTransfersParametersStorage::FindByAsyncRequestState(
-    const TransferAsyncRequestState* async_request_state, Item* result) const {
+    const TransferAsyncRequestState* async_request_state,
+    Item* result) const {
   const auto iter = async_request_state_mapping_.find(async_request_state);
-  if (iter == async_request_state_mapping_.end()) return false;
-  if (result) *result = iter->second;
+  if (iter == async_request_state_mapping_.end())
+    return false;
+  if (result)
+    *result = iter->second;
   return true;
 }
 
 bool UsbTransfersParametersStorage::FindAsyncByDestination(
-    const UsbTransferDestination& transfer_destination, Item* result) const {
+    const UsbTransferDestination& transfer_destination,
+    Item* result) const {
   const auto iter = async_destination_mapping_.find(transfer_destination);
-  if (iter == async_destination_mapping_.end()) return false;
+  if (iter == async_destination_mapping_.end())
+    return false;
   const std::set<const TransferAsyncRequestState*>& transfers = iter->second;
   GOOGLE_SMART_CARD_CHECK(!transfers.empty());
   GOOGLE_SMART_CARD_CHECK(FindByAsyncRequestState(*transfers.begin(), result));
@@ -161,11 +166,14 @@ bool UsbTransfersParametersStorage::FindAsyncByDestination(
 }
 
 bool UsbTransfersParametersStorage::FindAsyncByLibusbTransfer(
-    const libusb_transfer* transfer, Item* result) const {
+    const libusb_transfer* transfer,
+    Item* result) const {
   GOOGLE_SMART_CARD_CHECK(transfer);
   const auto iter = async_libusb_transfer_mapping_.find(transfer);
-  if (iter == async_libusb_transfer_mapping_.end()) return false;
-  if (result) *result = iter->second;
+  if (iter == async_libusb_transfer_mapping_.end())
+    return false;
+  if (result)
+    *result = iter->second;
   return true;
 }
 

--- a/third_party/libusb/naclport/src/usb_transfers_parameters_storage.h
+++ b/third_party/libusb/naclport/src/usb_transfers_parameters_storage.h
@@ -99,9 +99,11 @@ class UsbTransfersParametersStorage final {
 
  private:
   bool FindByAsyncRequestState(
-      const TransferAsyncRequestState* async_request_state, Item* result) const;
+      const TransferAsyncRequestState* async_request_state,
+      Item* result) const;
   bool FindAsyncByDestination(
-      const UsbTransferDestination& transfer_destination, Item* result) const;
+      const UsbTransferDestination& transfer_destination,
+      Item* result) const;
   bool FindAsyncByLibusbTransfer(const libusb_transfer* transfer,
                                  Item* result) const;
 

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite.h
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite.h
@@ -46,18 +46,22 @@ class PcscLite {
  public:
   virtual ~PcscLite() = default;
 
-  virtual LONG SCardEstablishContext(DWORD dwScope, LPCVOID pvReserved1,
+  virtual LONG SCardEstablishContext(DWORD dwScope,
+                                     LPCVOID pvReserved1,
                                      LPCVOID pvReserved2,
                                      LPSCARDCONTEXT phContext) = 0;
 
   virtual LONG SCardReleaseContext(SCARDCONTEXT hContext) = 0;
 
-  virtual LONG SCardConnect(SCARDCONTEXT hContext, LPCSTR szReader,
-                            DWORD dwShareMode, DWORD dwPreferredProtocols,
+  virtual LONG SCardConnect(SCARDCONTEXT hContext,
+                            LPCSTR szReader,
+                            DWORD dwShareMode,
+                            DWORD dwPreferredProtocols,
                             LPSCARDHANDLE phCard,
                             LPDWORD pdwActiveProtocol) = 0;
 
-  virtual LONG SCardReconnect(SCARDHANDLE hCard, DWORD dwShareMode,
+  virtual LONG SCardReconnect(SCARDHANDLE hCard,
+                              DWORD dwShareMode,
                               DWORD dwPreferredProtocols,
                               DWORD dwInitialization,
                               LPDWORD pdwActiveProtocol) = 0;
@@ -68,38 +72,54 @@ class PcscLite {
 
   virtual LONG SCardEndTransaction(SCARDHANDLE hCard, DWORD dwDisposition) = 0;
 
-  virtual LONG SCardStatus(SCARDHANDLE hCard, LPSTR szReaderName,
-                           LPDWORD pcchReaderLen, LPDWORD pdwState,
-                           LPDWORD pdwProtocol, LPBYTE pbAtr,
+  virtual LONG SCardStatus(SCARDHANDLE hCard,
+                           LPSTR szReaderName,
+                           LPDWORD pcchReaderLen,
+                           LPDWORD pdwState,
+                           LPDWORD pdwProtocol,
+                           LPBYTE pbAtr,
                            LPDWORD pcbAtrLen) = 0;
 
-  virtual LONG SCardGetStatusChange(SCARDCONTEXT hContext, DWORD dwTimeout,
+  virtual LONG SCardGetStatusChange(SCARDCONTEXT hContext,
+                                    DWORD dwTimeout,
                                     SCARD_READERSTATE* rgReaderStates,
                                     DWORD cReaders) = 0;
 
-  virtual LONG SCardControl(SCARDHANDLE hCard, DWORD dwControlCode,
-                            LPCVOID pbSendBuffer, DWORD cbSendLength,
-                            LPVOID pbRecvBuffer, DWORD cbRecvLength,
+  virtual LONG SCardControl(SCARDHANDLE hCard,
+                            DWORD dwControlCode,
+                            LPCVOID pbSendBuffer,
+                            DWORD cbSendLength,
+                            LPVOID pbRecvBuffer,
+                            DWORD cbRecvLength,
                             LPDWORD lpBytesReturned) = 0;
 
-  virtual LONG SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPBYTE pbAttr,
+  virtual LONG SCardGetAttrib(SCARDHANDLE hCard,
+                              DWORD dwAttrId,
+                              LPBYTE pbAttr,
                               LPDWORD pcbAttrLen) = 0;
 
-  virtual LONG SCardSetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPCBYTE pbAttr,
+  virtual LONG SCardSetAttrib(SCARDHANDLE hCard,
+                              DWORD dwAttrId,
+                              LPCBYTE pbAttr,
                               DWORD cbAttrLen) = 0;
 
   virtual LONG SCardTransmit(SCARDHANDLE hCard,
                              const SCARD_IO_REQUEST* pioSendPci,
-                             LPCBYTE pbSendBuffer, DWORD cbSendLength,
-                             SCARD_IO_REQUEST* pioRecvPci, LPBYTE pbRecvBuffer,
+                             LPCBYTE pbSendBuffer,
+                             DWORD cbSendLength,
+                             SCARD_IO_REQUEST* pioRecvPci,
+                             LPBYTE pbRecvBuffer,
                              LPDWORD pcbRecvLength) = 0;
 
-  virtual LONG SCardListReaders(SCARDCONTEXT hContext, LPCSTR mszGroups,
-                                LPSTR mszReaders, LPDWORD pcchReaders) = 0;
+  virtual LONG SCardListReaders(SCARDCONTEXT hContext,
+                                LPCSTR mszGroups,
+                                LPSTR mszReaders,
+                                LPDWORD pcchReaders) = 0;
 
   virtual LONG SCardFreeMemory(SCARDCONTEXT hContext, LPCVOID pvMem) = 0;
 
-  virtual LONG SCardListReaderGroups(SCARDCONTEXT hContext, LPSTR mszGroups,
+  virtual LONG SCardListReaderGroups(SCARDCONTEXT hContext,
+                                     LPSTR mszGroups,
                                      LPDWORD pcchGroups) = 0;
 
   virtual LONG SCardCancel(SCARDCONTEXT hContext) = 0;

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.cc
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.cc
@@ -34,7 +34,8 @@
 namespace google_smart_card {
 
 PcscLiteTracingWrapper::PcscLiteTracingWrapper(
-    PcscLite* pcsc_lite, const std::string& logging_prefix,
+    PcscLite* pcsc_lite,
+    const std::string& logging_prefix,
     LogSeverity log_severity)
     : pcsc_lite_(pcsc_lite),
       logging_prefix_(logging_prefix),
@@ -85,7 +86,8 @@ LONG PcscLiteTracingWrapper::SCardReleaseContext(SCARDCONTEXT hContext) {
 }
 
 LONG PcscLiteTracingWrapper::SCardConnect(SCARDCONTEXT hContext,
-                                          LPCSTR szReader, DWORD dwShareMode,
+                                          LPCSTR szReader,
+                                          DWORD dwShareMode,
                                           DWORD dwPreferredProtocols,
                                           LPSCARDHANDLE phCard,
                                           LPDWORD pdwActiveProtocol) {
@@ -105,7 +107,8 @@ LONG PcscLiteTracingWrapper::SCardConnect(SCARDCONTEXT hContext,
 
   tracer.AddReturnValue(DebugDumpSCardReturnCode(return_code));
   if (return_code == SCARD_S_SUCCESS) {
-    if (phCard) tracer.AddReturnedArg("*phCard", DebugDumpSCardHandle(*phCard));
+    if (phCard)
+      tracer.AddReturnedArg("*phCard", DebugDumpSCardHandle(*phCard));
     if (pdwActiveProtocol) {
       tracer.AddReturnedArg("*pdwActiveProtocol",
                             DebugDumpSCardProtocol(*pdwActiveProtocol));
@@ -195,10 +198,13 @@ LONG PcscLiteTracingWrapper::SCardEndTransaction(SCARDHANDLE hCard,
   return return_code;
 }
 
-LONG PcscLiteTracingWrapper::SCardStatus(SCARDHANDLE hCard, LPSTR szReaderName,
+LONG PcscLiteTracingWrapper::SCardStatus(SCARDHANDLE hCard,
+                                         LPSTR szReaderName,
                                          LPDWORD pcchReaderLen,
-                                         LPDWORD pdwState, LPDWORD pdwProtocol,
-                                         LPBYTE pbAtr, LPDWORD pcbAtrLen) {
+                                         LPDWORD pdwState,
+                                         LPDWORD pdwProtocol,
+                                         LPBYTE pbAtr,
+                                         LPDWORD pcbAtrLen) {
   FunctionCallTracer tracer("SCardStatus", logging_prefix_, log_severity_);
   tracer.AddPassedArg("hCard", DebugDumpSCardHandle(hCard));
   tracer.AddPassedArg("szReaderName", HexDumpPointer(szReaderName));
@@ -249,7 +255,9 @@ LONG PcscLiteTracingWrapper::SCardStatus(SCARDHANDLE hCard, LPSTR szReaderName,
 }
 
 LONG PcscLiteTracingWrapper::SCardGetStatusChange(
-    SCARDCONTEXT hContext, DWORD dwTimeout, SCARD_READERSTATE* rgReaderStates,
+    SCARDCONTEXT hContext,
+    DWORD dwTimeout,
+    SCARD_READERSTATE* rgReaderStates,
     DWORD cReaders) {
   FunctionCallTracer tracer("SCardGetStatusChange", logging_prefix_,
                             log_severity_);
@@ -273,10 +281,13 @@ LONG PcscLiteTracingWrapper::SCardGetStatusChange(
   return return_code;
 }
 
-LONG PcscLiteTracingWrapper::SCardControl(
-    SCARDHANDLE hCard, DWORD dwControlCode, LPCVOID pbSendBuffer,
-    DWORD cbSendLength, LPVOID pbRecvBuffer, DWORD cbRecvLength,
-    LPDWORD lpBytesReturned) {
+LONG PcscLiteTracingWrapper::SCardControl(SCARDHANDLE hCard,
+                                          DWORD dwControlCode,
+                                          LPCVOID pbSendBuffer,
+                                          DWORD cbSendLength,
+                                          LPVOID pbRecvBuffer,
+                                          DWORD cbRecvLength,
+                                          LPDWORD lpBytesReturned) {
   FunctionCallTracer tracer("SCardControl", logging_prefix_, log_severity_);
   tracer.AddPassedArg("hCard", DebugDumpSCardHandle(hCard));
   tracer.AddPassedArg("dwControlCode",
@@ -313,8 +324,10 @@ LONG PcscLiteTracingWrapper::SCardControl(
   return return_code;
 }
 
-LONG PcscLiteTracingWrapper::SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId,
-                                            LPBYTE pbAttr, LPDWORD pcbAttrLen) {
+LONG PcscLiteTracingWrapper::SCardGetAttrib(SCARDHANDLE hCard,
+                                            DWORD dwAttrId,
+                                            LPBYTE pbAttr,
+                                            LPDWORD pcbAttrLen) {
   FunctionCallTracer tracer("SCardGetAttrib", logging_prefix_, log_severity_);
   tracer.AddPassedArg("hCard", DebugDumpSCardHandle(hCard));
   tracer.AddPassedArg("dwAttrId", DebugDumpSCardAttributeId(dwAttrId));
@@ -344,8 +357,10 @@ LONG PcscLiteTracingWrapper::SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId,
   return return_code;
 }
 
-LONG PcscLiteTracingWrapper::SCardSetAttrib(SCARDHANDLE hCard, DWORD dwAttrId,
-                                            LPCBYTE pbAttr, DWORD cbAttrLen) {
+LONG PcscLiteTracingWrapper::SCardSetAttrib(SCARDHANDLE hCard,
+                                            DWORD dwAttrId,
+                                            LPCBYTE pbAttr,
+                                            DWORD cbAttrLen) {
   FunctionCallTracer tracer("SCardSetAttrib", logging_prefix_, log_severity_);
   tracer.AddPassedArg("hCard", DebugDumpSCardHandle(hCard));
   tracer.AddPassedArg("dwAttrId", DebugDumpSCardAttributeId(dwAttrId));
@@ -362,10 +377,13 @@ LONG PcscLiteTracingWrapper::SCardSetAttrib(SCARDHANDLE hCard, DWORD dwAttrId,
   return return_code;
 }
 
-LONG PcscLiteTracingWrapper::SCardTransmit(
-    SCARDHANDLE hCard, const SCARD_IO_REQUEST* pioSendPci, LPCBYTE pbSendBuffer,
-    DWORD cbSendLength, SCARD_IO_REQUEST* pioRecvPci, LPBYTE pbRecvBuffer,
-    LPDWORD pcbRecvLength) {
+LONG PcscLiteTracingWrapper::SCardTransmit(SCARDHANDLE hCard,
+                                           const SCARD_IO_REQUEST* pioSendPci,
+                                           LPCBYTE pbSendBuffer,
+                                           DWORD cbSendLength,
+                                           SCARD_IO_REQUEST* pioRecvPci,
+                                           LPBYTE pbRecvBuffer,
+                                           LPDWORD pcbRecvLength) {
   FunctionCallTracer tracer("SCardTransmit", logging_prefix_, log_severity_);
   tracer.AddPassedArg("hCard", DebugDumpSCardHandle(hCard));
   tracer.AddPassedArg("pioSendPci", DebugDumpSCardIoRequest(pioSendPci));

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.h
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.h
@@ -42,48 +42,73 @@ namespace google_smart_card {
 class PcscLiteTracingWrapper final : public PcscLite {
  public:
   explicit PcscLiteTracingWrapper(
-      PcscLite* pcsc_lite, const std::string& logging_prefix = "",
+      PcscLite* pcsc_lite,
+      const std::string& logging_prefix = "",
       LogSeverity log_severity = LogSeverity::kDebug);
   PcscLiteTracingWrapper(const PcscLiteTracingWrapper&) = delete;
   PcscLiteTracingWrapper& operator=(const PcscLiteTracingWrapper&) = delete;
   ~PcscLiteTracingWrapper();
 
   // PcscLite:
-  LONG SCardEstablishContext(DWORD dwScope, LPCVOID pvReserved1,
+  LONG SCardEstablishContext(DWORD dwScope,
+                             LPCVOID pvReserved1,
                              LPCVOID pvReserved2,
                              LPSCARDCONTEXT phContext) override;
   LONG SCardReleaseContext(SCARDCONTEXT hContext) override;
-  LONG SCardConnect(SCARDCONTEXT hContext, LPCSTR szReader, DWORD dwShareMode,
-                    DWORD dwPreferredProtocols, LPSCARDHANDLE phCard,
+  LONG SCardConnect(SCARDCONTEXT hContext,
+                    LPCSTR szReader,
+                    DWORD dwShareMode,
+                    DWORD dwPreferredProtocols,
+                    LPSCARDHANDLE phCard,
                     LPDWORD pdwActiveProtocol) override;
-  LONG SCardReconnect(SCARDHANDLE hCard, DWORD dwShareMode,
-                      DWORD dwPreferredProtocols, DWORD dwInitialization,
+  LONG SCardReconnect(SCARDHANDLE hCard,
+                      DWORD dwShareMode,
+                      DWORD dwPreferredProtocols,
+                      DWORD dwInitialization,
                       LPDWORD pdwActiveProtocol) override;
   LONG SCardDisconnect(SCARDHANDLE hCard, DWORD dwDisposition) override;
   LONG SCardBeginTransaction(SCARDHANDLE hCard) override;
   LONG SCardEndTransaction(SCARDHANDLE hCard, DWORD dwDisposition) override;
-  LONG SCardStatus(SCARDHANDLE hCard, LPSTR szReaderName, LPDWORD pcchReaderLen,
-                   LPDWORD pdwState, LPDWORD pdwProtocol, LPBYTE pbAtr,
+  LONG SCardStatus(SCARDHANDLE hCard,
+                   LPSTR szReaderName,
+                   LPDWORD pcchReaderLen,
+                   LPDWORD pdwState,
+                   LPDWORD pdwProtocol,
+                   LPBYTE pbAtr,
                    LPDWORD pcbAtrLen) override;
-  LONG SCardGetStatusChange(SCARDCONTEXT hContext, DWORD dwTimeout,
+  LONG SCardGetStatusChange(SCARDCONTEXT hContext,
+                            DWORD dwTimeout,
                             SCARD_READERSTATE* rgReaderStates,
                             DWORD cReaders) override;
-  LONG SCardControl(SCARDHANDLE hCard, DWORD dwControlCode,
-                    LPCVOID pbSendBuffer, DWORD cbSendLength,
-                    LPVOID pbRecvBuffer, DWORD cbRecvLength,
+  LONG SCardControl(SCARDHANDLE hCard,
+                    DWORD dwControlCode,
+                    LPCVOID pbSendBuffer,
+                    DWORD cbSendLength,
+                    LPVOID pbRecvBuffer,
+                    DWORD cbRecvLength,
                     LPDWORD lpBytesReturned) override;
-  LONG SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPBYTE pbAttr,
+  LONG SCardGetAttrib(SCARDHANDLE hCard,
+                      DWORD dwAttrId,
+                      LPBYTE pbAttr,
                       LPDWORD pcbAttrLen) override;
-  LONG SCardSetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPCBYTE pbAttr,
+  LONG SCardSetAttrib(SCARDHANDLE hCard,
+                      DWORD dwAttrId,
+                      LPCBYTE pbAttr,
                       DWORD cbAttrLen) override;
-  LONG SCardTransmit(SCARDHANDLE hCard, const SCARD_IO_REQUEST* pioSendPci,
-                     LPCBYTE pbSendBuffer, DWORD cbSendLength,
-                     SCARD_IO_REQUEST* pioRecvPci, LPBYTE pbRecvBuffer,
+  LONG SCardTransmit(SCARDHANDLE hCard,
+                     const SCARD_IO_REQUEST* pioSendPci,
+                     LPCBYTE pbSendBuffer,
+                     DWORD cbSendLength,
+                     SCARD_IO_REQUEST* pioRecvPci,
+                     LPBYTE pbRecvBuffer,
                      LPDWORD pcbRecvLength) override;
-  LONG SCardListReaders(SCARDCONTEXT hContext, LPCSTR mszGroups,
-                        LPSTR mszReaders, LPDWORD pcchReaders) override;
+  LONG SCardListReaders(SCARDCONTEXT hContext,
+                        LPCSTR mszGroups,
+                        LPSTR mszReaders,
+                        LPDWORD pcchReaders) override;
   LONG SCardFreeMemory(SCARDCONTEXT hContext, LPCVOID pvMem) override;
-  LONG SCardListReaderGroups(SCARDCONTEXT hContext, LPSTR mszGroups,
+  LONG SCardListReaderGroups(SCARDCONTEXT hContext,
+                             LPSTR mszGroups,
                              LPDWORD pcchGroups) override;
   LONG SCardCancel(SCARDCONTEXT hContext) override;
   LONG SCardIsValidContext(SCARDCONTEXT hContext) override;

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_debug_dump.cc
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_debug_dump.cc
@@ -95,7 +95,8 @@ template <size_t size>
 std::string GetDwordValueName(DWORD value,
                               const DwordValueAndName (&options)[size]) {
   for (const auto& option : options) {
-    if (value == option.value) return option.name;
+    if (value == option.value)
+      return option.name;
   }
   return HexDumpInteger(value);
 }
@@ -108,15 +109,18 @@ std::string DebugDumpSCardReturnCode(LONG return_code) {
 }
 
 std::string DebugDumpSCardCString(const char* value) {
-  if (!value) return "<NULL string>";
+  if (!value)
+    return "<NULL string>";
   return std::string("\"") + value + "\"";
 }
 
 std::string DebugDumpSCardMultiString(const char* value) {
-  if (!value) return "<NULL multi-string>";
+  if (!value)
+    return "<NULL multi-string>";
   std::string result;
   for (const std::string& item : ExtractMultiStringElements(value)) {
-    if (!result.empty()) result += ", ";
+    if (!result.empty())
+      result += ", ";
     result += "\"" + item + "\"";
   }
   return "MultiString[" + result + "]";
@@ -201,7 +205,8 @@ std::string DebugDumpSCardState(DWORD state) {
   const int kEventCountMaskShift = 16;
   const DWORD event_count = (state & kEventCountMask) >> kEventCountMaskShift;
   state &= ~kEventCountMask;
-  if (event_count) suffix = " with eventCount=" + std::to_string(event_count);
+  if (event_count)
+    suffix = " with eventCount=" + std::to_string(event_count);
 
   return DumpMask(state, {{SCARD_ABSENT, "SCARD_ABSENT"},
                           {SCARD_PRESENT, "SCARD_PRESENT"},
@@ -219,9 +224,11 @@ std::string DebugDumpSCardEventState(DWORD event_state) {
   const DWORD event_count =
       (event_state & kEventCountMask) >> kEventCountMaskShift;
   event_state &= ~kEventCountMask;
-  if (event_count) suffix = " with eventCount=" + std::to_string(event_count);
+  if (event_count)
+    suffix = " with eventCount=" + std::to_string(event_count);
 
-  if (!event_state) return "SCARD_STATE_UNAWARE" + suffix;
+  if (!event_state)
+    return "SCARD_STATE_UNAWARE" + suffix;
   return DumpMask(event_state,
                   {{SCARD_STATE_IGNORE, "SCARD_STATE_IGNORE"},
                    {SCARD_STATE_CHANGED, "SCARD_STATE_CHANGED"},
@@ -246,15 +253,19 @@ std::string DebugDumpSCardControlCode(DWORD control_code) {
 }
 
 std::string DebugDumpSCardIoRequest(const SCARD_IO_REQUEST& value) {
-  if (&value == SCARD_PCI_T0) return "SCARD_PCI_T0";
-  if (&value == SCARD_PCI_T1) return "SCARD_PCI_T1";
-  if (&value == SCARD_PCI_RAW) return "SCARD_PCI_RAW";
+  if (&value == SCARD_PCI_T0)
+    return "SCARD_PCI_T0";
+  if (&value == SCARD_PCI_T1)
+    return "SCARD_PCI_T1";
+  if (&value == SCARD_PCI_RAW)
+    return "SCARD_PCI_RAW";
   return "SCARD_IO_REQUEST(dwProtocol=" +
          DebugDumpSCardProtocol(value.dwProtocol) + ")";
 }
 
 std::string DebugDumpSCardIoRequest(const SCARD_IO_REQUEST* value) {
-  if (!value) return "NULL";
+  if (!value)
+    return "NULL";
   return HexDumpPointer(value) + "(" + DebugDumpSCardIoRequest(*value) + ")";
 }
 
@@ -267,10 +278,12 @@ std::string DebugDumpSCardInputReaderState(const SCARD_READERSTATE& value) {
 
 std::string DebugDumpSCardInputReaderStates(const SCARD_READERSTATE* begin,
                                             DWORD count) {
-  if (!begin) return "NULL";
+  if (!begin)
+    return "NULL";
   std::string result;
   for (DWORD index = 0; index < count; ++index) {
-    if (!result.empty()) result += ", ";
+    if (!result.empty())
+      result += ", ";
     result += DebugDumpSCardInputReaderState(begin[index]);
   }
   return HexDumpPointer(begin) + "([" + result + "])";
@@ -287,10 +300,12 @@ std::string DebugDumpSCardOutputReaderState(const SCARD_READERSTATE& value) {
 
 std::string DebugDumpSCardOutputReaderStates(const SCARD_READERSTATE* begin,
                                              DWORD count) {
-  if (!begin) return "NULL";
+  if (!begin)
+    return "NULL";
   std::string result;
   for (DWORD index = 0; index < count; ++index) {
-    if (!result.empty()) result += ", ";
+    if (!result.empty())
+      result += ", ";
     result += DebugDumpSCardOutputReaderState(begin[index]);
   }
   return HexDumpPointer(begin) + "([" + result + "])";
@@ -298,7 +313,8 @@ std::string DebugDumpSCardOutputReaderStates(const SCARD_READERSTATE* begin,
 
 std::string DebugDumpSCardBufferContents(const void* buffer,
                                          DWORD buffer_size) {
-  if (buffer_size) GOOGLE_SMART_CARD_CHECK(buffer);
+  if (buffer_size)
+    GOOGLE_SMART_CARD_CHECK(buffer);
 #ifdef NDEBUG
   return "stripped data of length " + std::to_string(buffer_size);
 #else
@@ -312,13 +328,15 @@ std::string DebugDumpSCardBufferContents(const std::vector<uint8_t>& buffer) {
 }
 
 std::string DebugDumpSCardInputBuffer(const void* buffer, DWORD buffer_size) {
-  if (!buffer) return "NULL";
+  if (!buffer)
+    return "NULL";
   return HexDumpPointer(buffer) + "(<" +
          DebugDumpSCardBufferContents(buffer, buffer_size) + ">)";
 }
 
 std::string DebugDumpSCardBufferSizeInputPointer(const DWORD* buffer_size) {
-  if (!buffer_size) return "NULL";
+  if (!buffer_size)
+    return "NULL";
   const std::string dumped_value = *buffer_size == SCARD_AUTOALLOCATE
                                        ? "SCARD_AUTOALLOCATE"
                                        : std::to_string(*buffer_size);

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.cc
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.cc
@@ -36,7 +36,8 @@ namespace {
 
 std::vector<uint8_t> GetSCardReaderStateAtr(
     const SCARD_READERSTATE& s_card_reader_state) {
-  if (!s_card_reader_state.cbAtr) return {};
+  if (!s_card_reader_state.cbAtr)
+    return {};
   GOOGLE_SMART_CARD_CHECK(s_card_reader_state.cbAtr <= MAX_ATR_SIZE);
   return std::vector<uint8_t>(
       s_card_reader_state.rgbAtr,
@@ -68,7 +69,8 @@ StructConverter<InboundSCardReaderState>::GetStructTypeName() {
 template <>
 template <typename Callback>
 void StructConverter<InboundSCardReaderState>::VisitFields(
-    const InboundSCardReaderState& value, Callback callback) {
+    const InboundSCardReaderState& value,
+    Callback callback) {
   callback(&value.reader_name, "reader_name");
   callback(&value.user_data, "user_data");
   callback(&value.current_state, "current_state");
@@ -99,7 +101,8 @@ StructConverter<OutboundSCardReaderState>::GetStructTypeName() {
 template <>
 template <typename Callback>
 void StructConverter<OutboundSCardReaderState>::VisitFields(
-    const OutboundSCardReaderState& value, Callback callback) {
+    const OutboundSCardReaderState& value,
+    Callback callback) {
   callback(&value.reader_name, "reader_name");
   callback(&value.user_data, "user_data");
   callback(&value.current_state, "current_state");
@@ -183,7 +186,8 @@ pp::Var MakeVar(const SCARD_READERSTATE& value) {
   return result_builder.Result();
 }
 
-bool VarAs(const pp::Var& var, InboundSCardReaderState* result,
+bool VarAs(const pp::Var& var,
+           InboundSCardReaderState* result,
            std::string* error_message) {
   return StructConverter<InboundSCardReaderState>::ConvertFromVar(
       var, result, error_message);
@@ -194,7 +198,8 @@ pp::Var MakeVar(const InboundSCardReaderState& value) {
   return StructConverter<InboundSCardReaderState>::ConvertToVar(value);
 }
 
-bool VarAs(const pp::Var& var, OutboundSCardReaderState* result,
+bool VarAs(const pp::Var& var,
+           OutboundSCardReaderState* result,
            std::string* error_message) {
   return StructConverter<OutboundSCardReaderState>::ConvertFromVar(
       var, result, error_message);
@@ -205,7 +210,8 @@ pp::Var MakeVar(const OutboundSCardReaderState& value) {
   return StructConverter<OutboundSCardReaderState>::ConvertToVar(value);
 }
 
-bool VarAs(const pp::Var& var, SCardIoRequest* result,
+bool VarAs(const pp::Var& var,
+           SCardIoRequest* result,
            std::string* error_message) {
   return StructConverter<SCardIoRequest>::ConvertFromVar(var, result,
                                                          error_message);

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.h
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.h
@@ -69,7 +69,8 @@ struct InboundSCardReaderState {
   InboundSCardReaderState() = default;
 
   InboundSCardReaderState(const std::string& reader_name,
-                          optional<uintptr_t> user_data, DWORD current_state)
+                          optional<uintptr_t> user_data,
+                          DWORD current_state)
       : reader_name(reader_name),
         user_data(user_data),
         current_state(current_state) {}
@@ -94,8 +95,10 @@ struct OutboundSCardReaderState {
   OutboundSCardReaderState() = default;
 
   OutboundSCardReaderState(const std::string& reader_name,
-                           optional<uintptr_t> user_data, DWORD current_state,
-                           DWORD event_state, const std::vector<uint8_t>& atr)
+                           optional<uintptr_t> user_data,
+                           DWORD current_state,
+                           DWORD event_state,
+                           const std::vector<uint8_t>& atr)
       : reader_name(reader_name),
         user_data(user_data),
         current_state(current_state),
@@ -125,19 +128,22 @@ struct SCardIoRequest {
   DWORD protocol;
 };
 
-bool VarAs(const pp::Var& var, InboundSCardReaderState* result,
+bool VarAs(const pp::Var& var,
+           InboundSCardReaderState* result,
            std::string* error_message);
 
 template <>
 pp::Var MakeVar(const InboundSCardReaderState& value);
 
-bool VarAs(const pp::Var& var, OutboundSCardReaderState* result,
+bool VarAs(const pp::Var& var,
+           OutboundSCardReaderState* result,
            std::string* error_message);
 
 template <>
 pp::Var MakeVar(const OutboundSCardReaderState& value);
 
-bool VarAs(const pp::Var& var, SCardIoRequest* result,
+bool VarAs(const pp::Var& var,
+           SCardIoRequest* result,
            std::string* error_message);
 
 template <>

--- a/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.cc
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.cc
@@ -62,7 +62,8 @@ namespace google_smart_card {
 
 class PcscLiteOverRequesterGlobal::Impl final {
  public:
-  Impl(TypedMessageRouter* typed_message_router, pp::Instance* pp_instance,
+  Impl(TypedMessageRouter* typed_message_router,
+       pp::Instance* pp_instance,
        pp::Core* pp_core)
       : pcsc_lite_over_requester_(
             MakeRequester(typed_message_router, pp_instance, pp_core)) {
@@ -77,13 +78,15 @@ class PcscLiteOverRequesterGlobal::Impl final {
   void Detach() { pcsc_lite_over_requester_.Detach(); }
 
   PcscLite* pcsc_lite() {
-    if (pcsc_lite_tracing_wrapper_) return pcsc_lite_tracing_wrapper_.get();
+    if (pcsc_lite_tracing_wrapper_)
+      return pcsc_lite_tracing_wrapper_.get();
     return &pcsc_lite_over_requester_;
   }
 
  private:
   static std::unique_ptr<Requester> MakeRequester(
-      TypedMessageRouter* typed_message_router, pp::Instance* pp_instance,
+      TypedMessageRouter* typed_message_router,
+      pp::Instance* pp_instance,
       pp::Core* pp_core) {
     return std::unique_ptr<Requester>(new JsRequester(
         kPcscLiteRequesterName, typed_message_router,
@@ -95,7 +98,8 @@ class PcscLiteOverRequesterGlobal::Impl final {
 };
 
 PcscLiteOverRequesterGlobal::PcscLiteOverRequesterGlobal(
-    TypedMessageRouter* typed_message_router, pp::Instance* pp_instance,
+    TypedMessageRouter* typed_message_router,
+    pp::Instance* pp_instance,
     pp::Core* pp_core)
     : impl_(new Impl(typed_message_router, pp_instance, pp_core)) {
   GOOGLE_SMART_CARD_CHECK(!g_pcsc_lite);
@@ -107,7 +111,9 @@ PcscLiteOverRequesterGlobal::~PcscLiteOverRequesterGlobal() {
   g_pcsc_lite = nullptr;
 }
 
-void PcscLiteOverRequesterGlobal::Detach() { impl_->Detach(); }
+void PcscLiteOverRequesterGlobal::Detach() {
+  impl_->Detach();
+}
 
 }  // namespace google_smart_card
 
@@ -120,8 +126,10 @@ const SCARD_IO_REQUEST g_rgSCardT1Pci = {SCARD_PROTOCOL_T1,
 const SCARD_IO_REQUEST g_rgSCardRawPci = {SCARD_PROTOCOL_RAW,
                                           sizeof(SCARD_IO_REQUEST)};
 
-LONG SCardEstablishContext(DWORD dwScope, LPCVOID pvReserved1,
-                           LPCVOID pvReserved2, LPSCARDCONTEXT phContext) {
+LONG SCardEstablishContext(DWORD dwScope,
+                           LPCVOID pvReserved1,
+                           LPCVOID pvReserved2,
+                           LPSCARDCONTEXT phContext) {
   return GetGlobalPcscLite()->SCardEstablishContext(dwScope, pvReserved1,
                                                     pvReserved2, phContext);
 }
@@ -130,16 +138,21 @@ LONG SCardReleaseContext(SCARDCONTEXT hContext) {
   return GetGlobalPcscLite()->SCardReleaseContext(hContext);
 }
 
-LONG SCardConnect(SCARDCONTEXT hContext, LPCSTR szReader, DWORD dwShareMode,
-                  DWORD dwPreferredProtocols, LPSCARDHANDLE phCard,
+LONG SCardConnect(SCARDCONTEXT hContext,
+                  LPCSTR szReader,
+                  DWORD dwShareMode,
+                  DWORD dwPreferredProtocols,
+                  LPSCARDHANDLE phCard,
                   LPDWORD pdwActiveProtocol) {
   return GetGlobalPcscLite()->SCardConnect(hContext, szReader, dwShareMode,
                                            dwPreferredProtocols, phCard,
                                            pdwActiveProtocol);
 }
 
-LONG SCardReconnect(SCARDHANDLE hCard, DWORD dwShareMode,
-                    DWORD dwPreferredProtocols, DWORD dwInitialization,
+LONG SCardReconnect(SCARDHANDLE hCard,
+                    DWORD dwShareMode,
+                    DWORD dwPreferredProtocols,
+                    DWORD dwInitialization,
                     LPDWORD pdwActiveProtocol) {
   return GetGlobalPcscLite()->SCardReconnect(
       hCard, dwShareMode, dwPreferredProtocols, dwInitialization,
@@ -158,50 +171,69 @@ LONG SCardEndTransaction(SCARDHANDLE hCard, DWORD dwDisposition) {
   return GetGlobalPcscLite()->SCardEndTransaction(hCard, dwDisposition);
 }
 
-LONG SCardStatus(SCARDHANDLE hCard, LPSTR szReaderName, LPDWORD pcchReaderLen,
-                 LPDWORD pdwState, LPDWORD pdwProtocol, LPBYTE pbAtr,
+LONG SCardStatus(SCARDHANDLE hCard,
+                 LPSTR szReaderName,
+                 LPDWORD pcchReaderLen,
+                 LPDWORD pdwState,
+                 LPDWORD pdwProtocol,
+                 LPBYTE pbAtr,
                  LPDWORD pcbAtrLen) {
   return GetGlobalPcscLite()->SCardStatus(hCard, szReaderName, pcchReaderLen,
                                           pdwState, pdwProtocol, pbAtr,
                                           pcbAtrLen);
 }
 
-LONG SCardGetStatusChange(SCARDCONTEXT hContext, DWORD dwTimeout,
-                          SCARD_READERSTATE* rgReaderStates, DWORD cReaders) {
+LONG SCardGetStatusChange(SCARDCONTEXT hContext,
+                          DWORD dwTimeout,
+                          SCARD_READERSTATE* rgReaderStates,
+                          DWORD cReaders) {
   return GetGlobalPcscLite()->SCardGetStatusChange(hContext, dwTimeout,
                                                    rgReaderStates, cReaders);
 }
 
-LONG SCardControl(SCARDHANDLE hCard, DWORD dwControlCode, LPCVOID pbSendBuffer,
-                  DWORD cbSendLength, LPVOID pbRecvBuffer, DWORD cbRecvLength,
+LONG SCardControl(SCARDHANDLE hCard,
+                  DWORD dwControlCode,
+                  LPCVOID pbSendBuffer,
+                  DWORD cbSendLength,
+                  LPVOID pbRecvBuffer,
+                  DWORD cbRecvLength,
                   LPDWORD lpBytesReturned) {
   return GetGlobalPcscLite()->SCardControl(hCard, dwControlCode, pbSendBuffer,
                                            cbSendLength, pbRecvBuffer,
                                            cbRecvLength, lpBytesReturned);
 }
 
-LONG SCardGetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPBYTE pbAttr,
+LONG SCardGetAttrib(SCARDHANDLE hCard,
+                    DWORD dwAttrId,
+                    LPBYTE pbAttr,
                     LPDWORD pcbAttrLen) {
   return GetGlobalPcscLite()->SCardGetAttrib(hCard, dwAttrId, pbAttr,
                                              pcbAttrLen);
 }
 
-LONG SCardSetAttrib(SCARDHANDLE hCard, DWORD dwAttrId, LPCBYTE pbAttr,
+LONG SCardSetAttrib(SCARDHANDLE hCard,
+                    DWORD dwAttrId,
+                    LPCBYTE pbAttr,
                     DWORD cbAttrLen) {
   return GetGlobalPcscLite()->SCardSetAttrib(hCard, dwAttrId, pbAttr,
                                              cbAttrLen);
 }
 
-LONG SCardTransmit(SCARDHANDLE hCard, const SCARD_IO_REQUEST* pioSendPci,
-                   LPCBYTE pbSendBuffer, DWORD cbSendLength,
-                   SCARD_IO_REQUEST* pioRecvPci, LPBYTE pbRecvBuffer,
+LONG SCardTransmit(SCARDHANDLE hCard,
+                   const SCARD_IO_REQUEST* pioSendPci,
+                   LPCBYTE pbSendBuffer,
+                   DWORD cbSendLength,
+                   SCARD_IO_REQUEST* pioRecvPci,
+                   LPBYTE pbRecvBuffer,
                    LPDWORD pcbRecvLength) {
   return GetGlobalPcscLite()->SCardTransmit(hCard, pioSendPci, pbSendBuffer,
                                             cbSendLength, pioRecvPci,
                                             pbRecvBuffer, pcbRecvLength);
 }
 
-LONG SCardListReaders(SCARDCONTEXT hContext, LPCSTR mszGroups, LPSTR mszReaders,
+LONG SCardListReaders(SCARDCONTEXT hContext,
+                      LPCSTR mszGroups,
+                      LPSTR mszReaders,
                       LPDWORD pcchReaders) {
   return GetGlobalPcscLite()->SCardListReaders(hContext, mszGroups, mszReaders,
                                                pcchReaders);
@@ -211,7 +243,8 @@ LONG SCardFreeMemory(SCARDCONTEXT hContext, LPCVOID pvMem) {
   return GetGlobalPcscLite()->SCardFreeMemory(hContext, pvMem);
 }
 
-LONG SCardListReaderGroups(SCARDCONTEXT hContext, LPSTR mszGroups,
+LONG SCardListReaderGroups(SCARDCONTEXT hContext,
+                           LPSTR mszGroups,
                            LPDWORD pcchGroups) {
   return GetGlobalPcscLite()->SCardListReaderGroups(hContext, mszGroups,
                                                     pcchGroups);

--- a/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.h
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.h
@@ -49,7 +49,8 @@ namespace google_smart_card {
 class PcscLiteOverRequesterGlobal final {
  public:
   PcscLiteOverRequesterGlobal(TypedMessageRouter* typed_message_router,
-                              pp::Instance* pp_instance, pp::Core* pp_core);
+                              pp::Instance* pp_instance,
+                              pp::Core* pp_core);
 
   PcscLiteOverRequesterGlobal(const PcscLiteOverRequesterGlobal&) = delete;
   PcscLiteOverRequesterGlobal& operator=(const PcscLiteOverRequesterGlobal&) =

--- a/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.cc
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.cc
@@ -80,7 +80,9 @@ SCardUniquePtr<T> CreateSCardUniquePtr() {
 // PC/SC-Lite client API, refer, for instance, to
 // <https://pcsclite.alioth.debian.org/api/group__API.html#gaacfec51917255b7a25b94c5104961602>.
 template <typename IterT, typename T>
-LONG FillOutputBufferArguments(IterT input_begin, IterT input_end, T* output,
+LONG FillOutputBufferArguments(IterT input_begin,
+                               IterT input_end,
+                               T* output,
                                LPDWORD output_size,
                                SCardUniquePtr<T>* allocated_buffer_holder) {
   const size_t input_size = std::distance(input_begin, input_end);
@@ -102,7 +104,8 @@ LONG FillOutputBufferArguments(IterT input_begin, IterT input_end, T* output,
       // output argument is actually a T** in that case, and it will receive
       // pointer to the allocated buffer (so this argument is checked to be
       // non-null).
-      if (!output) return SCARD_E_INVALID_PARAMETER;
+      if (!output)
+        return SCARD_E_INVALID_PARAMETER;
       target_buffer_begin = reinterpret_cast<T*>(std::malloc(input_size));
       GOOGLE_SMART_CARD_CHECK(target_buffer_begin);
       allocated_buffer_holder->reset(target_buffer_begin);
@@ -138,7 +141,8 @@ LONG FillOutputBufferArguments(IterT input_begin, IterT input_end, T* output,
 template <typename... Results>
 LONG ExtractRequestResultsAndCode(
     const std::string& function_name,
-    const GenericRequestResult& generic_request_result, Results*... results) {
+    const GenericRequestResult& generic_request_result,
+    Results*... results) {
   const std::string logging_prefix =
       kLoggingPrefix + function_name + " function call: ";
 
@@ -199,12 +203,17 @@ PcscLiteOverRequester::PcscLiteOverRequester(
 
 PcscLiteOverRequester::~PcscLiteOverRequester() = default;
 
-void PcscLiteOverRequester::Detach() { requester_->Detach(); }
+void PcscLiteOverRequester::Detach() {
+  requester_->Detach();
+}
 
 LONG PcscLiteOverRequester::SCardEstablishContext(
-    DWORD scope, LPCVOID reserved_1, LPCVOID reserved_2,
+    DWORD scope,
+    LPCVOID reserved_1,
+    LPCVOID reserved_2,
     LPSCARDCONTEXT s_card_context) {
-  if (!s_card_context) return SCARD_E_INVALID_PARAMETER;
+  if (!s_card_context)
+    return SCARD_E_INVALID_PARAMETER;
   if (reserved_1 || reserved_2) {
     // Only the NULL values of these parameters are supported by this PC/SC-Lite
     // client implementation. Anyway, PC/SC-Lite API states that these
@@ -226,12 +235,15 @@ LONG PcscLiteOverRequester::SCardReleaseContext(SCARDCONTEXT s_card_context) {
 }
 
 LONG PcscLiteOverRequester::SCardConnect(SCARDCONTEXT s_card_context,
-                                         LPCSTR reader_name, DWORD share_mode,
+                                         LPCSTR reader_name,
+                                         DWORD share_mode,
                                          DWORD preferred_protocols,
                                          LPSCARDHANDLE s_card_handle,
                                          LPDWORD active_protocol) {
-  if (!s_card_handle || !active_protocol) return SCARD_E_INVALID_PARAMETER;
-  if (!reader_name) return SCARD_E_UNKNOWN_READER;
+  if (!s_card_handle || !active_protocol)
+    return SCARD_E_INVALID_PARAMETER;
+  if (!reader_name)
+    return SCARD_E_UNKNOWN_READER;
 
   return ExtractRequestResultsAndCode(
       "SCardConnect",
@@ -245,7 +257,8 @@ LONG PcscLiteOverRequester::SCardReconnect(SCARDHANDLE s_card_handle,
                                            DWORD preferred_protocols,
                                            DWORD initialization_action,
                                            LPDWORD active_protocol) {
-  if (!active_protocol) return SCARD_E_INVALID_PARAMETER;
+  if (!active_protocol)
+    return SCARD_E_INVALID_PARAMETER;
 
   return ExtractRequestResultsAndCode(
       "SCardReconnect",
@@ -278,8 +291,10 @@ LONG PcscLiteOverRequester::SCardEndTransaction(SCARDHANDLE s_card_handle,
 LONG PcscLiteOverRequester::SCardStatus(SCARDHANDLE s_card_handle,
                                         LPSTR reader_name,
                                         LPDWORD reader_name_length,
-                                        LPDWORD state, LPDWORD protocol,
-                                        LPBYTE atr, LPDWORD atr_length) {
+                                        LPDWORD state,
+                                        LPDWORD protocol,
+                                        LPBYTE atr,
+                                        LPDWORD atr_length) {
   std::string reader_name_string;
   DWORD state_copy;
   DWORD protocol_copy;
@@ -289,7 +304,8 @@ LONG PcscLiteOverRequester::SCardStatus(SCARDHANDLE s_card_handle,
       remote_call_adaptor_.SyncCall("SCardStatus", s_card_handle),
       &reader_name_string, &state_copy, &protocol_copy, &atr_vector);
   GOOGLE_SMART_CARD_CHECK(result_code != SCARD_E_INSUFFICIENT_BUFFER);
-  if (result_code != SCARD_S_SUCCESS) return result_code;
+  if (result_code != SCARD_S_SUCCESS)
+    return result_code;
 
   SCardUniquePtr<char> reader_name_buffer_holder = CreateSCardUniquePtr<char>();
   const LONG reader_name_filling_result_code = FillOutputBufferArguments(
@@ -297,9 +313,11 @@ LONG PcscLiteOverRequester::SCardStatus(SCARDHANDLE s_card_handle,
       reader_name_string.c_str() + reader_name_string.length() + 1, reader_name,
       reader_name_length, &reader_name_buffer_holder);
 
-  if (state) *state = state_copy;
+  if (state)
+    *state = state_copy;
 
-  if (protocol) *protocol = protocol_copy;
+  if (protocol)
+    *protocol = protocol_copy;
 
   SCardUniquePtr<BYTE> atr_buffer_holder = CreateSCardUniquePtr<BYTE>();
   const LONG atr_filling_result_code =
@@ -316,9 +334,12 @@ LONG PcscLiteOverRequester::SCardStatus(SCARDHANDLE s_card_handle,
 }
 
 LONG PcscLiteOverRequester::SCardGetStatusChange(
-    SCARDCONTEXT s_card_context, DWORD timeout,
-    SCARD_READERSTATE* reader_states, DWORD reader_states_size) {
-  if (!reader_states && reader_states_size) return SCARD_E_INVALID_PARAMETER;
+    SCARDCONTEXT s_card_context,
+    DWORD timeout,
+    SCARD_READERSTATE* reader_states,
+    DWORD reader_states_size) {
+  if (!reader_states && reader_states_size)
+    return SCARD_E_INVALID_PARAMETER;
 
   std::vector<InboundSCardReaderState> reader_states_vector;
   for (DWORD index = 0; index < reader_states_size; ++index) {
@@ -332,7 +353,8 @@ LONG PcscLiteOverRequester::SCardGetStatusChange(
       remote_call_adaptor_.SyncCall("SCardGetStatusChange", s_card_context,
                                     timeout, reader_states_vector),
       &returned_reader_states_vector);
-  if (result_code != SCARD_S_SUCCESS) return result_code;
+  if (result_code != SCARD_S_SUCCESS)
+    return result_code;
 
   GOOGLE_SMART_CARD_CHECK(returned_reader_states_vector.size() ==
                           reader_states_size);
@@ -359,11 +381,15 @@ LONG PcscLiteOverRequester::SCardGetStatusChange(
   return SCARD_S_SUCCESS;
 }
 
-LONG PcscLiteOverRequester::SCardControl(
-    SCARDHANDLE s_card_handle, DWORD control_code, LPCVOID send_buffer,
-    DWORD send_buffer_length, LPVOID receive_buffer,
-    DWORD receive_buffer_length, LPDWORD bytes_returned) {
-  if (send_buffer_length) GOOGLE_SMART_CARD_CHECK(send_buffer);
+LONG PcscLiteOverRequester::SCardControl(SCARDHANDLE s_card_handle,
+                                         DWORD control_code,
+                                         LPCVOID send_buffer,
+                                         DWORD send_buffer_length,
+                                         LPVOID receive_buffer,
+                                         DWORD receive_buffer_length,
+                                         LPDWORD bytes_returned) {
+  if (send_buffer_length)
+    GOOGLE_SMART_CARD_CHECK(send_buffer);
   GOOGLE_SMART_CARD_CHECK(receive_buffer);
 
   std::vector<uint8_t> send_buffer_vector;
@@ -384,7 +410,8 @@ LONG PcscLiteOverRequester::SCardControl(
     // reported in case of any error.
     *bytes_returned = 0;
   }
-  if (result_code != SCARD_S_SUCCESS) return result_code;
+  if (result_code != SCARD_S_SUCCESS)
+    return result_code;
 
   if (received_buffer_vector.size() > receive_buffer_length)
     return SCARD_E_INSUFFICIENT_BUFFER;
@@ -392,12 +419,14 @@ LONG PcscLiteOverRequester::SCardControl(
     std::memcpy(receive_buffer, &received_buffer_vector[0],
                 received_buffer_vector.size());
   }
-  if (bytes_returned) *bytes_returned = received_buffer_vector.size();
+  if (bytes_returned)
+    *bytes_returned = received_buffer_vector.size();
   return SCARD_S_SUCCESS;
 }
 
 LONG PcscLiteOverRequester::SCardGetAttrib(SCARDHANDLE s_card_handle,
-                                           DWORD attribute_id, LPBYTE attribute,
+                                           DWORD attribute_id,
+                                           LPBYTE attribute,
                                            LPDWORD attribute_length) {
   std::vector<uint8_t> attribute_vector;
   const LONG result_code = ExtractRequestResultsAndCode(
@@ -406,7 +435,8 @@ LONG PcscLiteOverRequester::SCardGetAttrib(SCARDHANDLE s_card_handle,
                                     attribute_id),
       &attribute_vector);
   GOOGLE_SMART_CARD_CHECK(result_code != SCARD_E_INSUFFICIENT_BUFFER);
-  if (result_code != SCARD_S_SUCCESS) return result_code;
+  if (result_code != SCARD_S_SUCCESS)
+    return result_code;
 
   SCardUniquePtr<BYTE> attribute_buffer_holder = CreateSCardUniquePtr<BYTE>();
   const LONG attribute_filling_result_code = FillOutputBufferArguments(
@@ -437,9 +467,12 @@ LONG PcscLiteOverRequester::SCardSetAttrib(SCARDHANDLE s_card_handle,
 
 LONG PcscLiteOverRequester::SCardTransmit(
     SCARDHANDLE s_card_handle,
-    const SCARD_IO_REQUEST* send_protocol_information, LPCBYTE send_buffer,
-    DWORD send_buffer_length, SCARD_IO_REQUEST* receive_protocol_information,
-    LPBYTE receive_buffer, LPDWORD receive_buffer_length) {
+    const SCARD_IO_REQUEST* send_protocol_information,
+    LPCBYTE send_buffer,
+    DWORD send_buffer_length,
+    SCARD_IO_REQUEST* receive_protocol_information,
+    LPBYTE receive_buffer,
+    LPDWORD receive_buffer_length) {
   if (!send_protocol_information || !send_buffer || !receive_buffer ||
       !receive_buffer_length) {
     return SCARD_E_INVALID_PARAMETER;
@@ -465,7 +498,8 @@ LONG PcscLiteOverRequester::SCardTransmit(
           SCardIoRequest::FromSCardIoRequest(*send_protocol_information),
           send_buffer_vector, input_receive_protocol_information),
       &receive_protocol_information_copy, &received_buffer_vector);
-  if (result_code != SCARD_S_SUCCESS) return result_code;
+  if (result_code != SCARD_S_SUCCESS)
+    return result_code;
 
   if (receive_protocol_information) {
     *receive_protocol_information =
@@ -482,7 +516,8 @@ LONG PcscLiteOverRequester::SCardTransmit(
 }
 
 LONG PcscLiteOverRequester::SCardListReaders(SCARDCONTEXT s_card_context,
-                                             LPCSTR groups, LPSTR readers,
+                                             LPCSTR groups,
+                                             LPSTR readers,
                                              LPDWORD readers_size) {
   if (groups) {
     // Only the NULL value of this parameter is supported by this PC/SC-Lite
@@ -490,7 +525,8 @@ LONG PcscLiteOverRequester::SCardListReaders(SCARDCONTEXT s_card_context,
     // parameter is not used now, so it doesn't harm much limiting to NULL.
     return SCARD_E_INVALID_PARAMETER;
   }
-  if (!readers_size) return SCARD_E_INVALID_PARAMETER;
+  if (!readers_size)
+    return SCARD_E_INVALID_PARAMETER;
   GOOGLE_SMART_CARD_CHECK(readers_size);
 
   std::vector<std::string> readers_vector;
@@ -500,7 +536,8 @@ LONG PcscLiteOverRequester::SCardListReaders(SCARDCONTEXT s_card_context,
                                     pp::Var::Null()),
       &readers_vector);
   GOOGLE_SMART_CARD_CHECK(result_code != SCARD_E_INSUFFICIENT_BUFFER);
-  if (result_code != SCARD_S_SUCCESS) return result_code;
+  if (result_code != SCARD_S_SUCCESS)
+    return result_code;
 
   const std::string dumped_readers = CreateMultiString(readers_vector);
 
@@ -529,7 +566,8 @@ LONG PcscLiteOverRequester::SCardListReaderGroups(SCARDCONTEXT s_card_context,
       remote_call_adaptor_.SyncCall("SCardListReaderGroups", s_card_context),
       &groups_vector);
   GOOGLE_SMART_CARD_CHECK(result_code != SCARD_E_INSUFFICIENT_BUFFER);
-  if (result_code != SCARD_S_SUCCESS) return result_code;
+  if (result_code != SCARD_S_SUCCESS)
+    return result_code;
 
   const std::string dumped_groups = CreateMultiString(groups_vector);
 

--- a/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.h
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.h
@@ -88,47 +88,66 @@ class PcscLiteOverRequester final : public PcscLite {
   void Detach();
 
   // PcscLite:
-  LONG SCardEstablishContext(DWORD scope, LPCVOID reserved_1,
+  LONG SCardEstablishContext(DWORD scope,
+                             LPCVOID reserved_1,
                              LPCVOID reserved_2,
                              LPSCARDCONTEXT s_card_context) override;
   LONG SCardReleaseContext(SCARDCONTEXT s_card_context) override;
-  LONG SCardConnect(SCARDCONTEXT s_card_context, LPCSTR reader_name,
-                    DWORD share_mode, DWORD preferred_protocols,
+  LONG SCardConnect(SCARDCONTEXT s_card_context,
+                    LPCSTR reader_name,
+                    DWORD share_mode,
+                    DWORD preferred_protocols,
                     LPSCARDHANDLE s_card_handle,
                     LPDWORD active_protocol) override;
-  LONG SCardReconnect(SCARDHANDLE s_card_handle, DWORD share_mode,
-                      DWORD preferred_protocols, DWORD initialization_action,
+  LONG SCardReconnect(SCARDHANDLE s_card_handle,
+                      DWORD share_mode,
+                      DWORD preferred_protocols,
+                      DWORD initialization_action,
                       LPDWORD active_protocol) override;
   LONG SCardDisconnect(SCARDHANDLE s_card_handle, DWORD disposition) override;
   LONG SCardBeginTransaction(SCARDHANDLE s_card_handle) override;
   LONG SCardEndTransaction(SCARDHANDLE s_card_handle,
                            DWORD disposition_action) override;
-  LONG SCardStatus(SCARDHANDLE s_card_handle, LPSTR reader_name,
-                   LPDWORD reader_name_length, LPDWORD state, LPDWORD protocol,
-                   LPBYTE atr, LPDWORD atr_length) override;
-  LONG SCardGetStatusChange(SCARDCONTEXT s_card_context, DWORD timeout,
+  LONG SCardStatus(SCARDHANDLE s_card_handle,
+                   LPSTR reader_name,
+                   LPDWORD reader_name_length,
+                   LPDWORD state,
+                   LPDWORD protocol,
+                   LPBYTE atr,
+                   LPDWORD atr_length) override;
+  LONG SCardGetStatusChange(SCARDCONTEXT s_card_context,
+                            DWORD timeout,
                             SCARD_READERSTATE* reader_states,
                             DWORD reader_states_size) override;
-  LONG SCardControl(SCARDHANDLE s_card_handle, DWORD control_code,
-                    LPCVOID send_buffer, DWORD send_buffer_length,
-                    LPVOID receive_buffer, DWORD receive_buffer_length,
+  LONG SCardControl(SCARDHANDLE s_card_handle,
+                    DWORD control_code,
+                    LPCVOID send_buffer,
+                    DWORD send_buffer_length,
+                    LPVOID receive_buffer,
+                    DWORD receive_buffer_length,
                     LPDWORD bytes_returned) override;
-  LONG SCardGetAttrib(SCARDHANDLE s_card_handle, DWORD attribute_id,
+  LONG SCardGetAttrib(SCARDHANDLE s_card_handle,
+                      DWORD attribute_id,
                       LPBYTE attribute_buffer,
                       LPDWORD attribute_buffer_length) override;
-  LONG SCardSetAttrib(SCARDHANDLE s_card_handle, DWORD attribute_id,
+  LONG SCardSetAttrib(SCARDHANDLE s_card_handle,
+                      DWORD attribute_id,
                       LPCBYTE attribute_buffer,
                       DWORD attribute_buffer_length) override;
   LONG SCardTransmit(SCARDHANDLE s_card_handle,
                      const SCARD_IO_REQUEST* send_protocol_information,
-                     LPCBYTE send_buffer, DWORD send_buffer_length,
+                     LPCBYTE send_buffer,
+                     DWORD send_buffer_length,
                      SCARD_IO_REQUEST* receive_protocol_information,
                      LPBYTE receive_buffer,
                      LPDWORD receive_buffer_length) override;
-  LONG SCardListReaders(SCARDCONTEXT s_card_context, LPCSTR groups,
-                        LPSTR readers, LPDWORD readers_size) override;
+  LONG SCardListReaders(SCARDCONTEXT s_card_context,
+                        LPCSTR groups,
+                        LPSTR readers,
+                        LPDWORD readers_size) override;
   LONG SCardFreeMemory(SCARDCONTEXT s_card_context, LPCVOID memory) override;
-  LONG SCardListReaderGroups(SCARDCONTEXT s_card_context, LPSTR groups,
+  LONG SCardListReaderGroups(SCARDCONTEXT s_card_context,
+                             LPSTR groups,
                              LPDWORD groups_size) override;
   LONG SCardCancel(SCARDCONTEXT s_card_context) override;
   LONG SCardIsValidContext(SCARDCONTEXT s_card_context) override;

--- a/third_party/pcsc-lite/naclport/cpp_demo/src/google_smart_card_pcsc_lite_cpp_demo/demo.cc
+++ b/third_party/pcsc-lite/naclport/cpp_demo/src/google_smart_card_pcsc_lite_cpp_demo/demo.cc
@@ -111,7 +111,8 @@ size_t GetMultiStringLength(LPSTR multi_string) {
   size_t result = 0;
   for (const std::string& item : ExtractMultiStringElements(multi_string))
     result += item.length() + 1;
-  if (!result) return 2;
+  if (!result)
+    return 2;
   return result + 1;
 }
 
@@ -462,7 +463,8 @@ bool DoPcscLiteWaitingAndCancellation(SCARDCONTEXT s_card_context) {
 
 bool DoPcscLiteConnect(SCARDCONTEXT s_card_context,
                        const std::string& reader_name,
-                       SCARDHANDLE* s_card_handle, DWORD* active_protocol) {
+                       SCARDHANDLE* s_card_handle,
+                       DWORD* active_protocol) {
   GOOGLE_SMART_CARD_LOG_INFO << kLoggingPrefix << "  Calling SCardConnect() "
                              << "for connecting to the \"" << reader_name
                              << "\" reader...";

--- a/third_party/pcsc-lite/naclport/server/src/auth_nacl.cc
+++ b/third_party/pcsc-lite/naclport/server/src/auth_nacl.cc
@@ -30,7 +30,8 @@ extern "C" {
 #include "auth.h"
 }
 
-unsigned IsClientAuthorized(int socket, const char* action,
+unsigned IsClientAuthorized(int socket,
+                            const char* action,
                             const char* reader) {
   // This naclport of pcsc-lite library doesn't have a polkit authorization of
   // clients, so just allowing arbitrary client connections here.

--- a/third_party/pcsc-lite/naclport/server/src/dyn_nacl.cc
+++ b/third_party/pcsc-lite/naclport/server/src/dyn_nacl.cc
@@ -92,8 +92,10 @@ INTERNAL LONG DYN_CloseLibrary(void** pvLHandle) {
   return SCARD_S_SUCCESS;
 }
 
-INTERNAL LONG DYN_GetAddress(void* pvLHandle, void** pvFHandle,
-                             const char* pcFunction, int /*mayfail*/) {
+INTERNAL LONG DYN_GetAddress(void* pvLHandle,
+                             void** pvFHandle,
+                             const char* pcFunction,
+                             int /*mayfail*/) {
   GOOGLE_SMART_CARD_CHECK(pvLHandle == kFakeLHandle);
 
   std::string function = pcFunction;

--- a/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.cc
+++ b/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.cc
@@ -228,7 +228,8 @@ void PcscLiteServerGlobal::PostReaderRemoveMessage(const char* reader_name,
 }
 
 void PcscLiteServerGlobal::PostMessage(
-    const char* type, const pp::VarDictionary& message_data) const {
+    const char* type,
+    const pp::VarDictionary& message_data) const {
   const std::unique_lock<std::mutex> lock(mutex_);
   if (pp_instance_) {
     TypedMessage typed_message;

--- a/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.h
+++ b/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.h
@@ -77,10 +77,13 @@ class PcscLiteServerGlobal final {
   // already been initialized.
   void InitializeAndRunDaemonThread();
 
-  void PostReaderInitAddMessage(const char* reader_name, int port,
+  void PostReaderInitAddMessage(const char* reader_name,
+                                int port,
                                 const char* device) const;
-  void PostReaderFinishAddMessage(const char* reader_name, int port,
-                                  const char* device, long return_code) const;
+  void PostReaderFinishAddMessage(const char* reader_name,
+                                  int port,
+                                  const char* device,
+                                  long return_code) const;
   void PostReaderRemoveMessage(const char* reader_name, int port) const;
 
  private:

--- a/third_party/pcsc-lite/naclport/server/src/readerfactory_nacl.cc
+++ b/third_party/pcsc-lite/naclport/server/src/readerfactory_nacl.cc
@@ -35,12 +35,16 @@ extern "C" {
 }
 
 extern "C" {
-LONG RFAddReaderOriginal(const char* reader_name, int port, const char* library,
+LONG RFAddReaderOriginal(const char* reader_name,
+                         int port,
+                         const char* library,
                          const char* device);
 LONG RFRemoveReaderOriginal(const char* reader_name, int port);
 }
 
-LONG RFAddReader(const char* reader_name, int port, const char* library,
+LONG RFAddReader(const char* reader_name,
+                 int port,
+                 const char* library,
                  const char* device) {
   google_smart_card::PcscLiteServerGlobal::GetInstance()
       ->PostReaderInitAddMessage(reader_name, port, device);

--- a/third_party/pcsc-lite/naclport/server/src/socketpair_emulation.cc
+++ b/third_party/pcsc-lite/naclport/server/src/socketpair_emulation.cc
@@ -45,8 +45,7 @@ SocketpairEmulationManager* g_socketpair_emulation_manager = nullptr;
 
 class SocketpairEmulationManager::Socket final {
  public:
-  explicit Socket(int file_descriptor)
-      : file_descriptor_(file_descriptor) {
+  explicit Socket(int file_descriptor) : file_descriptor_(file_descriptor) {
     GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "A socket "
                                 << file_descriptor << " is created";
   }
@@ -75,13 +74,15 @@ class SocketpairEmulationManager::Socket final {
   void Close() {
     if (SetIsClosed()) {
       const std::shared_ptr<Socket> locked_other_end = other_end_.lock();
-      if (locked_other_end) locked_other_end->SetIsClosed();
+      if (locked_other_end)
+        locked_other_end->SetIsClosed();
     }
   }
 
   void Write(const uint8_t* data, int64_t size, bool* is_failure) {
     GOOGLE_SMART_CARD_CHECK(size >= 0);
-    if (!size) return;
+    if (!size)
+      return;
     GOOGLE_SMART_CARD_CHECK(data);
     const std::shared_ptr<Socket> locked_other_end = other_end_.lock();
     if (!locked_other_end) {
@@ -137,7 +138,8 @@ class SocketpairEmulationManager::Socket final {
                                   << "already been closed";
       return false;
     }
-    if (read_buffer_.empty()) return false;
+    if (read_buffer_.empty())
+      return false;
     *in_out_size =
         std::min(*in_out_size, static_cast<int64_t>(read_buffer_.size()));
     std::copy(read_buffer_.begin(), read_buffer_.begin() + *in_out_size,
@@ -150,7 +152,8 @@ class SocketpairEmulationManager::Socket final {
  private:
   bool SetIsClosed() {
     const std::unique_lock<std::mutex> lock(mutex_);
-    if (is_closed_) return false;
+    if (is_closed_)
+      return false;
     is_closed_ = true;
     GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "The socket "
                                 << file_descriptor() << " is closed";
@@ -221,8 +224,10 @@ void SocketpairEmulationManager::Close(int file_descriptor, bool* is_failure) {
   socket_map_.erase(socket_map_iter);
 }
 
-void SocketpairEmulationManager::Write(int file_descriptor, const uint8_t* data,
-                                       int64_t size, bool* is_failure) {
+void SocketpairEmulationManager::Write(int file_descriptor,
+                                       const uint8_t* data,
+                                       int64_t size,
+                                       bool* is_failure) {
   const std::shared_ptr<Socket> socket =
       FindSocketByFileDescriptor(file_descriptor);
   if (!socket) {
@@ -267,8 +272,10 @@ bool SocketpairEmulationManager::SelectForReading(int file_descriptor,
   return socket->SelectForReading(timeout_milliseconds, is_failure);
 }
 
-bool SocketpairEmulationManager::Read(int file_descriptor, uint8_t* buffer,
-                                      int64_t* in_out_size, bool* is_failure) {
+bool SocketpairEmulationManager::Read(int file_descriptor,
+                                      uint8_t* buffer,
+                                      int64_t* in_out_size,
+                                      bool* is_failure) {
   const std::shared_ptr<Socket> socket =
       FindSocketByFileDescriptor(file_descriptor);
   if (!socket) {
@@ -279,7 +286,8 @@ bool SocketpairEmulationManager::Read(int file_descriptor, uint8_t* buffer,
                                 << "already destroyed or never existed";
     return false;
   }
-  if (!socket->Read(buffer, in_out_size, is_failure)) return false;
+  if (!socket->Read(buffer, in_out_size, is_failure))
+    return false;
   GOOGLE_SMART_CARD_CHECK(*in_out_size > 0);
   return true;
 }
@@ -309,7 +317,8 @@ SocketpairEmulationManager::FindSocketByFileDescriptor(
     int file_descriptor) const {
   const std::unique_lock<std::mutex> lock(mutex_);
   const auto socket_map_iter = socket_map_.find(file_descriptor);
-  if (socket_map_iter == socket_map_.end()) return {};
+  if (socket_map_iter == socket_map_.end())
+    return {};
   return socket_map_iter->second;
 }
 
@@ -324,7 +333,9 @@ void Close(int file_descriptor, bool* is_failure) {
   SocketpairEmulationManager::GetInstance()->Close(file_descriptor, is_failure);
 }
 
-void Write(int file_descriptor, const uint8_t* data, int64_t size,
+void Write(int file_descriptor,
+           const uint8_t* data,
+           int64_t size,
            bool* is_failure) {
   SocketpairEmulationManager::GetInstance()->Write(file_descriptor, data, size,
                                                    is_failure);
@@ -335,13 +346,16 @@ void SelectForReading(int file_descriptor, bool* is_failure) {
                                                               is_failure);
 }
 
-bool SelectForReading(int file_descriptor, int64_t timeout_milliseconds,
+bool SelectForReading(int file_descriptor,
+                      int64_t timeout_milliseconds,
                       bool* is_failure) {
   return SocketpairEmulationManager::GetInstance()->SelectForReading(
       file_descriptor, timeout_milliseconds, is_failure);
 }
 
-bool Read(int file_descriptor, uint8_t* buffer, int64_t* in_out_size,
+bool Read(int file_descriptor,
+          uint8_t* buffer,
+          int64_t* in_out_size,
           bool* is_failure) {
   return SocketpairEmulationManager::GetInstance()->Read(
       file_descriptor, buffer, in_out_size, is_failure);

--- a/third_party/pcsc-lite/naclport/server/src/socketpair_emulation.h
+++ b/third_party/pcsc-lite/naclport/server/src/socketpair_emulation.h
@@ -83,7 +83,9 @@ class SocketpairEmulationManager final {
   //
   // If the specified file descriptor is unknown (or already closed), the error
   // is reported through the is_failure argument.
-  void Write(int file_descriptor, const uint8_t* data, int64_t size,
+  void Write(int file_descriptor,
+             const uint8_t* data,
+             int64_t size,
              bool* is_failure);
 
   // Blocks until any data becomes available at the specified end of the socket
@@ -100,7 +102,8 @@ class SocketpairEmulationManager final {
   //
   // If the specified file descriptor is unknown (or already closed), the error
   // is reported through the is_failure argument.
-  bool SelectForReading(int file_descriptor, int64_t timeout_milliseconds,
+  bool SelectForReading(int file_descriptor,
+                        int64_t timeout_milliseconds,
                         bool* is_failure);
 
   // Reads specified number of bytes from the specified end of the socket pair.
@@ -113,7 +116,9 @@ class SocketpairEmulationManager final {
   //
   // If the specified file descriptor is unknown (or already closed), the error
   // is reported through the is_failure argument.
-  bool Read(int file_descriptor, uint8_t* buffer, int64_t* in_out_size,
+  bool Read(int file_descriptor,
+            uint8_t* buffer,
+            int64_t* in_out_size,
             bool* is_failure);
 
  private:
@@ -151,14 +156,19 @@ void Create(int* file_descriptor_1, int* file_descriptor_2);
 
 void Close(int file_descriptor, bool* is_failure);
 
-void Write(int file_descriptor, const uint8_t* data, int64_t size,
+void Write(int file_descriptor,
+           const uint8_t* data,
+           int64_t size,
            bool* is_failure);
 
 void SelectForReading(int file_descriptor, bool* is_failure);
-bool SelectForReading(int file_descriptor, int64_t timeout_milliseconds,
+bool SelectForReading(int file_descriptor,
+                      int64_t timeout_milliseconds,
                       bool* is_failure);
 
-bool Read(int file_descriptor, uint8_t* buffer, int64_t* in_out_size,
+bool Read(int file_descriptor,
+          uint8_t* buffer,
+          int64_t* in_out_size,
           bool* is_failure);
 
 }  // namespace socketpair_emulation

--- a/third_party/pcsc-lite/naclport/server/src/winscard_msg_nacl.cc
+++ b/third_party/pcsc-lite/naclport/server/src/winscard_msg_nacl.cc
@@ -133,8 +133,10 @@ extern "C" int ServerCloseSession(int fd) {
 // (which is actually an emulated socket).
 //
 // This function may be called both by the client library and by the daemon.
-INTERNAL LONG MessageReceiveTimeout(uint32_t /*command*/, void* buffer_void,
-                                    uint64_t buffer_size, int32_t filedes,
+INTERNAL LONG MessageReceiveTimeout(uint32_t /*command*/,
+                                    void* buffer_void,
+                                    uint64_t buffer_size,
+                                    int32_t filedes,
                                     long timeOut) {
   GOOGLE_SMART_CARD_CHECK(buffer_void);
 
@@ -147,7 +149,8 @@ INTERNAL LONG MessageReceiveTimeout(uint32_t /*command*/, void* buffer_void,
         std::chrono::duration_cast<std::chrono::milliseconds>(
             current_time_point - start_time_point)
             .count();
-    if (milliseconds_passed > timeOut) return SCARD_E_TIMEOUT;
+    if (milliseconds_passed > timeOut)
+      return SCARD_E_TIMEOUT;
 
     bool is_failure = false;
 
@@ -172,8 +175,10 @@ INTERNAL LONG MessageReceiveTimeout(uint32_t /*command*/, void* buffer_void,
 // (which is actually an emulated socket).
 //
 // This function may be called both by the client library and by the daemon.
-INTERNAL LONG MessageSendWithHeader(uint32_t command, uint32_t dwClientID,
-                                    uint64_t size, void* data_void) {
+INTERNAL LONG MessageSendWithHeader(uint32_t command,
+                                    uint32_t dwClientID,
+                                    uint64_t size,
+                                    void* data_void) {
   struct rxHeader header;
   LONG ret;
 
@@ -182,7 +187,8 @@ INTERNAL LONG MessageSendWithHeader(uint32_t command, uint32_t dwClientID,
   ret = MessageSend(&header, sizeof(header), dwClientID);
 
   if (ret == SCARD_S_SUCCESS) {
-    if (size > 0) ret = MessageSend(data_void, size, dwClientID);
+    if (size > 0)
+      ret = MessageSend(data_void, size, dwClientID);
   }
 
   return ret;
@@ -192,7 +198,8 @@ INTERNAL LONG MessageSendWithHeader(uint32_t command, uint32_t dwClientID,
 // (which is actually an emulated socket).
 //
 // This function may be called both by the client library and by the daemon.
-INTERNAL LONG MessageSend(void* buffer_void, uint64_t buffer_size,
+INTERNAL LONG MessageSend(void* buffer_void,
+                          uint64_t buffer_size,
                           int32_t filedes) {
   bool is_failure = false;
   google_smart_card::socketpair_emulation::Write(
@@ -204,7 +211,8 @@ INTERNAL LONG MessageSend(void* buffer_void, uint64_t buffer_size,
 // (which is actually an emulated socket).
 //
 // This function may be called both by the client library and by the daemon.
-INTERNAL LONG MessageReceive(void* buffer_void, uint64_t buffer_size,
+INTERNAL LONG MessageReceive(void* buffer_void,
+                             uint64_t buffer_size,
                              int32_t filedes) {
   GOOGLE_SMART_CARD_CHECK(buffer_void);
 
@@ -215,7 +223,8 @@ INTERNAL LONG MessageReceive(void* buffer_void, uint64_t buffer_size,
 
     google_smart_card::socketpair_emulation::SelectForReading(filedes,
                                                               &is_failure);
-    if (is_failure) return SCARD_F_COMM_ERROR;
+    if (is_failure)
+      return SCARD_F_COMM_ERROR;
 
     int64_t read_size = left_size;
     if (!google_smart_card::socketpair_emulation::Read(

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.cc
@@ -123,7 +123,8 @@ void CleanupHandles(const std::string& logging_prefix,
 }  // namespace
 
 PcscLiteClientRequestProcessor::PcscLiteClientRequestProcessor(
-    int64_t client_handler_id, const optional<std::string>& client_app_id)
+    int64_t client_handler_id,
+    const optional<std::string>& client_app_id)
     : client_handler_id_(client_handler_id),
       client_app_id_(client_app_id),
       status_log_severity_(client_app_id ? LogSeverity::kInfo
@@ -164,7 +165,8 @@ void PcscLiteClientRequestProcessor::ScheduleRunningRequestsCancellation() {
 }
 
 void PcscLiteClientRequestProcessor::ProcessRequest(
-    const std::string& function_name, const pp::VarArray& arguments,
+    const std::string& function_name,
+    const pp::VarArray& arguments,
     RequestReceiver::ResultCallback result_callback) {
   GOOGLE_SMART_CARD_LOG_DEBUG
       << logging_prefix_ << "Started processing "
@@ -191,7 +193,8 @@ void PcscLiteClientRequestProcessor::ProcessRequest(
 // static
 void PcscLiteClientRequestProcessor::AsyncProcessRequest(
     std::shared_ptr<PcscLiteClientRequestProcessor> request_processor,
-    const std::string& function_name, const pp::VarArray& arguments,
+    const std::string& function_name,
+    const pp::VarArray& arguments,
     RequestReceiver::ResultCallback result_callback) {
   std::thread(&PcscLiteClientRequestProcessor::ProcessRequest,
               request_processor, function_name, arguments, result_callback)
@@ -257,7 +260,8 @@ void PcscLiteClientRequestProcessor::AddHandlerToHandlerMap(
 template <typename ArgsTuple, typename F, size_t... arg_indexes>
 PcscLiteClientRequestProcessor::Handler
 PcscLiteClientRequestProcessor::WrapHandler(
-    F handler, ArgIndexes<arg_indexes...> /*unused*/) {
+    F handler,
+    ArgIndexes<arg_indexes...> /*unused*/) {
   return
       [this, handler](const pp::VarArray& arguments) -> GenericRequestResult {
         ArgsTuple args_tuple;
@@ -283,7 +287,8 @@ void PcscLiteClientRequestProcessor::ScheduleHandlesCleanup() {
 }
 
 GenericRequestResult PcscLiteClientRequestProcessor::FindHandlerAndCall(
-    const std::string& function_name, const pp::VarArray& arguments) {
+    const std::string& function_name,
+    const pp::VarArray& arguments) {
   const HandlerMap::const_iterator handler_map_iter =
       handler_map_.find(function_name);
   if (handler_map_iter == handler_map_.end()) {
@@ -328,7 +333,9 @@ GenericRequestResult PcscLiteClientRequestProcessor::PcscStringifyError(
 }
 
 GenericRequestResult PcscLiteClientRequestProcessor::SCardEstablishContext(
-    DWORD scope, pp::Var::Null reserved_1, pp::Var::Null reserved_2) {
+    DWORD scope,
+    pp::Var::Null reserved_1,
+    pp::Var::Null reserved_2) {
   FunctionCallTracer tracer("SCardEstablishContext", logging_prefix_,
                             status_log_severity_);
   tracer.AddPassedArg("dwScope", DebugDumpSCardScope(scope));
@@ -345,7 +352,8 @@ GenericRequestResult PcscLiteClientRequestProcessor::SCardEstablishContext(
     tracer.AddReturnedArg("hContext", DebugDumpSCardContext(s_card_context));
   tracer.LogExit();
 
-  if (return_code != SCARD_S_SUCCESS) return ReturnValues(return_code);
+  if (return_code != SCARD_S_SUCCESS)
+    return ReturnValues(return_code);
   s_card_handles_registry_.AddContext(s_card_context);
   return ReturnValues(return_code, s_card_context);
 }
@@ -373,8 +381,10 @@ GenericRequestResult PcscLiteClientRequestProcessor::SCardReleaseContext(
 }
 
 GenericRequestResult PcscLiteClientRequestProcessor::SCardConnect(
-    SCARDCONTEXT s_card_context, const std::string& reader_name,
-    DWORD share_mode, DWORD preferred_protocols) {
+    SCARDCONTEXT s_card_context,
+    const std::string& reader_name,
+    DWORD share_mode,
+    DWORD preferred_protocols) {
   FunctionCallTracer tracer("SCardConnect", logging_prefix_,
                             status_log_severity_);
   tracer.AddPassedArg("hContext", DebugDumpSCardContext(s_card_context));
@@ -404,13 +414,16 @@ GenericRequestResult PcscLiteClientRequestProcessor::SCardConnect(
   }
   tracer.LogExit();
 
-  if (return_code != SCARD_S_SUCCESS) return ReturnValues(return_code);
+  if (return_code != SCARD_S_SUCCESS)
+    return ReturnValues(return_code);
   s_card_handles_registry_.AddHandle(s_card_context, s_card_handle);
   return ReturnValues(return_code, s_card_handle, active_protocol);
 }
 
 GenericRequestResult PcscLiteClientRequestProcessor::SCardReconnect(
-    SCARDHANDLE s_card_handle, DWORD share_mode, DWORD preferred_protocols,
+    SCARDHANDLE s_card_handle,
+    DWORD share_mode,
+    DWORD preferred_protocols,
     DWORD initialization_action) {
   FunctionCallTracer tracer("SCardReconnect", logging_prefix_,
                             status_log_severity_);
@@ -440,12 +453,14 @@ GenericRequestResult PcscLiteClientRequestProcessor::SCardReconnect(
   }
   tracer.LogExit();
 
-  if (return_code != SCARD_S_SUCCESS) return ReturnValues(return_code);
+  if (return_code != SCARD_S_SUCCESS)
+    return ReturnValues(return_code);
   return ReturnValues(return_code, active_protocol);
 }
 
 GenericRequestResult PcscLiteClientRequestProcessor::SCardDisconnect(
-    SCARDHANDLE s_card_handle, DWORD disposition_action) {
+    SCARDHANDLE s_card_handle,
+    DWORD disposition_action) {
   FunctionCallTracer tracer("SCardDisconnect", logging_prefix_,
                             status_log_severity_);
   tracer.AddPassedArg("hCard", DebugDumpSCardHandle(s_card_handle));
@@ -489,7 +504,8 @@ GenericRequestResult PcscLiteClientRequestProcessor::SCardBeginTransaction(
 }
 
 GenericRequestResult PcscLiteClientRequestProcessor::SCardEndTransaction(
-    SCARDHANDLE s_card_handle, DWORD disposition_action) {
+    SCARDHANDLE s_card_handle,
+    DWORD disposition_action) {
   FunctionCallTracer tracer("SCardEndTransaction", logging_prefix_,
                             status_log_severity_);
   tracer.AddPassedArg("hCard", DebugDumpSCardHandle(s_card_handle));
@@ -543,7 +559,8 @@ GenericRequestResult PcscLiteClientRequestProcessor::SCardStatus(
   }
   tracer.LogExit();
 
-  if (return_code != SCARD_S_SUCCESS) return ReturnValues(return_code);
+  if (return_code != SCARD_S_SUCCESS)
+    return ReturnValues(return_code);
   const std::string reader_name_copy = reader_name;
   FreeSCardMemory(reader_name);
   const pp::Var atr_var = MakeDumpedArrayBuffer(atr, atr_length);
@@ -552,7 +569,8 @@ GenericRequestResult PcscLiteClientRequestProcessor::SCardStatus(
 }
 
 GenericRequestResult PcscLiteClientRequestProcessor::SCardGetStatusChange(
-    SCARDCONTEXT s_card_context, DWORD timeout,
+    SCARDCONTEXT s_card_context,
+    DWORD timeout,
     const std::vector<InboundSCardReaderState>& reader_states) {
   std::vector<SCARD_READERSTATE> pcsc_lite_reader_states;
   for (const InboundSCardReaderState& reader_state : reader_states) {
@@ -608,7 +626,8 @@ GenericRequestResult PcscLiteClientRequestProcessor::SCardGetStatusChange(
   }
   tracer.LogExit();
 
-  if (return_code != SCARD_S_SUCCESS) return ReturnValues(return_code);
+  if (return_code != SCARD_S_SUCCESS)
+    return ReturnValues(return_code);
 
   std::vector<OutboundSCardReaderState> result_reader_states;
   for (const SCARD_READERSTATE& reader_state : pcsc_lite_reader_states) {
@@ -619,7 +638,8 @@ GenericRequestResult PcscLiteClientRequestProcessor::SCardGetStatusChange(
 }
 
 GenericRequestResult PcscLiteClientRequestProcessor::SCardControl(
-    SCARDHANDLE s_card_handle, DWORD control_code,
+    SCARDHANDLE s_card_handle,
+    DWORD control_code,
     const std::vector<uint8_t>& data_to_send) {
   FunctionCallTracer tracer("SCardControl", logging_prefix_,
                             status_log_severity_);
@@ -649,13 +669,15 @@ GenericRequestResult PcscLiteClientRequestProcessor::SCardControl(
   }
   tracer.LogExit();
 
-  if (return_code != SCARD_S_SUCCESS) return ReturnValues(return_code);
+  if (return_code != SCARD_S_SUCCESS)
+    return ReturnValues(return_code);
   return ReturnValues(return_code,
                       MakeDumpedArrayBuffer(&buffer[0], bytes_received));
 }
 
 GenericRequestResult PcscLiteClientRequestProcessor::SCardGetAttrib(
-    SCARDHANDLE s_card_handle, DWORD attribute_id) {
+    SCARDHANDLE s_card_handle,
+    DWORD attribute_id) {
   FunctionCallTracer tracer("SCardGetAttrib", logging_prefix_,
                             status_log_severity_);
   tracer.AddPassedArg("hCard", DebugDumpSCardHandle(s_card_handle));
@@ -681,7 +703,8 @@ GenericRequestResult PcscLiteClientRequestProcessor::SCardGetAttrib(
   }
   tracer.LogExit();
 
-  if (return_code != SCARD_S_SUCCESS) return ReturnValues(return_code);
+  if (return_code != SCARD_S_SUCCESS)
+    return ReturnValues(return_code);
   const pp::Var attribute_var =
       MakeDumpedArrayBuffer(attribute, attribute_length);
   FreeSCardMemory(attribute);
@@ -689,7 +712,8 @@ GenericRequestResult PcscLiteClientRequestProcessor::SCardGetAttrib(
 }
 
 GenericRequestResult PcscLiteClientRequestProcessor::SCardSetAttrib(
-    SCARDHANDLE s_card_handle, DWORD attribute_id,
+    SCARDHANDLE s_card_handle,
+    DWORD attribute_id,
     const std::vector<uint8_t>& attribute) {
   FunctionCallTracer tracer("SCardSetAttrib", logging_prefix_,
                             status_log_severity_);
@@ -715,7 +739,8 @@ GenericRequestResult PcscLiteClientRequestProcessor::SCardSetAttrib(
 }
 
 GenericRequestResult PcscLiteClientRequestProcessor::SCardTransmit(
-    SCARDHANDLE s_card_handle, const SCardIoRequest& send_protocol_information,
+    SCARDHANDLE s_card_handle,
+    const SCardIoRequest& send_protocol_information,
     const std::vector<uint8_t>& data_to_send,
     const optional<SCardIoRequest>& response_protocol_information) {
   const SCARD_IO_REQUEST scard_send_protocol_information =
@@ -786,7 +811,8 @@ GenericRequestResult PcscLiteClientRequestProcessor::SCardTransmit(
   }
   tracer.LogExit();
 
-  if (return_code != SCARD_S_SUCCESS) return ReturnValues(return_code);
+  if (return_code != SCARD_S_SUCCESS)
+    return ReturnValues(return_code);
   return ReturnValues(
       return_code,
       SCardIoRequest::FromSCardIoRequest(scard_response_protocol_information),
@@ -794,7 +820,8 @@ GenericRequestResult PcscLiteClientRequestProcessor::SCardTransmit(
 }
 
 GenericRequestResult PcscLiteClientRequestProcessor::SCardListReaders(
-    SCARDCONTEXT s_card_context, pp::Var::Null groups) {
+    SCARDCONTEXT s_card_context,
+    pp::Var::Null groups) {
   FunctionCallTracer tracer("SCardListReaders", logging_prefix_,
                             status_log_severity_);
   tracer.AddPassedArg("hContext", DebugDumpSCardContext(s_card_context));
@@ -818,7 +845,8 @@ GenericRequestResult PcscLiteClientRequestProcessor::SCardListReaders(
     tracer.AddReturnedArg("mszReaders", DebugDumpSCardMultiString(readers));
   tracer.LogExit();
 
-  if (return_code != SCARD_S_SUCCESS) return ReturnValues(return_code);
+  if (return_code != SCARD_S_SUCCESS)
+    return ReturnValues(return_code);
   const std::vector<std::string> readers_list =
       ExtractMultiStringElements(readers);
   FreeSCardMemory(readers);
@@ -851,7 +879,8 @@ GenericRequestResult PcscLiteClientRequestProcessor::SCardListReaderGroups(
   }
   tracer.LogExit();
 
-  if (return_code != SCARD_S_SUCCESS) return ReturnValues(return_code);
+  if (return_code != SCARD_S_SUCCESS)
+    return ReturnValues(return_code);
   const std::vector<std::string> reader_groups_list =
       ExtractMultiStringElements(reader_groups);
   FreeSCardMemory(reader_groups);

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h
@@ -129,7 +129,8 @@ class PcscLiteClientRequestProcessor final
   // Start processing the given PC/SC-Lite request in a background thread.
   static void AsyncProcessRequest(
       std::shared_ptr<PcscLiteClientRequestProcessor> request_processor,
-      const std::string& function_name, const pp::VarArray& arguments,
+      const std::string& function_name,
+      const pp::VarArray& arguments,
       RequestReceiver::ResultCallback result_callback);
 
  private:
@@ -174,7 +175,8 @@ class PcscLiteClientRequestProcessor final
                                            DWORD disposition_action);
   GenericRequestResult SCardStatus(SCARDHANDLE s_card_handle);
   GenericRequestResult SCardGetStatusChange(
-      SCARDCONTEXT s_card_context, DWORD timeout,
+      SCARDCONTEXT s_card_context,
+      DWORD timeout,
       const std::vector<InboundSCardReaderState>& reader_states);
   GenericRequestResult SCardControl(SCARDHANDLE s_card_handle,
                                     DWORD control_code,

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
@@ -85,7 +85,8 @@ StructConverter<CreateHandlerMessageData>::GetStructTypeName() {
 template <>
 template <typename Callback>
 void StructConverter<CreateHandlerMessageData>::VisitFields(
-    const CreateHandlerMessageData& value, Callback callback) {
+    const CreateHandlerMessageData& value,
+    Callback callback) {
   callback(&value.handler_id, "handler_id");
   callback(&value.client_app_id, "client_app_id");
 }
@@ -106,12 +107,14 @@ StructConverter<DeleteHandlerMessageData>::GetStructTypeName() {
 template <>
 template <typename Callback>
 void StructConverter<DeleteHandlerMessageData>::VisitFields(
-    const DeleteHandlerMessageData& value, Callback callback) {
+    const DeleteHandlerMessageData& value,
+    Callback callback) {
   callback(&value.handler_id, "handler_id");
 }
 
 PcscLiteServerClientsManager::PcscLiteServerClientsManager(
-    pp::Instance* pp_instance, TypedMessageRouter* typed_message_router)
+    pp::Instance* pp_instance,
+    TypedMessageRouter* typed_message_router)
     : pp_instance_(pp_instance),
       typed_message_router_(typed_message_router),
       create_handler_message_listener_(this),
@@ -123,7 +126,9 @@ PcscLiteServerClientsManager::PcscLiteServerClientsManager(
   typed_message_router_->AddRoute(&delete_handler_message_listener_);
 }
 
-PcscLiteServerClientsManager::~PcscLiteServerClientsManager() { Detach(); }
+PcscLiteServerClientsManager::~PcscLiteServerClientsManager() {
+  Detach();
+}
 
 void PcscLiteServerClientsManager::Detach() {
   GOOGLE_SMART_CARD_CHECK(typed_message_router_);
@@ -190,16 +195,20 @@ bool PcscLiteServerClientsManager::DeleteHandlerMessageListener ::
 }
 
 PcscLiteServerClientsManager::Handler::Handler(
-    int64_t handler_id, const optional<std::string>& client_app_id,
-    pp::Instance* pp_instance, TypedMessageRouter* typed_message_router)
+    int64_t handler_id,
+    const optional<std::string>& client_app_id,
+    pp::Instance* pp_instance,
+    TypedMessageRouter* typed_message_router)
     : handler_id_(handler_id),
       client_app_id_(client_app_id),
       request_processor_(
           new PcscLiteClientRequestProcessor(handler_id, client_app_id_)),
       request_receiver_(new JsRequestReceiver(
-          FormatPrintfTemplate(
-              "pcsc_lite_client_handler_%" PRId64 "_call_function", handler_id),
-          this, typed_message_router,
+          FormatPrintfTemplate("pcsc_lite_client_handler_%" PRId64
+                               "_call_function",
+                               handler_id),
+          this,
+          typed_message_router,
           MakeUnique<JsRequestReceiver::PpDelegateImpl>(pp_instance))) {}
 
 PcscLiteServerClientsManager::Handler::~Handler() {
@@ -217,7 +226,8 @@ PcscLiteServerClientsManager::Handler::~Handler() {
 }
 
 void PcscLiteServerClientsManager::Handler::HandleRequest(
-    Value payload, RequestReceiver::ResultCallback result_callback) {
+    Value payload,
+    RequestReceiver::ResultCallback result_callback) {
   // TODO: Parse `Value` directly instead of transforming into `pp::Var`.
   const pp::Var payload_var = ConvertValueToPpVar(payload);
   std::string function_name;
@@ -233,7 +243,8 @@ void PcscLiteServerClientsManager::Handler::HandleRequest(
 }
 
 void PcscLiteServerClientsManager::CreateHandler(
-    int64_t handler_id, const optional<std::string>& client_app_id) {
+    int64_t handler_id,
+    const optional<std::string>& client_app_id) {
   std::unique_ptr<Handler> handler(new Handler(
       handler_id, client_app_id, pp_instance_, typed_message_router_));
   if (!handler_map_.emplace(handler_id, std::move(handler)).second) {

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h
@@ -136,7 +136,8 @@ class PcscLiteServerClientsManager final {
   // a client (and delivered here by the JavaScript side).
   class Handler final : public RequestHandler {
    public:
-    Handler(int64_t handler_id, const optional<std::string>& client_app_id,
+    Handler(int64_t handler_id,
+            const optional<std::string>& client_app_id,
             pp::Instance* pp_instance,
             TypedMessageRouter* typed_message_router);
     Handler(const Handler&) = delete;

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.cc
@@ -45,7 +45,8 @@ class PcscLiteServerClientsManagementBackend::Impl final {
 };
 
 PcscLiteServerClientsManagementBackend::PcscLiteServerClientsManagementBackend(
-    pp::Instance* pp_instance, TypedMessageRouter* typed_message_router)
+    pp::Instance* pp_instance,
+    TypedMessageRouter* typed_message_router)
     : impl_(new Impl(pp_instance, typed_message_router)) {}
 
 PcscLiteServerClientsManagementBackend::

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.h
@@ -46,7 +46,8 @@ namespace google_smart_card {
 class PcscLiteServerClientsManagementBackend final {
  public:
   PcscLiteServerClientsManagementBackend(
-      pp::Instance* pp_instance, TypedMessageRouter* typed_message_router);
+      pp::Instance* pp_instance,
+      TypedMessageRouter* typed_message_router);
 
   PcscLiteServerClientsManagementBackend(
       const PcscLiteServerClientsManagementBackend&) = delete;

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/ready_message.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/ready_message.cc
@@ -31,8 +31,12 @@ namespace google_smart_card {
 
 constexpr char kMessageType[] = "pcsc_lite_ready";
 
-std::string GetPcscLiteServerReadyMessageType() { return kMessageType; }
+std::string GetPcscLiteServerReadyMessageType() {
+  return kMessageType;
+}
 
-pp::Var MakePcscLiteServerReadyMessageData() { return pp::VarDictionary(); }
+pp::Var MakePcscLiteServerReadyMessageData() {
+  return pp::VarDictionary();
+}
 
 }  // namespace google_smart_card


### PR DESCRIPTION
Change the format-code.sh script to tell clang-format to use the
"Chromium" style instead of the "Google" one. Also reformat all of the
existing code according to this new style (except the third-party code).

Given that the main product of this repository is the Smart Card
Connector app which is one of Chrome OS components (even if optional and
separately distributed), and given that all of this repository's
maintainers are also Chromium developers, it makes sense to switch to
the "Chromium" style guide.

Subjectively speaking, a big benefit of the "Chromium" style is that it
doesn't collapse short "if" statements into a single line - a two-line
format is, arguably, easier to read.

This commit is a follow-up to #202 and #187 which introduced the
strict "Google" style following in this repository.