### PR TITLE
Migrate remote_call_adaptor.{h|cc} to Value

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -37,6 +37,7 @@ SOURCES := \
 	$(SOURCES_PATH)/messaging/typed_message_router.cc \
 	$(SOURCES_PATH)/multi_string.cc \
 	$(SOURCES_PATH)/numeric_conversions.cc \
+	$(SOURCES_PATH)/requesting/remote_call_adaptor.cc \
 	$(SOURCES_PATH)/requesting/remote_call_arguments_conversion.cc \
 	$(SOURCES_PATH)/requesting/remote_call_message.cc \
 	$(SOURCES_PATH)/requesting/request_result.cc \
@@ -63,7 +64,6 @@ SOURCES += \
 	$(SOURCES_PATH)/external_logs_printer.cc \
 	$(SOURCES_PATH)/requesting/js_request_receiver.cc \
 	$(SOURCES_PATH)/requesting/js_requester.cc \
-	$(SOURCES_PATH)/requesting/remote_call_adaptor.cc \
 	$(SOURCES_PATH)/requesting/request_receiver.cc \
 
 else ifeq ($(TOOLCHAIN),emscripten)

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.cc
@@ -14,6 +14,15 @@
 
 #include <google_smart_card_common/requesting/remote_call_arguments_conversion.h>
 
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <google_smart_card_common/formatting.h>
+#include <google_smart_card_common/value.h>
+#include <google_smart_card_common/value_conversion.h>
+#include <google_smart_card_common/value_debug_dumping.h>
+
 namespace google_smart_card {
 
 namespace internal {
@@ -23,5 +32,60 @@ const char kRemoteCallArgumentConversionError[] =
     "Failed to convert argument #%d for %s(): %s";
 
 }  // namespace internal
+
+RemoteCallArgumentsExtractor::RemoteCallArgumentsExtractor(
+    std::string title,
+    std::vector<Value> argument_values)
+    : title_(std::move(title)), argument_values_(std::move(argument_values)) {}
+
+RemoteCallArgumentsExtractor::RemoteCallArgumentsExtractor(
+    std::string title,
+    Value arguments_as_value)
+    : title_(std::move(title)) {
+  if (!ConvertFromValue(std::move(arguments_as_value), &argument_values_,
+                        &error_message_)) {
+    success_ = false;
+    error_message_ =
+        FormatPrintfTemplate("Failed to convert arguments for %s(): %s",
+                             title_.c_str(), error_message_.c_str());
+  }
+}
+
+RemoteCallArgumentsExtractor::~RemoteCallArgumentsExtractor() = default;
+
+void RemoteCallArgumentsExtractor::Extract() {}
+
+bool RemoteCallArgumentsExtractor::Finish() {
+  VerifyNothingLeft();
+  return success_;
+}
+
+void RemoteCallArgumentsExtractor::VerifySufficientCount(
+    int arguments_to_convert) {
+  if (!success_)
+    return;
+  const size_t min_size = current_argument_index_ + arguments_to_convert;
+  if (min_size <= argument_values_.size())
+    return;
+  success_ = false;
+  error_message_ = FormatPrintfTemplate(
+      "Failed to convert arguments for %s(): expected at least %d argument(s), "
+      "received only %d",
+      title_.c_str(), static_cast<int>(min_size),
+      static_cast<int>(argument_values_.size()));
+}
+
+void RemoteCallArgumentsExtractor::VerifyNothingLeft() {
+  if (!success_ || current_argument_index_ == argument_values_.size())
+    return;
+  success_ = false;
+  error_message_ = FormatPrintfTemplate(
+      "Failed to convert arguments for %s(): expected exactly %d arguments, "
+      "received %d; first extra argument: %s",
+      title_.c_str(), static_cast<int>(current_argument_index_),
+      static_cast<int>(argument_values_.size()),
+      DebugDumpValueSanitized(argument_values_[current_argument_index_])
+          .c_str());
+}
 
 }  // namespace google_smart_card

--- a/third_party/libusb/naclport/src/chrome_usb/api_bridge.cc
+++ b/third_party/libusb/naclport/src/chrome_usb/api_bridge.cc
@@ -38,97 +38,94 @@ void ApiBridge::Detach() {
 
 RequestResult<GetDevicesResult> ApiBridge::GetDevices(
     const GetDevicesOptions& options) {
-  const GenericRequestResult generic_request_result =
+  GenericRequestResult generic_request_result =
       remote_call_adaptor_.SyncCall("getDevices", options);
   GetDevicesResult result;
-  return RemoteCallAdaptor::ConvertResultPayload(generic_request_result,
-                                                 &result, &result.devices);
+  return RemoteCallAdaptor::ConvertResultPayload(
+      std::move(generic_request_result), &result, &result.devices);
 }
 
 RequestResult<GetUserSelectedDevicesResult> ApiBridge::GetUserSelectedDevices(
     const GetUserSelectedDevicesOptions& options) {
-  const GenericRequestResult generic_request_result =
+  GenericRequestResult generic_request_result =
       remote_call_adaptor_.SyncCall("getUserSelectedDevices", options);
   GetUserSelectedDevicesResult result;
-  return RemoteCallAdaptor::ConvertResultPayload(generic_request_result,
-                                                 &result, &result.devices);
+  return RemoteCallAdaptor::ConvertResultPayload(
+      std::move(generic_request_result), &result, &result.devices);
 }
 
 RequestResult<GetConfigurationsResult> ApiBridge::GetConfigurations(
     const Device& device) {
-  const GenericRequestResult generic_request_result =
+  GenericRequestResult generic_request_result =
       remote_call_adaptor_.SyncCall("getConfigurations", device);
   GetConfigurationsResult result;
   return RemoteCallAdaptor::ConvertResultPayload(
-      generic_request_result, &result, &result.configurations);
+      std::move(generic_request_result), &result, &result.configurations);
 }
 
 RequestResult<OpenDeviceResult> ApiBridge::OpenDevice(const Device& device) {
-  const GenericRequestResult generic_request_result =
+  GenericRequestResult generic_request_result =
       remote_call_adaptor_.SyncCall("openDevice", device);
   OpenDeviceResult result;
   return RemoteCallAdaptor::ConvertResultPayload(
-      generic_request_result, &result, &result.connection_handle);
+      std::move(generic_request_result), &result, &result.connection_handle);
 }
 
 RequestResult<CloseDeviceResult> ApiBridge::CloseDevice(
     const ConnectionHandle& connection_handle) {
-  const GenericRequestResult generic_request_result =
+  GenericRequestResult generic_request_result =
       remote_call_adaptor_.SyncCall("closeDevice", connection_handle);
   CloseDeviceResult result;
-  return RemoteCallAdaptor::ConvertResultPayload(generic_request_result,
-                                                 &result);
+  return RemoteCallAdaptor::ConvertResultPayload(
+      std::move(generic_request_result), &result);
 }
 
 RequestResult<SetConfigurationResult> ApiBridge::SetConfiguration(
     const ConnectionHandle& connection_handle,
     int64_t configuration_value) {
-  const GenericRequestResult generic_request_result =
-      remote_call_adaptor_.SyncCall("setConfiguration", connection_handle,
-                                    configuration_value);
+  GenericRequestResult generic_request_result = remote_call_adaptor_.SyncCall(
+      "setConfiguration", connection_handle, configuration_value);
   SetConfigurationResult result;
-  return RemoteCallAdaptor::ConvertResultPayload(generic_request_result,
-                                                 &result);
+  return RemoteCallAdaptor::ConvertResultPayload(
+      std::move(generic_request_result), &result);
 }
 
 RequestResult<GetConfigurationResult> ApiBridge::GetConfiguration(
     const ConnectionHandle& connection_handle) {
-  const GenericRequestResult generic_request_result =
+  GenericRequestResult generic_request_result =
       remote_call_adaptor_.SyncCall("getConfiguration", connection_handle);
   GetConfigurationResult result;
   return RemoteCallAdaptor::ConvertResultPayload(
-      generic_request_result, &result, &result.configuration);
+      std::move(generic_request_result), &result, &result.configuration);
 }
 
 RequestResult<ListInterfacesResult> ApiBridge::ListInterfaces(
     const ConnectionHandle& connection_handle) {
-  const GenericRequestResult generic_request_result =
+  GenericRequestResult generic_request_result =
       remote_call_adaptor_.SyncCall("listInterfaces", connection_handle);
   ListInterfacesResult result;
-  return RemoteCallAdaptor::ConvertResultPayload(generic_request_result,
-                                                 &result, &result.descriptors);
+  return RemoteCallAdaptor::ConvertResultPayload(
+      std::move(generic_request_result), &result, &result.descriptors);
 }
 
 RequestResult<ClaimInterfaceResult> ApiBridge::ClaimInterface(
     const ConnectionHandle& connection_handle,
     int64_t interface_number) {
-  const GenericRequestResult generic_request_result =
-      remote_call_adaptor_.SyncCall("claimInterface", connection_handle,
-                                    interface_number);
+  GenericRequestResult generic_request_result = remote_call_adaptor_.SyncCall(
+      "claimInterface", connection_handle, interface_number);
   ClaimInterfaceResult result;
-  return RemoteCallAdaptor::ConvertResultPayload(generic_request_result,
-                                                 &result);
+  return RemoteCallAdaptor::ConvertResultPayload(
+      std::move(generic_request_result), &result);
 }
 
 RequestResult<ReleaseInterfaceResult> ApiBridge::ReleaseInterface(
     const ConnectionHandle& connection_handle,
     int64_t interface_number) {
-  const GenericRequestResult generic_request_result =
-      remote_call_adaptor_.SyncCall("releaseInterface", connection_handle,
-                                    interface_number);
+  GenericRequestResult generic_request_result = remote_call_adaptor_.SyncCall(
+      "releaseInterface", connection_handle, interface_number);
   ReleaseInterfaceResult result;
-  return RemoteCallAdaptor::ConvertResultPayload(generic_request_result,
-                                                 &result);
+  return RemoteCallAdaptor::ConvertResultPayload(
+      std::move(generic_request_result), &result);
 }
 
 namespace {
@@ -138,7 +135,7 @@ GenericAsyncRequestCallback WrapAsyncTransferCallback(
   return [callback](GenericRequestResult generic_request_result) {
     TransferResult result;
     return callback(RemoteCallAdaptor::ConvertResultPayload(
-        generic_request_result, &result, &result.result_info));
+        std::move(generic_request_result), &result, &result.result_info));
   };
 }
 
@@ -171,11 +168,11 @@ void ApiBridge::AsyncInterruptTransfer(
 
 RequestResult<ResetDeviceResult> ApiBridge::ResetDevice(
     const ConnectionHandle& connection_handle) {
-  const GenericRequestResult generic_request_result =
+  GenericRequestResult generic_request_result =
       remote_call_adaptor_.SyncCall("resetDevice", connection_handle);
   ResetDeviceResult result;
   return RemoteCallAdaptor::ConvertResultPayload(
-      generic_request_result, &result, &result.reset_success);
+      std::move(generic_request_result), &result, &result.reset_success);
 }
 
 }  // namespace chrome_usb


### PR DESCRIPTION
This commit changes the RemoteCallAdaptor class to use the
toolchain-independent Value class instead of Native Client specific
classes (like pp::Var). This contributes to the effort tracked
by #185.

Besides mechanical replacements, this change introduces a helper class
for converting the input/output remote call arguments from Values into
any supported C++ type. Unlike old NaCl-based conversion helpers,
this class is more flexible (e.g., in case the argument list doesn't have a
fixed length) and produces better error messages.

As a side effect bonus, this commit made the following files
toolchain-independent as well:
* chrome_usb/api_bridge.cc;
* pcsc_lite_over_requester.cc.