### PR TITLE
Implement message channel for Emscripten JS loader

### DIFF
--- a/common/js/src/executable-module/emscripten-module.js
+++ b/common/js/src/executable-module/emscripten-module.js
@@ -80,6 +80,7 @@ EmscriptenModule.prototype.startLoading = function() {
 EmscriptenModule.prototype.disposeInternal = function() {
   this.logger.fine('Disposed');
   delete this.googleSmartCardModule_;
+  this.messageChannel.dispose();
   EmscriptenModule.base(this, 'disposeInternal');
 };
 


### PR DESCRIPTION
Extend the JavaScript "EmscriptenModule" class to have a bidirectional
message pipe with the executable. This message pipe conforms to the
Closure Library's goog.messaging.MessageChannel interface. Messages to
the module are sent by calling the "postMessage()" method on the
GoogleSmartCardModule class exposed by it via Embind. Messages in the
reverse direction are received via the callback passed to the class'
constructor.

This contributes to the WebAssembly migration effort, as tracked
by #220.