### PR TITLE
Emscripten: rebuild on library/dependency change

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -186,10 +186,15 @@ endef
 # L: Add the specified directory into the .a library search paths.
 # l: Link the specified .a library.
 define LINK_EXECUTABLE_RULE
+# Dependency on the input object files:
 $(BUILD_DIR)/$(TARGET).js $(BUILD_DIR)/$(TARGET).wasm $(BUILD_DIR)/$(TARGET).worker.js: $(foreach src,$(1),$(call OBJ_FILE_NAME,$(src)))
+# Dependency on the input static libraries:
 $(BUILD_DIR)/$(TARGET).js $(BUILD_DIR)/$(TARGET).wasm $(BUILD_DIR)/$(TARGET).worker.js: $(foreach lib,$(2),$(LIB_DIR)/lib$(lib).a)
+# Dependency on additionally specified targets:
 $(BUILD_DIR)/$(TARGET).js $(BUILD_DIR)/$(TARGET).wasm $(BUILD_DIR)/$(TARGET).worker.js: $(3)
+# Order-only dependency on the destination directory stamp:
 $(BUILD_DIR)/$(TARGET).js $(BUILD_DIR)/$(TARGET).wasm $(BUILD_DIR)/$(TARGET).worker.js: | $(BUILD_DIR)/dir.stamp
+# The recipe that performs the linking and creates the resulting files:
 $(BUILD_DIR)/$(TARGET).js $(BUILD_DIR)/$(TARGET).wasm $(BUILD_DIR)/$(TARGET).worker.js &:
 	emcc \
 		-o $(BUILD_DIR)/$(TARGET).js \
@@ -198,7 +203,9 @@ $(BUILD_DIR)/$(TARGET).js $(BUILD_DIR)/$(TARGET).wasm $(BUILD_DIR)/$(TARGET).wor
 		$(foreach lib,$(2),-l$(lib)) \
 		$(EMSCRIPTEN_FLAGS) \
 		$(4)
+# Add linking into the default "all" target's prerequisite:
 all: $(BUILD_DIR)/$(TARGET).js $(BUILD_DIR)/$(TARGET).wasm $(BUILD_DIR)/$(TARGET).worker.js
+# Copy the resulting files into the out directory:
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(BUILD_DIR)/$(TARGET).js))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(BUILD_DIR)/$(TARGET).wasm))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(BUILD_DIR)/$(TARGET).worker.js))

--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -186,7 +186,11 @@ endef
 # L: Add the specified directory into the .a library search paths.
 # l: Link the specified .a library.
 define LINK_EXECUTABLE_RULE
-$(BUILD_DIR)/$(TARGET).js $(BUILD_DIR)/$(TARGET).wasm $(BUILD_DIR)/$(TARGET).worker.js &: $(foreach src,$(1),$(call OBJ_FILE_NAME,$(src))) | $(BUILD_DIR)/dir.stamp
+$(BUILD_DIR)/$(TARGET).js $(BUILD_DIR)/$(TARGET).wasm $(BUILD_DIR)/$(TARGET).worker.js: $(foreach src,$(1),$(call OBJ_FILE_NAME,$(src)))
+$(BUILD_DIR)/$(TARGET).js $(BUILD_DIR)/$(TARGET).wasm $(BUILD_DIR)/$(TARGET).worker.js: $(foreach lib,$(2),$(LIB_DIR)/lib$(lib).a)
+$(BUILD_DIR)/$(TARGET).js $(BUILD_DIR)/$(TARGET).wasm $(BUILD_DIR)/$(TARGET).worker.js: $(3)
+$(BUILD_DIR)/$(TARGET).js $(BUILD_DIR)/$(TARGET).wasm $(BUILD_DIR)/$(TARGET).worker.js: | $(BUILD_DIR)/dir.stamp
+$(BUILD_DIR)/$(TARGET).js $(BUILD_DIR)/$(TARGET).wasm $(BUILD_DIR)/$(TARGET).worker.js &:
 	emcc \
 		-o $(BUILD_DIR)/$(TARGET).js \
 		-L$(LIB_DIR) \

--- a/example_cpp_smart_card_client_app/build/nacl_module/Makefile
+++ b/example_cpp_smart_card_client_app/build/nacl_module/Makefile
@@ -59,12 +59,6 @@ LIBS := \
 	$(CPP_COMMON_LIB) \
 	$(DEFAULT_NACL_LIBS) \
 
-DEPS := \
-	$(CPP_COMMON_LIB) \
-	$(PCSC_LITE_CLIENT_LIB) \
-	$(PCSC_LITE_COMMON_LIB) \
-	$(PCSC_LITE_CPP_DEMO_LIB) \
-
 CPPFLAGS := \
 	-I$(SOURCES_DIR) \
 	-I$(ROOT_PATH)/common/cpp/src \
@@ -80,4 +74,4 @@ CPPFLAGS := \
 
 $(foreach src,$(SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CPPFLAGS))))
 
-$(eval $(call LINK_EXECUTABLE_RULE,$(SOURCES),$(LIBS),$(DEPS)))
+$(eval $(call LINK_EXECUTABLE_RULE,$(SOURCES),$(LIBS)))


### PR DESCRIPTION
This commit adds automatic detection of static library or any other
specified dependency changes, triggering the rebuild of the resulting
Emscripten .wasm/.js files.

This resolves one of the feature gaps between our Emscripten builds
scripts and the Native Client ones. This effort is tracked by #177.

The commit also drops DEPS dependencies from the
//example_cpp_smart_card_client_app, since the referenced targets aren't
implemented in Emscripten builds. Moreover, our new approach will be to
drop these DEPS wherever possible, and only leave the dependencies
described in the root //Makefile; this will make the build scripts simpler
and more reliable.