### PR TITLE
Add missing header guards

### DIFF
--- a/example_cpp_smart_card_client_app/src/application.h
+++ b/example_cpp_smart_card_client_app/src/application.h
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef SMART_CARD_CLIENT_APPLICATION_H_
+#define SMART_CARD_CLIENT_APPLICATION_H_
+
 #include <memory>
 #include <mutex>
 
@@ -100,3 +103,5 @@ class Application final {
 };
 
 }  // namespace smart_card_client
+
+#endif  // SMART_CARD_CLIENT_APPLICATION_H_

--- a/smart_card_connector_app/src/application.h
+++ b/smart_card_connector_app/src/application.h
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef SMART_CARD_CONNECTOR_APP_APPLICATION_H_
+#define SMART_CARD_CONNECTOR_APP_APPLICATION_H_
+
 #include <functional>
 #include <memory>
 
@@ -63,3 +66,5 @@ class Application final {
 };
 
 }  // namespace google_smart_card
+
+#endif  // SMART_CARD_CONNECTOR_APP_APPLICATION_H_


### PR DESCRIPTION
Fix two C++ headers to have the include guard that was missing.
This is a pure refactoring change.

This was found by clang-tidy (the "llvm-header-guard" diagnostic).