### PR TITLE
Suppress the "default browser" popups in test runs

### DIFF
--- a/common/make/common.mk
+++ b/common/make/common.mk
@@ -232,8 +232,16 @@ CHROME_ENV ?=
 #
 # This is intended to be customized by the user in case of some special needs.
 #
+# Explanation of arguments:
+# no-first-run: Suppress first-run dialogs, like about making Chrome the default
+#   browser.
+# password-store: Disable using the system-wide encryption storage backend, to
+#   avoid notifications about system backend initialization issues.
+#
 
-CHROME_ARGS ?= --password-store=basic
+CHROME_ARGS ?= \
+	--no-first-run \
+	--password-store=basic \
 
 
 #

--- a/common/make/common.mk
+++ b/common/make/common.mk
@@ -233,9 +233,9 @@ CHROME_ENV ?=
 # This is intended to be customized by the user in case of some special needs.
 #
 # Explanation of arguments:
-# no-first-run: Suppress first-run dialogs, like about making Chrome the default
+# no-first-run: Suppresses first-run dialogs, such as making Chrome the default
 #   browser.
-# password-store: Disable using the system-wide encryption storage backend, to
+# password-store: Disables using the system-wide encryption storage backend, to
 #   avoid notifications about system backend initialization issues.
 #
 


### PR DESCRIPTION
This suppresses the first-run dialogs when running Chrome for executing
tests. In particular, this allows to skip the blocking popup "make
Chrome the default browser" that was introduced in recent Chrome
versions, and which required a manual mouse click to proceed to the
tests.