### PR TITLE
Fix goog.async.Deferred not available in JS code

### DIFF
--- a/third_party/closure-library/include.mk
+++ b/third_party/closure-library/include.mk
@@ -40,6 +40,9 @@ CLOSURE_LIBRARY_SOURCES_AND_DIRS := \
 # Function for obtaining the input list for the Closure Compiler that correspond
 # to the Closure Library.
 #
+# The "third_party/closure" directory is additionally included, since it
+# contains the deferred.js file.
+#
 # Test and perf files are excluded from compilation, because some of them may
 # contain duplicate symbols and some not correspond to some strict validation
 # rules.
@@ -47,6 +50,7 @@ CLOSURE_LIBRARY_SOURCES_AND_DIRS := \
 
 CLOSURE_LIBRARY_COMPILER_INPUTS = \
 	$(call RELATIVE_PATH,$(CURDIR)/$(CLOSURE_LIBRARY_DIR_PATH),$(ROOT_PATH))/closure \
+	$(call RELATIVE_PATH,$(CURDIR)/$(CLOSURE_LIBRARY_DIR_PATH),$(ROOT_PATH))/third_party/closure \
 	!$(call RELATIVE_PATH,$(CURDIR)/$(CLOSURE_LIBRARY_DIR_PATH),$(ROOT_PATH))/**_test.js \
 	!$(call RELATIVE_PATH,$(CURDIR)/$(CLOSURE_LIBRARY_DIR_PATH),$(ROOT_PATH))/**_perf.js \
 	!$(call RELATIVE_PATH,$(CURDIR)/$(CLOSURE_LIBRARY_DIR_PATH),$(ROOT_PATH))/closure/bin/**.js \

--- a/third_party/closure-library/include.mk
+++ b/third_party/closure-library/include.mk
@@ -40,8 +40,8 @@ CLOSURE_LIBRARY_SOURCES_AND_DIRS := \
 # Function for obtaining the input list for the Closure Compiler that correspond
 # to the Closure Library.
 #
-# The "third_party/closure" directory is additionally included, since it
-# contains the deferred.js file.
+# The "third_party/closure" directory is included since it contains the
+# deferred.js file.
 #
 # Test and perf files are excluded from compilation, because some of them may
 # contain duplicate symbols and some not correspond to some strict validation


### PR DESCRIPTION
This commit adds the
//third_party/closure-library/src/third_party/closure directory into the
list of source directories for JavaScript builds performed by Closure
Compiler.

This fixes the issue with inability to use the goog.async.Deferred
class, since it's defined in a file that was under this third_party
subdirectory of the Closure Library, which we didn't include before.

This is a preparatory CL for introducing Emscripten/WebAssembly support
into the Example C++ App (tracked by #220), since the proposed way of
loading the Emscripten module will involve goog.async.Deferred.