### PR TITLE
Mark constructors as explicit when possible

### DIFF
--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -175,7 +175,7 @@ class StructToValueConverter final : public StructToValueConverterBase {
 // child classes.
 class StructFromValueConverterBase {
  protected:
-  StructFromValueConverterBase(Value value_to_convert);
+  explicit StructFromValueConverterBase(Value value_to_convert);
   StructFromValueConverterBase(const StructFromValueConverterBase&) = delete;
   StructFromValueConverterBase& operator=(const StructFromValueConverterBase&) =
       delete;

--- a/third_party/libusb/naclport/src/libusb_tracing_wrapper.h
+++ b/third_party/libusb/naclport/src/libusb_tracing_wrapper.h
@@ -32,7 +32,7 @@ namespace google_smart_card {
 // libusb requests that were started through it.
 class LibusbTracingWrapper : public LibusbInterface {
  public:
-  LibusbTracingWrapper(LibusbInterface* wrapped_libusb);
+  explicit LibusbTracingWrapper(LibusbInterface* wrapped_libusb);
   LibusbTracingWrapper(const LibusbTracingWrapper&) = delete;
   LibusbTracingWrapper& operator=(const LibusbTracingWrapper&) = delete;
   ~LibusbTracingWrapper();


### PR DESCRIPTION
Fix a couple of occasions where a C++ single-argument constructor
isn't marked as "explicit". This is a pure refactoring change.

This was found by clang-tidy (the "google-explicit-constructor"
diagnostic).