### PR TITLE
Fix error message when Emscripten env is unset

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -27,7 +27,7 @@
 
 # Check that the environment is set up.
 ifeq (,$(EMSDK))
-$(error You must run "source env/activate" in the repository root directory at
+$(error You must run "source env/activate" in the repository root directory at \
 		least once before running "make".)
 endif
 


### PR DESCRIPTION
Make the Makefile scripts display the correct error message when the
Emscripten build is requested without the required environment variables
being set.

The problem was a syntax error in the $(error) function invocation, as
the multi-line message was missing the backslash escape.

This change contributes to the WebAssembly migration effort tracked
by #177.