### PR TITLE
Use g instead of g4 with Emscripten

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -119,7 +119,7 @@ else ifeq ($(CONFIG),Debug)
 #
 # Explanation:
 # O0: Disable optimizations.
-# g3: Preserve debug information, including DWARF data.
+# g: Preserve debug information, including DWARF data.
 EMSCRIPTEN_COMMON_FLAGS += \
   -O0 \
   -g \

--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -119,10 +119,10 @@ else ifeq ($(CONFIG),Debug)
 #
 # Explanation:
 # O0: Disable optimizations.
-# g4: Preserve maximum debug information, including source maps.
+# g3: Preserve maximum debug information, including DWARF data.
 EMSCRIPTEN_COMMON_FLAGS += \
   -O0 \
-  -g4 \
+  -g3 \
 
 # Add linker flags specific to debug builds.
 #

--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -119,10 +119,10 @@ else ifeq ($(CONFIG),Debug)
 #
 # Explanation:
 # O0: Disable optimizations.
-# g3: Preserve maximum debug information, including DWARF data.
+# g3: Preserve debug information, including DWARF data.
 EMSCRIPTEN_COMMON_FLAGS += \
   -O0 \
-  -g3 \
+  -g \
 
 # Add linker flags specific to debug builds.
 #


### PR DESCRIPTION
Replace the "-g4" compiler/linker flag with "-g" when using
Emscripten. Apparently, "-g" started to produce more useful debug
information than "-g4" in recent Emscripten versions, in particular
regarding the recently added DWARF debug format support:
https://github.com/emscripten-core/emscripten/issues/13534

Note that the debug source maps are only produced at "g4", but we
never supported them properly in this project (in particular, due to
DevTools not being able to load them in Extensions/Apps - see
https://crbug.com/974543).

This contributes to the WebAssembly/Emscripten migration effort, as
tracked by #177.