### PR TITLE
Silence Emscripten Pthreads performance warning

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -97,12 +97,15 @@ EMSCRIPTEN_COMPILER_FLAGS := \
 # MODULARIZE: Puts Emscripten module JavaScript loading code into a factory
 #   function, in order to control its loading from other JS code and to avoid
 #   name conflicts with unrelated code.
+# no-pthreads-mem-growth: Suppress the linker warning about the performance of
+#   the "Pthreads + ALLOW_MEMORY_GROWTH" combination.
 EMSCRIPTEN_LINKER_FLAGS := \
   -s ABORTING_MALLOC=1 \
   -s ALLOW_MEMORY_GROWTH=1 \
   -s DYNAMIC_EXECUTION=0 \
   -s 'EXPORT_NAME="loadEmscriptenModule_$(TARGET)"' \
   -s MODULARIZE=1 \
+  -Wno-pthreads-mem-growth \
 
 ifeq ($(CONFIG),Release)
 


### PR DESCRIPTION
Suppress the link-time warning emitted by Emscripten due to our usage of
multi-threading together with dynamic memory growth:

  warning: USE_PTHREADS + ALLOW_MEMORY_GROWTH may run non-wasm code
  slowly, see https://github.com/WebAssembly/design/issues/1271

We took this warning into consideration and decided to trade the
performance in favor of lower memory consumption. (In reality, the
performance loss is likely small, since a big chunk of the run time is
spent on interprocess communication.)

So reduce the build log spam by silencing this warning, which was
emitted many times - once for every target binary or static library.
This change is a small improvement to the WebAssembly build
support that is tracked by #177.