### PR TITLE
Update Emscripten to 2.0.24

### DIFF
--- a/env/constants.sh
+++ b/env/constants.sh
@@ -18,7 +18,7 @@
 DEPOT_TOOLS_REPOSITORY_URL="https://chromium.googlesource.com/chromium/tools/depot_tools.git"
 
 EMSCRIPTEN_SDK_REPOSITORY_URL="https://github.com/emscripten-core/emsdk.git"
-EMSCRIPTEN_VERSION="2.0.13"
+EMSCRIPTEN_VERSION="2.0.24"
 
 NACL_SDK_VERSION="47"
 


### PR DESCRIPTION
Switch the version hardcoded in the env initialization scripts to use
the currently up-to-date version of Emscripten. It brings various
improvements that the Emscripten team made recently, and at the same
time doesn't regress on our use cases (we couldn't update earlier due to
a few blockers in the previous releases, like Clang crashes).