### PR TITLE
libusb: Drop unused variable

### DIFF
--- a/third_party/libusb/naclport/src/libusb_over_chrome_usb.cc
+++ b/third_party/libusb/naclport/src/libusb_over_chrome_usb.cc
@@ -1134,10 +1134,8 @@ LibusbOverChromeUsb::TransferAsyncRequestCallback
 LibusbOverChromeUsb::WrapLibusbTransferCallback(libusb_transfer* transfer) {
   GOOGLE_SMART_CARD_CHECK(transfer);
 
-  libusb_context* const context = GetLibusbTransferContextChecked(transfer);
-
-  return [this, transfer,
-          context](RequestResult<chrome_usb::TransferResult> request_result) {
+  return [this,
+          transfer](RequestResult<chrome_usb::TransferResult> request_result) {
     if (request_result.is_successful()) {
       //
       // Note that the control transfers have a special libusb_control_setup


### PR DESCRIPTION
This commit is a small cleanup: an unused variable is deleted from
LibusbOverChromeUsb::WrapLibusbTransferCallback().

This is a preparation for migrating the libusb library port to
Emscripten, since the latter's compiler detects the unused lambda
capture as a warning (causing a compilation error).