### PR TITLE
Cleanup returning const objects

### DIFF
--- a/common/cpp/src/google_smart_card_common/formatting.cc
+++ b/common/cpp/src/google_smart_card_common/formatting.cc
@@ -29,7 +29,7 @@ constexpr size_t kInitialPrintfBufferSize = 100;
 std::string FormatPrintfTemplate(const char* format, ...) {
   va_list var_args;
   va_start(var_args, format);
-  const std::string result = FormatPrintfTemplate(format, var_args);
+  std::string result = FormatPrintfTemplate(format, var_args);
   va_end(var_args);
   return result;
 }

--- a/common/cpp/src/google_smart_card_common/multi_string.cc
+++ b/common/cpp/src/google_smart_card_common/multi_string.cc
@@ -52,7 +52,7 @@ std::vector<std::string> ExtractMultiStringElements(
   GOOGLE_SMART_CARD_CHECK(multi_string.length());
   GOOGLE_SMART_CARD_CHECK(multi_string.back() == '\0');
   const char* multi_string_end;
-  const std::vector<std::string> result =
+  std::vector<std::string> result =
       ExtractMultiStringElements(multi_string.c_str(), &multi_string_end);
   GOOGLE_SMART_CARD_CHECK(multi_string_end ==
                           multi_string.c_str() + multi_string.length());

--- a/third_party/libusb/naclport/src/libusb_contexts_storage.cc
+++ b/third_party/libusb/naclport/src/libusb_contexts_storage.cc
@@ -25,7 +25,7 @@ LibusbContextsStorage::~LibusbContextsStorage() = default;
 std::shared_ptr<libusb_context> LibusbContextsStorage::CreateContext() {
   const std::unique_lock<std::mutex> lock(mutex_);
 
-  const auto result = std::make_shared<libusb_context>();
+  auto result = std::make_shared<libusb_context>();
   GOOGLE_SMART_CARD_CHECK(mapping_.emplace(result.get(), result).second);
   return result;
 }


### PR DESCRIPTION
Make sure that non-trivial local C++ variables that are returned by
value aren't marked as "const", since this is a pessimization that
prevents move'ing the returned object. This is mostly a refactoring,
since the performance difference must be negligible in these cases.

This was found via clang-tidy ("performance-no-automatic-move"
diagnostic).