### PR TITLE
Fix setCertificates() JS error when there's no API

### DIFF
--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
@@ -244,8 +244,9 @@ Backend.prototype.handleRequest_ = function(payload) {
 
   const promiseResolver = goog.Promise.withResolver();
 
-  const apiFunction = chrome.certificateProvider[
-      remoteCallMessage.functionName];
+  // Check whether the API and the method are available.
+  const apiFunction = chrome.certificateProvider ?
+      chrome.certificateProvider[remoteCallMessage.functionName] : undefined;
   if (apiFunction) {
     const transformedFunctionArguments = transformFunctionArguments(
         remoteCallMessage.functionName, remoteCallMessage.functionArguments);

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-integrationtest.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-integrationtest.js
@@ -123,6 +123,14 @@ goog.exportSymbol('testChromeCertificateProviderApiBridge', {
       }]});
     });
   },
+
+  testSetCertificates_noApi: function() {
+    // Note the missing setUpApiStubs() call.
+    // Just verify that no crash happens.
+    return testController.sendMessageToCppHelper(
+        'ChromeCertificateProviderApiBridge',
+        /*messageForHelper=*/'setCertificates_empty');
+  },
 });
 
 });  // goog.scope


### PR DESCRIPTION
Fix the JavaScript exception being raised during the
chrome.certificateProvider.setCertificates() method call, in case the
whole chrome.certificateProvider API is unavailable.

This is expected to be a rare corner case - for example, when running
the Example C++ App in a desktop Chrome browser - nevertheless, it's
better to fix it to simplify testing and debugging it. Note that the
consequence of the bug was not only a JS error in the console, but also
hanging of the setCertificates() call.