### PR TITLE
Better compile error for optional-to-Value convert

### DIFF
--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -410,6 +410,12 @@ class StructValueDescriptor {
   internal::StructFromValueConverter<T>* const from_value_converter_;
 };
 
+// Explicitly forbid instantiating this class with unwanted types. Without doing
+// this, the errors will appear only at the linking stage and without mentioning
+// the place in the code that misuses this class.
+template <typename T>
+class StructValueDescriptor<optional<T>>;
+
 ///////////// ConvertToValue /////////////////////
 
 // Group of overloads that perform trivial conversions to `Value`.


### PR DESCRIPTION
Improve compilation error messages that appear when the caller misuses
the value_conversion.h file to convert a Value to/from an optional<>
object. Such conversions are intentionally unsupported (and only
supported for optional<> fields of structs and for optional<> remote
call arguments). This commit makes sure that misuses fail immediately
and provide an informative compilation error message that points to the
culprit code.

Before this commit, the failure would only occur at the linking stage,
since the optional<> class satisfies the std::is_class criteria and
therefore will accidentally be picked up by the struct-to-dictionary
conversion code.

This commit is a small developer-only improvement of the
toolchain-independent code that was added for the Emscripten/WebAssembly
project as tracked by #185.