### PR TITLE
Fix copy constructor signature

### DIFF
--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.h
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.h
@@ -123,7 +123,7 @@ class RemoteCallArgumentsExtractor final {
                                std::vector<Value> argument_values);
   // Same as above, but attempts to convert the given `Value` into `vector`.
   RemoteCallArgumentsExtractor(std::string title, Value arguments_as_value);
-  RemoteCallArgumentsExtractor(RemoteCallArgumentsExtractor&) = delete;
+  RemoteCallArgumentsExtractor(const RemoteCallArgumentsExtractor&) = delete;
   RemoteCallArgumentsExtractor& operator=(const RemoteCallArgumentsExtractor&) =
       delete;
   ~RemoteCallArgumentsExtractor();


### PR DESCRIPTION
Fix the RemoteCallArgumentsExtractor's class copy constructor signature
to the canonical form: const-ref instead of a non-const-ref. This is a
pure refactoring change.

This was found by the "google-runtime-references" clang-tidy diagnostic.