### PR TITLE
Remove relative time from JS logs

### DIFF
--- a/common/js/src/logging/log-formatting.js
+++ b/common/js/src/logging/log-formatting.js
@@ -34,6 +34,7 @@ const GSC = GoogleSmartCard;
  */
 const textFormatter = new goog.debug.TextFormatter();
 textFormatter.showAbsoluteTime = true;
+textFormatter.showRelativeTime = false;
 textFormatter.showSeverityLevel = true;
 
 /**

--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -296,7 +296,9 @@ function reloadApp() {
 
 function setupConsoleLogging() {
   const console = new goog.debug.Console;
-  console.getFormatter().showAbsoluteTime = true;
+  const formatter = console.getFormatter();
+  formatter.showAbsoluteTime = true;
+  formatter.showRelativeTime = false;
   console.setCapturing(true);
 }
 


### PR DESCRIPTION
Stop printing relative times (like "[  0.007s]") in the JavaScript logs.
These times aren't really necessary now that we're printing absolute
times since #108.

The only remaining benefit of relative times was that they allowed
to distinguish logs from multiple instances in case they work
concurrently and their logs are squashed together. However, in
practice this was only relevant in a specific scenario (reading
Chrome OS system logs from a device that is locked and has the
NaCl-based smart card applications installed both in-session
and on the Login Screen). Assuming this a rare scenario that will
anyway disappear with the NaCl deprecation, it seems fine to
reduce the log clutter by removing the relative times.

This change contributes to the logging improvements tracked
by #146.