### PR TITLE
Drop unused "using" directives and declarations

### DIFF
--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
@@ -28,7 +28,6 @@
 #include <google_smart_card_common/value_conversion.h>
 
 namespace scc = smart_card_client;
-namespace ccp = scc::chrome_certificate_provider;
 namespace gsc = google_smart_card;
 
 namespace smart_card_client {

--- a/third_party/libusb/naclport/src/libusb_over_chrome_usb_unittest.cc
+++ b/third_party/libusb/naclport/src/libusb_over_chrome_usb_unittest.cc
@@ -53,7 +53,6 @@
 
 using testing::_;
 using testing::Assign;
-using testing::Eq;
 using testing::Invoke;
 using testing::InvokeWithoutArgs;
 using testing::Mock;


### PR DESCRIPTION
Delete "using" directives and declarations from C++ code where they're
not actually used. This is a pure refactoring change.

This was found via clang-tidy ("misc-unused-alias-decls" and
"misc-unused-using-decls" diagnostics).