### PR TITLE
Detect NaCl crash loops before Chrome throttles us

### DIFF
--- a/common/js/src/logging/crash-loop-detection-unittest.js
+++ b/common/js/src/logging/crash-loop-detection-unittest.js
@@ -181,6 +181,25 @@ goog.exportSymbol('testCrashLoopDetection', {
     });
   },
 
+  // Test that the crash loop is detected before Chrome decides to disable the
+  // NaCl module due to too many crashes. Unlike the "testCrashLoop" test, this
+  // test simulates slower timing that corresponds to the restrictions hardcoded
+  // in Chrome (which, as of 2021-06-07, are "3 crashes within 120 seconds").
+  testCrashLoopNotHitsNaClThreshold: function() {
+    const TOTAL_CRASH_COUNT = 3;
+    const CRASH_INTERVAL = 30 * 1000;
+    const recentCrashTimestamps = [];
+    for (let crashIndex = 0; crashIndex < TOTAL_CRASH_COUNT - 1; ++crashIndex) {
+      const intervalsAgoCount = TOTAL_CRASH_COUNT - 1 - crashIndex;
+      recentCrashTimestamps.push(
+          SOME_DATE.getTime() - CRASH_INTERVAL * intervalsAgoCount);
+    }
+    currentStorage = {'crash_timestamps': recentCrashTimestamps};
+    return CrashLoopDetection.handleImminentCrash().then((isInCrashLoop) => {
+      assertTrue(isInCrashLoop);
+    });
+  },
+
   // Test the case when the chrome.storage API is not available (e.g., due to a
   // missing permission) - the implementation should still not break in this
   // case (although no crash loop detection is possible).

--- a/common/js/src/logging/crash-loop-detection.js
+++ b/common/js/src/logging/crash-loop-detection.js
@@ -49,9 +49,14 @@ const CRASH_LOOP_WINDOW_MILLISECONDS = 60 * 1000;
 //    seconds after the launch":
 //    <https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc;l=172-173;drc=d17745f350d4956a07cb1113ee19e9cbc4be699f>.
 // 2. Chrome's Native Client system disables the module when it crashes too
-//    frequently, with the criteria currently being "3 crashes within 2
-//    minutes":
+//    frequently, with the criteria currently being "forbid subsequent load
+//    attempts after 3 crashes within 2 minutes":
 //    <https://source.chromium.org/chromium/chromium/src/+/main:components/nacl/browser/nacl_browser.cc;l=113-114;drc=d17745f350d4956a07cb1113ee19e9cbc4be699f>.
+//
+// We're choosing the largest possible value that satisfies these restrictions
+// in order to reduce the risk of false positives, i.e., 3. Note that despite
+// this value is exactly equal to restriction#2, it's still fine, since
+// throttling breaks subsequent load attempts, which is exactly what we avoid.
 const CRASH_LOOP_THRESHOLD_COUNT = 3;
 
 /** @type {boolean} */

--- a/common/js/src/logging/crash-loop-detection.js
+++ b/common/js/src/logging/crash-loop-detection.js
@@ -38,11 +38,19 @@ const CRASH_LOOP_WINDOW_MILLISECONDS = 60 * 1000;
 // crash loop.
 //
 // Note that |CRASH_LOOP_WINDOW_MILLISECONDS| and |CRASH_LOOP_THRESHOLD_COUNT|
-// have to be chosen in a way that the crash loop is detected earlier than the
-// Chrome's Extension system decides to disable the extension due to too many
-// reloads, which is triggered by the "5 reloads, each within 10 seconds after
-// the launch" condition (as of 2020-08-13).
-const CRASH_LOOP_THRESHOLD_COUNT = 4;
+// have to be chosen in a way that the crash loop is detected earlier than
+// Chrome starts to throttle us, since that would leave the application in a
+// state without any useful logs.
+//
+// As of 2021-06-07, two subsystems in Chrome have to be taken into account as
+// follows:
+// 1. Chrome's Extension system disables the extension when it reloads too
+//    frequently, with the criteria currently being "5 reloads, each within 10
+//    seconds after the launch".
+// 2. Chrome's Native Client system disables the module when it crashes too
+//    requently, with the criteria currently being "3 crashes within 2 minutes":
+//    https://source.chromium.org/chromium/chromium/src/+/main:components/nacl/browser/nacl_browser.cc;l=113-114;drc=d17745f350d4956a07cb1113ee19e9cbc4be699f
+const CRASH_LOOP_THRESHOLD_COUNT = 3;
 
 /** @type {boolean} */
 let crashing = false;

--- a/common/js/src/logging/crash-loop-detection.js
+++ b/common/js/src/logging/crash-loop-detection.js
@@ -46,10 +46,12 @@ const CRASH_LOOP_WINDOW_MILLISECONDS = 60 * 1000;
 // follows:
 // 1. Chrome's Extension system disables the extension when it reloads too
 //    frequently, with the criteria currently being "5 reloads, each within 10
-//    seconds after the launch".
+//    seconds after the launch":
+//    <https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc;l=172-173;drc=d17745f350d4956a07cb1113ee19e9cbc4be699f>.
 // 2. Chrome's Native Client system disables the module when it crashes too
-//    requently, with the criteria currently being "3 crashes within 2 minutes":
-//    https://source.chromium.org/chromium/chromium/src/+/main:components/nacl/browser/nacl_browser.cc;l=113-114;drc=d17745f350d4956a07cb1113ee19e9cbc4be699f
+//    frequently, with the criteria currently being "3 crashes within 2
+//    minutes":
+//    <https://source.chromium.org/chromium/chromium/src/+/main:components/nacl/browser/nacl_browser.cc;l=113-114;drc=d17745f350d4956a07cb1113ee19e9cbc4be699f>.
 const CRASH_LOOP_THRESHOLD_COUNT = 3;
 
 /** @type {boolean} */


### PR DESCRIPTION
Improve the crash loop detector for the case when the crash happens in
the C/C++ code compiled under Native Client. Before this commit, the
crash loop detection would be triggered too late, after Chrome Native
Client system already began the throttling. This means that instead of
useful logs that contain information before the actual crash, the only
information would be like this:

>   Failed to load NaCl module with the following message: NaCl module
>   load failed: ServiceRuntime: failed to start

With the following information in Chrome logs:

>  NaCl process launch failed: Process creation was throttled due to
>  excessive crashes

This commit avoids this situation by tightening the crash loop detection
constants, so that the detector is triggered earlier and therefore
avoids this dead loop and preserves valuable logs.

P.S. Meanwhile this commit is applied to both NaCl and WebAssembly
builds, it's presumably OK, since all we do is tightening the crash loop
detection constants. If we discover later that WebAssembly contains a
similar, but even more aggressive throttling, we can tighten the
constants further; otherwise they don't harm.