### PR TITLE
Make clean-all.sh preserve env by default

### DIFF
--- a/clean-all.sh
+++ b/clean-all.sh
@@ -15,7 +15,8 @@
 # limitations under the License.
 
 # This script removes the temporary files and output files produced by building
-# of the libraries and Apps of this project, and clears the env.
+# of the libraries and Apps of this project. Optionally, if the "-f" flag is
+# specified, it clears the SDKs stored under //env/ as well.
 #
 # Note: the env/activate file must be source'd into the shell before this script
 # execution.

--- a/clean-all.sh
+++ b/clean-all.sh
@@ -72,10 +72,25 @@ clean_env() {
 SCRIPTPATH=$(dirname $(realpath ${0}))
 cd ${SCRIPTPATH}
 
+force_env_clean=0
+while getopts ":f" opt; do
+  case $opt in
+    f)
+      force_env_clean=1
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
 for dir in ${DIRS}; do
 	clean_dir_with_all_configs ${dir}
 done
 clean_built_app_packages
-clean_env
+if [ "${force_env_clean}" -eq "1" ]; then
+	clean_env
+fi
 
 log_message "Cleaning finished."


### PR DESCRIPTION
Change the //clean-all.sh script to keep the //env intact by default.
This means that the SDKs downloaded by the //env/initialize.sh script
(Emscripten and Native Client SDK) are preserved.

This makes the clean-all.sh script more convenient to use, since
developers usually need to delete intermediate build artifacts but not
SDKs, and reinitializing SDKs is a time-consuming step.

The "-f" option is also added that reverts to the old behavior, cleaning
both build artifacts and the env.