### PR TITLE
Parallelize clean-all.sh

### DIFF
--- a/clean-all.sh
+++ b/clean-all.sh
@@ -41,7 +41,7 @@ clean_dir_with_toolchain_and_config() {
 	local config=${2}
 
 	log_message "Cleaning \"${toolchain}\" \"${config}\"..."
-	TOOLCHAIN=${toolchain} CONFIG=${config} make clean || true
+	TOOLCHAIN=${toolchain} CONFIG=${config} make clean -j10 || true
 }
 
 clean_built_app_packages() {


### PR DESCRIPTION
Speed up the clean-all.sh script by running make with "-j10", which
makes it process directories in parallel. This is the same number of
parallel processes that is used in the make-all.sh script.