### PR TITLE
Not install //third_party/libusb headers

### DIFF
--- a/smart_card_connector_app/build/nacl_module/Makefile
+++ b/smart_card_connector_app/build/nacl_module/Makefile
@@ -65,6 +65,7 @@ $(eval $(call DEPEND_RULE,nacl_io))
 CXXFLAGS := \
 	-I$(PCSC_LITE_SERVER_INCLUDE_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
+	-I$(ROOT_PATH)/third_party/libusb/naclport/src \
 	-Wall \
 	-Werror \
 	-Wextra \

--- a/third_party/ccid/naclport/build/Makefile
+++ b/third_party/ccid/naclport/build/Makefile
@@ -53,7 +53,6 @@ COMMON_CPPFLAGS := \
 	-Dlog_xxd=ccid_log_xxd \
 	-DPCSCLITE_HP_DROPDIR='"/crx/pcsc/drivers"' \
 	-I$(CCID_SOURCES_PATH) \
-	-I$(LIBUSB_INCLUDE_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-Wall \
 
@@ -86,6 +85,7 @@ CCID_CPPFLAGS := \
 	-I$(CCID_NACL_SOURCES_PATH) \
 	-I$(PCSC_LITE_ORIGINAL_HEADERS_DIR_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src/google_smart_card_common/logging/syslog \
+	-I$(ROOT_PATH)/third_party/libusb/src/libusb \
 	-Wno-macro-redefined \
 
 $(foreach src,$(CCID_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CCID_CPPFLAGS))))
@@ -128,6 +128,7 @@ CCID_TOWITOKO_CPPFLAGS := \
 	$(COMMON_CPPFLAGS) \
 	-I$(CCID_NACL_SOURCES_PATH) \
 	-I$(PCSC_LITE_ORIGINAL_HEADERS_DIR_PATH) \
+	-I$(ROOT_PATH)/third_party/libusb/src/libusb \
 
 $(foreach src,$(CCID_TOWITOKO_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CCID_TOWITOKO_CPPFLAGS))))
 
@@ -140,12 +141,6 @@ SOURCES := \
 	$(CCID_OPENCT_SOURCES) \
 	$(CCID_SIMCLIST_SOURCES) \
 	$(CCID_TOWITOKO_SOURCES) \
-
-
-# Rules for adding a dependency on the installation of the separate libraries'
-# headers
-
-$(foreach src,$(SOURCES),$(eval $(call DEPEND_COMPILE_ON_NACL_LIBRARY_HEADERS,$(src),$(LIBUSB_HEADERS_INSTALLATION_STAMP_FILE))))
 
 
 # Rules for building the driver config file and putting it into the resulting

--- a/third_party/libusb/naclport/build/Makefile
+++ b/third_party/libusb/naclport/build/Makefile
@@ -71,13 +71,6 @@ $(foreach src,$(CXX_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CPPFLAGS) $(CXX
 $(eval $(call LIB_RULE,$(TARGET),$(SOURCES)))
 
 
-INSTALLING_HEADERS := \
-	$(LIBUSB_INSTALLED_HEADER_DIR_NAME):$(LIBUSB_SOURCES_PATH)/libusb:libusb.h \
-	google_smart_card_libusb:$(LIBUSB_NACL_SOURCES_PATH)/google_smart_card_libusb:global.h \
-
-$(eval $(call NACL_LIBRARY_HEADERS_INSTALLATION_RULE,$(INSTALLING_HEADERS)))
-
-
 test::
 	+$(MAKE) --directory tests run_test
 	+$(MAKE) --directory js_unittests run_test

--- a/third_party/libusb/naclport/build/tests/Makefile
+++ b/third_party/libusb/naclport/build/tests/Makefile
@@ -28,8 +28,8 @@ SOURCES := \
 
 CXXFLAGS := \
 	-I$(SOURCES_PATH) \
-	-I$(NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH)/google_smart_card_libusb/libusb-1.0 \
 	-I$(ROOT_PATH)/common/cpp/src \
+	-I$(ROOT_PATH)/third_party/libusb/src/libusb \
 	-pedantic \
 	-Wall \
 	-Werror \

--- a/third_party/libusb/naclport/include.mk
+++ b/third_party/libusb/naclport/include.mk
@@ -30,18 +30,3 @@ LIBUSB_DIR_PATH := $(THIRD_PARTY_DIR_PATH)/libusb
 
 
 LIBUSB_JS_COMPILER_INPUT_DIR_PATHS := $(LIBUSB_DIR_PATH)/naclport/src
-
-
-LIBUSB_INSTALLED_HEADER_DIR_NAME := google_smart_card_libusb/libusb-1.0
-
-LIBUSB_INCLUDE_PATH := \
-	$(NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH)/$(LIBUSB_INSTALLED_HEADER_DIR_NAME)
-
-
-#
-# Helper target that installs the library headers.
-#
-# This target can be used in dependant libraries.
-#
-
-$(eval $(call DEFINE_NACL_LIBRARY_HEADERS_INSTALLATION_TARGET,LIBUSB_HEADERS_INSTALLATION_STAMP_FILE,$(LIBUSB_DIR_PATH)/naclport/build))

--- a/third_party/pcsc-lite/naclport/server/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server/build/Makefile
@@ -87,8 +87,8 @@ PCSC_LITE_COMMON_CPPFLAGS := \
 	-DPCSCLITE_HP_DROPDIR='"/crx/pcsc/drivers"' \
 	-DUSE_IPCDIR='"IPCDIR_is_not_expected_to_be_used"' \
 	-DUSE_USB \
-	-I$(LIBUSB_INCLUDE_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src/google_smart_card_common/logging/syslog \
+	-I$(ROOT_PATH)/third_party/libusb/src/libusb \
 
 # Part of the list of the original PC/SC-Lite daemon source files to be
 # compiled (see also PCSC_LITE_SERVER_SVC_SOURCES,

--- a/third_party/pcsc-lite/naclport/server/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server/build/Makefile
@@ -216,11 +216,6 @@ SOURCES := \
 	$(PCSC_LITE_SERVER_NACL_SOURCES) \
 	$(PCSC_LITE_SERVER_READERFACTORY_SOURCES) \
 
-# Rules for adding a dependency on the installation of the separate libraries'
-# headers
-
-$(foreach src,$(SOURCES),$(eval $(call DEPEND_COMPILE_ON_NACL_LIBRARY_HEADERS,$(src),$(LIBUSB_HEADERS_INSTALLATION_STAMP_FILE))))
-
 
 # Rules for linking of the compiled object files and installing the resulting
 # static library into the NaCl SDK libraries directory


### PR DESCRIPTION
This commit disables installation of "public" headers from the
//third_party/libusb library into a common include directory.
Instead, the path to this library is simply added into the include
search path in needed makefiles.

More background on this refactoring is in #132.