### PR TITLE
Log function call indices

### DIFF
--- a/common/cpp/src/google_smart_card_common/logging/function_call_tracer.cc
+++ b/common/cpp/src/google_smart_card_common/logging/function_call_tracer.cc
@@ -17,7 +17,6 @@
 #include <stdint.h>
 
 #include <atomic>
-#include <cstdint>
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/logging/function_call_tracer.cc
+++ b/common/cpp/src/google_smart_card_common/logging/function_call_tracer.cc
@@ -14,12 +14,25 @@
 
 #include <google_smart_card_common/logging/function_call_tracer.h>
 
+#include <atomic>
+#include <cstdint>
+
 namespace google_smart_card {
+
+namespace {
+
+int64_t GenerateFunctionCallId() {
+  static std::atomic<int64_t> next_function_call_id;
+  return ++next_function_call_id;
+}
+
+}  // namespace
 
 FunctionCallTracer::FunctionCallTracer(const std::string& function_name,
                                        const std::string& logging_prefix,
                                        LogSeverity log_severity)
-    : function_name_(function_name),
+    : function_call_id_(GenerateFunctionCallId()),
+      function_name_(function_name),
       logging_prefix_(logging_prefix),
       log_severity_(log_severity) {}
 
@@ -42,8 +55,8 @@ void FunctionCallTracer::AddReturnedArg(const std::string& name,
 
 void FunctionCallTracer::LogEntrance() const {
   GOOGLE_SMART_CARD_LOG(log_severity_)
-      << logging_prefix_ << function_name_ << "(" << DumpArgs(passed_args_)
-      << "): called...";
+      << logging_prefix_ << function_name_ << "#" << function_call_id_ << "("
+      << DumpArgs(passed_args_) << "): called...";
 }
 
 void FunctionCallTracer::LogExit() const {
@@ -57,8 +70,8 @@ void FunctionCallTracer::LogExit() const {
   }
 
   GOOGLE_SMART_CARD_LOG(log_severity_)
-      << logging_prefix_ << function_name_ << ": returning"
-      << (results_part.empty() ? "" : " ") << results_part;
+      << logging_prefix_ << function_name_ << "#" << function_call_id_
+      << ": returning" << (results_part.empty() ? "" : " ") << results_part;
 }
 
 FunctionCallTracer::ArgNameWithValue::ArgNameWithValue(

--- a/common/cpp/src/google_smart_card_common/logging/function_call_tracer.cc
+++ b/common/cpp/src/google_smart_card_common/logging/function_call_tracer.cc
@@ -23,7 +23,7 @@ namespace google_smart_card {
 namespace {
 
 int64_t GenerateFunctionCallId() {
-  static std::atomic<int64_t> next_function_call_id;
+  static std::atomic<int64_t> next_function_call_id(0);
   return ++next_function_call_id;
 }
 

--- a/common/cpp/src/google_smart_card_common/logging/function_call_tracer.cc
+++ b/common/cpp/src/google_smart_card_common/logging/function_call_tracer.cc
@@ -14,6 +14,8 @@
 
 #include <google_smart_card_common/logging/function_call_tracer.h>
 
+#include <stdint.h>
+
 #include <atomic>
 #include <cstdint>
 

--- a/common/cpp/src/google_smart_card_common/logging/function_call_tracer.h
+++ b/common/cpp/src/google_smart_card_common/logging/function_call_tracer.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_SMART_CARD_COMMON_LOGGING_FUNCTION_CALL_TRACER_H_
 #define GOOGLE_SMART_CARD_COMMON_LOGGING_FUNCTION_CALL_TRACER_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -60,6 +61,7 @@ class FunctionCallTracer final {
 
   static std::string DumpArgs(const std::vector<ArgNameWithValue>& args);
 
+  const int64_t function_call_id_;
   const std::string function_name_;
   const std::string logging_prefix_;
   const LogSeverity log_severity_;

--- a/common/cpp/src/google_smart_card_common/logging/function_call_tracer.h
+++ b/common/cpp/src/google_smart_card_common/logging/function_call_tracer.h
@@ -15,7 +15,8 @@
 #ifndef GOOGLE_SMART_CARD_COMMON_LOGGING_FUNCTION_CALL_TRACER_H_
 #define GOOGLE_SMART_CARD_COMMON_LOGGING_FUNCTION_CALL_TRACER_H_
 
-#include <cstdint>
+#include <stdint.h>
+
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Print a function call index (a shared monotonically incrementing
counter) when logging function call tracer.

This should simplify investigating log messages collected in the field,
since it'll be possible to correlate the "called..." and the "returning"
log messages, therefore knowing which input parameters were passed to
the completed call and being able to distinguish between multiple calls
with the same parameters.