### PR TITLE
Add missing include for size_t

### DIFF
--- a/common/cpp/src/google_smart_card_common/tuple_unpacking.h
+++ b/common/cpp/src/google_smart_card_common/tuple_unpacking.h
@@ -15,6 +15,8 @@
 #ifndef GOOGLE_SMART_CARD_COMMON_TUPLE_UNPACKING_H_
 #define GOOGLE_SMART_CARD_COMMON_TUPLE_UNPACKING_H_
 
+#include <stddef.h>
+
 namespace google_smart_card {
 
 // Helper template class that holds a compile-time integer sequence as its


### PR DESCRIPTION
Add inclusion of stddef.h into tuple_unpacking.h, since the latter uses
size_t, which is not a built-in type but rather a definition in one of
the standard header files. This is a pure refactoring change.

This issue was highlighted by the build error when running clang-tidy.