### PR TITLE
Make PostMessageToJs() consume the Value object

### DIFF
--- a/common/cpp/src/google_smart_card_common/global_context.h
+++ b/common/cpp/src/google_smart_card_common/global_context.h
@@ -27,10 +27,9 @@ class GlobalContext {
  public:
   virtual ~GlobalContext() = default;
 
-  // Sends the given message to the JavaScript side. Returns whether the message
-  // was sent successfully (note that the status doesn't tell anything about the
-  // result of the message handling on the JS side).
-  virtual bool PostMessageToJs(const Value& message) = 0;
+  // Sends the given message to the JavaScript side. Note: The delivery isn't
+  // guaranteed, in case the executable's shutdown process started.
+  virtual void PostMessageToJs(Value message) = 0;
 
   // Returns whether the current thread is the main event loop thread. Is
   // intended to be used to avoid blocking/deadlocking the main thread.

--- a/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.cc
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.cc
@@ -32,16 +32,14 @@ GlobalContextImplEmscripten::GlobalContextImplEmscripten(
 
 GlobalContextImplEmscripten::~GlobalContextImplEmscripten() = default;
 
-bool GlobalContextImplEmscripten::PostMessageToJs(const Value& message) {
+void GlobalContextImplEmscripten::PostMessageToJs(Value message) {
   // Converting the value before entering the mutex, in order to minimize the
   // time spent under the lock.
   const emscripten::val val = ConvertValueToEmscriptenVal(message);
 
   const std::unique_lock<std::mutex> lock(mutex_);
-  if (post_message_callback_.isUndefined())
-    return false;
-  post_message_callback_(val);
-  return true;
+  if (!post_message_callback_.isUndefined())
+    post_message_callback_(val);
 }
 
 bool GlobalContextImplEmscripten::IsMainEventLoopThread() const {

--- a/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.h
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.h
@@ -43,7 +43,7 @@ class GlobalContextImplEmscripten final : public GlobalContext {
   ~GlobalContextImplEmscripten() override;
 
   // GlobalContext:
-  bool PostMessageToJs(const Value& message) override;
+  void PostMessageToJs(Value message) override;
   bool IsMainEventLoopThread() const override;
   void DisableJsCommunication() override;
 

--- a/common/cpp/src/google_smart_card_common/global_context_impl_nacl.cc
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_nacl.cc
@@ -31,16 +31,14 @@ GlobalContextImplNacl::GlobalContextImplNacl(pp::Core* pp_core,
 
 GlobalContextImplNacl::~GlobalContextImplNacl() = default;
 
-bool GlobalContextImplNacl::PostMessageToJs(const Value& message) {
+void GlobalContextImplNacl::PostMessageToJs(Value message) {
   // Converting the value before entering the mutex, in order to minimize the
   // time spent under the lock.
   const pp::Var var = ConvertValueToPpVar(message);
 
   const std::unique_lock<std::mutex> lock(mutex_);
-  if (!pp_instance_)
-    return false;
-  pp_instance_->PostMessage(var);
-  return true;
+  if (pp_instance_)
+    pp_instance_->PostMessage(var);
 }
 
 bool GlobalContextImplNacl::IsMainEventLoopThread() const {

--- a/common/cpp/src/google_smart_card_common/global_context_impl_nacl.h
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_nacl.h
@@ -39,7 +39,7 @@ class GlobalContextImplNacl final : public GlobalContext {
   ~GlobalContextImplNacl() override;
 
   // GlobalContext:
-  bool PostMessageToJs(const Value& message) override;
+  void PostMessageToJs(Value message) override;
   bool IsMainEventLoopThread() const override;
   void DisableJsCommunication() override;
 

--- a/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.cc
@@ -55,8 +55,8 @@ void JsRequestReceiver::PostResult(RequestId request_id,
   message.data =
       ConvertToValueOrDie(ResponseMessageData::CreateFromRequestResult(
           request_id, std::move(request_result)));
-  const Value message_value = ConvertToValueOrDie(std::move(message));
-  global_context_->PostMessageToJs(message_value);
+  Value message_value = ConvertToValueOrDie(std::move(message));
+  global_context_->PostMessageToJs(std::move(message_value));
 }
 
 std::string JsRequestReceiver::GetListenedMessageType() const {

--- a/example_cpp_smart_card_client_app/src/ui_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/ui_bridge.cc
@@ -94,7 +94,7 @@ void UiBridge::SendMessageToUi(gsc::Value message) {
   typed_message.data = std::move(message);
   gsc::Value typed_message_value =
       gsc::ConvertToValueOrDie(std::move(typed_message));
-  global_context_->PostMessageToJs(typed_message_value);
+  global_context_->PostMessageToJs(std::move(typed_message_value));
 }
 
 std::string UiBridge::GetListenedMessageType() const {


### PR DESCRIPTION
Change the GlobalContext::PostMessageToJs()'s signature to take the
Value object by value (instead of const-ref) and remove the boolean
return value.

The reason is that on the Emscripten/WebAssembly platform we'll need to
schedule the message sending job to a different thread (in case we're not
on the main thread), which means that we want to grab the ownership of
the value until it's actually sent. Moreover, it means that we cannot
reliably tell the caller whether the delivery was successful (because it'll
happen asynchronously), therefore the return value is changed to "void".

This is a preparatory commit for the abovementioned change. The overall
WebAssembly migration effort of this library is tracked by #185.