### PR TITLE
Put built JS files into dir depending on toolchain

### DIFF
--- a/common/js/src/executable-module/executable-module.js
+++ b/common/js/src/executable-module/executable-module.js
@@ -54,8 +54,7 @@ ExecutableModule.Toolchain = {
 };
 
 /** @define {string} */
-const TOOLCHAIN = goog.define(
-    'GoogleSmartCard.ExecutableModule.TOOLCHAIN', 'pnacl');
+const TOOLCHAIN = goog.define('GoogleSmartCard.ExecutableModule.TOOLCHAIN', '');
 GSC.Logging.check(
     Object.values(GSC.ExecutableModule.Toolchain).includes(TOOLCHAIN),
     'Unexpected value of GoogleSmartCard.ExecutableModule.TOOLCHAIN: ' +

--- a/common/make/common.mk
+++ b/common/make/common.mk
@@ -27,10 +27,14 @@ endif
 
 
 #
-# Determine build configuration. By default, use Release mode.
+# Determine build configuration.
 #
 
+# Supported values: "Release" (default), "Debug".
 CONFIG ?= Release
+# Supported values: "pnacl" (Portable Native Client; default), "emscripten"
+# (Emscripten/WebAssembly).
+TOOLCHAIN ?= pnacl
 
 
 #

--- a/common/make/executable_building.mk
+++ b/common/make/executable_building.mk
@@ -16,13 +16,8 @@
 # can be run in web-based applications.
 #
 # The actually used technology depends on the TOOLCHAIN environment variable.
-# Currently, the only supported value is "pnacl", which corresponds to the
-# Google Native Client technology.
 #
 # common.mk must be included before including this file.
-
-# Default to using the "pnacl" toolchain.
-TOOLCHAIN ?= pnacl
 
 # Common documentation for definitions provided by this file (they are
 # implemented in toolchain-specific .mk files, but share the same interface):

--- a/common/make/js_building_common.mk
+++ b/common/make/js_building_common.mk
@@ -38,10 +38,13 @@ include $(THIRD_PARTY_DIR_PATH)/closure-library/include.mk
 # copying to the out directory (this is separate from the out directory, because
 # the latter is cleared on each rebuild).
 #
+# Note that the directory depends on both TOOLCHAIN and CONFIG variables, so
+# that JavaScript files from different build configurations aren't mixed up.
+#
 
 JS_BUILD_DIR_ROOT_PATH := js_build
 
-JS_BUILD_DIR_PATH := $(JS_BUILD_DIR_ROOT_PATH)/$(CONFIG)
+JS_BUILD_DIR_PATH := $(JS_BUILD_DIR_ROOT_PATH)/$(TOOLCHAIN)_$(CONFIG)
 
 $(JS_BUILD_DIR_PATH):
 	@mkdir -p $(JS_BUILD_DIR_PATH)
@@ -74,6 +77,7 @@ endif
 
 JS_BUILD_COMPILATION_FLAGS += \
 	--compilation_level=SIMPLE \
+	--define='GoogleSmartCard.ExecutableModule.TOOLCHAIN=$(TOOLCHAIN)' \
 	--define='GoogleSmartCard.Logging.USE_SCOPED_LOGGERS=false' \
 	--dependency_mode=STRICT \
 	--jscomp_error=accessControls \
@@ -122,13 +126,6 @@ JS_BUILD_COMPILATION_FLAGS += \
 	--jscomp_off unknownDefines \
 	--use_types_for_optimization=false \
 	--warning_level=VERBOSE \
-
-ifneq ($(TOOLCHAIN),)
-
-JS_BUILD_COMPILATION_FLAGS += \
-	--define='GoogleSmartCard.ExecutableModule.TOOLCHAIN=$(TOOLCHAIN)' \
-
-endif
 
 
 #


### PR DESCRIPTION
Make compiled JavaScript files be stored in different locations
depending on the TOOLCHAIN environment variable.

This fixes the problem that JS files can stay non-recompiled after
switching the TOOLCHAIN variable. E.g., in the following scenario
resulting JS files would still refer to emscripten if built without this
commit:

  TOOLCHAIN=emscripten make && TOOLCHAIN=pnacl make

The underlying reason is that when both the input files are unchanged
and the resulting file paths don't depend on the toolchain, Make
doesn't see any reason to trigger recompilation. We don't have
prerequisites that depend on the compilation flags, and this would
be tricky to implement.

The solution in this commit makes sure that JS files are put into
different locations for pnacl and emscripten, which bypasses the problem
with missing recompilation. The only downside is a bit of uglyness for
the JS files that don't depend on the toolchain, but it's only a problem
for intermediate build files.

This commit contributes to the WebAssembly migration effort tracked
by #177.