### PR TITLE
Delete NaCl conv from cert provider types.{h|cc}

### DIFF
--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.cc
@@ -14,30 +14,11 @@
 
 #include "chrome_certificate_provider/types.h"
 
-#include <google_smart_card_common/pp_var_utils/enum_converter.h>
-#include <google_smart_card_common/pp_var_utils/struct_converter.h>
 #include <google_smart_card_common/value_conversion.h>
 
-namespace scc = smart_card_client;
-namespace ccp = scc::chrome_certificate_provider;
-namespace gsc = google_smart_card;
+namespace ccp = smart_card_client::chrome_certificate_provider;
 
 namespace google_smart_card {
-
-using AlgorithmConverter = EnumConverter<ccp::Algorithm, std::string>;
-using ErrorConverter = EnumConverter<ccp::Error, std::string>;
-using PinRequestTypeConverter = EnumConverter<ccp::PinRequestType, std::string>;
-using PinRequestErrorTypeConverter =
-    EnumConverter<ccp::PinRequestErrorType, std::string>;
-using ClientCertificateInfoConverter =
-    StructConverter<ccp::ClientCertificateInfo>;
-using SetCertificatesDetailsConverter =
-    StructConverter<ccp::SetCertificatesDetails>;
-using SignatureRequestConverter = StructConverter<ccp::SignatureRequest>;
-using RequestPinOptionsConverter = StructConverter<ccp::RequestPinOptions>;
-using RequestPinResultsConverter = StructConverter<ccp::RequestPinResults>;
-using StopPinRequestOptionsConverter =
-    StructConverter<ccp::StopPinRequestOptions>;
 
 template <>
 EnumValueDescriptor<ccp::Algorithm>::Description
@@ -56,24 +37,6 @@ EnumValueDescriptor<ccp::Algorithm>::GetDescription() {
                 "RSASSA_PKCS1_v1_5_SHA512");
 }
 
-// static
-template <>
-constexpr const char* AlgorithmConverter::GetEnumTypeName() {
-  return "chrome_certificate_provider::Algorithm";
-}
-
-// static
-template <>
-template <typename Callback>
-void AlgorithmConverter::VisitCorrespondingPairs(Callback callback) {
-  callback(ccp::Algorithm::kRsassaPkcs1v15Md5Sha1,
-           "RSASSA_PKCS1_v1_5_MD5_SHA1");
-  callback(ccp::Algorithm::kRsassaPkcs1v15Sha1, "RSASSA_PKCS1_v1_5_SHA1");
-  callback(ccp::Algorithm::kRsassaPkcs1v15Sha256, "RSASSA_PKCS1_v1_5_SHA256");
-  callback(ccp::Algorithm::kRsassaPkcs1v15Sha384, "RSASSA_PKCS1_v1_5_SHA384");
-  callback(ccp::Algorithm::kRsassaPkcs1v15Sha512, "RSASSA_PKCS1_v1_5_SHA512");
-}
-
 template <>
 EnumValueDescriptor<ccp::Error>::Description
 EnumValueDescriptor<ccp::Error>::GetDescription() {
@@ -81,19 +44,6 @@ EnumValueDescriptor<ccp::Error>::GetDescription() {
   // chrome.certificateProvider API.
   return Describe("chrome_certificate_provider::Error")
       .WithItem(ccp::Error::kGeneral, "GENERAL_ERROR");
-}
-
-// static
-template <>
-constexpr const char* ErrorConverter::GetEnumTypeName() {
-  return "chrome_certificate_provider::Error";
-}
-
-// static
-template <>
-template <typename Callback>
-void ErrorConverter::VisitCorrespondingPairs(Callback callback) {
-  callback(ccp::Error::kGeneral, "GENERAL_ERROR");
 }
 
 template <>
@@ -104,20 +54,6 @@ EnumValueDescriptor<ccp::PinRequestType>::GetDescription() {
   return Describe("chrome_certificate_provider::PinRequestType")
       .WithItem(ccp::PinRequestType::kPin, "PIN")
       .WithItem(ccp::PinRequestType::kPuk, "PUK");
-}
-
-// static
-template <>
-constexpr const char* PinRequestTypeConverter::GetEnumTypeName() {
-  return "chrome_certificate_provider::PinRequestType";
-}
-
-// static
-template <>
-template <typename Callback>
-void PinRequestTypeConverter::VisitCorrespondingPairs(Callback callback) {
-  callback(ccp::PinRequestType::kPin, "PIN");
-  callback(ccp::PinRequestType::kPuk, "PUK");
 }
 
 template <>
@@ -133,23 +69,6 @@ EnumValueDescriptor<ccp::PinRequestErrorType>::GetDescription() {
       .WithItem(ccp::PinRequestErrorType::kUnknownError, "UNKNOWN_ERROR");
 }
 
-// static
-template <>
-constexpr const char* PinRequestErrorTypeConverter::GetEnumTypeName() {
-  return "chrome_certificate_provider::PinRequestErrorType";
-}
-
-// static
-template <>
-template <typename Callback>
-void PinRequestErrorTypeConverter::VisitCorrespondingPairs(Callback callback) {
-  callback(ccp::PinRequestErrorType::kInvalidPin, "INVALID_PIN");
-  callback(ccp::PinRequestErrorType::kInvalidPuk, "INVALID_PUK");
-  callback(ccp::PinRequestErrorType::kMaxAttemptsExceeded,
-           "MAX_ATTEMPTS_EXCEEDED");
-  callback(ccp::PinRequestErrorType::kUnknownError, "UNKNOWN_ERROR");
-}
-
 template <>
 StructValueDescriptor<ccp::ClientCertificateInfo>::Description
 StructValueDescriptor<ccp::ClientCertificateInfo>::GetDescription() {
@@ -159,22 +78,6 @@ StructValueDescriptor<ccp::ClientCertificateInfo>::GetDescription() {
       .WithField(&ccp::ClientCertificateInfo::certificate, "certificate")
       .WithField(&ccp::ClientCertificateInfo::supported_algorithms,
                  "supportedAlgorithms");
-}
-
-// static
-template <>
-constexpr const char* ClientCertificateInfoConverter::GetStructTypeName() {
-  return "chrome_certificate_provider::ClientCertificateInfo";
-}
-
-// static
-template <>
-template <typename Callback>
-void ClientCertificateInfoConverter::VisitFields(
-    const ccp::ClientCertificateInfo& value,
-    Callback callback) {
-  callback(&value.certificate, "certificate");
-  callback(&value.supported_algorithms, "supportedAlgorithms");
 }
 
 template <>
@@ -190,23 +93,6 @@ StructValueDescriptor<ccp::SetCertificatesDetails>::GetDescription() {
                  "clientCertificates");
 }
 
-// static
-template <>
-constexpr const char* SetCertificatesDetailsConverter::GetStructTypeName() {
-  return "chrome_certificate_provider::SetCertificatesDetails";
-}
-
-// static
-template <>
-template <typename Callback>
-void SetCertificatesDetailsConverter::VisitFields(
-    const ccp::SetCertificatesDetails& value,
-    Callback callback) {
-  callback(&value.certificates_request_id, "certificatesRequestId");
-  callback(&value.error, "error");
-  callback(&value.client_certificates, "clientCertificates");
-}
-
 template <>
 StructValueDescriptor<ccp::SignatureRequest>::Description
 StructValueDescriptor<ccp::SignatureRequest>::GetDescription() {
@@ -218,24 +104,6 @@ StructValueDescriptor<ccp::SignatureRequest>::GetDescription() {
       .WithField(&ccp::SignatureRequest::digest, "digest")
       .WithField(&ccp::SignatureRequest::algorithm, "algorithm")
       .WithField(&ccp::SignatureRequest::certificate, "certificate");
-}
-
-// static
-template <>
-constexpr const char* SignatureRequestConverter::GetStructTypeName() {
-  return "chrome_certificate_provider::SignatureRequest";
-}
-
-// static
-template <>
-template <typename Callback>
-void SignatureRequestConverter::VisitFields(const ccp::SignatureRequest& value,
-                                            Callback callback) {
-  callback(&value.sign_request_id, "signRequestId");
-  callback(&value.input, "input");
-  callback(&value.digest, "digest");
-  callback(&value.algorithm, "algorithm");
-  callback(&value.certificate, "certificate");
 }
 
 template <>
@@ -250,24 +118,6 @@ StructValueDescriptor<ccp::RequestPinOptions>::GetDescription() {
       .WithField(&ccp::RequestPinOptions::attempts_left, "attemptsLeft");
 }
 
-// static
-template <>
-constexpr const char* RequestPinOptionsConverter::GetStructTypeName() {
-  return "chrome_certificate_provider::RequestPinOptions";
-}
-
-// static
-template <>
-template <typename Callback>
-void RequestPinOptionsConverter::VisitFields(
-    const ccp::RequestPinOptions& value,
-    Callback callback) {
-  callback(&value.sign_request_id, "signRequestId");
-  callback(&value.request_type, "requestType");
-  callback(&value.error_type, "errorType");
-  callback(&value.attempts_left, "attemptsLeft");
-}
-
 template <>
 StructValueDescriptor<ccp::RequestPinResults>::Description
 StructValueDescriptor<ccp::RequestPinResults>::GetDescription() {
@@ -275,21 +125,6 @@ StructValueDescriptor<ccp::RequestPinResults>::GetDescription() {
   // the chrome.certificateProvider API.
   return Describe("chrome_certificate_provider::RequestPinResults")
       .WithField(&ccp::RequestPinResults::user_input, "userInput");
-}
-
-// static
-template <>
-constexpr const char* RequestPinResultsConverter::GetStructTypeName() {
-  return "chrome_certificate_provider::RequestPinResults";
-}
-
-// static
-template <>
-template <typename Callback>
-void RequestPinResultsConverter::VisitFields(
-    const ccp::RequestPinResults& value,
-    Callback callback) {
-  callback(&value.user_input, "userInput");
 }
 
 template <>
@@ -302,132 +137,4 @@ StructValueDescriptor<ccp::StopPinRequestOptions>::GetDescription() {
       .WithField(&ccp::StopPinRequestOptions::error_type, "errorType");
 }
 
-// static
-template <>
-constexpr const char* StopPinRequestOptionsConverter::GetStructTypeName() {
-  return "chrome_certificate_provider::StopPinRequestOptions";
-}
-
-// static
-template <>
-template <typename Callback>
-void StopPinRequestOptionsConverter::VisitFields(
-    const ccp::StopPinRequestOptions& value,
-    Callback callback) {
-  callback(&value.sign_request_id, "signRequestId");
-  callback(&value.error_type, "errorType");
-}
-
 }  // namespace google_smart_card
-
-namespace smart_card_client {
-
-namespace chrome_certificate_provider {
-
-bool VarAs(const pp::Var& var, Algorithm* result, std::string* error_message) {
-  return gsc::AlgorithmConverter::ConvertFromVar(var, result, error_message);
-}
-
-pp::Var MakeVar(Algorithm value) {
-  return gsc::AlgorithmConverter::ConvertToVar(value);
-}
-
-bool VarAs(const pp::Var& var, Error* result, std::string* error_message) {
-  return gsc::ErrorConverter::ConvertFromVar(var, result, error_message);
-}
-
-pp::Var MakeVar(Error value) {
-  return gsc::ErrorConverter::ConvertToVar(value);
-}
-
-bool VarAs(const pp::Var& var,
-           PinRequestType* result,
-           std::string* error_message) {
-  return gsc::PinRequestTypeConverter::ConvertFromVar(var, result,
-                                                      error_message);
-}
-
-pp::Var MakeVar(PinRequestType value) {
-  return gsc::PinRequestTypeConverter::ConvertToVar(value);
-}
-
-bool VarAs(const pp::Var& var,
-           PinRequestErrorType* result,
-           std::string* error_message) {
-  return gsc::PinRequestErrorTypeConverter::ConvertFromVar(var, result,
-                                                           error_message);
-}
-
-pp::Var MakeVar(PinRequestErrorType value) {
-  return gsc::PinRequestErrorTypeConverter::ConvertToVar(value);
-}
-
-bool VarAs(const pp::Var& var,
-           ClientCertificateInfo* result,
-           std::string* error_message) {
-  return gsc::ClientCertificateInfoConverter::ConvertFromVar(var, result,
-                                                             error_message);
-}
-
-pp::Var MakeVar(const ClientCertificateInfo& value) {
-  return gsc::ClientCertificateInfoConverter::ConvertToVar(value);
-}
-
-bool VarAs(const pp::Var& var,
-           SetCertificatesDetails* result,
-           std::string* error_message) {
-  return gsc::SetCertificatesDetailsConverter::ConvertFromVar(var, result,
-                                                              error_message);
-}
-
-pp::Var MakeVar(const SetCertificatesDetails& value) {
-  return gsc::SetCertificatesDetailsConverter::ConvertToVar(value);
-}
-
-bool VarAs(const pp::Var& var,
-           SignatureRequest* result,
-           std::string* error_message) {
-  return gsc::SignatureRequestConverter::ConvertFromVar(var, result,
-                                                        error_message);
-}
-
-pp::Var MakeVar(const SignatureRequest& value) {
-  return gsc::SignatureRequestConverter::ConvertToVar(value);
-}
-
-bool VarAs(const pp::Var& var,
-           RequestPinOptions* result,
-           std::string* error_message) {
-  return gsc::RequestPinOptionsConverter::ConvertFromVar(var, result,
-                                                         error_message);
-}
-
-pp::Var MakeVar(const RequestPinOptions& value) {
-  return gsc::RequestPinOptionsConverter::ConvertToVar(value);
-}
-
-bool VarAs(const pp::Var& var,
-           RequestPinResults* result,
-           std::string* error_message) {
-  return gsc::RequestPinResultsConverter::ConvertFromVar(var, result,
-                                                         error_message);
-}
-
-pp::Var MakeVar(const RequestPinResults& value) {
-  return gsc::RequestPinResultsConverter::ConvertToVar(value);
-}
-
-bool VarAs(const pp::Var& var,
-           StopPinRequestOptions* result,
-           std::string* error_message) {
-  return gsc::StopPinRequestOptionsConverter::ConvertFromVar(var, result,
-                                                             error_message);
-}
-
-pp::Var MakeVar(const StopPinRequestOptions& value) {
-  return gsc::StopPinRequestOptionsConverter::ConvertToVar(value);
-}
-
-}  // namespace chrome_certificate_provider
-
-}  // namespace smart_card_client

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.h
@@ -29,11 +29,7 @@
 #include <string>
 #include <vector>
 
-#include <ppapi/cpp/var.h>
-
 #include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/pp_var_utils/construction.h>
-#include <google_smart_card_common/pp_var_utils/extraction.h>
 
 namespace smart_card_client {
 
@@ -153,52 +149,6 @@ struct StopPinRequestOptions {
   int sign_request_id;
   google_smart_card::optional<PinRequestErrorType> error_type;
 };
-
-bool VarAs(const pp::Var& var, Algorithm* result, std::string* error_message);
-pp::Var MakeVar(Algorithm value);
-
-bool VarAs(const pp::Var& var, Error* result, std::string* error_message);
-pp::Var MakeVar(Error value);
-
-bool VarAs(const pp::Var& var,
-           PinRequestType* result,
-           std::string* error_message);
-pp::Var MakeVar(PinRequestType value);
-
-bool VarAs(const pp::Var& var,
-           PinRequestErrorType* result,
-           std::string* error_message);
-pp::Var MakeVar(PinRequestErrorType value);
-
-bool VarAs(const pp::Var& var,
-           ClientCertificateInfo* result,
-           std::string* error_message);
-pp::Var MakeVar(const ClientCertificateInfo& value);
-
-bool VarAs(const pp::Var& var,
-           SetCertificatesDetails* result,
-           std::string* error_message);
-pp::Var MakeVar(const SetCertificatesDetails& value);
-
-bool VarAs(const pp::Var& var,
-           SignatureRequest* result,
-           std::string* error_message);
-pp::Var MakeVar(const SignatureRequest& value);
-
-bool VarAs(const pp::Var& var,
-           RequestPinOptions* result,
-           std::string* error_message);
-pp::Var MakeVar(const RequestPinOptions& value);
-
-bool VarAs(const pp::Var& var,
-           RequestPinResults* result,
-           std::string* error_message);
-pp::Var MakeVar(const RequestPinResults& value);
-
-bool VarAs(const pp::Var& var,
-           StopPinRequestOptions* result,
-           std::string* error_message);
-pp::Var MakeVar(const StopPinRequestOptions& value);
 
 }  // namespace chrome_certificate_provider
 


### PR DESCRIPTION
Delete the code for conversions to/from Native Client pp::Var types from
chrome_certificate_provider/types.{h|cc} files in
//example_cpp_smart_card_client_app. There's no code that uses them
anymore, and the conversions to/from the toolchain-independent Value
class are used instead.

This commit makes it possible to compile these files in
Emscripten/WebAssembly builds, contributing to the migration effort
tracked by #220.