### PR TITLE
Uprev pinned Emscripten to 2.0.13

### DIFF
--- a/env/constants.sh
+++ b/env/constants.sh
@@ -18,7 +18,7 @@
 DEPOT_TOOLS_REPOSITORY_URL="https://chromium.googlesource.com/chromium/tools/depot_tools.git"
 
 EMSCRIPTEN_SDK_REPOSITORY_URL="https://github.com/emscripten-core/emsdk.git"
-EMSCRIPTEN_VERSION="2.0.6"
+EMSCRIPTEN_VERSION="2.0.13"
 
 NACL_SDK_VERSION="47"
 


### PR DESCRIPTION
Update the env initialization scripts to use a newer Emscripten
version - 2.0.13. This version brings a few relevant bugfixes
(notably, fixes for some threading-related crashes).

This version was tested a bit manually with the applications from this
repository and showed positive results.