### PR TITLE
Add missing override specifiers

### DIFF
--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_router.h
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_router.h
@@ -45,7 +45,7 @@ class TypedMessageRouter final : public MessageListener {
   TypedMessageRouter();
   TypedMessageRouter(const TypedMessageRouter&) = delete;
   TypedMessageRouter& operator=(const TypedMessageRouter&) = delete;
-  ~TypedMessageRouter();
+  ~TypedMessageRouter() override;
 
   // Adds a new listener, which will handle all messages having the type equal
   // to the GetListenedMessageType return value.

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
@@ -55,7 +55,7 @@ class IntegrationTestService final : public RequestHandler {
 
  private:
   IntegrationTestService();
-  ~IntegrationTestService();
+  ~IntegrationTestService() override;
 
   IntegrationTestHelper* FindHelperByName(const std::string& name);
   void SetUpHelper(const std::string& helper_name, Value data_for_helper);

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
@@ -97,7 +97,7 @@ class ApiBridge final : public google_smart_card::RequestHandler {
   ApiBridge(const ApiBridge&) = delete;
   ApiBridge& operator=(const ApiBridge&) = delete;
 
-  ~ApiBridge();
+  ~ApiBridge() override;
 
   void Detach();
 

--- a/third_party/libusb/naclport/src/chrome_usb/api_bridge.h
+++ b/third_party/libusb/naclport/src/chrome_usb/api_bridge.h
@@ -46,7 +46,7 @@ class ApiBridge final : public ApiBridgeInterface {
   explicit ApiBridge(std::unique_ptr<Requester> requester);
   ApiBridge(const ApiBridge&) = delete;
   ApiBridge& operator=(const ApiBridge&) = delete;
-  ~ApiBridge();
+  ~ApiBridge() override;
 
   void Detach();
 

--- a/third_party/libusb/naclport/src/libusb_over_chrome_usb.h
+++ b/third_party/libusb/naclport/src/libusb_over_chrome_usb.h
@@ -54,7 +54,7 @@ class LibusbOverChromeUsb final : public LibusbInterface {
       chrome_usb::ApiBridgeInterface* chrome_usb_api_bridge);
   LibusbOverChromeUsb(const LibusbOverChromeUsb&) = delete;
   LibusbOverChromeUsb& operator=(const LibusbOverChromeUsb&) = delete;
-  ~LibusbOverChromeUsb();
+  ~LibusbOverChromeUsb() override;
 
   // LibusbInterface:
   int LibusbInit(libusb_context** ctx) override;

--- a/third_party/libusb/naclport/src/libusb_tracing_wrapper.h
+++ b/third_party/libusb/naclport/src/libusb_tracing_wrapper.h
@@ -35,7 +35,7 @@ class LibusbTracingWrapper : public LibusbInterface {
   explicit LibusbTracingWrapper(LibusbInterface* wrapped_libusb);
   LibusbTracingWrapper(const LibusbTracingWrapper&) = delete;
   LibusbTracingWrapper& operator=(const LibusbTracingWrapper&) = delete;
-  ~LibusbTracingWrapper();
+  ~LibusbTracingWrapper() override;
 
   // LibusbInterface:
   int LibusbInit(libusb_context** ctx) override;

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.h
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.h
@@ -47,7 +47,7 @@ class PcscLiteTracingWrapper final : public PcscLite {
       LogSeverity log_severity = LogSeverity::kDebug);
   PcscLiteTracingWrapper(const PcscLiteTracingWrapper&) = delete;
   PcscLiteTracingWrapper& operator=(const PcscLiteTracingWrapper&) = delete;
-  ~PcscLiteTracingWrapper();
+  ~PcscLiteTracingWrapper() override;
 
   // PcscLite:
   LONG SCardEstablishContext(DWORD dwScope,

--- a/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.h
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.h
@@ -64,7 +64,7 @@ class PcscLiteOverRequester final : public PcscLite {
   PcscLiteOverRequester(const PcscLiteOverRequester&) = delete;
   PcscLiteOverRequester& operator=(const PcscLiteOverRequester&) = delete;
 
-  ~PcscLiteOverRequester();
+  ~PcscLiteOverRequester() override;
 
   // Detaches the linked requester, which prevents making any further requests
   // through it and prevents waiting for the responses of the already started


### PR DESCRIPTION
Add the "override" specific to C++ methods where they were missing
(mainly for destructors). This is a pure refactoring change.

This was found via clang-tidy (the "modernize-use-override" diagnostic).