### PR TITLE
Rename nacl_module_dependency_in_app_common.mk

### DIFF
--- a/common/make/executable_module_recursive_build.mk
+++ b/common/make/executable_module_recursive_build.mk
@@ -12,31 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-#
-# This file contains some helper definitions for including the Chrome Native
-# Client modules in Chrome Apps.
-# TODO(#177): Generalize the file to support Emscripten as well.
+# This file contains provides helper definitions for performing recursive make
+# builds of executable modules (which are themselves built via
+# executable_building.mk).
 #
 # common.mk must be included before including this file.
+
+# Macro rule that builds the specified executable module (as a recursive make
+# invocation) and copies the latter's resulting build artifacts into the "out"
+# directory.
 #
+# Arguments:
+# $1 ("MODULE_NAME"): The executable module's name (note that, by convention,
+#   it's both the name of the module's build directory name and the value of the
+#   TARGET variable inside the module's makefile).
 
-
-ifeq (,$(NACL_SDK_ROOT))
-$(error You must specify the NACL_SDK_ROOT environment variable with a path to \
-		a downloaded NaCl SDK directory)
-endif
-
-
-#
-# Macro rule that adds some auxiliary rules for depending on the specified
-# Native Client module.
-#
-# These rules provide automatic re-building of the Native Client module when
-# necessary, copying its built binaries into the out directory.
-#
-
-define ADD-NACL-MODULE-DEPENDENCY
+define RECURSIVELY_BUILD_EXECUTABLE_MODULE
 
 .PHONY: $(1)
 
@@ -46,11 +37,11 @@ $(1):
 clean:
 	+$(MAKE) --directory $(1) clean
 
-.PHONY: generate_out_nacl_module_$(1)
+.PHONY: generate_out_executable_module_$(1)
 
-generate_out_nacl_module_$(1): $(OUT_DIR_PATH) $(1)
+generate_out_executable_module_$(1): $(OUT_DIR_PATH) $(1)
 	@cp -pr $(1)/out/$(1)/* $(OUT_DIR_PATH)
 
-generate_out: generate_out_nacl_module_$(1)
+generate_out: generate_out_executable_module_$(1)
 
 endef

--- a/common/make/executable_module_recursive_build.mk
+++ b/common/make/executable_module_recursive_build.mk
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file contains provides helper definitions for performing recursive make
-# builds of executable modules (which are themselves built via
-# executable_building.mk).
+# This file contains helper definitions for performing recursive make builds of
+# executable modules (which are themselves built via executable_building.mk).
 #
 # common.mk must be included before including this file.
 

--- a/example_cpp_smart_card_client_app/build/Makefile
+++ b/example_cpp_smart_card_client_app/build/Makefile
@@ -23,7 +23,7 @@ include $(COMMON_DIR_PATH)/js/include.mk
 
 include $(COMMON_DIR_PATH)/make/app_building_common.mk
 
-include $(COMMON_DIR_PATH)/make/nacl_module_dependency_in_app_common.mk
+include $(COMMON_DIR_PATH)/make/executable_module_recursive_build.mk
 
 include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/common/include.mk
 include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/js_client/include.mk
@@ -59,7 +59,7 @@ $(eval $(call BUILD_JS_SCRIPT,built-in-pin-dialog.js,$(JS_COMPILER_INPUT_PATHS),
 # Rules for invoking recursive make files that build the app's binary executable
 # module (build rules for it can be found at ./executable_module/Makefile).
 
-$(eval $(call ADD-NACL-MODULE-DEPENDENCY,executable_module))
+$(eval $(call RECURSIVELY_BUILD_EXECUTABLE_MODULE,executable_module))
 
 
 # Rules for copying the static resources files into the app's out directory.

--- a/smart_card_connector_app/build/Makefile
+++ b/smart_card_connector_app/build/Makefile
@@ -44,7 +44,7 @@ include $(COMMON_DIR_PATH)/js/include.mk
 
 include $(COMMON_DIR_PATH)/make/app_building_common.mk
 
-include $(COMMON_DIR_PATH)/make/nacl_module_dependency_in_app_common.mk
+include $(COMMON_DIR_PATH)/make/executable_module_recursive_build.mk
 
 include $(THIRD_PARTY_DIR_PATH)/libusb/naclport/include.mk
 include $(THIRD_PARTY_DIR_PATH)/ccid/naclport/include.mk
@@ -97,7 +97,7 @@ $(eval $(call BUILD_JS_SCRIPT,window.js,$(JS_COMPILER_WINDOW_INPUT_PATHS),Google
 # (the actual recursive rules can be found at ./executable_module/Makefile).
 #
 
-$(eval $(call ADD-NACL-MODULE-DEPENDENCY,executable_module))
+$(eval $(call RECURSIVELY_BUILD_EXECUTABLE_MODULE,executable_module))
 
 
 #


### PR DESCRIPTION
Rename this helper makefile to reflect the fact that this file is
toolchain-agnostic, i.e., can be used with either Emscripten or Native
Client builds. Also rename the rules inside this file accordingly, and
drop unneeded assertions on NaCl.

This is a non-functional change. This contributes to the WebAssembly
migration effort tracked by #177.