### PR TITLE
Support Emscripten in Connector's background JS

### DIFF
--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -83,7 +83,7 @@ function createExecutableModule() {
  * @type {!GSC.ExecutableModule}
  */
 const executableModule = createExecutableModule();
-executableModule.addOnDisposeCallback(naclModuleDisposedListener);
+executableModule.addOnDisposeCallback(executableModuleDisposedListener);
 
 if (logBufferForwarderToNaclModule) {
   executableModule.getLoadPromise().then(() => {
@@ -129,13 +129,13 @@ chrome.runtime.onConnectExternal.addListener(externalConnectionListener);
 chrome.runtime.onMessageExternal.addListener(externalMessageListener);
 
 /**
- * Called when the NaCl module is disposed of.
+ * Called when the executable module is disposed of.
  */
-function naclModuleDisposedListener() {
+function executableModuleDisposedListener() {
   if (!goog.DEBUG) {
     // Trigger the fatal error in the Release mode, that will emit an error
     // message and trigger the app reload.
-    GSC.Logging.failWithLogger(logger, 'Server NaCl module was disposed of');
+    GSC.Logging.failWithLogger(logger, 'Executable module was disposed of');
   }
 }
 


### PR DESCRIPTION
Add support of Emscripten modules into the Smart Card Connector's
background page JavaScript code. With this commit, the JS behavior will
depend on the TOOLCHAIN constant (which, in turn, is filled based on the
environment variable), loading either the Emscripten or the Native
Client module.

This commit contributes to the Emscripten/WebAssembly migration effort,
as tracked by #233.