### PR TITLE
Add forgotten Emscripten-Value conversion tests

### DIFF
--- a/common/cpp/build/tests/Makefile
+++ b/common/cpp/build/tests/Makefile
@@ -35,7 +35,12 @@ SOURCES := \
 	$(SOURCES_PATH)/value_debug_dumping_unittest.cc \
 	$(SOURCES_PATH)/value_unittest.cc \
 
-ifeq ($(TOOLCHAIN),pnacl)
+ifeq ($(TOOLCHAIN),emscripten)
+
+SOURCES += \
+	$(SOURCES_PATH)/value_emscripten_val_conversion_unittest.cc \
+
+else ifeq ($(TOOLCHAIN),pnacl)
 
 SOURCES += \
 	$(SOURCES_PATH)/pp_var_utils/construction_unittest.cc \


### PR DESCRIPTION
Add the "value_emscripten_val_conversion_unittest.cc" file into build
scripts, so that it's executed with all other tests.

Previously it was forgotten (in both #211 and #218), likely due to some
merge conflict. The tracking issue is #185.