### PR TITLE
Enable C++ exceptions in Emscripten builds

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -105,6 +105,7 @@ else ifeq ($(CONFIG),Debug)
 # g4: Preserve maximum debug information, including source maps.
 # ASSERTIONS: Enable runtime checks, like for memory allocation errors.
 # DEMANGLE_SUPPORT: Demangle C++ function names in stack traces.
+# DISABLE_EXCEPTION_CATCHING: Enable support for C++ exceptions.
 # EXCEPTION_DEBUG: Enables printing exceptions coming from the executable.
 # SAFE_HEAP: Enable memory access checks.
 EMSCRIPTEN_FLAGS += \
@@ -112,6 +113,7 @@ EMSCRIPTEN_FLAGS += \
   -g4 \
   -s ASSERTIONS=2 \
   -s DEMANGLE_SUPPORT=1 \
+  -s DISABLE_EXCEPTION_CATCHING=0 \
   -s EXCEPTION_DEBUG=1 \
   -s SAFE_HEAP=1 \
 


### PR DESCRIPTION
Enable the "DISABLE_EXCEPTION_CATCHING=0" flag when compiling C++ files
under Emscripten, so that the C++ exception support is enabled.

This flag was disabled by default since it affects performance and
binary size, but we're enabling this, as smart card middleware apps
reportedly rely on C++ exceptions. We don't set the flag only for
example_cpp_smart_card_client_app, since the flag must be used
consistently, which includes the common libraries that are linked into
it.

This commit contributes to the Emscripten/WebAssembly migration effort
tracked by #220.