### PR TITLE
Explicitly cast unowned release() to void

### DIFF
--- a/example_cpp_smart_card_client_app/src/application.cc
+++ b/example_cpp_smart_card_client_app/src/application.cc
@@ -310,7 +310,7 @@ Application::~Application() {
   // Intentionally leak `pcsc_lite_over_requester_global_` without destroying
   // it, because there might still be background threads that access it.
   pcsc_lite_over_requester_global_->Detach();
-  pcsc_lite_over_requester_global_.release();
+  (void)pcsc_lite_over_requester_global_.release();
 
   built_in_pin_dialog_server_->Detach();
   chrome_certificate_provider_api_bridge_->Detach();

--- a/example_cpp_smart_card_client_app/src/entry_point_nacl.cc
+++ b/example_cpp_smart_card_client_app/src/entry_point_nacl.cc
@@ -79,7 +79,7 @@ class PpInstance final : public pp::Instance {
     // Intentionally leak `global_context_` without destroying it, because there
     // might still be background threads that access it.
     global_context_->DisableJsCommunication();
-    global_context_.release();
+    (void)global_context_.release();
   }
 
   // This method is called with each message received by the NaCl module from

--- a/smart_card_connector_app/src/application.cc
+++ b/smart_card_connector_app/src/application.cc
@@ -51,8 +51,8 @@ Application::~Application() {
   // Intentionally leak objects that might still be used by background threads.
   // Only detach them from `this` and the JavaScript side.
   libusb_over_chrome_usb_global_->Detach();
-  libusb_over_chrome_usb_global_.release();
-  pcsc_lite_server_global_.release();
+  (void)libusb_over_chrome_usb_global_.release();
+  (void)pcsc_lite_server_global_.release();
 }
 
 void Application::ScheduleServicesInitialization() {

--- a/smart_card_connector_app/src/entry_point_nacl.cc
+++ b/smart_card_connector_app/src/entry_point_nacl.cc
@@ -67,7 +67,7 @@ class PpInstance final : public pp::Instance {
     // Intentionally leak the global context as it might still be used by
     // background threads. Only detach it from the JavaScript side.
     global_context_->DisableJsCommunication();
-    global_context_.release();
+    (void)global_context_.release();
   }
 
   void HandleMessage(const pp::Var& message) override {

--- a/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.cc
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.cc
@@ -290,8 +290,8 @@ LONG PcscLiteOverRequester::SCardStatus(SCARDHANDLE s_card_handle,
     return reader_name_filling_result_code;
   if (atr_filling_result_code != SCARD_S_SUCCESS)
     return atr_filling_result_code;
-  reader_name_buffer_holder.release();
-  atr_buffer_holder.release();
+  (void)reader_name_buffer_holder.release();
+  (void)atr_buffer_holder.release();
   return SCARD_S_SUCCESS;
 }
 
@@ -406,7 +406,7 @@ LONG PcscLiteOverRequester::SCardGetAttrib(SCARDHANDLE s_card_handle,
       attribute_length, &attribute_buffer_holder);
   if (attribute_filling_result_code != SCARD_S_SUCCESS)
     return attribute_filling_result_code;
-  attribute_buffer_holder.release();
+  (void)attribute_buffer_holder.release();
   return SCARD_S_SUCCESS;
 }
 
@@ -509,7 +509,7 @@ LONG PcscLiteOverRequester::SCardListReaders(SCARDCONTEXT s_card_context,
                                 readers, readers_size, &readers_buffer_holder);
   if (readers_filling_result_code != SCARD_S_SUCCESS)
     return readers_filling_result_code;
-  readers_buffer_holder.release();
+  (void)readers_buffer_holder.release();
   return SCARD_S_SUCCESS;
 }
 
@@ -539,7 +539,7 @@ LONG PcscLiteOverRequester::SCardListReaderGroups(SCARDCONTEXT s_card_context,
                                 groups, groups_size, &groups_buffer_holder);
   if (groups_filling_result_code != SCARD_S_SUCCESS)
     return groups_filling_result_code;
-  groups_buffer_holder.release();
+  (void)groups_buffer_holder.release();
   return SCARD_S_SUCCESS;
 }
 


### PR DESCRIPTION
Add explicit casts to void in places that call
std::unique_ptr::release() without storing its result anywhere. This
clearly shows the programmer's intention, as opposed to potential places
where this could be done by mistake. This is a pure refactoring change,
made in order to improve readability and to silence the clang-tidy
diagnostic.

This was found by the "bugprone-unused-return-value" clang-tidy
diagnostic.