### PR TITLE
Migrate js_request_receiver.{h|cc} to GlobalContext

### DIFF
--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h
@@ -17,8 +17,6 @@
 
 #include <string>
 
-#include <ppapi/cpp/core.h>
-#include <ppapi/cpp/instance.h>
 #include <ppapi/cpp/var.h>
 
 #include <google_smart_card_common/global_context.h>
@@ -50,8 +48,6 @@ class IntegrationTestHelper {
 
   virtual std::string GetName() const = 0;
   virtual void SetUp(GlobalContext* /*global_context*/,
-                     pp::Instance* /*pp_instance*/,
-                     pp::Core* /*pp_core*/,
                      TypedMessageRouter* /*typed_message_router*/,
                      const pp::Var& /*data*/) {}
   virtual void TearDown() {}

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_pp_module.cc
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_pp_module.cc
@@ -42,8 +42,7 @@ class IntegrationTestPpInstance final : public pp::Instance {
   explicit IntegrationTestPpInstance(PP_Instance instance)
       : pp::Instance(instance),
         global_context_(pp::Module::Get()->core(), this) {
-    IntegrationTestService::GetInstance()->Activate(&global_context_, this,
-                                                    pp::Module::Get()->core(),
+    IntegrationTestService::GetInstance()->Activate(&global_context_,
                                                     &typed_message_router_);
   }
 

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
@@ -20,8 +20,6 @@
 #include <string>
 #include <vector>
 
-#include <ppapi/cpp/core.h>
-#include <ppapi/cpp/instance.h>
 #include <ppapi/cpp/var.h>
 
 #include <google_smart_card_common/global_context.h>
@@ -48,8 +46,6 @@ class IntegrationTestService final : public RequestHandler {
   // Starts listening for incoming requests and translating them into commands
   // for test helpers.
   void Activate(GlobalContext* global_context,
-                pp::Instance* pp_instance,
-                pp::Core* pp_core,
                 TypedMessageRouter* typed_message_router);
   // Tears down all previously set up helpers and stops listening for incoming
   // requests.
@@ -72,8 +68,6 @@ class IntegrationTestService final : public RequestHandler {
                            RequestReceiver::ResultCallback result_callback);
 
   GlobalContext* global_context_ = nullptr;
-  pp::Instance* pp_instance_ = nullptr;
-  pp::Core* pp_core_ = nullptr;
   TypedMessageRouter* typed_message_router_ = nullptr;
   std::shared_ptr<JsRequestReceiver> js_request_receiver_;
   std::vector<std::unique_ptr<IntegrationTestHelper>> helpers_;

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
@@ -97,17 +97,14 @@ void ProcessSignatureRequest(
 
 ApiBridge::ApiBridge(gsc::GlobalContext* global_context,
                      gsc::TypedMessageRouter* typed_message_router,
-                     pp::Instance* pp_instance,
                      std::shared_ptr<std::mutex> request_handling_mutex)
     : request_handling_mutex_(request_handling_mutex),
       requester_(kRequesterName, global_context, typed_message_router),
       remote_call_adaptor_(&requester_),
-      request_receiver_(new gsc::JsRequestReceiver(
-          kRequestReceiverName,
-          this,
-          typed_message_router,
-          gsc::MakeUnique<gsc::JsRequestReceiver::PpDelegateImpl>(
-              pp_instance))) {}
+      request_receiver_(new gsc::JsRequestReceiver(kRequestReceiverName,
+                                                   this,
+                                                   global_context,
+                                                   typed_message_router)) {}
 
 ApiBridge::~ApiBridge() = default;
 

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
@@ -26,7 +26,6 @@
 #include <string>
 #include <vector>
 
-#include <ppapi/cpp/instance.h>
 #include <ppapi/cpp/var.h>
 #include <ppapi/cpp/var_array.h>
 
@@ -95,7 +94,6 @@ class ApiBridge final : public google_smart_card::RequestHandler {
   // executed only once the previous one finishes.
   ApiBridge(google_smart_card::GlobalContext* global_context,
             google_smart_card::TypedMessageRouter* typed_message_router,
-            pp::Instance* pp_instance,
             std::shared_ptr<std::mutex> request_handling_mutex);
 
   ApiBridge(const ApiBridge&) = delete;

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
@@ -85,8 +85,6 @@ class ApiBridgeIntegrationTestHelper final : public gsc::IntegrationTestHelper {
   // IntegrationTestHelper:
   std::string GetName() const override;
   void SetUp(gsc::GlobalContext* global_context,
-             pp::Instance* pp_instance,
-             pp::Core* pp_core,
              gsc::TypedMessageRouter* typed_message_router,
              const pp::Var& data) override;
   void TearDown() override;
@@ -112,13 +110,11 @@ std::string ApiBridgeIntegrationTestHelper::GetName() const {
 
 void ApiBridgeIntegrationTestHelper::SetUp(
     gsc::GlobalContext* global_context,
-    pp::Instance* pp_instance,
-    pp::Core* /*pp_core*/,
     gsc::TypedMessageRouter* typed_message_router,
     const pp::Var& /*data*/) {
-  api_bridge_ = std::make_shared<ApiBridge>(global_context,
-                                            typed_message_router, pp_instance,
-                                            /*request_handling_mutex=*/nullptr);
+  api_bridge_ =
+      std::make_shared<ApiBridge>(global_context, typed_message_router,
+                                  /*request_handling_mutex=*/nullptr);
 }
 
 void ApiBridgeIntegrationTestHelper::TearDown() {

--- a/example_cpp_smart_card_client_app/src/pp_module.cc
+++ b/example_cpp_smart_card_client_app/src/pp_module.cc
@@ -151,7 +151,6 @@ class PpInstance final : public pp::Instance {
         chrome_certificate_provider_api_bridge_(
             new ccp::ApiBridge(global_context_.get(),
                                &typed_message_router_,
-                               this,
                                request_handling_mutex_)),
         ui_bridge_(new UiBridge(&typed_message_router_,
                                 this,

--- a/smart_card_connector_app/src/pp_module.cc
+++ b/smart_card_connector_app/src/pp_module.cc
@@ -103,7 +103,7 @@ class PpInstance final : public pp::Instance {
     pcsc_lite_server_global_->InitializeAndRunDaemonThread();
 
     pcsc_lite_server_clients_management_backend_.reset(
-        new PcscLiteServerClientsManagementBackend(this,
+        new PcscLiteServerClientsManagementBackend(global_context_.get(),
                                                    &typed_message_router_));
 
     GOOGLE_SMART_CARD_LOG_DEBUG << "All services are successfully "

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h
@@ -32,8 +32,7 @@
 #include <string>
 #include <unordered_map>
 
-#include <ppapi/cpp/instance.h>
-
+#include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/messaging/typed_message_listener.h>
 #include <google_smart_card_common/messaging/typed_message_router.h>
 #include <google_smart_card_common/requesting/js_request_receiver.h>
@@ -84,7 +83,7 @@ namespace google_smart_card {
 // the same thread.
 class PcscLiteServerClientsManager final {
  public:
-  PcscLiteServerClientsManager(pp::Instance* pp_instance,
+  PcscLiteServerClientsManager(GlobalContext* global_context,
                                TypedMessageRouter* typed_message_router);
 
   PcscLiteServerClientsManager(const PcscLiteServerClientsManager&) = delete;
@@ -138,7 +137,7 @@ class PcscLiteServerClientsManager final {
    public:
     Handler(int64_t handler_id,
             const optional<std::string>& client_app_id,
-            pp::Instance* pp_instance,
+            GlobalContext* global_context,
             TypedMessageRouter* typed_message_router);
     Handler(const Handler&) = delete;
 
@@ -164,7 +163,7 @@ class PcscLiteServerClientsManager final {
   void DeleteHandler(int64_t client_handler_id);
   void DeleteAllHandlers();
 
-  pp::Instance* pp_instance_;
+  GlobalContext* const global_context_;
   TypedMessageRouter* typed_message_router_;
   CreateHandlerMessageListener create_handler_message_listener_;
   DeleteHandlerMessageListener delete_handler_message_listener_;

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.cc
@@ -27,27 +27,27 @@
 
 #include "clients_manager.h"
 
+#include <google_smart_card_common/global_context.h>
+
 namespace google_smart_card {
 
 class PcscLiteServerClientsManagementBackend::Impl final {
  public:
-  Impl(pp::Instance* pp_instance, TypedMessageRouter* typed_message_router)
-      : typed_message_router_(typed_message_router),
-        clients_manager_(pp_instance, typed_message_router_) {}
+  Impl(GlobalContext* global_context, TypedMessageRouter* typed_message_router)
+      : clients_manager_(global_context, typed_message_router) {}
 
   Impl(const Impl&) = delete;
 
   ~Impl() { clients_manager_.Detach(); }
 
  private:
-  TypedMessageRouter* typed_message_router_;
   PcscLiteServerClientsManager clients_manager_;
 };
 
 PcscLiteServerClientsManagementBackend::PcscLiteServerClientsManagementBackend(
-    pp::Instance* pp_instance,
+    GlobalContext* global_context,
     TypedMessageRouter* typed_message_router)
-    : impl_(new Impl(pp_instance, typed_message_router)) {}
+    : impl_(new Impl(global_context, typed_message_router)) {}
 
 PcscLiteServerClientsManagementBackend::
     ~PcscLiteServerClientsManagementBackend() {}

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.h
@@ -28,8 +28,7 @@
 
 #include <memory>
 
-#include <ppapi/cpp/instance.h>
-
+#include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/messaging/typed_message_router.h>
 
 namespace google_smart_card {
@@ -46,7 +45,7 @@ namespace google_smart_card {
 class PcscLiteServerClientsManagementBackend final {
  public:
   PcscLiteServerClientsManagementBackend(
-      pp::Instance* pp_instance,
+      GlobalContext* global_context,
       TypedMessageRouter* typed_message_router);
 
   PcscLiteServerClientsManagementBackend(


### PR DESCRIPTION
Change the JsRequestReceiver class to use the toolchain-independent
GlobalContext interface instead of directly operating Native Client
specific objects (pp::Core, pp::Instance).

This makes the whole JsRequestReceiver class work under both
Emscripten/WebAssembly and Native Client (contributing to the
effort tracked by #185).

As a side effect bonus, this commit made the following files
toolchain-independent as well:
* google_smart_card_pcsc_lite_server_clients_management/backend.{h|cc}.