### PR TITLE
Fix shutdown bug in PcscLiteServerClientsManager

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
@@ -102,7 +102,8 @@ PcscLiteServerClientsManager::~PcscLiteServerClientsManager() {
 }
 
 void PcscLiteServerClientsManager::Detach() {
-  GOOGLE_SMART_CARD_CHECK(typed_message_router_);
+  if (!typed_message_router_)
+    return;
   typed_message_router_->RemoveRoute(&create_handler_message_listener_);
   typed_message_router_->RemoveRoute(&delete_handler_message_listener_);
   DeleteAllHandlers();


### PR DESCRIPTION
Fix the crash that's happening in case
PcscLiteServerClientsManager::Detach() was used, with the crash
potentially happenning during the app shutdown.

The bug is that the destructor will be calling Detach() for the second
time, meanwhile that method is asserting against being called multiple
times. The fix is to replace the assert with an early exit.

This commit contributes to the Emscripten/WebAssembly migration effort,
tracked by #233.