### PR TITLE
Introduce top-level Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,6 @@ endef
 # "make test" will compile and execute all unit and integration tests.
 # Implementation note: A single rule with a sequence of commands in the recipe
 # is used, so that tests don't run in parallel (otherwise they might break).
+.PHONY: test
 test: all
 	$(foreach target,$(TEST_TARGETS),$(call DO_RUN_TEST,$(target)))
-.PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,138 @@
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a top-level makefile that builds all libraries, programs,
+# extensions/apps in this project. This makefile hardcodes dependencies between
+# the targets, allowing parallel builds.
+
+
+# Common definitions ############################
+
+# Declare "all" as the default target that is built when "make" is run without
+# extra arguments.
+all:
+.PHONY: all
+
+
+# Toolchain-agnostic targets ####################
+
+TARGETS := \
+	common/cpp/build \
+	example_cpp_smart_card_client_app/build \
+	example_js_smart_card_client_app/build \
+	example_js_standalone_smart_card_client_library \
+	third_party/pcsc-lite/naclport/common/build \
+	third_party/pcsc-lite/naclport/cpp_client/build \
+	third_party/pcsc-lite/naclport/cpp_demo/build \
+
+example_cpp_smart_card_client_app/build: common/cpp/build
+example_cpp_smart_card_client_app/build: third_party/pcsc-lite/naclport/common/build
+example_cpp_smart_card_client_app/build: third_party/pcsc-lite/naclport/cpp_client/build
+example_cpp_smart_card_client_app/build: third_party/pcsc-lite/naclport/cpp_demo/build
+
+TEST_TARGETS := \
+	common/cpp/build/tests \
+	common/js/build/unittests \
+	third_party/libusb/naclport/build/js_unittests \
+	third_party/pcsc-lite/naclport/server_clients_management/build/js_unittests \
+
+common/cpp/build/tests: common/cpp/build
+
+# Toolchain related definitions #################
+
+TOOLCHAIN ?= pnacl
+
+ifeq ($(TOOLCHAIN),emscripten)
+
+# Emscripten-specific definitions ###############
+
+TARGETS += \
+	third_party/googletest/webport/build \
+
+common/cpp/build/tests: third_party/googletest/webport/build
+
+else ifeq ($(TOOLCHAIN),pnacl)
+
+# Native Client specific definitions ############
+
+TARGETS += \
+	smart_card_connector_app/build \
+	third_party/ccid/naclport/build \
+	third_party/libusb/naclport/build \
+	third_party/pcsc-lite/naclport/server/build \
+	third_party/pcsc-lite/naclport/server_clients_management/build \
+
+smart_card_connector_app/build: common/cpp/build
+smart_card_connector_app/build: third_party/ccid/naclport/build
+smart_card_connector_app/build: third_party/libusb/naclport/build
+smart_card_connector_app/build: third_party/pcsc-lite/naclport/common/build
+smart_card_connector_app/build: third_party/pcsc-lite/naclport/server/build
+smart_card_connector_app/build: third_party/pcsc-lite/naclport/server_clients_management/build
+third_party/ccid/naclport/build: third_party/libusb/naclport/build
+third_party/pcsc-lite/naclport/server/build: third_party/libusb/naclport/build
+third_party/pcsc-lite/naclport/server_clients_management/build: third_party/pcsc-lite/naclport/server/build
+
+TEST_TARGETS += \
+	common/integration_testing/build \
+	example_cpp_smart_card_client_app/build/integration_tests \
+	third_party/libusb/naclport/build/tests \
+
+example_cpp_smart_card_client_app/build/integration_tests: common/cpp/build
+example_cpp_smart_card_client_app/build/integration_tests: common/integration_testing/build
+example_cpp_smart_card_client_app/build/integration_tests: example_cpp_smart_card_client_app/build
+third_party/libusb/naclport/build/tests: common/cpp/build
+third_party/libusb/naclport/build/tests: third_party/ccid/naclport/build
+
+else
+
+$(error Unknown TOOLCHAIN "$(TOOLCHAIN)".)
+
+endif
+
+
+# Combined "all" targets ########################
+
+# "make" or "make all" will recursively compile all targets.
+.PHONY: $(TARGETS) $(TEST_TARGETS)
+$(TARGETS) $(TEST_TARGETS):
+	+$(MAKE) --directory=$@
+all: $(TARGETS) $(TEST_TARGETS)
+
+define CLEAN_RULE
+.PHONY: clean_$(1)
+clean_$(1):
+	+$(MAKE) --directory=$(1) clean
+clean: clean_$(1)
+endef
+
+# "make clean" will recursively clean all files produced by other targets.
+.PHONY: clean
+$(foreach target,$(TARGETS) $(TEST_TARGETS),$(eval $(call CLEAN_RULE,$(target))))
+
+
+# Test targets ##################################
+
+# The trailing blank line is needed, so that the "foreach" result is
+# multi-lined, as opposed to squashing all commands into a single line.
+define DO_RUN_TEST
++$(MAKE) --directory=$(1) run_test
+
+endef
+
+# "make test" will compile and execute all unit and integration tests.
+# Implementation note: A single rule with a sequence of commands in the recipe
+# is used, so that tests don't run in parallel (otherwise they might break).
+test: all
+	$(foreach target,$(TEST_TARGETS),$(call DO_RUN_TEST,$(target)))
+.PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ example_cpp_smart_card_client_app/build/integration_tests: common/cpp/build
 example_cpp_smart_card_client_app/build/integration_tests: common/integration_testing/build
 example_cpp_smart_card_client_app/build/integration_tests: example_cpp_smart_card_client_app/build
 third_party/libusb/naclport/build/tests: common/cpp/build
-third_party/libusb/naclport/build/tests: third_party/ccid/naclport/build
+third_party/libusb/naclport/build/tests: third_party/libusb/naclport/build
 
 else
 


### PR DESCRIPTION
This commit adds a new makefile, located in the project's root
directory. This makefile can be used to build the whole project in the
specified configuration, namely the TOOLCHAIN (can be "pnacl" [default]
or "emscripten") and the CONFIG (can be "Release" [default] or "Debug").

The main benefit is that the makefile syntax is more suitable than shell
scripts for describing rules like "target foo should always be compiled,
but target bar only under toolchain X" and similar more complex ones.
The makefile also naturally describes dependencies and prerequisites, as
opposed to hardcoding the "magically working" order of targets in shell
scripts.

Currently, only a few targets can be built in the TOOLCHAIN=emscripten
configuration. Follow-up changes will migrate the remaining targets, so
that everything can be compiled in all configurations.

Potentially, the //make-all.sh, //clean-all.sh, //test-all.sh scripts
will be rewritten to use this new makefile. This will make those scripts
simpler and keep the information about targets and their dependencies in
a single place.

This commit contributes to the WebAssembly migration effort, tracked
by #177.