### PR TITLE
Cherry-pick PC/SC-Lite bugfix for thread function

### DIFF
--- a/docs/updating-pcsc-lite.md
+++ b/docs/updating-pcsc-lite.md
@@ -55,22 +55,27 @@ somewhat outdated version of the PC/SC-Lite daemon.
    (Hint: Pay attention to the directory structure; e.g., you should have the
    `AUTHORS` file located at `//third_party/pcsc-lite/src/AUTHORS` in the end.)
 
-4. Edit the URL and the version in the `//third_party/pcsc-lite/README.google`
+4. Apply the patches from the `//third_party/pcsc-lite/patches/` directory to
+   the files unpacked at the previous step. (Hint: We only have a single tiny
+   patch currently, so probably it's the simplest to just manually apply the
+   modification shown in that patch file.)
+
+5. Edit the URL and the version in the `//third_party/pcsc-lite/README.google`
    file.
 
-5. Compile the Smart Card Connector app and all other targets, by running the
+6. Compile the Smart Card Connector app and all other targets, by running the
    `make-all.sh` script.
 
-6. In case of any errors discovered at the previous step, investigate and fix
+7. In case of any errors discovered at the previous step, investigate and fix
    them. (Hint: In case a new file was created in the daemon, you have to add it
    into `//third_party/pcsc-lite/naclport/server/build/Makefile` into one of the
    sections.)
 
-7. Start the just-built Smart Card Connector app (e.g., by running `make run` in
+8. Start the just-built Smart Card Connector app (e.g., by running `make run` in
    the `//smart_card_connector/build/` directory) and perform some manual QA
    testing using physical reader(s).
 
-8. If everything is OK, prepare a commit / a Pull Request with all these
+9. If everything is OK, prepare a commit / a Pull Request with all these
    changes.
 
 Additional tasks to be performed later, when rolling out a new version of the

--- a/third_party/pcsc-lite/patches/0001-Fix-compiler-warning.patch
+++ b/third_party/pcsc-lite/patches/0001-Fix-compiler-warning.patch
@@ -1,0 +1,50 @@
+From 199f8455745654d3856251a949ad630c4d1a3c13 Mon Sep 17 00:00:00 2001
+From: Ludovic Rousseau <ludovic.rousseau@free.fr>
+Date: Thu, 2 Jul 2020 19:44:36 +0200
+Subject: [PATCH] Fix compiler warning
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+hotplug_libusb.c: In function ‘HPSearchHotPluggables’:
+hotplug_libusb.c:498:4: warning: cast between incompatible function types from ‘void (*)(int *)’ to ‘void * (*)(void *)’ [-Wcast-function-type]
+  498 |    (PCSCLITE_THREAD_FUNCTION( )) HPEstablishUSBNotifications, pipefd);
+      |    ^
+---
+ src/hotplug_libusb.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/hotplug_libusb.c b/src/hotplug_libusb.c
+index 996bc0c..22762a2 100644
+--- a/src/hotplug_libusb.c
++++ b/src/hotplug_libusb.c
+@@ -403,7 +403,7 @@ static void HPRescanUsbBus(void)
+ 	libusb_free_device_list(devs, 1);
+ }
+ 
+-static void HPEstablishUSBNotifications(int pipefd[2])
++static void * HPEstablishUSBNotifications(int pipefd[2])
+ {
+ 	int i, do_polling;
+ 	int r;
+@@ -415,7 +415,7 @@ static void HPEstablishUSBNotifications(int pipefd[2])
+ 		Log2(PCSC_LOG_CRITICAL, "libusb_init failed: %d", r);
+ 		/* emergency exit */
+ 		kill(getpid(), SIGTERM);
+-		return;
++		return NULL;
+ 	}
+ 
+ 	/* scan the USB bus for devices at startup */
+@@ -470,6 +470,8 @@ static void HPEstablishUSBNotifications(int pipefd[2])
+ 		close(rescan_pipe[0]);
+ 		rescan_pipe[0] = -1;
+ 	}
++
++	return NULL;
+ }
+ 
+ LONG HPSearchHotPluggables(void)
+-- 
+2.30.0.284.gd98b1dd5eaa7-goog
+

--- a/third_party/pcsc-lite/src/src/hotplug_libusb.c
+++ b/third_party/pcsc-lite/src/src/hotplug_libusb.c
@@ -410,7 +410,7 @@ static void HPRescanUsbBus(void)
 	libusb_free_device_list(devs, 1);
 }
 
-static void HPEstablishUSBNotifications(int pipefd[2])
+static void * HPEstablishUSBNotifications(int pipefd[2])
 {
 	int i, do_polling;
 	int r;
@@ -422,7 +422,7 @@ static void HPEstablishUSBNotifications(int pipefd[2])
 		Log2(PCSC_LOG_CRITICAL, "libusb_init failed: %d", r);
 		/* emergency exit */
 		kill(getpid(), SIGTERM);
-		return;
+		return NULL;
 	}
 
 	/* scan the USB bus for devices at startup */
@@ -477,6 +477,8 @@ static void HPEstablishUSBNotifications(int pipefd[2])
 		close(rescan_pipe[0]);
 		rescan_pipe[0] = -1;
 	}
+
+	return NULL;
 }
 
 LONG HPSearchHotPluggables(void)


### PR DESCRIPTION
Cherry-pick the following commit from the upstream PC/SC-Lite
repository:

  199f8455745654d3856251a949ad630c4d1a3c13
  Fix compiler warning

  hotplug_libusb.c: In function ‘HPSearchHotPluggables’:
  hotplug_libusb.c:498:4: warning: cast between incompatible function
  types from ‘void (*)(int *)’ to ‘void * (*)(void *)’
  [-Wcast-function-type]
    498 |    (PCSCLITE_THREAD_FUNCTION( )) HPEstablishUSBNotifications, pipefd);
        |    ^

This cherry-picked fix is necessary for the WebAssembly build of
PC/SC-Lite to work (tracking issue #233), since it fixes the wrong
function signature that's causing stack corruption when run under
Emscripten. (For some reason, this bug wasn't causing any issues
when run as a native binary or under Native Client.)

The cherry-picked patch file can be deleted once the upstream PC/SC-Lite
repository makes a new release that includes this commit.