### PR TITLE
pcsc-lite: Migrate server/daemon to Emscripten

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ TARGETS := \
 	third_party/pcsc-lite/naclport/common/build \
 	third_party/pcsc-lite/naclport/cpp_client/build \
 	third_party/pcsc-lite/naclport/cpp_demo/build \
+	third_party/pcsc-lite/naclport/server/build \
 
 example_cpp_smart_card_client_app/build: common/cpp/build
 example_cpp_smart_card_client_app/build: third_party/pcsc-lite/naclport/common/build
@@ -73,7 +74,6 @@ else ifeq ($(TOOLCHAIN),pnacl)
 TARGETS += \
 	smart_card_connector_app/build \
 	third_party/ccid/naclport/build \
-	third_party/pcsc-lite/naclport/server/build \
 	third_party/pcsc-lite/naclport/server_clients_management/build \
 
 smart_card_connector_app/build: common/cpp/build
@@ -83,7 +83,6 @@ smart_card_connector_app/build: third_party/pcsc-lite/naclport/common/build
 smart_card_connector_app/build: third_party/pcsc-lite/naclport/server/build
 smart_card_connector_app/build: third_party/pcsc-lite/naclport/server_clients_management/build
 third_party/ccid/naclport/build: third_party/libusb/naclport/build
-third_party/pcsc-lite/naclport/server/build: third_party/libusb/naclport/build
 third_party/pcsc-lite/naclport/server_clients_management/build: third_party/pcsc-lite/naclport/server/build
 
 TEST_TARGETS += \

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ TARGETS := \
 	example_cpp_smart_card_client_app/build \
 	example_js_smart_card_client_app/build \
 	example_js_standalone_smart_card_client_library \
+	third_party/ccid/naclport/build \
 	third_party/libusb/naclport/build \
 	third_party/pcsc-lite/naclport/common/build \
 	third_party/pcsc-lite/naclport/cpp_client/build \
@@ -46,7 +47,6 @@ example_cpp_smart_card_client_app/build: third_party/pcsc-lite/naclport/cpp_demo
 TEST_TARGETS := \
 	common/cpp/build/tests \
 	common/js/build/unittests \
-	third_party/ccid/naclport/build \
 	third_party/libusb/naclport/build/js_unittests \
 	third_party/libusb/naclport/build/tests \
 	third_party/pcsc-lite/naclport/server_clients_management/build/js_unittests \
@@ -67,6 +67,7 @@ TARGETS += \
 	third_party/googletest/webport/build \
 
 common/cpp/build/tests: third_party/googletest/webport/build
+third_party/libusb/naclport/build/tests: third_party/googletest/webport/build
 
 else ifeq ($(TOOLCHAIN),pnacl)
 
@@ -74,8 +75,6 @@ else ifeq ($(TOOLCHAIN),pnacl)
 
 TARGETS += \
 	smart_card_connector_app/build \
-	third_party/ccid/naclport/build \
-	third_party/pcsc-lite/naclport/server/build \
 	third_party/pcsc-lite/naclport/server_clients_management/build \
 
 smart_card_connector_app/build: common/cpp/build
@@ -84,8 +83,6 @@ smart_card_connector_app/build: third_party/libusb/naclport/build
 smart_card_connector_app/build: third_party/pcsc-lite/naclport/common/build
 smart_card_connector_app/build: third_party/pcsc-lite/naclport/server/build
 smart_card_connector_app/build: third_party/pcsc-lite/naclport/server_clients_management/build
-third_party/ccid/naclport/build: third_party/libusb/naclport/build
-third_party/pcsc-lite/naclport/server/build: third_party/libusb/naclport/build
 third_party/pcsc-lite/naclport/server_clients_management/build: third_party/pcsc-lite/naclport/server/build
 
 TEST_TARGETS += \

--- a/smart_card_connector_app/src/pp_module.cc
+++ b/smart_card_connector_app/src/pp_module.cc
@@ -57,7 +57,8 @@ class PpInstance final : public pp::Instance {
         libusb_over_chrome_usb_global_(
             MakeUnique<LibusbOverChromeUsbGlobal>(global_context_.get(),
                                                   &typed_message_router_)),
-        pcsc_lite_server_global_(new PcscLiteServerGlobal(this)) {
+        pcsc_lite_server_global_(
+            MakeUnique<PcscLiteServerGlobal>(global_context_.get())) {
     typed_message_router_.AddRoute(&external_logs_printer_);
 
     StartServicesInitialization();

--- a/smart_card_connector_app/src/pp_module.cc
+++ b/smart_card_connector_app/src/pp_module.cc
@@ -72,7 +72,6 @@ class PpInstance final : public pp::Instance {
     global_context_.release();
     libusb_over_chrome_usb_global_->Detach();
     libusb_over_chrome_usb_global_.release();
-    pcsc_lite_server_global_->Detach();
     pcsc_lite_server_global_.release();
   }
 


### PR DESCRIPTION
This commit allows to compile the "pcsc_lite_server" component
(which is a webport of the PC/SC-Lite daemon) under Emscripten.

Brief overview of the changes:
* Replace the usage of Native Client specific pp::Instance class with
  the toolchain-agnostic GlobalContext class;
* Replace the usage of Native Client specific pp::Var* classes with
  the toolchain-independent Value class;
* Drop unneeded dependency on the compilation of "libusb" (it's not
  required since the change that disabled installation of libusb headers
  into a common directory);
* Change the top-level makefile to compile the server regardless of the
  chosen toolchain.

This commit contributes to the Emscripten/WebAssembly migration effort,
as tracked by #233.