### PR TITLE
Suppress JS error on message port connection error

### DIFF
--- a/common/js/src/messaging/port-message-channel.js
+++ b/common/js/src/messaging/port-message-channel.js
@@ -173,7 +173,10 @@ PortMessageChannel.prototype.getPortExtensionId_ = function(port) {
 
 /** @private */
 PortMessageChannel.prototype.disconnectEventHandler_ = function() {
-  this.logger.fine('Port was disconnected, disposing...');
+  let reason = '';
+  if (chrome.runtime.lastError && chrome.runtime.lastError.message)
+    reason = ` due to '${chrome.runtime.lastError.message}'`;
+  this.logger.info(`Message port was disconnected${reason}, disposing...`);
   this.dispose();
 };
 


### PR DESCRIPTION
This commit avoids emitting the following JavaScript error in the
DevTools console in case the cross-extension message port fails to
connect:

  "Unchecked runtime.lastError: Could not establish connection.
  Receiving end does not exist."

This could happen when, for example, the middleware app tries to talk to
the Connector app, but the latter is not installed.

This commit is only a cosmetic improvement: instead of logging something
about unhandled errors, which might be confusing, an "info" log message
is printed. The actual error handling isn't affected by this commit: as
before, the connection error causes the message channel to be shut down.