### PR TITLE
Migrate [js_]request_receiver.{h|cc} to Value

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -37,9 +37,11 @@ SOURCES := \
 	$(SOURCES_PATH)/messaging/typed_message_router.cc \
 	$(SOURCES_PATH)/multi_string.cc \
 	$(SOURCES_PATH)/numeric_conversions.cc \
+	$(SOURCES_PATH)/requesting/js_request_receiver.cc \
 	$(SOURCES_PATH)/requesting/js_requester.cc \
 	$(SOURCES_PATH)/requesting/remote_call_arguments_conversion.cc \
 	$(SOURCES_PATH)/requesting/remote_call_message.cc \
+	$(SOURCES_PATH)/requesting/request_receiver.cc \
 	$(SOURCES_PATH)/requesting/request_result.cc \
 	$(SOURCES_PATH)/requesting/requester.cc \
 	$(SOURCES_PATH)/requesting/requester_message.cc \
@@ -62,9 +64,7 @@ SOURCES += \
 # TODO(#185): Migrate these to support the Emscripten toolchain as well.
 SOURCES += \
 	$(SOURCES_PATH)/external_logs_printer.cc \
-	$(SOURCES_PATH)/requesting/js_request_receiver.cc \
 	$(SOURCES_PATH)/requesting/remote_call_adaptor.cc \
-	$(SOURCES_PATH)/requesting/request_receiver.cc \
 
 else ifeq ($(TOOLCHAIN),emscripten)
 

--- a/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.cc
@@ -16,15 +16,12 @@
 
 #include <utility>
 
-#include <ppapi/cpp/var.h>
-
 #include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/messaging/typed_message.h>
 #include <google_smart_card_common/requesting/requester_message.h>
 #include <google_smart_card_common/value.h>
 #include <google_smart_card_common/value_conversion.h>
-#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
 
 namespace google_smart_card {
 
@@ -67,11 +64,9 @@ std::string JsRequestReceiver::GetListenedMessageType() const {
 }
 
 bool JsRequestReceiver::OnTypedMessageReceived(Value data) {
-  const RequestMessageData message_data =
+  RequestMessageData message_data =
       ConvertFromValueOrDie<RequestMessageData>(std::move(data));
-  // TODO(#185): Directly pass `Value` instead of `pp::Var`.
-  HandleRequest(message_data.request_id,
-                ConvertValueToPpVar(message_data.payload));
+  HandleRequest(message_data.request_id, std::move(message_data.payload));
   return true;
 }
 

--- a/common/cpp/src/google_smart_card_common/requesting/request_receiver.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/request_receiver.cc
@@ -18,7 +18,7 @@
 
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/requesting/request_handler.h>
-#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
+#include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
 
@@ -34,11 +34,8 @@ std::string RequestReceiver::name() const {
   return name_;
 }
 
-void RequestReceiver::HandleRequest(RequestId request_id,
-                                    const pp::Var& payload) {
-  // TODO(#185): Directly receive `Value` instead of converting from `pp::Var`.
-  handler_->HandleRequest(ConvertPpVarToValueOrDie(payload),
-                          MakeResultCallback(request_id));
+void RequestReceiver::HandleRequest(RequestId request_id, Value payload) {
+  handler_->HandleRequest(std::move(payload), MakeResultCallback(request_id));
 }
 
 RequestReceiver::ResultCallbackImpl::ResultCallbackImpl(

--- a/common/cpp/src/google_smart_card_common/requesting/request_receiver.h
+++ b/common/cpp/src/google_smart_card_common/requesting/request_receiver.h
@@ -19,10 +19,9 @@
 #include <memory>
 #include <string>
 
-#include <ppapi/cpp/var.h>
-
 #include <google_smart_card_common/requesting/request_id.h>
 #include <google_smart_card_common/requesting/request_result.h>
+#include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
 
@@ -79,7 +78,7 @@ class RequestReceiver : public std::enable_shared_from_this<RequestReceiver> {
 
   // Runs the associated request handler with the specified request and with
   // created ResultCallback functor.
-  void HandleRequest(RequestId request_id, const pp::Var& payload);
+  void HandleRequest(RequestId request_id, Value payload);
 
  private:
   class ResultCallbackImpl final {


### PR DESCRIPTION
Change the RequestReceiver and JsRequestReceiver classes to use the
toolchain-independent Value class instead of the Native Client specific
pp::Var class.

This makes these classes compile and work both under Native Client
and Emscripten/WebAssembly, contributing to the effort of migration of
the //common/cpp library (as tracked by #185).