### PR TITLE
Delete old references to NaCl from Example C++ App

### DIFF
--- a/example_cpp_smart_card_client_app/src/application.h
+++ b/example_cpp_smart_card_client_app/src/application.h
@@ -37,10 +37,9 @@ namespace smart_card_client {
 // or PIN requests) should be never executed on the main event loop thread. This
 // is because all communication with the JavaScript side works through
 // exchanging of messages between the executable module and JavaScript side, and
-// the incoming messages are received and routed on the main thread (see
-// <https://developer.chrome.com/native-client/devguide/coding/message-system>).
-// Actually, most of the blocking operations implemented in this code contain
-// assertions that they are not called on the main thread.
+// the incoming messages are received and routed on the main thread. Actually,
+// most of the blocking operations implemented in this code contain assertions
+// that they are not called on the main thread.
 class Application final {
  public:
   // Initializes and starts the application. The `typed_message_router` argument

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog-backend.js
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog-backend.js
@@ -16,7 +16,7 @@
 
 /**
  * @fileoverview Backend that handles built-in PIN dialog requests received from
- * the NaCl module.
+ * the executable module.
  *
  * NOTE: This should only be used for the PIN requests that aren't associated
  * with signature requests made by Chrome, since for those the
@@ -56,8 +56,8 @@ const GSC = GoogleSmartCard;
 const logger = GSC.Logging.getLogger('SmartCardClientApp.BuiltInPinDialog');
 
 /**
- * Backend that handles built-in PIN dialog requests received from the NaCl
- * module.
+ * Backend that handles built-in PIN dialog requests received from the
+ * executable module.
  *
  * On construction, subscribes at the passed message channel for receiving
  * messages of the special type representing PIN requests.
@@ -65,17 +65,15 @@ const logger = GSC.Logging.getLogger('SmartCardClientApp.BuiltInPinDialog');
  * Once the message with the PIN request is received, opens the built-in PIN
  * dialog and, once it finishes, sends its result as a message through the
  * message channel.
- *
- * TODO(#220): Get rid of hardcoded references to NaCl.
- * @param {!goog.messaging.AbstractChannel} naclModuleMessageChannel
+ * @param {!goog.messaging.AbstractChannel} executableModuleMessageChannel
  * @constructor
  */
 SmartCardClientApp.BuiltInPinDialog.Backend = function(
-    naclModuleMessageChannel) {
+    executableModuleMessageChannel) {
   // Note: the request receiver instance is not stored anywhere, as it makes
   // itself being owned by the message channel.
   new GSC.RequestReceiver(
-      REQUESTER_NAME, naclModuleMessageChannel, handleRequest);
+      REQUESTER_NAME, executableModuleMessageChannel, handleRequest);
 };
 
 const Backend = SmartCardClientApp.BuiltInPinDialog.Backend;

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
@@ -37,11 +37,15 @@ namespace chrome_certificate_provider {
 
 namespace {
 
-constexpr char kRequesterName[] = "certificate_provider_nacl_outgoing";
-constexpr char kRequestReceiverName[] = "certificate_provider_nacl_incoming";
+// These constants must match the ones in bridge-backend.js.
+constexpr char kRequesterName[] =
+    "certificate_provider_request_from_executable";
+constexpr char kRequestReceiverName[] =
+    "certificate_provider_request_to_executable";
 constexpr char kHandleCertificatesRequestFunctionName[] =
     "HandleCertificatesRequest";
 constexpr char kHandleSignatureRequestFunctionName[] = "HandleSignatureRequest";
+
 constexpr char kFunctionCallLoggingPrefix[] = "chrome.certificateProvider.";
 
 void ProcessCertificatesRequest(


### PR DESCRIPTION
Rename variables/functions and reword comments to use generic terms
instead of referring to Native Client, since the code can be compiled in
two modes now: Native Client and Emscripten/WebAssembly.

This is a pure refactoring CL; the tracking issue is #220.