### PR TITLE
Not install pcsc-lite/naclport/cpp_demo headers

### DIFF
--- a/example_cpp_smart_card_client_app/build/nacl_module/Makefile
+++ b/example_cpp_smart_card_client_app/build/nacl_module/Makefile
@@ -69,6 +69,7 @@ CPPFLAGS := \
 	-I$(SOURCES_DIR) \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-I$(ROOT_PATH)/third_party/pcsc-lite/naclport/cpp_client/src \
+	-I$(ROOT_PATH)/third_party/pcsc-lite/naclport/cpp_demo/src \
 	-I$(ROOT_PATH)/third_party/pcsc-lite/src/src/PCSC \
 	-Wall \
 	-Werror \

--- a/third_party/pcsc-lite/naclport/cpp_demo/build/Makefile
+++ b/third_party/pcsc-lite/naclport/cpp_demo/build/Makefile
@@ -39,7 +39,6 @@ include ../include.mk
 
 SOURCES_PATH := ../src
 
-
 SOURCES := \
 	$(SOURCES_PATH)/google_smart_card_pcsc_lite_cpp_demo/demo.cc \
 
@@ -52,11 +51,4 @@ CXXFLAGS := \
 
 $(foreach src,$(SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
 
-
 $(eval $(call LIB_RULE,$(TARGET),$(SOURCES)))
-
-
-INSTALLING_HEADERS := \
-	google_smart_card_pcsc_lite_cpp_demo:$(SOURCES_PATH)/google_smart_card_pcsc_lite_cpp_demo:demo.h \
-
-$(eval $(call NACL_LIBRARY_HEADERS_INSTALLATION_RULE,$(INSTALLING_HEADERS)))


### PR DESCRIPTION
This commit disables installation of "public" headers from the
//third_party/pcsc-lite/naclport/cpp_demo library into a common
include directory. Instead, the path to this library is simply
added into the include search path in needed makefiles.

More background on this refactoring is in #132.