### PR TITLE
Build PCSC server_clients_management in Emscripten

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ TARGETS := \
 	third_party/pcsc-lite/naclport/cpp_client/build \
 	third_party/pcsc-lite/naclport/cpp_demo/build \
 	third_party/pcsc-lite/naclport/server/build \
+	third_party/pcsc-lite/naclport/server_clients_management/build \
 
 example_cpp_smart_card_client_app/build: common/cpp/build
 example_cpp_smart_card_client_app/build: third_party/pcsc-lite/naclport/common/build
@@ -75,7 +76,6 @@ else ifeq ($(TOOLCHAIN),pnacl)
 
 TARGETS += \
 	smart_card_connector_app/build \
-	third_party/pcsc-lite/naclport/server_clients_management/build \
 
 smart_card_connector_app/build: common/cpp/build
 smart_card_connector_app/build: third_party/ccid/naclport/build
@@ -83,7 +83,6 @@ smart_card_connector_app/build: third_party/libusb/naclport/build
 smart_card_connector_app/build: third_party/pcsc-lite/naclport/common/build
 smart_card_connector_app/build: third_party/pcsc-lite/naclport/server/build
 smart_card_connector_app/build: third_party/pcsc-lite/naclport/server_clients_management/build
-third_party/pcsc-lite/naclport/server_clients_management/build: third_party/pcsc-lite/naclport/server/build
 
 TEST_TARGETS += \
 	common/integration_testing/build \


### PR DESCRIPTION
This commit allows building the PC/SC-Lite server_clients_management
library in the Emscripten mode. Previously it was built only for
Native Client builds, but due to the landed series of commits it can be
compiled using any of the two toolchains now.

This commit contributes to the Emscripten/WebAssembly migration effort
tracked by #233.