### PR TITLE
Remove prefix from the syslog log messages

### DIFF
--- a/common/cpp/src/google_smart_card_common/logging/syslog/syslog.cc
+++ b/common/cpp/src/google_smart_card_common/logging/syslog/syslog.cc
@@ -36,17 +36,10 @@
 #include <google_smart_card_common/formatting.h>
 #include <google_smart_card_common/logging/logging.h>
 
-namespace {
-
-constexpr char kLoggingPrefix[] = "[syslog] ";
-
-}  // namespace
-
 void syslog(int priority, const char* format, ...) {
   va_list var_args;
   va_start(var_args, format);
   const std::string message =
-      kLoggingPrefix +
       google_smart_card::FormatPrintfTemplate(format, var_args);
   va_end(var_args);
 


### PR DESCRIPTION
Delete the "[syslog]" prefix printed in every log message that's created
via the syslog() call. This prefix is not really useful - the original
idea was to visually disambiguate the logs printed by C++ code from the
logs emitted by third-party C code that uses syslog. In reality, there's
not much ambiguity there, so this prefix was just cluttering the logs.

This change contributes to the logging improvements tracked
by #146.