### PR TITLE
Make methods static when possible

### DIFF
--- a/third_party/libusb/naclport/src/libusb_over_chrome_usb.cc
+++ b/third_party/libusb/naclport/src/libusb_over_chrome_usb.cc
@@ -100,6 +100,24 @@ std::unique_ptr<uint8_t[]> CopyRawData(const std::vector<uint8_t>& data) {
   return CopyRawData(&data[0], data.size());
 }
 
+libusb_context* GetLibusbTransferContext(const libusb_transfer* transfer) {
+  if (!transfer)
+    return nullptr;
+  libusb_device_handle* const device_handle = transfer->dev_handle;
+  if (!device_handle)
+    return nullptr;
+  return device_handle->context();
+}
+
+libusb_context* GetLibusbTransferContextChecked(
+    const libusb_transfer* transfer) {
+  GOOGLE_SMART_CARD_CHECK(transfer);
+
+  libusb_context* const result = GetLibusbTransferContext(transfer);
+  GOOGLE_SMART_CARD_CHECK(result);
+  return result;
+}
+
 }  // namespace
 
 LibusbOverChromeUsb::LibusbOverChromeUsb(
@@ -1105,25 +1123,6 @@ libusb_context* LibusbOverChromeUsb::SubstituteDefaultContextIfNull(
   if (context_or_nullptr)
     return context_or_nullptr;
   return default_context_.get();
-}
-
-libusb_context* LibusbOverChromeUsb::GetLibusbTransferContext(
-    const libusb_transfer* transfer) const {
-  if (!transfer)
-    return nullptr;
-  libusb_device_handle* const device_handle = transfer->dev_handle;
-  if (!device_handle)
-    return nullptr;
-  return device_handle->context();
-}
-
-libusb_context* LibusbOverChromeUsb::GetLibusbTransferContextChecked(
-    const libusb_transfer* transfer) const {
-  GOOGLE_SMART_CARD_CHECK(transfer);
-
-  libusb_context* const result = GetLibusbTransferContext(transfer);
-  GOOGLE_SMART_CARD_CHECK(result);
-  return result;
 }
 
 LibusbOverChromeUsb::TransferAsyncRequestCallback

--- a/third_party/libusb/naclport/src/libusb_over_chrome_usb.h
+++ b/third_party/libusb/naclport/src/libusb_over_chrome_usb.h
@@ -131,10 +131,6 @@ class LibusbOverChromeUsb final : public LibusbInterface {
 
   libusb_context* SubstituteDefaultContextIfNull(
       libusb_context* context_or_nullptr) const;
-  libusb_context* GetLibusbTransferContext(
-      const libusb_transfer* transfer) const;
-  libusb_context* GetLibusbTransferContextChecked(
-      const libusb_transfer* transfer) const;
   TransferAsyncRequestCallback WrapLibusbTransferCallback(
       libusb_transfer* transfer);
   int LibusbHandleEventsWithTimeout(libusb_context* context,

--- a/third_party/libusb/naclport/src/libusb_over_chrome_usb_unittest.cc
+++ b/third_party/libusb/naclport/src/libusb_over_chrome_usb_unittest.cc
@@ -428,7 +428,6 @@ class LibusbOverChromeUsbTransfersTest
 
   static void SetUpTransferCallbackMockExpectations(
       size_t transfer_index,
-      bool /*is_output*/,
       bool is_canceled,
       MockFunction<void(libusb_transfer_status)>* transfer_callback) {
     EXPECT_CALL(*transfer_callback,
@@ -437,7 +436,6 @@ class LibusbOverChromeUsbTransfersTest
 
   static void SetUpTransferCallbackMockExpectations(
       size_t transfer_index,
-      bool /*is_output*/,
       bool is_canceled,
       MockFunction<void(libusb_transfer_status)>* transfer_callback,
       int* completed) {
@@ -652,8 +650,7 @@ TEST_P(LibusbOverChromeUsbSingleTransferTest, AsyncControlTransfer) {
   chrome_usb_transfer_resolver();
 
   ASSERT_TRUE(Mock::VerifyAndClearExpectations(&transfer_callback));
-  SetUpTransferCallbackMockExpectations(GetParam().transfer_index,
-                                        GetParam().is_transfer_output, false,
+  SetUpTransferCallbackMockExpectations(GetParam().transfer_index, false,
                                         &transfer_callback);
   libusb_over_chrome_usb->LibusbHandleEvents(nullptr);
 }
@@ -693,9 +690,9 @@ TEST_P(LibusbOverChromeUsbSingleTransferTest, AsyncTransferCancellation) {
   }
 
   ASSERT_TRUE(Mock::VerifyAndClearExpectations(&transfer_callback));
-  SetUpTransferCallbackMockExpectations(
-      GetParam().transfer_index, GetParam().is_transfer_output,
-      is_cancellation_successful, &transfer_callback);
+  SetUpTransferCallbackMockExpectations(GetParam().transfer_index,
+                                        is_cancellation_successful,
+                                        &transfer_callback);
   libusb_over_chrome_usb->LibusbHandleEvents(nullptr);
 }
 
@@ -733,11 +730,9 @@ TEST_P(LibusbOverChromeUsbSingleTransferTest,
 
   ASSERT_TRUE(Mock::VerifyAndClearExpectations(&first_transfer_callback));
   ASSERT_TRUE(Mock::VerifyAndClearExpectations(&second_transfer_callback));
-  SetUpTransferCallbackMockExpectations(GetParam().transfer_index,
-                                        GetParam().is_transfer_output, true,
+  SetUpTransferCallbackMockExpectations(GetParam().transfer_index, true,
                                         &first_transfer_callback);
-  SetUpTransferCallbackMockExpectations(GetParam().transfer_index,
-                                        GetParam().is_transfer_output, false,
+  SetUpTransferCallbackMockExpectations(GetParam().transfer_index, false,
                                         &second_transfer_callback);
   libusb_over_chrome_usb->LibusbHandleEvents(nullptr);
   libusb_over_chrome_usb->LibusbHandleEvents(nullptr);
@@ -905,8 +900,7 @@ TEST_F(LibusbOverChromeUsbAsyncTransfersMultiThreadingTest,
 
         for (bool is_transfer_output : kBoolValues) {
           SetUpTransferCallbackMockExpectations(
-              transfer_index, is_transfer_output, false,
-              &transfer_callback[is_transfer_output],
+              transfer_index, false, &transfer_callback[is_transfer_output],
               &transfer_completed[is_transfer_output]);
           StartAsyncControlTransfer(transfer_index, is_transfer_output,
                                     &transfer_callback[is_transfer_output]);

--- a/third_party/libusb/naclport/src/libusb_over_chrome_usb_unittest.cc
+++ b/third_party/libusb/naclport/src/libusb_over_chrome_usb_unittest.cc
@@ -426,7 +426,7 @@ class LibusbOverChromeUsbTransfersTest
     return transfer;
   }
 
-  void SetUpTransferCallbackMockExpectations(
+  static void SetUpTransferCallbackMockExpectations(
       size_t transfer_index,
       bool /*is_output*/,
       bool is_canceled,
@@ -435,7 +435,7 @@ class LibusbOverChromeUsbTransfersTest
                 Call(GetExpectedTransferStatus(transfer_index, is_canceled)));
   }
 
-  void SetUpTransferCallbackMockExpectations(
+  static void SetUpTransferCallbackMockExpectations(
       size_t transfer_index,
       bool /*is_output*/,
       bool is_canceled,
@@ -518,8 +518,8 @@ class LibusbOverChromeUsbTransfersTest
     return transfer_info;
   }
 
-  std::vector<uint8_t> GenerateTransferData(size_t transfer_index,
-                                            bool is_output) {
+  static std::vector<uint8_t> GenerateTransferData(size_t transfer_index,
+                                                   bool is_output) {
     std::vector<uint8_t> result;
     result.push_back(is_output);
     while (transfer_index) {


### PR DESCRIPTION
Change a few C++ class methods to be static methods or global-namespace
functions, in cases when they don't use any of the class internal state.
This is a pure refactoring change.

This was found by clang-tidy (the
"readability-convert-member-functions-to-static" diagnostic).