### PR TITLE
Fix unordered move in socketpair_emulation

### DIFF
--- a/third_party/pcsc-lite/naclport/server/src/socketpair_emulation.cc
+++ b/third_party/pcsc-lite/naclport/server/src/socketpair_emulation.cc
@@ -308,8 +308,9 @@ void SocketpairEmulationManager::AddSocket(std::shared_ptr<Socket> socket) {
   GOOGLE_SMART_CARD_CHECK(socket);
   GOOGLE_SMART_CARD_CHECK(socket.unique());
   const std::unique_lock<std::mutex> lock(mutex_);
+  const int file_descriptor = socket->file_descriptor();
   GOOGLE_SMART_CARD_CHECK(
-      socket_map_.emplace(socket->file_descriptor(), std::move(socket)).second);
+      socket_map_.emplace(file_descriptor, std::move(socket)).second);
 }
 
 std::shared_ptr<SocketpairEmulationManager::Socket>


### PR DESCRIPTION
Fix a potential bug in PC/SC-Lite webport's socketpair_emulation.cc that
could lead to reading from a null shared pointer. The bug is that
std::move() and dereference are occurring within the same
sub-expression, for which C++ doesn't give guarantee about the ordering
between these two operations.

We don't have any evidence that this bug could occur in practice
(especially in the NaCl builds this code seemed to work reliable), but
it's important to fix this potential unspecified behavior anyway.