### PR TITLE
Migrate js_requester.{h|cc} to GlobalContext

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -37,6 +37,7 @@ SOURCES := \
 	$(SOURCES_PATH)/messaging/typed_message_router.cc \
 	$(SOURCES_PATH)/multi_string.cc \
 	$(SOURCES_PATH)/numeric_conversions.cc \
+	$(SOURCES_PATH)/requesting/js_requester.cc \
 	$(SOURCES_PATH)/requesting/remote_call_arguments_conversion.cc \
 	$(SOURCES_PATH)/requesting/remote_call_message.cc \
 	$(SOURCES_PATH)/requesting/request_result.cc \
@@ -62,7 +63,6 @@ SOURCES += \
 SOURCES += \
 	$(SOURCES_PATH)/external_logs_printer.cc \
 	$(SOURCES_PATH)/requesting/js_request_receiver.cc \
-	$(SOURCES_PATH)/requesting/js_requester.cc \
 	$(SOURCES_PATH)/requesting/remote_call_adaptor.cc \
 	$(SOURCES_PATH)/requesting/request_receiver.cc \
 

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h
@@ -21,6 +21,7 @@
 #include <ppapi/cpp/instance.h>
 #include <ppapi/cpp/var.h>
 
+#include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/messaging/typed_message_router.h>
 #include <google_smart_card_common/requesting/request_receiver.h>
 
@@ -48,7 +49,8 @@ class IntegrationTestHelper {
   virtual ~IntegrationTestHelper() = default;
 
   virtual std::string GetName() const = 0;
-  virtual void SetUp(pp::Instance* /*pp_instance*/,
+  virtual void SetUp(GlobalContext* /*global_context*/,
+                     pp::Instance* /*pp_instance*/,
                      pp::Core* /*pp_core*/,
                      TypedMessageRouter* /*typed_message_router*/,
                      const pp::Var& /*data*/) {}

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_pp_module.cc
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_pp_module.cc
@@ -22,6 +22,7 @@
 #include <ppapi/cpp/module.h>
 #include <ppapi/cpp/var.h>
 
+#include <google_smart_card_common/global_context_impl_nacl.h>
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/messaging/typed_message_router.h>
 #include <google_smart_card_common/optional.h>
@@ -39,9 +40,11 @@ namespace {
 class IntegrationTestPpInstance final : public pp::Instance {
  public:
   explicit IntegrationTestPpInstance(PP_Instance instance)
-      : pp::Instance(instance) {
-    IntegrationTestService::GetInstance()->Activate(
-        this, pp::Module::Get()->core(), &typed_message_router_);
+      : pp::Instance(instance),
+        global_context_(pp::Module::Get()->core(), this) {
+    IntegrationTestService::GetInstance()->Activate(&global_context_, this,
+                                                    pp::Module::Get()->core(),
+                                                    &typed_message_router_);
   }
 
   ~IntegrationTestPpInstance() override {
@@ -64,6 +67,7 @@ class IntegrationTestPpInstance final : public pp::Instance {
   }
 
  private:
+  GlobalContextImplNacl global_context_;
   TypedMessageRouter typed_message_router_;
 };
 

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.cc
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.cc
@@ -24,6 +24,7 @@
 #include <ppapi/cpp/var.h>
 #include <ppapi/cpp/var_array.h>
 
+#include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/messaging/typed_message_router.h>
 #include <google_smart_card_common/pp_var_utils/debug_dump.h>
@@ -60,16 +61,20 @@ IntegrationTestHelper* IntegrationTestService::RegisterHelper(
 }
 
 void IntegrationTestService::Activate(
+    GlobalContext* global_context,
     pp::Instance* pp_instance,
     pp::Core* pp_core,
     TypedMessageRouter* typed_message_router) {
+  GOOGLE_SMART_CARD_CHECK(global_context);
   GOOGLE_SMART_CARD_CHECK(pp_instance);
   GOOGLE_SMART_CARD_CHECK(pp_core);
   GOOGLE_SMART_CARD_CHECK(typed_message_router);
+  GOOGLE_SMART_CARD_CHECK(!global_context_);
   GOOGLE_SMART_CARD_CHECK(!pp_instance_);
   GOOGLE_SMART_CARD_CHECK(!pp_core_);
   GOOGLE_SMART_CARD_CHECK(!typed_message_router_);
   GOOGLE_SMART_CARD_CHECK(!js_request_receiver_);
+  global_context_ = global_context;
   pp_instance_ = pp_instance;
   pp_core_ = pp_core;
   typed_message_router_ = typed_message_router;
@@ -140,7 +145,8 @@ void IntegrationTestService::SetUpHelper(const std::string& helper_name,
     GOOGLE_SMART_CARD_LOG_FATAL << "Unknown helper " << helper_name;
   GOOGLE_SMART_CARD_CHECK(!set_up_helpers_.count(helper));
   set_up_helpers_.insert(helper);
-  helper->SetUp(pp_instance_, pp_core_, typed_message_router_, data_for_helper);
+  helper->SetUp(global_context_, pp_instance_, pp_core_, typed_message_router_,
+                data_for_helper);
 }
 
 void IntegrationTestService::TearDownAllHelpers() {

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
@@ -24,6 +24,7 @@
 #include <ppapi/cpp/instance.h>
 #include <ppapi/cpp/var.h>
 
+#include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/messaging/typed_message_listener.h>
 #include <google_smart_card_common/requesting/js_request_receiver.h>
 #include <google_smart_card_common/value.h>
@@ -46,7 +47,8 @@ class IntegrationTestService final : public RequestHandler {
 
   // Starts listening for incoming requests and translating them into commands
   // for test helpers.
-  void Activate(pp::Instance* pp_instance,
+  void Activate(GlobalContext* global_context,
+                pp::Instance* pp_instance,
                 pp::Core* pp_core,
                 TypedMessageRouter* typed_message_router);
   // Tears down all previously set up helpers and stops listening for incoming
@@ -69,6 +71,7 @@ class IntegrationTestService final : public RequestHandler {
                            const pp::Var& message_for_helper,
                            RequestReceiver::ResultCallback result_callback);
 
+  GlobalContext* global_context_ = nullptr;
   pp::Instance* pp_instance_ = nullptr;
   pp::Core* pp_core_ = nullptr;
   TypedMessageRouter* typed_message_router_ = nullptr;

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.cc
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.cc
@@ -16,9 +16,9 @@
 
 #include <ppapi/cpp/var_dictionary.h>
 
+#include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/pp_var_utils/extraction.h>
 #include <google_smart_card_common/requesting/request_result.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
 #include <google_smart_card_common/value.h>
 #include <google_smart_card_common/value_nacl_pp_var_conversion.h>
 
@@ -47,15 +47,9 @@ void ExtractPinRequestResult(
 }  // namespace
 
 BuiltInPinDialogServer::BuiltInPinDialogServer(
-    google_smart_card::TypedMessageRouter* typed_message_router,
-    pp::Instance* pp_instance,
-    pp::Core* pp_core)
-    : js_requester_(
-          kRequesterName,
-          typed_message_router,
-          google_smart_card::MakeUnique<
-              google_smart_card::JsRequester::PpDelegateImpl>(pp_instance,
-                                                              pp_core)) {}
+    google_smart_card::GlobalContext* global_context,
+    google_smart_card::TypedMessageRouter* typed_message_router)
+    : js_requester_(kRequesterName, global_context, typed_message_router) {}
 
 BuiltInPinDialogServer::~BuiltInPinDialogServer() = default;
 

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.h
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.h
@@ -17,9 +17,7 @@
 
 #include <string>
 
-#include <ppapi/cpp/core.h>
-#include <ppapi/cpp/instance.h>
-
+#include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/messaging/typed_message_router.h>
 #include <google_smart_card_common/requesting/js_requester.h>
 
@@ -43,24 +41,24 @@ class BuiltInPinDialogServer final {
  public:
   // Creates the object and an internal JsRequester object, which adds a route
   // into the specified TypedMessageRouter for receiving the request responses.
+  // `global_context` - must outlive `this`.
   BuiltInPinDialogServer(
-      google_smart_card::TypedMessageRouter* typed_message_router,
-      pp::Instance* pp_instance,
-      pp::Core* pp_core);
+      google_smart_card::GlobalContext* global_context,
+      google_smart_card::TypedMessageRouter* typed_message_router);
 
   BuiltInPinDialogServer(const BuiltInPinDialogServer&) = delete;
   BuiltInPinDialogServer& operator=(const BuiltInPinDialogServer&) = delete;
 
   ~BuiltInPinDialogServer();
 
-  // Detaches from the Pepper module and the typed message router, which
-  // prevents any further requests and waiting for the request responses.
+  // Detaches from the typed message router and the JavaScript side, which
+  // prevents making any further requests and prevents waiting for the responses
+  // of the already started requests.
   //
-  // This function is primarily intended to be used during the Pepper module
+  // This function is primarily intended to be used during the executable
   // shutdown process, for preventing the situations when some other threads
-  // currently issuing PIN requests or waiting for the finish of the already
-  // started requests try to access the destroyed pp::Instance object or some
-  // other associated objects.
+  // currently executing PIN requests would trigger accesses to already
+  // destroyed objects.
   //
   // This function is safe to be called from any thread.
   void Detach();

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
@@ -19,6 +19,7 @@
 
 #include <ppapi/cpp/var.h>
 
+#include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/logging/function_call_tracer.h>
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/pp_var_utils/construction.h>
@@ -94,15 +95,12 @@ void ProcessSignatureRequest(
 
 }  // namespace
 
-ApiBridge::ApiBridge(gsc::TypedMessageRouter* typed_message_router,
+ApiBridge::ApiBridge(gsc::GlobalContext* global_context,
+                     gsc::TypedMessageRouter* typed_message_router,
                      pp::Instance* pp_instance,
-                     pp::Core* pp_core,
                      std::shared_ptr<std::mutex> request_handling_mutex)
     : request_handling_mutex_(request_handling_mutex),
-      requester_(kRequesterName,
-                 typed_message_router,
-                 gsc::MakeUnique<gsc::JsRequester::PpDelegateImpl>(pp_instance,
-                                                                   pp_core)),
+      requester_(kRequesterName, global_context, typed_message_router),
       remote_call_adaptor_(&requester_),
       request_receiver_(new gsc::JsRequestReceiver(
           kRequestReceiverName,

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
@@ -26,11 +26,11 @@
 #include <string>
 #include <vector>
 
-#include <ppapi/cpp/core.h>
 #include <ppapi/cpp/instance.h>
 #include <ppapi/cpp/var.h>
 #include <ppapi/cpp/var_array.h>
 
+#include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/messaging/typed_message_router.h>
 #include <google_smart_card_common/requesting/js_request_receiver.h>
 #include <google_smart_card_common/requesting/js_requester.h>
@@ -89,12 +89,13 @@ class ApiBridge final : public google_smart_card::RequestHandler {
   // messages through the supplied TypedMessageRouter typed_message_router
   // instance.
   //
+  // |global_context| - must outlive |this|.
   // The |request_handling_mutex| parameter, when non-null, allows to avoid
   // simultaneous execution of multiple requests: each next request will be
   // executed only once the previous one finishes.
-  ApiBridge(google_smart_card::TypedMessageRouter* typed_message_router,
+  ApiBridge(google_smart_card::GlobalContext* global_context,
+            google_smart_card::TypedMessageRouter* typed_message_router,
             pp::Instance* pp_instance,
-            pp::Core* pp_core,
             std::shared_ptr<std::mutex> request_handling_mutex);
 
   ApiBridge(const ApiBridge&) = delete;

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
@@ -23,6 +23,7 @@
 #include <ppapi/cpp/instance.h>
 #include <ppapi/cpp/var.h>
 
+#include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/messaging/typed_message_router.h>
 #include <google_smart_card_common/pp_var_utils/debug_dump.h>
@@ -83,7 +84,8 @@ class ApiBridgeIntegrationTestHelper final : public gsc::IntegrationTestHelper {
  public:
   // IntegrationTestHelper:
   std::string GetName() const override;
-  void SetUp(pp::Instance* pp_instance,
+  void SetUp(gsc::GlobalContext* global_context,
+             pp::Instance* pp_instance,
              pp::Core* pp_core,
              gsc::TypedMessageRouter* typed_message_router,
              const pp::Var& data) override;
@@ -109,13 +111,14 @@ std::string ApiBridgeIntegrationTestHelper::GetName() const {
 }
 
 void ApiBridgeIntegrationTestHelper::SetUp(
+    gsc::GlobalContext* global_context,
     pp::Instance* pp_instance,
-    pp::Core* pp_core,
+    pp::Core* /*pp_core*/,
     gsc::TypedMessageRouter* typed_message_router,
     const pp::Var& /*data*/) {
-  api_bridge_ =
-      std::make_shared<ApiBridge>(typed_message_router, pp_instance, pp_core,
-                                  /*request_handling_mutex=*/nullptr);
+  api_bridge_ = std::make_shared<ApiBridge>(global_context,
+                                            typed_message_router, pp_instance,
+                                            /*request_handling_mutex=*/nullptr);
 }
 
 void ApiBridgeIntegrationTestHelper::TearDown() {

--- a/smart_card_connector_app/src/pp_module.cc
+++ b/smart_card_connector_app/src/pp_module.cc
@@ -24,12 +24,14 @@
 #include <ppapi/cpp/var.h>
 
 #include <google_smart_card_common/external_logs_printer.h>
+#include <google_smart_card_common/global_context_impl_nacl.h>
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/messaging/typed_message.h>
 #include <google_smart_card_common/messaging/typed_message_router.h>
 #include <google_smart_card_common/nacl_io_utils.h>
 #include <google_smart_card_common/optional.h>
 #include <google_smart_card_common/pp_var_utils/debug_dump.h>
+#include <google_smart_card_common/unique_ptr_utils.h>
 #include <google_smart_card_common/value.h>
 #include <google_smart_card_common/value_conversion.h>
 #include <google_smart_card_common/value_nacl_pp_var_conversion.h>
@@ -50,10 +52,11 @@ class PpInstance final : public pp::Instance {
  public:
   explicit PpInstance(PP_Instance instance)
       : pp::Instance(instance),
+        global_context_(
+            MakeUnique<GlobalContextImplNacl>(pp::Module::Get()->core(), this)),
         libusb_over_chrome_usb_global_(
-            new LibusbOverChromeUsbGlobal(&typed_message_router_,
-                                          this,
-                                          pp::Module::Get()->core())),
+            MakeUnique<LibusbOverChromeUsbGlobal>(global_context_.get(),
+                                                  &typed_message_router_)),
         pcsc_lite_server_global_(new PcscLiteServerGlobal(this)) {
     typed_message_router_.AddRoute(&external_logs_printer_);
 
@@ -63,12 +66,12 @@ class PpInstance final : public pp::Instance {
   ~PpInstance() override {
     typed_message_router_.RemoveRoute(&external_logs_printer_);
 
-    // Detach the LibusbNaclGlobal and leak it intentionally, so that any
-    // concurrent libusb_* function calls still don't result in UB.
+    // Intentionally leak objects that might still be used by background
+    // threads. Only detach them from `this` and the JavaScript side.
+    global_context_->DisableJsCommunication();
+    global_context_.release();
     libusb_over_chrome_usb_global_->Detach();
     libusb_over_chrome_usb_global_.release();
-    // Detach the PcscLiteServerGlobal and leak it intentionally to allow
-    // graceful shutdown (because of possible concurrent calls).
     pcsc_lite_server_global_->Detach();
     pcsc_lite_server_global_.release();
   }
@@ -115,6 +118,7 @@ class PpInstance final : public pp::Instance {
     PostMessage(ConvertValueToPpVar(ready_message_value));
   }
 
+  std::unique_ptr<GlobalContextImplNacl> global_context_;
   TypedMessageRouter typed_message_router_;
   ExternalLogsPrinter external_logs_printer_{kJsLogsHandlerMessageType};
   std::unique_ptr<LibusbOverChromeUsbGlobal> libusb_over_chrome_usb_global_;

--- a/third_party/libusb/naclport/src/google_smart_card_libusb/global.h
+++ b/third_party/libusb/naclport/src/google_smart_card_libusb/global.h
@@ -19,9 +19,7 @@
 
 #include <memory>
 
-#include <ppapi/cpp/core.h>
-#include <ppapi/cpp/instance.h>
-
+#include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/messaging/typed_message_router.h>
 
 namespace google_smart_card {
@@ -39,9 +37,8 @@ namespace google_smart_card {
 // concurrent libusb_* function calls.
 class LibusbOverChromeUsbGlobal final {
  public:
-  LibusbOverChromeUsbGlobal(TypedMessageRouter* typed_message_router,
-                            pp::Instance* pp_instance,
-                            pp::Core* pp_core);
+  LibusbOverChromeUsbGlobal(GlobalContext* global_context,
+                            TypedMessageRouter* typed_message_router);
 
   LibusbOverChromeUsbGlobal(const LibusbOverChromeUsbGlobal&) = delete;
   LibusbOverChromeUsbGlobal& operator=(const LibusbOverChromeUsbGlobal&) =
@@ -54,19 +51,18 @@ class LibusbOverChromeUsbGlobal final {
   // behavior).
   ~LibusbOverChromeUsbGlobal();
 
-  // Detaches from the Pepper module and the typed message router, which
-  // prevents making any further requests through them and prevents waiting for
-  // the responses of the already started requests.
+  // Detaches from the typed message router and the JavaScript side, which
+  // prevents making any further requests and prevents waiting for the responses
+  // of the already started requests.
   //
   // After this function call, the global libusb_* functions are still allowed
   // to be called, but they will return errors instead of performing the real
   // requests.
   //
-  // This function is primarily intended to be used during the Pepper module
+  // This function is primarily intended to be used during the executable
   // shutdown process, for preventing the situations when some other threads
-  // currently calling global libusb_* functions or waiting for the finish of
-  // the already called functions try to access the destroyed pp::Instance
-  // object or some other associated objects.
+  // currently executing global libusb_* functions would trigger accesses to
+  // already destroyed objects.
   //
   // This function is safe to be called from any thread.
   void Detach();

--- a/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.h
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.h
@@ -28,9 +28,7 @@
 
 #include <memory>
 
-#include <ppapi/cpp/core.h>
-#include <ppapi/cpp/instance.h>
-
+#include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/messaging/typed_message_router.h>
 
 namespace google_smart_card {
@@ -48,9 +46,8 @@ namespace google_smart_card {
 // concurrent PC/SC-Lite client API function calls.
 class PcscLiteOverRequesterGlobal final {
  public:
-  PcscLiteOverRequesterGlobal(TypedMessageRouter* typed_message_router,
-                              pp::Instance* pp_instance,
-                              pp::Core* pp_core);
+  PcscLiteOverRequesterGlobal(GlobalContext* global_context,
+                              TypedMessageRouter* typed_message_router);
 
   PcscLiteOverRequesterGlobal(const PcscLiteOverRequesterGlobal&) = delete;
   PcscLiteOverRequesterGlobal& operator=(const PcscLiteOverRequesterGlobal&) =
@@ -63,19 +60,18 @@ class PcscLiteOverRequesterGlobal final {
   // undefined behavior).
   ~PcscLiteOverRequesterGlobal();
 
-  // Detaches from the Pepper module and the typed message router, which
-  // prevents making any further requests through them and prevents waiting for
-  // the responses of the already started requests.
+  // Detaches from the typed message router and the JavaScript side, which
+  // prevents making any further requests and prevents waiting for the responses
+  // of the already started requests.
   //
   // After this function call, the global PC/SC-Lite client API functions are
   // still allowed to be called, but they will return errors instead of
   // performing the real requests.
   //
-  // This function is primarily intended to be used during the Pepper module
+  // This function is primarily intended to be used during the executable
   // shutdown process, for preventing the situations when some other threads
-  // currently calling global PC/SC-Lite client API functions or waiting for the
-  // finish of the already called functions try to access the destroyed
-  // pp::Instance object or some other associated objects.
+  // currently executing global PC/SC-Lite client API functions would trigger
+  // accesses to already destroyed objects.
   //
   // This function is safe to be called from any thread.
   void Detach();


### PR DESCRIPTION
This commit changes the JsRequester class to use the
toolchain-independent GlobalContext interface instead of directly
operating Native Client specific objects (pp::Core, pp::Instance).

This makes the whole JsRequester class work under both
Emscripten/WebAssembly and Native Client (contributing to the
effort tracked by #185). Besides the mechanical replacement, the
commit had to introduce construction of the GlobalContext object
in entry point .cc files and passing them through down to the
JsRequester constructors.

As a side effect bonus, this commit made the following files
toolchain-independent as well:
* google_smart_card_libusb/global.{h|cc};
* google_smart_card_pcsc_lite_client/global.{h|cc}.