### PR TITLE
ccid: Enable compilation under Emscripten

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ example_cpp_smart_card_client_app/build: third_party/pcsc-lite/naclport/cpp_demo
 TEST_TARGETS := \
 	common/cpp/build/tests \
 	common/js/build/unittests \
+	third_party/ccid/naclport/build \
 	third_party/libusb/naclport/build/js_unittests \
 	third_party/libusb/naclport/build/tests \
 	third_party/pcsc-lite/naclport/server_clients_management/build/js_unittests \
@@ -72,7 +73,6 @@ else ifeq ($(TOOLCHAIN),pnacl)
 
 TARGETS += \
 	smart_card_connector_app/build \
-	third_party/ccid/naclport/build \
 	third_party/pcsc-lite/naclport/server/build \
 	third_party/pcsc-lite/naclport/server_clients_management/build \
 
@@ -82,7 +82,6 @@ smart_card_connector_app/build: third_party/libusb/naclport/build
 smart_card_connector_app/build: third_party/pcsc-lite/naclport/common/build
 smart_card_connector_app/build: third_party/pcsc-lite/naclport/server/build
 smart_card_connector_app/build: third_party/pcsc-lite/naclport/server_clients_management/build
-third_party/ccid/naclport/build: third_party/libusb/naclport/build
 third_party/pcsc-lite/naclport/server/build: third_party/libusb/naclport/build
 third_party/pcsc-lite/naclport/server_clients_management/build: third_party/pcsc-lite/naclport/server/build
 


### PR DESCRIPTION
This commit enables compiling the CCID Free Software Driver in the
Emscripten/WebAssembly mode.

The code in this driver is a pure C code that doesn't use itself
low-level OS interfaces (like direct USB access), which is why it can
be compiled using Emscripten without code adaptations.

This commit contributes to the Emscripten/WebAssembly migration
effort tracked by #233.