### PR TITLE
Delete header installation scripts

### DIFF
--- a/common/integration_testing/build/Makefile
+++ b/common/integration_testing/build/Makefile
@@ -30,7 +30,7 @@ SOURCES := \
 	$(SOURCES_PATH)/integration_test_service.cc \
 
 CXXFLAGS := \
-	-I$(SOURCES_PATH) \
+	-I$(ROOT_SOURCES_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-pedantic \
 	-Wall \

--- a/common/make/common.mk
+++ b/common/make/common.mk
@@ -304,20 +304,3 @@ UNIQUE = $(shell echo $(1) | xargs -n1 | sort -u)
 #
 
 JOIN_WITH_DELIMITER = $(subst $(SPACE),$(2),$(1))
-
-
-#
-# Returns the item with the required index from the passed colon-separated list.
-#
-# Note: the items of the list should not contain spaces between non-space
-# characters.
-#
-# Arguments:
-#    $1: Input list of colon-separated items.
-#
-
-GET_COLON_SEPARATED_FIRST = $(word 1,$(subst :, ,$(1)))
-
-GET_COLON_SEPARATED_SECOND = $(word 2,$(subst :, ,$(1)))
-
-GET_COLON_SEPARATED_THIRD = $(word 3,$(subst :, ,$(1)))

--- a/common/make/executable_building.mk
+++ b/common/make/executable_building.mk
@@ -47,42 +47,6 @@
 #   $3 ("DEPS", optional): Libraries whose building will be added as
 #     dependencies of this target.
 #   $4 ("LDFLAGS", optional): Linker flags.
-#
-# * NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH variable:
-#   TODO(#177): Rename to a toolchain-independent name.
-#   Path where library headers are installed by the
-#   NACL_LIBRARY_HEADERS_INSTALLATION_RULE macro.
-#
-# * NACL_LIBRARY_HEADERS_INSTALLATION_RULE macro:
-#   TODO(#177): Rename to a toolchain-independent name.
-#   Installs specified headers into $NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH.
-#   Arguments:
-#   $1 ("INSTALLING_HEADERS"): List of header descriptions, where each list item
-#     should contain colon-separated destination directory (relative to
-#     NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH), source directory and source
-#     file path (relative to the source directory). Example:
-#     "foolib:../src:a.h foolib:../src:b/c.h", which denotes installation of
-#     file ../src/a.h into
-#     $NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH/libfoo/a.h and of file
-#     ../src/b/c.h into
-#     $NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH/libfoo/b/c.h.
-#
-# * DEPEND_COMPILE_ON_NACL_LIBRARY_HEADERS macro:
-#   TODO(#177): Rename to a toolchain-independent name.
-#   Adds the specified library as a prerequisite for compilation rule of the
-#   the specified file.
-#   Arguments:
-#   $1 ("SOURCES"): Source file paths,
-#   $2 ("STAMP_FILE"): The library's header installation stamp file, defined via
-#     the DEFINE_NACL_LIBRARY_HEADERS_INSTALLATION_TARGET rule.
-#
-# * DEFINE_NACL_LIBRARY_HEADERS_INSTALLATION_TARGET macro:
-#   TODO(#177): Rename to a toolchain-independent name.
-#   Defines the target for the library headers installation and sets the
-#   variable containing the target name.
-#   Arguments:
-#   $1 ("STAMP_FILE_VAR"): Variable to be set to the stamp file name.
-#   $2 ("LIB_DIR"): Path to the library's build directory.
 
 # Load the toolchain-specific file.
 ifeq ($(TOOLCHAIN),emscripten)

--- a/common/make/internal/executable_building_nacl.mk
+++ b/common/make/internal/executable_building_nacl.mk
@@ -83,68 +83,6 @@ endef
 
 
 #
-# Documented at ../binary_executable_building.mk.
-#
-
-NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH := \
-	$(NACL_SDK_ROOT)/include/$(TOOLCHAIN)
-
-
-#
-# File name of the stamp file produced by the headers installation rule.
-#
-
-NACL_LIBRARY_HEADERS_INSTALLATION_STAMP_FILE_NAME := headers_installed.stamp
-
-
-#
-# Documented at ../binary_executable_building.mk.
-#
-
-define NACL_LIBRARY_HEADERS_INSTALLATION_RULE
-
-$(NACL_LIBRARY_HEADERS_INSTALLATION_STAMP_FILE_NAME): $(foreach item,$(1),$(call GET_COLON_SEPARATED_SECOND,$(item))/$(call GET_COLON_SEPARATED_THIRD,$(item)))
-	@rm -f $(NACL_LIBRARY_HEADERS_INSTALLATION_STAMP_FILE_NAME)
-	@$(foreach item,$(1),rm -rf $(NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH)/$(call GET_COLON_SEPARATED_FIRST,$(item));)
-	@$(foreach item,$(1),$(call RACE_FREE_CP,$(call GET_COLON_SEPARATED_SECOND,$(item))/$(call GET_COLON_SEPARATED_THIRD,$(item)),$(NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH)/$(call GET_COLON_SEPARATED_FIRST,$(item))/$(call GET_COLON_SEPARATED_THIRD,$(item)),true);)
-	@echo Headers installation stamp > $(NACL_LIBRARY_HEADERS_INSTALLATION_STAMP_FILE_NAME)
-	@echo Headers installed into $(call JOIN_WITH_DELIMITER,$(call UNIQUE,$(foreach item,$(1),$(NACL_LIBRARY_HEADERS_INSTALLATION_DIR_PATH)/$(call GET_COLON_SEPARATED_FIRST,$(item)) )), and ).
-
-all: $(NACL_LIBRARY_HEADERS_INSTALLATION_STAMP_FILE_NAME)
-
-$(STAMPDIR)/$(TARGET).stamp: $(NACL_LIBRARY_HEADERS_INSTALLATION_STAMP_FILE_NAME)
-
-$(eval $(call CLEAN_RULE,$(NACL_LIBRARY_HEADERS_INSTALLATION_STAMP_FILE_NAME)))
-
-endef
-
-
-#
-# Documented at ../binary_executable_building.mk.
-#
-
-define DEPEND_COMPILE_ON_NACL_LIBRARY_HEADERS
-
-$(call SRC_TO_OBJ,$(1)): $(2)
-
-endef
-
-
-#
-# Documented at ../binary_executable_building.mk.
-#
-
-define DEFINE_NACL_LIBRARY_HEADERS_INSTALLATION_TARGET
-
-$(1) := $(2)/$(NACL_LIBRARY_HEADERS_INSTALLATION_STAMP_FILE_NAME)
-
-$(2)/$(NACL_LIBRARY_HEADERS_INSTALLATION_STAMP_FILE_NAME)::
-	+$(MAKE) -C $(2) $(NACL_LIBRARY_HEADERS_INSTALLATION_STAMP_FILE_NAME)
-
-endef
-
-
-#
 # Auxiliary macro rule that adds rules for linking the resulting NaCl binaries.
 #
 # The PNaCl workflow uses both an unstripped and finalized/stripped binary; on


### PR DESCRIPTION
This commit deletes the makefile rules that implement the
installation of libraries' headers into the comment include directory.
All usages of these rules have been removed by now.

Also fix one remaining usage of common installed headers - the
//common/integration_testing library - which was incorrectly specifying
the include directories.

This completes the refactoring tracked by #132.