### PR TITLE
Shorten log prefix for incoming PC/SC commands

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.cc
@@ -139,7 +139,7 @@ PcscLiteClientRequestProcessor::PcscLiteClientRequestProcessor(
       status_log_severity_(client_app_id ? LogSeverity::kInfo
                                          : LogSeverity::kDebug),
       logging_prefix_(FormatPrintfTemplate(
-          "[PC/SC-Lite client handler for %s (id %" PRId64 ")] ",
+          "[PC/SC from %s (id %" PRId64 ")] ",
           client_app_id ? ("\"" + *client_app_id + "\"").c_str() : "own app",
           client_handler_id)) {
   BuildHandlerMap();


### PR DESCRIPTION
Replace the "PC/SC-Lite client handler for ..." text in log messages
with just "PC/SC from ...". This makes the log messages shorter a bit
while preserving all information, which helps readability.

This change contributes to the logging improvements tracked
by #146.