### PR TITLE
Fix missing Info.plist file build error

### DIFF
--- a/third_party/ccid/naclport/build/Makefile
+++ b/third_party/ccid/naclport/build/Makefile
@@ -155,6 +155,7 @@ Info.plist: $(CCID_SOURCES_PATH)/create_Info_plist.pl $(CCID_SUPPORTED_READERS_C
 		--version=$(CCID_VERSION) > Info.plist.build
 	@mv Info.plist.build Info.plist
 
+all: Info.plist
 $(eval $(call CLEAN_RULE,Info.plist.build))
 $(eval $(call CLEAN_RULE,Info.plist))
 


### PR DESCRIPTION
Make sure the Info.plist file is produced by the CCID webport's makefile
by default, since this file is used by other makefiles in this project.

This is a follow-up to change #302 (linked to the issue #233 that tracks
the Emscripten/WebAssembly migration), which mistakenly removed the
Info.plist file from being produced by default.