### PR TITLE
Double the log buffer capacity

### DIFF
--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -91,7 +91,7 @@ const ROOT_LOGGER_LEVEL = goog.DEBUG ? goog.log.Level.FINE : goog.log.Level.INFO
  * middle will be removed (so only some first and some last messages will be
  * kept at any given moment of time).
  */
-const LOG_BUFFER_CAPACITY = goog.DEBUG ? 10 * 1000 : 1000;
+const LOG_BUFFER_CAPACITY = goog.DEBUG ? 20 * 1000 : 2000;
 
 /**
  * @type {!goog.log.Logger}


### PR DESCRIPTION
Make the number of log messages retained for the Log Export to be twice
as much as before: in Release builds, it becomes 2000 messages now.
This should help in investigating some customer issues, because
apparently sometimes real-world logs contained information just around
the zone that was cut off.

This change is still a conservative change, because we need to take
memory consumption in mind. Extra 1000 messages added here would mean
100-200 KB of extra memory, which sounds tolerable.