### PR TITLE
Update Emscripten to 2.0.10

### DIFF
--- a/env/constants.sh
+++ b/env/constants.sh
@@ -18,7 +18,7 @@
 DEPOT_TOOLS_REPOSITORY_URL="https://chromium.googlesource.com/chromium/tools/depot_tools.git"
 
 EMSCRIPTEN_SDK_REPOSITORY_URL="https://github.com/emscripten-core/emsdk.git"
-EMSCRIPTEN_VERSION="2.0.6"
+EMSCRIPTEN_VERSION="2.0.10"
 
 NACL_SDK_VERSION="47"
 


### PR DESCRIPTION
Bump the Emscripten dependency to the latest available version - 2.0.10.
This brings a few bugfixes for some issues in the Emscripten toolchain.