### PR TITLE
Implement Emscripten entry point for Connector app

### DIFF
--- a/smart_card_connector_app/build/nacl_module/Makefile
+++ b/smart_card_connector_app/build/nacl_module/Makefile
@@ -66,7 +66,14 @@ CXXFLAGS := \
 	-pedantic \
 	-std=$(CXX_DIALECT) \
 
-ifeq ($(TOOLCHAIN),pnacl)
+ifeq ($(TOOLCHAIN),emscripten)
+
+# Emscripten specific build definitions:
+
+SOURCES += \
+	$(SOURCES_DIR)/entry_point_emscripten.cc \
+
+else ifeq ($(TOOLCHAIN),pnacl)
 
 # Native Client specific build definitions:
 

--- a/smart_card_connector_app/src/entry_point_emscripten.cc
+++ b/smart_card_connector_app/src/entry_point_emscripten.cc
@@ -78,7 +78,8 @@ class GoogleSmartCardModule final {
  private:
   std::shared_ptr<GlobalContextImplEmscripten> global_context_;
   TypedMessageRouter typed_message_router_;
-  Application application_{global_context_.get(), &typed_message_router_, /*background_initialization_callback=*/{}};
+  Application application_{global_context_.get(), &typed_message_router_,
+                           /*background_initialization_callback=*/{}};
 };
 
 }  // namespace

--- a/smart_card_connector_app/src/entry_point_emscripten.cc
+++ b/smart_card_connector_app/src/entry_point_emscripten.cc
@@ -1,0 +1,94 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains the application's entry point that is used in Emscripten
+// builds. It performs the necessary initialization and then instantiates the
+// Application class, which implements the actual functionality of the
+// PC/SC-Lite daemon.
+
+#ifndef __EMSCRIPTEN__
+#error "This file should only be used in Emscripten builds"
+#endif  // __EMSCRIPTEN__
+
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+
+#include <google_smart_card_common/global_context_impl_emscripten.h>
+#include <google_smart_card_common/optional.h>
+#include <google_smart_card_common/messaging/typed_message_router.h>
+#include <google_smart_card_common/value.h>
+#include <google_smart_card_common/value_emscripten_val_conversion.h>
+
+#include "application.h"
+
+namespace google_smart_card {
+
+namespace {
+
+// A class that is instantiated by the JavaScript code in order to start the
+// application and for exchanging messages with it.
+class GoogleSmartCardModule final {
+ public:
+  explicit GoogleSmartCardModule(emscripten::val post_message_callback)
+      : global_context_(std::make_shared<GlobalContextImplEmscripten>(
+            std::this_thread::get_id(),
+            post_message_callback)) {}
+
+  GoogleSmartCardModule(const GoogleSmartCardModule&) = delete;
+  GoogleSmartCardModule& operator=(const GoogleSmartCardModule&) = delete;
+
+  ~GoogleSmartCardModule() {
+    // Intentionally leak `global_context_` without destroying it, because there
+    // might still be background threads that access it.
+    global_context_->DisableJsCommunication();
+    new std::shared_ptr<GlobalContextImplEmscripten>(global_context_);
+  }
+
+  void OnMessageReceivedFromJs(emscripten::val message) {
+    std::string error_message;
+    optional<Value> message_value =
+        ConvertEmscriptenValToValue(message, &error_message);
+    if (!message_value) {
+      GOOGLE_SMART_CARD_LOG_FATAL
+          << "Unexpected JS message received - cannot parse: " << error_message;
+    }
+    if (!typed_message_router_.OnMessageReceived(std::move(*message_value),
+                                                 &error_message)) {
+      GOOGLE_SMART_CARD_LOG_FATAL << "Failure while handling JS message: "
+                                  << error_message;
+    }
+  }
+
+ private:
+  std::shared_ptr<GlobalContextImplEmscripten> global_context_;
+  TypedMessageRouter typed_message_router_;
+  Application application_{global_context_.get(), &typed_message_router_, /*background_initialization_callback=*/{}};
+};
+
+}  // namespace
+
+// Expose using the Emscripten's Embind functionality the
+// `GoogleSmartCardModule` class to JavaScript code.
+EMSCRIPTEN_BINDINGS(google_smart_card) {
+  emscripten::class_<GoogleSmartCardModule>("GoogleSmartCardModule")
+      .constructor<emscripten::val>()
+      .function("postMessage", &GoogleSmartCardModule::OnMessageReceivedFromJs);
+}
+
+}  // namespace google_smart_card

--- a/smart_card_connector_app/src/entry_point_nacl.cc
+++ b/smart_card_connector_app/src/entry_point_nacl.cc
@@ -17,6 +17,10 @@
 // the Application class, which implements the actual functionality of the
 // PC/SC-Lite daemon.
 
+#ifndef __native_client__
+#error "This file should only be used in Native Client builds"
+#endif  // __native_client__
+
 #include <functional>
 #include <memory>
 #include <string>


### PR DESCRIPTION
Add implementation of the C++ entry point code for the Smart Card
Connector app in Emscripten builds. This entry point implements the
necessary bootstrapping and creates the Application class that
implements the toolchain-independent PC/SC-Lite daemon functionality.

This commit contributes to the Emscripten/WebAssembly migration effort
tracked by #233.