### PR TITLE
.gitignore Emscripten temporary build artifacts

### DIFF
--- a/common/cpp/build/tests/.gitignore
+++ b/common/cpp/build/tests/.gitignore
@@ -1,3 +1,4 @@
 /out/
+/out-artifacts-emscripten/
 /pnacl/
 /user-data-dir/

--- a/example_cpp_smart_card_client_app/build/executable_module/.gitignore
+++ b/example_cpp_smart_card_client_app/build/executable_module/.gitignore
@@ -1,2 +1,3 @@
 /out/
+/out-artifacts-emscripten/
 /pnacl/

--- a/example_cpp_smart_card_client_app/build/integration_tests/.gitignore
+++ b/example_cpp_smart_card_client_app/build/integration_tests/.gitignore
@@ -1,4 +1,5 @@
 /js_build/
 /out/
+/out-artifacts-emscripten/
 /pnacl/
 /user-data-dir/

--- a/smart_card_connector_app/build/nacl_module/.gitignore
+++ b/smart_card_connector_app/build/nacl_module/.gitignore
@@ -1,2 +1,3 @@
 /out/
+/out-artifacts-emscripten/
 /pnacl/

--- a/third_party/ccid/naclport/build/.gitignore
+++ b/third_party/ccid/naclport/build/.gitignore
@@ -2,4 +2,5 @@
 /app_manifest_usb_devices.json
 /headers_installed.stamp
 /out/
+/out-artifacts-emscripten/
 /pnacl/

--- a/third_party/libusb/naclport/build/.gitignore
+++ b/third_party/libusb/naclport/build/.gitignore
@@ -1,2 +1,3 @@
 /headers_installed.stamp
+/out-artifacts-emscripten/
 /pnacl/

--- a/third_party/libusb/naclport/build/tests/.gitignore
+++ b/third_party/libusb/naclport/build/tests/.gitignore
@@ -1,3 +1,4 @@
 /out/
+/out-artifacts-emscripten/
 /pnacl/
 /user-data-dir/

--- a/third_party/pcsc-lite/naclport/common/build/.gitignore
+++ b/third_party/pcsc-lite/naclport/common/build/.gitignore
@@ -1,2 +1,3 @@
 /headers_installed.stamp
+/out-artifacts-emscripten/
 /pnacl/

--- a/third_party/pcsc-lite/naclport/cpp_client/build/.gitignore
+++ b/third_party/pcsc-lite/naclport/cpp_client/build/.gitignore
@@ -1,2 +1,3 @@
 /headers_installed.stamp
+/out-artifacts-emscripten/
 /pnacl/

--- a/third_party/pcsc-lite/naclport/cpp_demo/build/.gitignore
+++ b/third_party/pcsc-lite/naclport/cpp_demo/build/.gitignore
@@ -1,2 +1,3 @@
 /headers_installed.stamp
+/out-artifacts-emscripten/
 /pnacl/

--- a/third_party/pcsc-lite/naclport/server/build/.gitignore
+++ b/third_party/pcsc-lite/naclport/server/build/.gitignore
@@ -1,3 +1,4 @@
 /headers_installed.stamp
 /out/
+/out-artifacts-emscripten/
 /pnacl/

--- a/third_party/pcsc-lite/naclport/server_clients_management/build/.gitignore
+++ b/third_party/pcsc-lite/naclport/server_clients_management/build/.gitignore
@@ -3,4 +3,5 @@
 /js_unittests/js_build/
 /js_unittests/out/
 /out/
+/out-artifacts-emscripten/
 /pnacl/


### PR DESCRIPTION
Add directories that are produced by Emscripten/WebAssembly builds in
this project into .gitignore files, as these are temporary files that
shouldn't be tracked by the version control system.

This is a minor cleanup for the effort tracked by #177.