### PR TITLE
Wire up Emscripten module in C++ Example App

### DIFF
--- a/common/js/src/executable-module/executable-module.js
+++ b/common/js/src/executable-module/executable-module.js
@@ -22,6 +22,7 @@
 
 goog.provide('GoogleSmartCard.ExecutableModule');
 
+goog.require('GoogleSmartCard.Logging');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 goog.require('goog.Disposable');
@@ -42,6 +43,32 @@ GSC.ExecutableModule = function() {};
 
 const ExecutableModule = GSC.ExecutableModule;
 goog.inherits(ExecutableModule, goog.Disposable);
+
+/**
+ * Type of the toolchain used for building the binary executable module.
+ * @enum {string}
+ */
+ExecutableModule.Toolchain = {
+  EMSCRIPTEN: 'emscripten',
+  PNACL: 'pnacl',
+};
+
+/** @define {string} */
+const TOOLCHAIN = goog.define(
+    'GoogleSmartCard.ExecutableModule.TOOLCHAIN', 'pnacl');
+GSC.Logging.check(
+    Object.values(GSC.ExecutableModule.Toolchain).includes(TOOLCHAIN),
+    'Unexpected value of GoogleSmartCard.ExecutableModule.TOOLCHAIN: ' +
+    '`${TOOLCHAIN}`');
+/**
+ * The toolchain that is used for building the executable module. This constant
+ * is coming from the build scripts, which take it from the "TOOLCHAIN"
+ * environment variable.
+ * @type {!ExecutableModule.Toolchain}
+ * @const
+ */
+ExecutableModule.TOOLCHAIN = /** @type {!ExecutableModule.Toolchain} */ (
+    TOOLCHAIN);
 
 /**
  * @abstract

--- a/common/make/js_building_common.mk
+++ b/common/make/js_building_common.mk
@@ -113,15 +113,22 @@ JS_BUILD_COMPILATION_FLAGS += \
 	--jscomp_error=undefinedNames \
 	--jscomp_error=undefinedVars \
 	--jscomp_error=underscore \
-	--jscomp_error=unknownDefines \
 	--jscomp_error=unusedLocalVariables \
 	--jscomp_error=unusedPrivateMembers \
 	--jscomp_error=uselessCode \
 	--jscomp_error=useOfGoogBase \
 	--jscomp_error=visibility \
 	--jscomp_off reportUnknownTypes \
+	--jscomp_off unknownDefines \
 	--use_types_for_optimization=false \
 	--warning_level=VERBOSE \
+
+ifneq ($(TOOLCHAIN),)
+
+JS_BUILD_COMPILATION_FLAGS += \
+	--define='GoogleSmartCard.ExecutableModule.TOOLCHAIN=$(TOOLCHAIN)' \
+
+endif
 
 
 #


### PR DESCRIPTION
Change the C++ Example App to conditionally load either the
Emscripten/WebAssembly or the Native Client module, depending on the
build configuration.

This completes the first workable prototype of the WebAssembly version
of the C++ Example App, as tracked by #220.