### PR TITLE
Fix env/initialize.sh Python 2 errors

### DIFF
--- a/third_party/webports/src/src/build_tools/pip_install.sh
+++ b/third_party/webports/src/src/build_tools/pip_install.sh
@@ -24,7 +24,7 @@ if [ ! -f "$pip_bin" ]; then
   echo "Installing pip.."
   # Use local file rather than pipeline so we can detect failure of the curl
   # command.
-  curl --silent --show-error https://bootstrap.pypa.io/get-pip.py > get-pip.py
+  curl --silent --show-error https://bootstrap.pypa.io/pip/2.7/get-pip.py > get-pip.py
   python get-pip.py --force-reinstall --user
   rm -f get-pip.py
   hash -r

--- a/third_party/webports/src/src/requirements.txt
+++ b/third_party/webports/src/src/requirements.txt
@@ -7,3 +7,4 @@ pylint==1.4.0
 rednose==0.4.1
 termcolor==1.1.0
 yapf==0.1.8
+astroid<2.0


### PR DESCRIPTION
Python 2 isn't maintained anymore, so more and more stuff stops working.
But as NaCl env build scripts are using it (and no one is interested in
migrating them to Pytnon 3), this commit fixes the issues that are
happening right now:

* pip should be fetched from a different URL (a special URL for a
  2.7-compatible version),
* some module called "astroid" should be installed with the version
  before 2.0, otherwise it fails with syntax errors.