### PR TITLE
ifdef NaCl code in scard_structs_serialization

### DIFF
--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.cc
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.cc
@@ -27,8 +27,11 @@
 
 #include <cstring>
 
-#include <google_smart_card_common/pp_var_utils/struct_converter.h>
 #include <google_smart_card_common/value_conversion.h>
+
+#ifdef __native_client__
+#include <google_smart_card_common/pp_var_utils/struct_converter.h>
+#endif  // __native_client__
 
 namespace google_smart_card {
 
@@ -58,6 +61,8 @@ StructValueDescriptor<InboundSCardReaderState>::GetDescription() {
       .WithField(&InboundSCardReaderState::current_state, "current_state");
 }
 
+#ifdef __native_client__
+
 // static
 template <>
 constexpr const char*
@@ -76,6 +81,8 @@ void StructConverter<InboundSCardReaderState>::VisitFields(
   callback(&value.current_state, "current_state");
 }
 
+#endif  // __native_client__
+
 template <>
 StructValueDescriptor<OutboundSCardReaderState>::Description
 StructValueDescriptor<OutboundSCardReaderState>::GetDescription() {
@@ -89,6 +96,8 @@ StructValueDescriptor<OutboundSCardReaderState>::GetDescription() {
       .WithField(&OutboundSCardReaderState::event_state, "event_state")
       .WithField(&OutboundSCardReaderState::atr, "atr");
 }
+
+#ifdef __native_client__
 
 // static
 template <>
@@ -110,6 +119,8 @@ void StructConverter<OutboundSCardReaderState>::VisitFields(
   callback(&value.atr, "atr");
 }
 
+#endif  // __native_client__
+
 template <>
 StructValueDescriptor<SCardIoRequest>::Description
 StructValueDescriptor<SCardIoRequest>::GetDescription() {
@@ -118,6 +129,8 @@ StructValueDescriptor<SCardIoRequest>::GetDescription() {
   return Describe("SCARD_IO_REQUEST")
       .WithField(&SCardIoRequest::protocol, "protocol");
 }
+
+#ifdef __native_client__
 
 // static
 template <>
@@ -132,6 +145,8 @@ void StructConverter<SCardIoRequest>::VisitFields(const SCardIoRequest& value,
                                                   Callback callback) {
   callback(&value.protocol, "protocol");
 }
+
+#endif  // __native_client__
 
 // static
 InboundSCardReaderState InboundSCardReaderState::FromSCardReaderState(
@@ -167,6 +182,8 @@ SCardIoRequest SCardIoRequest::FromSCardIoRequest(
     const SCARD_IO_REQUEST& value) {
   return SCardIoRequest(value.dwProtocol);
 }
+
+#ifdef __native_client__
 
 template <>
 pp::Var MakeVar(const SCARD_READERSTATE& value) {
@@ -221,5 +238,7 @@ template <>
 pp::Var MakeVar(const SCardIoRequest& value) {
   return StructConverter<SCardIoRequest>::ConvertToVar(value);
 }
+
+#endif  // __native_client__
 
 }  // namespace google_smart_card

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.h
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.h
@@ -24,18 +24,14 @@
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // This file contains structure and function definitions that help to perform
-// (de)serialization of PC/SC-Lite API structures from/to Pepper values.
+// (de)serialization of PC/SC-Lite API structures from/to `Value`s.
 //
-// One of the reasons of defining separate intermediate structures is that the
-// original PC/SC API functions do not belong to the google_smart_card
-// namespace, which in some situations makes the corresponding VarAs/MakeVar
-// functions overloads unavailable. Another reason is difficulties with memory
-// management when passing data between the C structures from the PC/SC-Lite API
-// and the C++ variables.
-//
-// Overloads of the VarAs function and specializations of the MakeVar function
-// brings the support of the defined structures into these tools for converting
-// from/to Pepper values.
+// The main reason for why this file defines separate intermediate structures is
+// memory management: the C structures from the PC/SC-Lite API use raw pointers
+// (some of which are owned and some unowned), have separate fields for storing
+// the size of the referenced pointer, etc. Instead of writing custom
+// (de)serialization code, we convert those C structures into C++ intermediate
+// structures that have clear memory management.
 
 #ifndef GOOGLE_SMART_CARD_THIRD_PARTY_PCSC_LITE_COMMON_SCARD_STRUCTS_SERIALIZATION_H_
 #define GOOGLE_SMART_CARD_THIRD_PARTY_PCSC_LITE_COMMON_SCARD_STRUCTS_SERIALIZATION_H_
@@ -50,11 +46,13 @@
 #include <winscard.h>
 #include <wintypes.h>
 
-#include <ppapi/cpp/var.h>
-
 #include <google_smart_card_common/optional.h>
+
+#ifdef __native_client__
+#include <ppapi/cpp/var.h>
 #include <google_smart_card_common/pp_var_utils/construction.h>
 #include <google_smart_card_common/pp_var_utils/extraction.h>
+#endif  // __native_client__
 
 namespace google_smart_card {
 
@@ -128,6 +126,8 @@ struct SCardIoRequest {
   DWORD protocol;
 };
 
+#ifdef __native_client__
+
 bool VarAs(const pp::Var& var,
            InboundSCardReaderState* result,
            std::string* error_message);
@@ -148,6 +148,8 @@ bool VarAs(const pp::Var& var,
 
 template <>
 pp::Var MakeVar(const SCardIoRequest& value);
+
+#endif  // __native_client__
 
 }  // namespace google_smart_card
 


### PR DESCRIPTION
Surround the Native Client specific code with #ifdef's in
scard_structs_serialization.{h|cc}, so that it's only compiled in Native
Client builds. This way, these files can be used both by code that is
fully migrated to Emscripten/WebAssembly and the code that is still
using Native Client specific primitives.

This is a temporary step in order to accomplish the migration of the
//example_cpp_smart_card_client_app App (tracked by #220) earlier,
before the Smart Card Connector App gets migrated as well. Later,
once everything is migrated, all these #ifdef's together with the
code inside them will be removed.