### PR TITLE
Migrate client_request_processor.{h,cc} to Value

### DIFF
--- a/common/cpp/src/google_smart_card_common/value_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion.cc
@@ -17,6 +17,7 @@
 #include <inttypes.h>
 #include <stdint.h>
 
+#include <cstddef>
 #include <limits>
 #include <string>
 #include <utility>

--- a/common/cpp/src/google_smart_card_common/value_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion.cc
@@ -325,6 +325,19 @@ bool ConvertFromValue(Value value,
 }
 
 bool ConvertFromValue(Value value,
+                      nullptr_t* /*null*/,
+                      std::string* error_message) {
+  if (value.is_null()) {
+    // No data needs to be written into `*null`.
+    return true;
+  }
+  FormatPrintfTemplateAndSet(
+      error_message, internal::kErrorWrongTypeValueConversion,
+      Value::kNullTypeTitle, DebugDumpValueSanitized(value).c_str());
+  return false;
+}
+
+bool ConvertFromValue(Value value,
                       std::vector<uint8_t>* bytes,
                       std::string* error_message) {
   if (value.is_binary()) {

--- a/common/cpp/src/google_smart_card_common/value_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion.cc
@@ -325,7 +325,7 @@ bool ConvertFromValue(Value value,
 }
 
 bool ConvertFromValue(Value value,
-                      nullptr_t* /*null*/,
+                      std::nullptr_t* /*null*/,
                       std::string* error_message) {
   if (value.is_null()) {
     // No data needs to be written into `*null`.

--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -489,6 +489,14 @@ inline bool ConvertToValue(std::string characters,
   return true;
 }
 
+// Converts `nullptr_t` into a null `Value`.
+inline bool ConvertToValue(nullptr_t /*null*/,
+                           Value* value,
+                           std::string* /*error_message*/ = nullptr) {
+  *value = Value();
+  return true;
+}
+
 // Forbid conversion of pointers other than `const char*`. Without this deleted
 // overload, the `bool`-argument overload would be silently picked up.
 bool ConvertToValue(const void* pointer_value,
@@ -606,6 +614,11 @@ bool ConvertFromValue(Value value,
                       std::string* error_message = nullptr);
 bool ConvertFromValue(Value value,
                       std::string* characters,
+                      std::string* error_message = nullptr);
+
+// Verifies that the `value` is null.
+bool ConvertFromValue(Value value,
+                      nullptr_t* null,
                       std::string* error_message = nullptr);
 
 // Converts from a string `Value` into an enum. The enum type has to be

--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -26,6 +26,7 @@
 //   `Value`, in case it's within the range of precisely representable numbers);
 // * `double`;
 // * `std::string`;
+// * `std::nullptr_t` (converts to/from a null `Value`);
 // * `std::vector` of any supported type (note: there's also a special case that
 //    `std::vector<uint8_t>` is converted to/from a binary `Value` and can
 //    additionally be converted from an array `Value`).
@@ -41,6 +42,7 @@
 
 #include <stdint.h>
 
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <type_traits>

--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -489,8 +489,8 @@ inline bool ConvertToValue(std::string characters,
   return true;
 }
 
-// Converts `nullptr_t` into a null `Value`.
-inline bool ConvertToValue(nullptr_t /*null*/,
+// Converts `std::nullptr_t` into a null `Value`.
+inline bool ConvertToValue(std::nullptr_t /*null*/,
                            Value* value,
                            std::string* /*error_message*/ = nullptr) {
   *value = Value();
@@ -618,7 +618,7 @@ bool ConvertFromValue(Value value,
 
 // Verifies that the `value` is null.
 bool ConvertFromValue(Value value,
-                      nullptr_t* null,
+                      std::nullptr_t* null,
                       std::string* error_message = nullptr);
 
 // Converts from a string `Value` into an enum. The enum type has to be

--- a/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
@@ -1075,6 +1075,47 @@ TEST(ValueConversion, ValueToStringError) {
   EXPECT_FALSE(ConvertFromValue(Value(123), &converted));
 }
 
+TEST(ValueConversion, NullptrToValue) {
+  std::string error_message;
+  Value value;
+  EXPECT_TRUE(ConvertToValue(nullptr, &value, &error_message));
+  EXPECT_TRUE(error_message.empty());
+  EXPECT_TRUE(value.is_null());
+}
+
+TEST(ValueConversion, ValueToNullptr) {
+  {
+    std::string error_message;
+    nullptr_t converted;
+    EXPECT_TRUE(ConvertFromValue(Value(), &converted, &error_message));
+    EXPECT_TRUE(error_message.empty());
+  }
+
+  {
+    nullptr_t converted;
+    EXPECT_TRUE(ConvertFromValue(Value(), &converted));
+  }
+}
+
+TEST(ValueConversion, ValueToNullptrError) {
+  nullptr_t converted;
+
+  {
+    std::string error_message;
+    EXPECT_FALSE(ConvertFromValue(Value(false), &converted, &error_message));
+#ifdef NDEBUG
+    EXPECT_EQ(error_message,
+              "Expected value of type null, instead got: boolean");
+#else
+    EXPECT_EQ(error_message, "Expected value of type null, instead got: false");
+#endif
+  }
+
+  EXPECT_FALSE(ConvertFromValue(Value(123), &converted));
+
+  EXPECT_FALSE(ConvertFromValue(Value("foo"), &converted));
+}
+
 TEST(ValueConversion, EnumToValue) {
   {
     std::string error_message;

--- a/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
@@ -16,6 +16,7 @@
 
 #include <stdint.h>
 
+#include <cstddef>
 #include <limits>
 #include <string>
 #include <utility>

--- a/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
@@ -1086,19 +1086,19 @@ TEST(ValueConversion, NullptrToValue) {
 TEST(ValueConversion, ValueToNullptr) {
   {
     std::string error_message;
-    nullptr_t converted;
+    std::nullptr_t converted;
     EXPECT_TRUE(ConvertFromValue(Value(), &converted, &error_message));
     EXPECT_TRUE(error_message.empty());
   }
 
   {
-    nullptr_t converted;
+    std::nullptr_t converted;
     EXPECT_TRUE(ConvertFromValue(Value(), &converted));
   }
 }
 
 TEST(ValueConversion, ValueToNullptrError) {
-  nullptr_t converted;
+  std::nullptr_t converted;
 
   {
     std::string error_message;

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.cc
@@ -570,7 +570,7 @@ GenericRequestResult PcscLiteClientRequestProcessor::SCardStatus(
     return ReturnValues(return_code);
   const std::string reader_name_copy = reader_name;
   FreeSCardMemory(reader_name);
-  std::vector<uint8_t> atr_copy(atr, atr + atr_length);
+  const std::vector<uint8_t> atr_copy(atr, atr + atr_length);
   FreeSCardMemory(atr);
   return ReturnValues(return_code, reader_name_copy, state, protocol, atr_copy);
 }

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h
@@ -28,6 +28,7 @@
 
 #include <stdint.h>
 
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <string>
@@ -39,15 +40,13 @@
 #include <winscard.h>
 #include <wintypes.h>
 
-#include <ppapi/cpp/var.h>
-#include <ppapi/cpp/var_array.h>
-
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/optional.h>
 #include <google_smart_card_common/requesting/remote_call_message.h>
 #include <google_smart_card_common/requesting/request_receiver.h>
 #include <google_smart_card_common/requesting/request_result.h>
 #include <google_smart_card_common/tuple_unpacking.h>
+#include <google_smart_card_common/value.h>
 #include <google_smart_card_pcsc_lite_common/scard_structs_serialization.h>
 
 #include "client_handles_registry.h"
@@ -134,7 +133,7 @@ class PcscLiteClientRequestProcessor final
 
  private:
   using Handler =
-      std::function<GenericRequestResult(const pp::VarArray& arguments)>;
+      std::function<GenericRequestResult(std::vector<Value> arguments)>;
   using HandlerMap = std::unordered_map<std::string, Handler>;
 
   void BuildHandlerMap();
@@ -146,18 +145,20 @@ class PcscLiteClientRequestProcessor final
           Args... args));
 
   template <typename ArgsTuple, typename F, size_t... arg_indexes>
-  Handler WrapHandler(F handler, ArgIndexes<arg_indexes...> /*unused*/);
+  Handler WrapHandler(const std::string& name,
+                      F handler,
+                      ArgIndexes<arg_indexes...> /*unused*/);
 
   GenericRequestResult FindHandlerAndCall(const std::string& function_name,
-                                          const pp::VarArray& arguments);
+                                          std::vector<Value> arguments);
 
   void ScheduleHandlesCleanup();
 
   GenericRequestResult PcscLiteVersionNumber();
   GenericRequestResult PcscStringifyError(LONG error);
   GenericRequestResult SCardEstablishContext(DWORD scope,
-                                             pp::Var::Null reserved_1,
-                                             pp::Var::Null reserved_2);
+                                             std::nullptr_t reserved_1,
+                                             std::nullptr_t reserved_2);
   GenericRequestResult SCardReleaseContext(SCARDCONTEXT s_card_context);
   GenericRequestResult SCardConnect(SCARDCONTEXT s_card_context,
                                     const std::string& reader_name,
@@ -191,7 +192,7 @@ class PcscLiteClientRequestProcessor final
       const std::vector<uint8_t>& data_to_send,
       const optional<SCardIoRequest>& response_protocol_information);
   GenericRequestResult SCardListReaders(SCARDCONTEXT s_card_context,
-                                        pp::Var::Null groups);
+                                        std::nullptr_t groups);
   GenericRequestResult SCardListReaderGroups(SCARDCONTEXT s_card_context);
   GenericRequestResult SCardCancel(SCARDCONTEXT s_card_context);
   GenericRequestResult SCardIsValidContext(SCARDCONTEXT s_card_context);


### PR DESCRIPTION
Change the implementation of the PC/SC-Lite server_clients_management
client_request_processor.{h,cc} files to use the toolchain-independent
Value class instead of the Native Client specific primitives.

This contributes to the Emscripten/WebAssembly migration effort, as
tracked by #233.