### PR TITLE
Free C++ object on Emscripten module disposal

### DIFF
--- a/common/js/src/executable-module/emscripten-module.js
+++ b/common/js/src/executable-module/emscripten-module.js
@@ -103,7 +103,9 @@ EmscriptenModule.prototype.disposeInternal = function() {
   this.logger_.fine('Disposed');
   // Call `delete()` on the C++ object before dropping the reference on it, in
   // order to make the C++ destructor called.
-  this.googleSmartCardModule_.delete();
+  // Note: The method is accessed using the square bracket notation, to make
+  // sure that Closure Compiler doesn't rename this method call.
+  this.googleSmartCardModule_['delete']();
   delete this.googleSmartCardModule_;
   this.messageChannel_.dispose();
   EmscriptenModule.base(this, 'disposeInternal');
@@ -275,6 +277,8 @@ EmscriptenModuleMessageChannel.prototype.onMessageFromModule =
 EmscriptenModuleMessageChannel.prototype.sendNow_ = function(message) {
   // Note: The method name must match the string in the GoogleSmartCardModule
   // Embind class definition in the entry_point_emscripten.cc files.
+  // The method is accessed using the square bracket notation, to make sure that
+  // Closure Compiler doesn't rename this method call.
   this.googleSmartCardModule_['postMessage'](message);
 };
 

--- a/common/js/src/executable-module/emscripten-module.js
+++ b/common/js/src/executable-module/emscripten-module.js
@@ -101,6 +101,9 @@ EmscriptenModule.prototype.getMessageChannel = function() {
 /** @override */
 EmscriptenModule.prototype.disposeInternal = function() {
   this.logger_.fine('Disposed');
+  // Call `delete()` on the C++ object before dropping the reference on it, in
+  // order to make the C++ destructor called.
+  this.googleSmartCardModule_.delete();
   delete this.googleSmartCardModule_;
   this.messageChannel_.dispose();
   EmscriptenModule.base(this, 'disposeInternal');


### PR DESCRIPTION
Make sure the destructor of the GoogleSmartCardModule C++ class is
called when the JavaScript class GoogleSmartCard.EmscriptenModule is
disposed of. This makes sure the C++ memory is freed in this flow.

This change is a small cleanup that isn't extremely useful for
real-world use cases, since a smart card client app never shuts down the
module (unless it crashes, but in that case the whole app is
self-reloaded). But the code is more sane this way, and also might make
integration tests consume less memory. The tracking issue is #220.