### PR TITLE
Migrate ready_message.{h,cc} to Value

### DIFF
--- a/smart_card_connector_app/src/pp_module.cc
+++ b/smart_card_connector_app/src/pp_module.cc
@@ -110,9 +110,7 @@ class PpInstance final : public pp::Instance {
                                 << "initialized, posting ready message...";
     TypedMessage ready_message;
     ready_message.type = GetPcscLiteServerReadyMessageType();
-    // TODO: Directly create `Value` instead of transforming from `pp::Var`.
-    ready_message.data =
-        ConvertPpVarToValueOrDie(MakePcscLiteServerReadyMessageData());
+    ready_message.data = MakePcscLiteServerReadyMessageData();
     Value ready_message_value = ConvertToValueOrDie(std::move(ready_message));
     // TODO: Directly post `Value` instead of `pp::Var`.
     PostMessage(ConvertValueToPpVar(ready_message_value));

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/ready_message.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/ready_message.cc
@@ -25,7 +25,9 @@
 
 #include <google_smart_card_pcsc_lite_server_clients_management/ready_message.h>
 
-#include <ppapi/cpp/var_dictionary.h>
+#include <string>
+
+#include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
 
@@ -35,8 +37,8 @@ std::string GetPcscLiteServerReadyMessageType() {
   return kMessageType;
 }
 
-pp::Var MakePcscLiteServerReadyMessageData() {
-  return pp::VarDictionary();
+Value MakePcscLiteServerReadyMessageData() {
+  return Value(Value::Type::kDictionary);
 }
 
 }  // namespace google_smart_card

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/ready_message.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/ready_message.h
@@ -34,7 +34,7 @@
 
 #include <string>
 
-#include <ppapi/cpp/var.h>
+#include <google_smart_card_common/value.h>
 
 namespace google_smart_card {
 
@@ -43,7 +43,7 @@ std::string GetPcscLiteServerReadyMessageType();
 
 // Constructs the "PC/SC-Lite ready" message data (it's actually an empty
 // dictionary, but the function is here for the uniformity purpose).
-pp::Var MakePcscLiteServerReadyMessageData();
+Value MakePcscLiteServerReadyMessageData();
 
 }  // namespace google_smart_card
 


### PR DESCRIPTION
Change the implementation of the PC/SC-Lite server_clients_management
ready_message.{h,cc} files to use the toolchain-independent Value
class instead of the Native Client specific primitives.

This contributes to the Emscripten/WebAssembly migration effort, as
tracked by #233.