### PR TITLE
Omit "NaCl module" log prefix in Emscripten builds

### DIFF
--- a/common/cpp/src/google_smart_card_common/logging/logging.cc
+++ b/common/cpp/src/google_smart_card_common/logging/logging.cc
@@ -73,8 +73,11 @@ void EmitLogMessageToStderr(LogSeverity severity,
   // Prepare the whole message in advance, so that we don't mess with other
   // threads writing to std::cerr too.
   std::ostringstream stream;
-  stream << "[NaCl module " << StringifyLogSeverity(severity) << "] "
-         << message_text << std::endl;
+  stream << "[";
+#ifdef __native_client__
+  stream << "NaCl module ";
+#endif  // __native_client__
+  stream << StringifyLogSeverity(severity) << "] " << message_text << std::endl;
 
   std::cerr << stream.str();
   std::cerr.flush();


### PR DESCRIPTION
This commit is a cosmetic improvement of log messages from the
Emscripten modules: the "NaCl module" prefix won't be printed
anymore in non-NaCl builds.

For the background, the reason why this prefix is added under Native
Client is that the NaCl logs are redirected to Chrome's own stderr logs.
Therefore, to simplify reading the logs, we added this distinguished
prefix in NaCl builds. In Emscripten, on the contrary, such prefixes are
useless as Chrome doesn't embed Emscripten logs into its own logs.

This commit contributes to the Emscripten/WebAssembly migration effort,
as tracked by #185.