### PR TITLE
Extract NaCl-specific entry point of Connector app

### DIFF
--- a/smart_card_connector_app/build/nacl_module/Makefile
+++ b/smart_card_connector_app/build/nacl_module/Makefile
@@ -36,10 +36,12 @@ include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/server_clients_management/inc
 include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/server_clients_management/dependency.mk
 
 
+# Common build definitions:
+
 SOURCES_DIR := ../../src
 
 SOURCES := \
-	$(SOURCES_DIR)/pp_module.cc \
+	$(SOURCES_DIR)/application.cc \
 
 LIBS := \
 	$(PCSC_LITE_SERVER_CLIENTS_MANAGEMENT_LIB) \
@@ -49,18 +51,8 @@ LIBS := \
 	$(LIBUSB_LIB) \
 	$(CPP_COMMON_LIB) \
 	$(DEFAULT_NACL_LIBS) \
-	nacl_io \
 
-DEPS := \
-	$(CCID_LIB) \
-	$(CPP_COMMON_LIB) \
-	$(LIBUSB_LIB) \
-	$(PCSC_LITE_COMMON_LIB) \
-	$(PCSC_LITE_SERVER_CLIENTS_MANAGEMENT_LIB) \
-	$(PCSC_LITE_SERVER_LIB) \
-	nacl_io \
-
-$(eval $(call DEPEND_RULE,nacl_io))
+DEPS :=
 
 CXXFLAGS := \
 	-I$(ROOT_PATH)/common/cpp/src \
@@ -73,6 +65,26 @@ CXXFLAGS := \
 	-Wno-zero-length-array \
 	-pedantic \
 	-std=$(CXX_DIALECT) \
+
+ifeq ($(TOOLCHAIN),pnacl)
+
+# Native Client specific build definitions:
+
+SOURCES += \
+	$(SOURCES_DIR)/entry_point_nacl.cc \
+
+LIBS += \
+	nacl_io \
+
+DEPS += \
+	nacl_io \
+
+$(eval $(call DEPEND_RULE,nacl_io))
+
+endif
+
+
+# Common build rules:
 
 $(foreach src,$(SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
 

--- a/smart_card_connector_app/src/application.cc
+++ b/smart_card_connector_app/src/application.cc
@@ -1,0 +1,84 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "application.h"
+
+#include <functional>
+#include <thread>
+#include <utility>
+
+#include <google_smart_card_common/global_context.h>
+#include <google_smart_card_common/logging/logging.h>
+#include <google_smart_card_common/messaging/typed_message.h>
+#include <google_smart_card_common/messaging/typed_message_router.h>
+#include <google_smart_card_common/unique_ptr_utils.h>
+#include <google_smart_card_common/value.h>
+#include <google_smart_card_common/value_conversion.h>
+#include <google_smart_card_libusb/global.h>
+#include <google_smart_card_pcsc_lite_server/global.h>
+#include <google_smart_card_pcsc_lite_server_clients_management/backend.h>
+#include <google_smart_card_pcsc_lite_server_clients_management/ready_message.h>
+
+namespace google_smart_card {
+
+Application::Application(
+    GlobalContext* global_context,
+    TypedMessageRouter* typed_message_router,
+    std::function<void()> background_initialization_callback)
+    : global_context_(global_context),
+      typed_message_router_(typed_message_router),
+      background_initialization_callback_(background_initialization_callback),
+      libusb_over_chrome_usb_global_(
+          MakeUnique<LibusbOverChromeUsbGlobal>(global_context_,
+                                                typed_message_router_)),
+      pcsc_lite_server_global_(
+          MakeUnique<PcscLiteServerGlobal>(global_context_)) {
+  ScheduleServicesInitialization();
+}
+
+Application::~Application() {
+  // Intentionally leak objects that might still be used by background threads.
+  // Only detach them from `this` and the JavaScript side.
+  libusb_over_chrome_usb_global_->Detach();
+  libusb_over_chrome_usb_global_.release();
+  pcsc_lite_server_global_.release();
+}
+
+void Application::ScheduleServicesInitialization() {
+  // TODO(emaxx): Ensure the correct lifetime of `this`.
+  std::thread(&Application::InitializeServicesOnBackgroundThread, this)
+      .detach();
+}
+
+void Application::InitializeServicesOnBackgroundThread() {
+  GOOGLE_SMART_CARD_LOG_DEBUG << "Performing services initialization...";
+
+  if (background_initialization_callback_)
+    background_initialization_callback_();
+  pcsc_lite_server_global_->InitializeAndRunDaemonThread();
+
+  pcsc_lite_server_clients_management_backend_ =
+      MakeUnique<PcscLiteServerClientsManagementBackend>(global_context_,
+                                                         typed_message_router_);
+
+  GOOGLE_SMART_CARD_LOG_DEBUG << "All services are successfully "
+                              << "initialized, posting ready message...";
+  TypedMessage ready_message;
+  ready_message.type = GetPcscLiteServerReadyMessageType();
+  ready_message.data = MakePcscLiteServerReadyMessageData();
+  global_context_->PostMessageToJs(
+      ConvertToValueOrDie(std::move(ready_message)));
+}
+
+}  // namespace google_smart_card

--- a/smart_card_connector_app/src/application.h
+++ b/smart_card_connector_app/src/application.h
@@ -1,0 +1,65 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <functional>
+#include <memory>
+
+#include <google_smart_card_common/global_context.h>
+#include <google_smart_card_common/messaging/typed_message_router.h>
+#include <google_smart_card_libusb/global.h>
+#include <google_smart_card_pcsc_lite_server/global.h>
+#include <google_smart_card_pcsc_lite_server_clients_management/backend.h>
+
+namespace google_smart_card {
+
+// The core class of the application. This class initializes and runs the
+// PC/SC-Lite daemon, handler of client requests and other related
+// functionality.
+//
+// This class' interface is toolchain-independent; it's used by
+// toolchain-specific entry point implementations (the Emscripten and the Native
+// Client ones).
+class Application final {
+ public:
+  // Initializes and starts the application. The `typed_message_router` argument
+  // is used for subscribing to messages received from the JavaScript side. The
+  // `background_initialization_callback` callback will be executed on a
+  // background thread before any other initialization.
+  //
+  // Both `global_context` and `typed_message_router` must outlive `this`.
+  Application(GlobalContext* global_context,
+              TypedMessageRouter* typed_message_router,
+              std::function<void()> background_initialization_callback);
+
+  Application(const Application&) = delete;
+  Application& operator=(const Application&) = delete;
+
+  // Note that the destructor is not guaranteed to be called, as the framework
+  // using for running the executable may terminate it instantly.
+  ~Application();
+
+ private:
+  void ScheduleServicesInitialization();
+  void InitializeServicesOnBackgroundThread();
+
+  GlobalContext* const global_context_;
+  TypedMessageRouter* const typed_message_router_;
+  std::function<void()> background_initialization_callback_;
+  std::unique_ptr<LibusbOverChromeUsbGlobal> libusb_over_chrome_usb_global_;
+  std::unique_ptr<PcscLiteServerClientsManagementBackend>
+      pcsc_lite_server_clients_management_backend_;
+  std::unique_ptr<PcscLiteServerGlobal> pcsc_lite_server_global_;
+};
+
+}  // namespace google_smart_card


### PR DESCRIPTION
Refactor the Smart Card Connector app's core code into a Native Client
specific entry_point_nacl.cc and a toolchain-independent
application.{h,cc} piece.

This commit is a preparation for implementing another - Emscripten
specific - entry point for WebAssembly builds. This migration effort is
tracked by #233.