### PR TITLE
Support optional in RemoteCallArgumentsExtractor

### DIFF
--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.h
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.h
@@ -150,6 +150,7 @@ class RemoteCallArgumentsExtractor final {
   bool Finish();
 
  private:
+  // Attempts to convert the value with the current index into the given `arg`.
   template <typename Arg>
   void ExtractArgument(Arg* arg) {
     if (!success_)
@@ -164,6 +165,21 @@ class RemoteCallArgumentsExtractor final {
         FormatPrintfTemplate(internal::kRemoteCallArgumentConversionError,
                              static_cast<int>(current_argument_index_),
                              title_.c_str(), error_message_.c_str());
+  }
+
+  // Specialized version of the overload above that supports converting a null
+  // `Value` into a null `optional`.
+  template <typename Arg>
+  void ExtractArgument(optional<Arg>* arg) {
+    if (!success_)
+      return;
+    if (argument_values_[current_argument_index_].is_null()) {
+      arg->reset();
+      ++current_argument_index_;
+      return;
+    }
+    *arg = Arg();
+    ExtractArgument(&arg->value());
   }
 
   void VerifySufficientCount(int arguments_to_convert);


### PR DESCRIPTION
Extend the RemoteCallArgumentsExtractor class to support extracting
optional arguments: for such arguments, the Value can be equal to null,
which denotes that the optional argument is unset.

This capability will be used in follow-up commits in order to support
receiving remote calls for functions with optional arguments.

This commit contributes to the Emscripten/WebAssembly migration effort,
as tracked by #233.