### PR TITLE
Enable more Emscripten debugging capabilities

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -102,10 +102,18 @@ else ifeq ($(CONFIG),Debug)
 #
 # Explanation:
 # O0: Disable optimizations.
-# g: Preserve debug information.
+# g4: Preserve maximum debug information, including source maps.
+# ASSERTIONS: Enable runtime checks, like for memory allocation errors.
+# DEMANGLE_SUPPORT: Demangle C++ function names in stack traces.
+# EXCEPTION_DEBUG: Enables printing exceptions coming from the executable.
+# SAFE_HEAP: Enable memory access checks.
 EMSCRIPTEN_FLAGS += \
   -O0 \
-  -g \
+  -g4 \
+  -s ASSERTIONS=2 \
+  -s DEMANGLE_SUPPORT=1 \
+  -s EXCEPTION_DEBUG=1 \
+  -s SAFE_HEAP=1 \
 
 else
 


### PR DESCRIPTION
This commit enables several Emscripten debugging features when the code
is compiled in the CONFIG=Debug mode.

These debugging features (more extensive debug symbols, runtime memory
access checks, etc.) will aid developers to debug the applications.
There's no change for the Release builds, since many of these checks
introduce a significant runtime overhead.

This commit contributes to the WebAssembly migration effort, as tracked
by #177.