### PR TITLE
Fix JS exception in ArrayBuffer substitution test

### DIFF
--- a/common/js/src/messaging/port-message-channel.js
+++ b/common/js/src/messaging/port-message-channel.js
@@ -174,8 +174,10 @@ PortMessageChannel.prototype.getPortExtensionId_ = function(port) {
 /** @private */
 PortMessageChannel.prototype.disconnectEventHandler_ = function() {
   let reason = '';
-  if (chrome.runtime.lastError && chrome.runtime.lastError.message)
+  if (chrome.runtime && chrome.runtime.lastError &&
+      chrome.runtime.lastError.message) {
     reason = ` due to '${chrome.runtime.lastError.message}'`;
+  }
   this.logger.info(`Message port was disconnected${reason}, disposing...`);
   this.dispose();
 };


### PR DESCRIPTION
Fix the JS error that was occurring in the
"testSubstituteArrayBuffersRecursively" JavaScript test, caused by some
global object not being mocked. The fix is to silence this error by
adding a check of that global object, which also makes the production
code slightly more bullet-proof.

This is a follow-up to PR #226, which introduced this test.