### PR TITLE
Not install //common/integration_testing headers

### DIFF
--- a/common/integration_testing/build/Makefile
+++ b/common/integration_testing/build/Makefile
@@ -41,9 +41,3 @@ CXXFLAGS := \
 $(foreach src,$(SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
 
 $(eval $(call LIB_RULE,$(TARGET),$(SOURCES)))
-
-INSTALLING_HEADERS := \
-	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):integration_test_helper.h \
-	$(ROOT_SOURCES_SUBDIR):$(SOURCES_PATH):integration_test_service.h \
-
-$(eval $(call NACL_LIBRARY_HEADERS_INSTALLATION_RULE,$(INSTALLING_HEADERS)))

--- a/common/integration_testing/include.mk
+++ b/common/integration_testing/include.mk
@@ -29,12 +29,3 @@ INTEGRATION_TESTING_DIR_PATH := $(COMMON_DIR_PATH)/integration_testing
 # compiling the code using this library.
 INTEGRATION_TESTING_JS_COMPILER_INPUT_DIR_PATHS := \
 	$(INTEGRATION_TESTING_DIR_PATH) \
-
-
-#
-# Helper target that installs the library headers.
-#
-# This target can be used in dependant libraries.
-#
-
-$(eval $(call DEFINE_NACL_LIBRARY_HEADERS_INSTALLATION_TARGET,INTEGRATION_TESTING_HEADERS_INSTALLATION_STAMP_FILE,$(INTEGRATION_TESTING_DIR_PATH)/build))

--- a/example_cpp_smart_card_client_app/build/integration_tests/Makefile
+++ b/example_cpp_smart_card_client_app/build/integration_tests/Makefile
@@ -58,6 +58,7 @@ DEPS := \
 CPPFLAGS := \
 	-I$(SOURCE_DIR) \
 	-I$(ROOT_PATH)/common/cpp/src \
+	-I$(ROOT_PATH)/common/integration_testing/src \
 	-pedantic \
 	-std=gnu++11 \
 	-Wall \
@@ -67,8 +68,6 @@ CPPFLAGS := \
 
 $(foreach src,$(CPP_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CPPFLAGS))))
 $(eval $(call LINK_EXECUTABLE_RULE,$(CPP_SOURCES),$(LIBS),$(DEPS)))
-
-$(foreach src,$(CPP_SOURCES),$(eval $(call DEPEND_COMPILE_ON_NACL_LIBRARY_HEADERS,$(src),$(INTEGRATION_TESTING_HEADERS_INSTALLATION_STAMP_FILE))))
 
 $(eval $(call BUILD_TESTING_JS_SCRIPT,tests.js,$(JS_COMPILER_INPUT_PATHS)))
 


### PR DESCRIPTION
This commit disables installation of "public" headers from the
//common/integration_testing library into a common include
directory. Instead, the path to this library is simply added
into the include search path in needed makefiles.

More background on this refactoring is in #132.