### PR TITLE
Cherry-pick PC/SC-Lite bugfix for unsupported commands

### DIFF
--- a/docs/updating-pcsc-lite.md
+++ b/docs/updating-pcsc-lite.md
@@ -55,22 +55,27 @@ somewhat outdated version of the PC/SC-Lite daemon.
    (Hint: Pay attention to the directory structure; e.g., you should have the
    `AUTHORS` file located at `//third_party/pcsc-lite/src/AUTHORS` in the end.)
 
-4. Edit the URL and the version in the `//third_party/pcsc-lite/README.google`
+4. Apply the patches from the `//third_party/pcsc-lite/patches/` directory to
+   the files unpacked at the previous step. (Hint: We only have a single tiny
+   patch currently, so probably it's the simplest to just manually apply the
+   modification shown in that patch file.)
+
+5. Edit the URL and the version in the `//third_party/pcsc-lite/README.google`
    file.
 
-5. Compile the Smart Card Connector app and all other targets, by running the
+6. Compile the Smart Card Connector app and all other targets, by running the
    `make-all.sh` script.
 
-6. In case of any errors discovered at the previous step, investigate and fix
+7. In case of any errors discovered at the previous step, investigate and fix
    them. (Hint: In case a new file was created in the daemon, you have to add it
    into `//third_party/pcsc-lite/naclport/server/build/Makefile` into one of the
    sections.)
 
-7. Start the just-built Smart Card Connector app (e.g., by running `make run` in
+8. Start the just-built Smart Card Connector app (e.g., by running `make run` in
    the `//smart_card_connector/build/` directory) and perform some manual QA
    testing using physical reader(s).
 
-8. If everything is OK, prepare a commit / a Pull Request with all these
+9. If everything is OK, prepare a commit / a Pull Request with all these
    changes.
 
 Additional tasks to be performed later, when rolling out a new version of the

--- a/third_party/pcsc-lite/patches/0001-Fix-IFD_NOT_SUPPORTED.patch
+++ b/third_party/pcsc-lite/patches/0001-Fix-IFD_NOT_SUPPORTED.patch
@@ -1,0 +1,52 @@
+From 7730f6c54d7fb6a910d291e2d48c92d2a5abf688 Mon Sep 17 00:00:00 2001
+From: Ludovic Rousseau <ludovic.rousseau@free.fr>
+Date: Thu, 17 Jun 2021 10:48:40 +0200
+Subject: [PATCH] SetProtocol: Handle IFD_NOT_SUPPORTED from the driver
+
+If the driver returns IFD_NOT_SUPPORTED from the function
+IFDHSetProtocolParameters() it indicates the "command" is not supported.
+It is different from IFD_PROTOCOL_NOT_SUPPORTED that indicates the
+"prorocol" is not supported.
+
+The problem was with a ACR38U CCID and a memory card. The
+SetParameters() fails but the card can still be used using the default
+protocol.
+
+The behaviour is identical to what we had before the commit
+5d58577093f56dbcfbf754940f885ed8fcdba206.
+
+Thanks to Godfrey Chung for the bug report
+"pcsc-lite 1.9.1: memory card connection failed #103"
+https://github.com/LudovicRousseau/PCSC/issues/103
+---
+ src/prothandler.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/prothandler.c b/src/prothandler.c
+index 1e21264..56c00ea 100644
+--- a/src/prothandler.c
++++ b/src/prothandler.c
+@@ -114,9 +114,9 @@ DWORD PHSetProtocol(struct ReaderContext * rContext,
+ 			protocol = ucChosen;
+ 			break;
+ 
+-		case IFD_NOT_SUPPORTED:
+ 		case IFD_PROTOCOL_NOT_SUPPORTED:
+ 		case IFD_ERROR_NOT_SUPPORTED:
++			/* protocol not supported */
+ 			if (protocol != dwPreferred)
+ 			{
+ 				Log3(PCSC_LOG_INFO,
+@@ -131,6 +131,12 @@ DWORD PHSetProtocol(struct ReaderContext * rContext,
+ 			}
+ 			break;
+ 
++		case IFD_NOT_SUPPORTED:
++			/* command not supported */
++			Log3(PCSC_LOG_INFO, "Set PTS failed (%ld). Using T=%d", rv,
++				(SCARD_PROTOCOL_T0 == protocol) ? 0 : 1);
++			break;
++
+ 		default:
+ 			Log2(PCSC_LOG_INFO, "Set PTS failed (%ld)", rv);
+ 

--- a/third_party/pcsc-lite/src/src/prothandler.c
+++ b/third_party/pcsc-lite/src/src/prothandler.c
@@ -114,9 +114,9 @@ DWORD PHSetProtocol(struct ReaderContext * rContext,
 			protocol = ucChosen;
 			break;
 
-		case IFD_NOT_SUPPORTED:
 		case IFD_PROTOCOL_NOT_SUPPORTED:
 		case IFD_ERROR_NOT_SUPPORTED:
+			/* protocol not supported */
 			if (protocol != dwPreferred)
 			{
 				Log3(PCSC_LOG_INFO,
@@ -129,6 +129,12 @@ DWORD PHSetProtocol(struct ReaderContext * rContext,
 				Log2(PCSC_LOG_INFO, "PTS protocol failed (%ld)", rv);
 				protocol = SET_PROTOCOL_PPS_FAILED;
 			}
+			break;
+
+		case IFD_NOT_SUPPORTED:
+			/* command not supported */
+			Log3(PCSC_LOG_INFO, "Set PTS failed (%ld). Using T=%d", rv,
+				(SCARD_PROTOCOL_T0 == protocol) ? 0 : 1);
 			break;
 
 		default:


### PR DESCRIPTION
Cherry-pick the following commit from the upstream PC/SC-Lite
repository, which fixes a 1.9.1 regression:

>   7730f6c54d7fb6a910d291e2d48c92d2a5abf688
>   SetProtocol: Handle IFD_NOT_SUPPORTED from the driver
> 
>   If the driver returns IFD_NOT_SUPPORTED from the function
>   IFDHSetProtocolParameters() it indicates the "command" is not
>   supported.
>   It is different from IFD_PROTOCOL_NOT_SUPPORTED that indicates the
>   "prorocol" is not supported.
> 
>   The problem was with a ACR38U CCID and a memory card. The
>   SetParameters() fails but the card can still be used using the default
>   protocol.
> 
>   The behaviour is identical to what we had before the commit
>   5d58577093f56dbcfbf754940f885ed8fcdba206.
> 
>   Thanks to Godfrey Chung for the bug report
>   "pcsc-lite 1.9.1: memory card connection failed #103"