### PR TITLE
Add conversion of Value to/from nullptr

### DIFF
--- a/common/cpp/src/google_smart_card_common/value_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion.cc
@@ -17,6 +17,7 @@
 #include <inttypes.h>
 #include <stdint.h>
 
+#include <cstddef>
 #include <limits>
 #include <string>
 #include <utility>

--- a/common/cpp/src/google_smart_card_common/value_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion.cc
@@ -325,6 +325,19 @@ bool ConvertFromValue(Value value,
 }
 
 bool ConvertFromValue(Value value,
+                      nullptr_t* /*null*/,
+                      std::string* error_message) {
+  if (value.is_null()) {
+    // No data needs to be written into `*null`.
+    return true;
+  }
+  FormatPrintfTemplateAndSet(
+      error_message, internal::kErrorWrongTypeValueConversion,
+      Value::kNullTypeTitle, DebugDumpValueSanitized(value).c_str());
+  return false;
+}
+
+bool ConvertFromValue(Value value,
                       std::vector<uint8_t>* bytes,
                       std::string* error_message) {
   if (value.is_binary()) {

--- a/common/cpp/src/google_smart_card_common/value_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion.cc
@@ -325,7 +325,7 @@ bool ConvertFromValue(Value value,
 }
 
 bool ConvertFromValue(Value value,
-                      nullptr_t* /*null*/,
+                      std::nullptr_t* /*null*/,
                       std::string* error_message) {
   if (value.is_null()) {
     // No data needs to be written into `*null`.

--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -489,6 +489,14 @@ inline bool ConvertToValue(std::string characters,
   return true;
 }
 
+// Converts `nullptr_t` into a null `Value`.
+inline bool ConvertToValue(nullptr_t /*null*/,
+                           Value* value,
+                           std::string* /*error_message*/ = nullptr) {
+  *value = Value();
+  return true;
+}
+
 // Forbid conversion of pointers other than `const char*`. Without this deleted
 // overload, the `bool`-argument overload would be silently picked up.
 bool ConvertToValue(const void* pointer_value,
@@ -606,6 +614,11 @@ bool ConvertFromValue(Value value,
                       std::string* error_message = nullptr);
 bool ConvertFromValue(Value value,
                       std::string* characters,
+                      std::string* error_message = nullptr);
+
+// Verifies that the `value` is null.
+bool ConvertFromValue(Value value,
+                      nullptr_t* null,
                       std::string* error_message = nullptr);
 
 // Converts from a string `Value` into an enum. The enum type has to be

--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -26,6 +26,7 @@
 //   `Value`, in case it's within the range of precisely representable numbers);
 // * `double`;
 // * `std::string`;
+// * `std::nullptr_t` (converts to/from a null `Value`);
 // * `std::vector` of any supported type (note: there's also a special case that
 //    `std::vector<uint8_t>` is converted to/from a binary `Value` and can
 //    additionally be converted from an array `Value`).
@@ -41,6 +42,7 @@
 
 #include <stdint.h>
 
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <type_traits>

--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -489,8 +489,8 @@ inline bool ConvertToValue(std::string characters,
   return true;
 }
 
-// Converts `nullptr_t` into a null `Value`.
-inline bool ConvertToValue(nullptr_t /*null*/,
+// Converts `std::nullptr_t` into a null `Value`.
+inline bool ConvertToValue(std::nullptr_t /*null*/,
                            Value* value,
                            std::string* /*error_message*/ = nullptr) {
   *value = Value();
@@ -618,7 +618,7 @@ bool ConvertFromValue(Value value,
 
 // Verifies that the `value` is null.
 bool ConvertFromValue(Value value,
-                      nullptr_t* null,
+                      std::nullptr_t* null,
                       std::string* error_message = nullptr);
 
 // Converts from a string `Value` into an enum. The enum type has to be

--- a/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
@@ -1075,6 +1075,47 @@ TEST(ValueConversion, ValueToStringError) {
   EXPECT_FALSE(ConvertFromValue(Value(123), &converted));
 }
 
+TEST(ValueConversion, NullptrToValue) {
+  std::string error_message;
+  Value value;
+  EXPECT_TRUE(ConvertToValue(nullptr, &value, &error_message));
+  EXPECT_TRUE(error_message.empty());
+  EXPECT_TRUE(value.is_null());
+}
+
+TEST(ValueConversion, ValueToNullptr) {
+  {
+    std::string error_message;
+    nullptr_t converted;
+    EXPECT_TRUE(ConvertFromValue(Value(), &converted, &error_message));
+    EXPECT_TRUE(error_message.empty());
+  }
+
+  {
+    nullptr_t converted;
+    EXPECT_TRUE(ConvertFromValue(Value(), &converted));
+  }
+}
+
+TEST(ValueConversion, ValueToNullptrError) {
+  nullptr_t converted;
+
+  {
+    std::string error_message;
+    EXPECT_FALSE(ConvertFromValue(Value(false), &converted, &error_message));
+#ifdef NDEBUG
+    EXPECT_EQ(error_message,
+              "Expected value of type null, instead got: boolean");
+#else
+    EXPECT_EQ(error_message, "Expected value of type null, instead got: false");
+#endif
+  }
+
+  EXPECT_FALSE(ConvertFromValue(Value(123), &converted));
+
+  EXPECT_FALSE(ConvertFromValue(Value("foo"), &converted));
+}
+
 TEST(ValueConversion, EnumToValue) {
   {
     std::string error_message;

--- a/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
@@ -16,6 +16,7 @@
 
 #include <stdint.h>
 
+#include <cstddef>
 #include <limits>
 #include <string>
 #include <utility>

--- a/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
@@ -1086,19 +1086,19 @@ TEST(ValueConversion, NullptrToValue) {
 TEST(ValueConversion, ValueToNullptr) {
   {
     std::string error_message;
-    nullptr_t converted;
+    std::nullptr_t converted;
     EXPECT_TRUE(ConvertFromValue(Value(), &converted, &error_message));
     EXPECT_TRUE(error_message.empty());
   }
 
   {
-    nullptr_t converted;
+    std::nullptr_t converted;
     EXPECT_TRUE(ConvertFromValue(Value(), &converted));
   }
 }
 
 TEST(ValueConversion, ValueToNullptrError) {
-  nullptr_t converted;
+  std::nullptr_t converted;
 
   {
     std::string error_message;


### PR DESCRIPTION
Implement a special case in the to/from Value conversions that converts
a null value into nullptr and vice versa.

This is a "fake" conversion in the sense that it's only used to denote
the type being null - there's no other payload involved. This special
case will be used in follow-up commits in order to support functions
whose input or output argument must always be null (such functions exist
in the PC/SC-Lite API). Previously, the Native Client's pp::Var::Null
type has been used for such arguments, but this commit adds a
toolchain-independent alternative that can be used in WebAssembly
builds.

This commit contributes to the Emscripten/WebAssembly migration effort
tracked by #185.