### PR TITLE
Fix paths in prepare-binaries-for-github-release.py

### DIFF
--- a/prepare-binaries-for-github-release.py
+++ b/prepare-binaries-for-github-release.py
@@ -43,11 +43,11 @@ BINARY_CONTENTS_RELATIVES_PATHS = [
 # Paths to the files and directories to be copied into the resulting binary
 # archives, accompanied with the relative target file paths.
 PATHS_TO_COPY = [
-  ['example_js_standalone_smart_card_client_library/js_build/Debug/'
-   'google-smart-card-client-library.js',
+  ['example_js_standalone_smart_card_client_library/js_build/'
+   'emscripten_Debug/google-smart-card-client-library.js',
    'google-smart-card-client-library.debug.js'],
-  ['example_js_standalone_smart_card_client_library/js_build/Release/'
-   'google-smart-card-client-library.js',
+  ['example_js_standalone_smart_card_client_library/js_build/'
+   'emscripten_Release/google-smart-card-client-library.js',
    'google-smart-card-client-library.js'],
 ]
 


### PR DESCRIPTION
Fix this error shown when running this script in recent versions:

>  IOError: [Errno 2] No such file or directory:
>  './example_js_standalone_smart_card_client_library/js_build/Debug/google-smart-card-client-library.js'

The root cause is that, since #274, compiled JavaScript files are put
into toolchain-specific directories. For example, instead of a single
"Debug" directory there are now two directories "emscripten_Debug" and
"pnacl_Debug" (for the reasons explained on that change).

In case of google-smart-card-client-library.js, the code in both
directories is the same, so we're free to choose any of them. I'm
proceeding with "emscripten_Debug", since, eventually, we'll drop the
NaCl support completely.