### PR TITLE
Workaround for chrome.usb.getConfigurations issue

### DIFF
--- a/third_party/libusb/webport/src/libusb_over_chrome_usb.cc
+++ b/third_party/libusb/webport/src/libusb_over_chrome_usb.cc
@@ -388,7 +388,7 @@ int LibusbOverChromeUsb::LibusbGetActiveConfigDescriptor(
   for (const auto& chrome_usb_config : chrome_usb_configs) {
     if (chrome_usb_config.active) {
       if (*config) {
-        // Normally there should be only one active coniguration, but the
+        // Normally there should be only one active configuration, but the
         // chrome.usb API implementation misbehaves on some devices: see
         // <https://crbug.com/1218141>. As a workaround, proceed with the first
         // received configuration that's marked as active.

--- a/third_party/libusb/webport/src/libusb_over_chrome_usb.cc
+++ b/third_party/libusb/webport/src/libusb_over_chrome_usb.cc
@@ -395,7 +395,7 @@ int LibusbOverChromeUsb::LibusbGetActiveConfigDescriptor(
         GOOGLE_SMART_CARD_LOG_WARNING
             << "Unexpected result from the chrome.usb.getConfigurations() API: "
                "received multiple active configurations";
-        continue;
+        break;
       }
 
       *config = new libusb_config_descriptor;

--- a/third_party/libusb/webport/src/libusb_over_chrome_usb.cc
+++ b/third_party/libusb/webport/src/libusb_over_chrome_usb.cc
@@ -387,9 +387,16 @@ int LibusbOverChromeUsb::LibusbGetActiveConfigDescriptor(
   *config = nullptr;
   for (const auto& chrome_usb_config : chrome_usb_configs) {
     if (chrome_usb_config.active) {
-      // Only one active configuration is expected to be returned by chrome.usb
-      // API.
-      GOOGLE_SMART_CARD_CHECK(!*config);
+      if (*config) {
+        // Normally there should be only one active coniguration, but the
+        // chrome.usb API implementation misbehaves on some devices: see
+        // <https://crbug.com/1218141>. As a workaround, proceed with the first
+        // received configuration that's marked as active.
+        GOOGLE_SMART_CARD_LOG_WARNING
+            << "Unexpected result from the chrome.usb.getConfigurations() API: "
+               "received multiple active configurations";
+        continue;
+      }
 
       *config = new libusb_config_descriptor;
       FillLibusbConfigDescriptor(chrome_usb_config, *config);


### PR DESCRIPTION
Change the USB wrapper (used in the webport of libusb, which is
transitively used for the CCID driver and therefore the Smart Card
Connector app) to stop asserting that chrome.usb.getConfigurations() can
only return a single active configuration. Instead, just proceed with
the first configuration among those that are marked as active.

Meanwhile multiple active configurations is most likely a bug in the
chrome.usb API (https://crbug.com/1218141), we need this workaround
until that issue is fixed in Chrome, since currently the Connector app
ends up in a crash loop when such device is attached.