### PR TITLE
Convert //common/integration_testing to Value

### DIFF
--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.h
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.h
@@ -176,6 +176,37 @@ class RemoteCallArgumentsExtractor final {
   std::string error_message_;
 };
 
+// Shortcut method for converting the given list of arguments via
+// `RemoteCallArgumentsExtractor`.
+template <typename... Args>
+bool ExtractRemoteCallArguments(std::string function_name,
+                                std::vector<Value> argument_values,
+                                std::string* error_message,
+                                Args... args) {
+  RemoteCallArgumentsExtractor extractor(std::move(function_name),
+                                         std::move(argument_values));
+  extractor.Extract(args...);
+  if (extractor.Finish())
+    return true;
+  if (error_message)
+    *error_message = extractor.error_message();
+  return false;
+}
+
+// Shortcut method for converting the given list of arguments via
+// `RemoteCallArgumentsExtractor`, with immediately crashing the program on
+// failures.
+template <typename... Args>
+void ExtractRemoteCallArgumentsOrDie(std::string function_name,
+                                     std::vector<Value> argument_values,
+                                     Args... args) {
+  std::string error_message;
+  if (!ExtractRemoteCallArguments(std::move(function_name),
+                                  std::move(argument_values), &error_message,
+                                  args...))
+    GOOGLE_SMART_CARD_LOG_FATAL << error_message;
+}
+
 }  // namespace google_smart_card
 
 #endif  // GOOGLE_SMART_CARD_COMMON_REQUESTING_REMOTE_CALL_ARGUMENTS_CONVERSION_H_

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion_unittest.cc
@@ -506,4 +506,30 @@ TEST(RemoteCallArgumentsExtractor, EnumArgumentExpected) {
   EXPECT_EQ(enum_argument, SomeEnum::kFirst);
 }
 
+TEST(ExtractRemoteCallArguments, Basic) {
+  std::vector<Value> values;
+  values.emplace_back(123);
+  values.emplace_back("foo");
+
+  std::string error_message;
+  int int_argument = 0;
+  std::string string_argument;
+  EXPECT_TRUE(ExtractRemoteCallArguments(kSomeFunc, std::move(values),
+                                         &error_message, &int_argument,
+                                         &string_argument));
+  EXPECT_TRUE(error_message.empty());
+  EXPECT_EQ(int_argument, 123);
+  EXPECT_EQ(string_argument, "foo");
+}
+
+TEST(ExtractRemoteCallArguments, Error) {
+  std::string error_message;
+  int int_argument;
+  EXPECT_FALSE(ExtractRemoteCallArguments(kSomeFunc, std::vector<Value>(),
+                                          &error_message, &int_argument));
+  EXPECT_EQ(error_message,
+            "Failed to convert arguments for someFunc(): expected at least 1 "
+            "argument(s), received only 0");
+}
+
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion_unittest.cc
@@ -532,4 +532,18 @@ TEST(ExtractRemoteCallArguments, Error) {
             "argument(s), received only 0");
 }
 
+// As death tests aren't supported, we don't test failure scenarios.
+TEST(ExtractRemoteCallArgumentsOrDie, Basic) {
+  std::vector<Value> values;
+  values.emplace_back(123);
+  values.emplace_back("foo");
+
+  int int_argument = 0;
+  std::string string_argument;
+  ExtractRemoteCallArgumentsOrDie(kSomeFunc, std::move(values), &int_argument,
+                                  &string_argument);
+  EXPECT_EQ(int_argument, 123);
+  EXPECT_EQ(string_argument, "foo");
+}
+
 }  // namespace google_smart_card

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h
@@ -17,11 +17,10 @@
 
 #include <string>
 
-#include <ppapi/cpp/var.h>
-
 #include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/messaging/typed_message_router.h>
 #include <google_smart_card_common/requesting/request_receiver.h>
+#include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
 
@@ -49,10 +48,10 @@ class IntegrationTestHelper {
   virtual std::string GetName() const = 0;
   virtual void SetUp(GlobalContext* /*global_context*/,
                      TypedMessageRouter* /*typed_message_router*/,
-                     const pp::Var& /*data*/) {}
+                     Value /*data*/) {}
   virtual void TearDown() {}
   virtual void OnMessageFromJs(
-      const pp::Var& data,
+      Value data,
       RequestReceiver::ResultCallback result_callback) = 0;
 };
 

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
@@ -20,8 +20,6 @@
 #include <string>
 #include <vector>
 
-#include <ppapi/cpp/var.h>
-
 #include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/messaging/typed_message_listener.h>
 #include <google_smart_card_common/requesting/js_request_receiver.h>
@@ -60,11 +58,10 @@ class IntegrationTestService final : public RequestHandler {
   ~IntegrationTestService();
 
   IntegrationTestHelper* FindHelperByName(const std::string& name);
-  void SetUpHelper(const std::string& helper_name,
-                   const pp::Var& data_for_helper);
+  void SetUpHelper(const std::string& helper_name, Value data_for_helper);
   void TearDownAllHelpers();
   void SendMessageToHelper(const std::string& helper_name,
-                           const pp::Var& message_for_helper,
+                           Value message_for_helper,
                            RequestReceiver::ResultCallback result_callback);
 
   GlobalContext* global_context_ = nullptr;

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
@@ -121,7 +121,8 @@ void ApiBridgeIntegrationTestHelper::TearDown() {
 void ApiBridgeIntegrationTestHelper::OnMessageFromJs(
     gsc::Value data,
     gsc::RequestReceiver::ResultCallback result_callback) {
-  const std::string command = gsc::ConvertFromValueOrDie<std::string>(std::move(data));
+  const std::string command =
+      gsc::ConvertFromValueOrDie<std::string>(std::move(data));
   if (command == "setCertificates_empty") {
     ScheduleSetCertificatesCall(/*certificates=*/{}, result_callback);
   } else if (command == "setCertificates_fakeCerts") {


### PR DESCRIPTION
Change the implementation of test helpers in
//common/integration_testing to use the platform-independent Value
class, instead of Native Client specific pp::Var class. This contributes
to the goal of making the common C++ libraries in this project work
under Emscripten/WebAssembly (as tracked by #185).

Other changes made in this commit:
* Helper methods added for a single-line conversion of incoming remote
  call arguments from Values into C++ objects;
* api_bridge_integration_test_helper.cc became, as a bonus side effect,
  toolchain-independent as well.