### PR TITLE
Fix heuristics for hiding spuriously failed reader

### DIFF
--- a/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
+++ b/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
@@ -355,7 +355,7 @@ TrackerThroughPcscServerHook.prototype.shouldHideFailedReader_ = function(
   // talk to from the reader whose name contains interface equal to zero.
   // Therefore it makes sense to just hide from UI these items as they don't
   // actually signal about any error.
-  return /:libhal:.*serialnotneeded_if[1-9][0-9]*$/.test(device);
+  return /:[1-9][0-9]*$/.test(device);
 };
 
 });  // goog.scope


### PR DESCRIPTION
Update the heuristic we use in the Smart Card Connector app for hiding
failure readers from the UI.

The background on this heuristic is the following: some USB devices are
composite devices, which means they expose several different interfaces
for different purposes (e.g., one having bInterfaceClass=11
(Chip/SmartCard) and another bInterfaceClass=2 (Communications)). The
CCID driver we use is implemented in a way that it tries to connect to
every interface. Failures on unrelated interfaces are handled by the
driver in roughly the same way as failures on unsupported smart card
interfaces. We want to inform the user about the latter but not the
former, which is why we implemented the heuristics: let's hide the
failed readers that have the interface number greater than zero.

After updating to PC/SC-Lite 1.9.1, our heuristic stopped working,
because the upstream changed the internal formatting of device names:
https://github.com/LudovicRousseau/PCSC/commit/69082a68f0fe2939a658f4f0857095e5b887a10d

Example:
* before that commit:
"usb:076b/5427:libhal:/org/freedesktop/Hal/devices/usb_device_076b_5427_serialnotneeded_if1".
* after that commit: "usb:076b/5427:libusb-1.0:1:7:1".

Given that our heuristic is based on parsing of this name (as it's the
most straightforward way of doing this at the JavaScript layer), we need
to accomodate for this change in our regexp in the JS code.