### PR TITLE
Make Emscripten C++ object untyped in JavaScript

### DIFF
--- a/common/js/src/executable-module/emscripten-module.js
+++ b/common/js/src/executable-module/emscripten-module.js
@@ -65,7 +65,7 @@ GSC.EmscriptenModule = function(moduleName) {
   // messages with it. Untyped, since the class "GoogleSmartCardModule" is
   // defined within the Emscripten module (using Embind) and therefore isn't
   // known to Closure Compiler.
-  /** @private */
+  /** @type {?} @private */
   this.googleSmartCardModule_ = null;
 };
 
@@ -211,7 +211,7 @@ function EmscriptenModuleMessageChannel() {
   /** @type {!Array<!Object>} @private */
   this.pendingOutgoingMessages_ = [];
   // Instance of the "GoogleSmartCardModule" class that is defined via Embind.
-  /** @private */
+  /** @type {?} @private */
   this.googleSmartCardModule_ = null;
 }
 


### PR DESCRIPTION
Mark the reference to the C++ "GoogleSmartCardModule" object in
JavaScript as having unknown type ("?" in the Closure Compiler
notation), so that the compiler doesn't emit warnings on accessing
unknown properties of it.

This is small cleanup for the effort tracked by #220.