### PR TITLE
Avoid unnamed namespace in a header file

### DIFF
--- a/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.cc
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.cc
@@ -42,6 +42,9 @@
 
 namespace google_smart_card {
 
+// Definitions of constants declared in the .h file:
+const char kPcscLiteRequesterName[] = "pcsc_lite";
+
 namespace {
 
 constexpr char kLoggingPrefix[] = "[PC/SC-Lite over requester] ";

--- a/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.h
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.h
@@ -39,14 +39,10 @@
 
 namespace google_smart_card {
 
-namespace {
-
 // The name of the requester that should be used for the requests made by the
 // PcscLiteOverRequester class (see also the
 // google_smart_card_common/requesting/requester.h header).
-constexpr char kPcscLiteRequesterName[] = "pcsc_lite";
-
-}  // namespace
+extern const char kPcscLiteRequesterName[];
 
 // This class provides an implementation for the PC/SC-Lite client API that
 // forwards all calls through the passed requester to its counterpart library


### PR DESCRIPTION
Fix the pcsc_lite_over_requester.h header to not contain the unnamed
namespace - such namespace usage isn't canonical and can lead to symbol
duplication (across every .cc file that included it). Also, while we're
here, move the string constant from the .h file to the .cc file. This is
a pure refactoring change.

This was found by clang-tidy ("google-build-namespaces" and
"misc-definitions-in-headers" diagnostics).