### PR TITLE
Don't pass Emscripten linker flags to compiler

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -99,7 +99,7 @@ EMSCRIPTEN_LINKER_FLAGS := \
 
 ifeq ($(CONFIG),Release)
 
-# Add compiler/linker flags specific to release builds.
+# Add compiler and linker flags specific to release builds.
 #
 # Explanation:
 # O3: Enable advanced optimizations.
@@ -115,7 +115,7 @@ EMSCRIPTEN_COMPILER_FLAGS += \
 
 else ifeq ($(CONFIG),Debug)
 
-# Add compiler/linker flags specific to debug builds.
+# Add compiler and linker flags specific to debug builds.
 #
 # Explanation:
 # O0: Disable optimizations.


### PR DESCRIPTION
This commit attempts to avoid passing useless flags to the Emscripten
compiler and linker (emcc), by maintaining compilation and linking flags
separately instead of putting all of them together. This makes the build
logs slightly more readable (as the number of command-line flags becomes
less on average) and also avoids nonsensical no-op flags (like
EXPORT_NAME pointing to the name of a static library).

The main information about which Emscripten flags are needed on which
stage is present in this file:
https://github.com/emscripten-core/emscripten/blob/master/src/settings.js

This commit is expected to bring no functional differences on the
resulting build program. The tracking issue is #177.