### PR TITLE
Document CMake dependency

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -30,6 +30,8 @@ Connector App and examples of how programs can communicate with the app.
 
 * **Java Runtime Environment 7**.
 
+* **CMake** (needed only in Emscripten builds).
+
 In order to **run** the built apps, you will need *either* of these:
 
 * a **Chromebook** with Chrome OS >= 48.


### PR DESCRIPTION
Add a note into the docs that CMake needs to be installed when compiling
the code from this repository under Emscripten.

This commit contributes to the WebAssembly/Emscripten migration effort
tracked by #177.