### PR TITLE
Apply clang-format to all JS files

### DIFF
--- a/common/integration_testing/src/google_smart_card_integration_testing/integration-test-controller.js
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration-test-controller.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2020 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,8 +41,8 @@ GSC.IntegrationTestController = function() {
   /** @type {!goog.testing.PropertyReplacer} */
   this.propertyReplacer = new goog.testing.PropertyReplacer;
   /** @type {!GSC.NaclModule} */
-  this.naclModule = new GSC.NaclModule(
-      NACL_MODULE_PATH, GSC.NaclModule.Type.PNACL);
+  this.naclModule =
+      new GSC.NaclModule(NACL_MODULE_PATH, GSC.NaclModule.Type.PNACL);
   /** @type {!GSC.Requester} @private */
   this.naclModuleRequester_ = new GSC.Requester(
       INTEGRATION_TEST_NACL_MODULE_REQUESTER_NAME,
@@ -60,8 +61,8 @@ GSC.IntegrationTestController.prototype.initAsync = function() {
  * @return {!goog.Promise<void>}
  */
 GSC.IntegrationTestController.prototype.disposeAsync = function() {
-  return this.callCpp_('TearDownAll', /*functionArguments=*/[]).thenAlways(
-      () => {
+  return this.callCpp_('TearDownAll', /*functionArguments=*/[])
+      .thenAlways(() => {
         this.naclModuleRequester_.dispose();
         this.naclModule.dispose();
         this.propertyReplacer.reset();
@@ -102,10 +103,9 @@ GSC.IntegrationTestController.prototype.sendMessageToCppHelper = function(
  */
 GSC.IntegrationTestController.prototype.callCpp_ = function(
     functionName, functionArguments) {
-  const remoteCallMessage = new GSC.RemoteCallMessage(
-      functionName, functionArguments);
+  const remoteCallMessage =
+      new GSC.RemoteCallMessage(functionName, functionArguments);
   return this.naclModuleRequester_.postRequest(
       remoteCallMessage.makeRequestPayload());
 };
-
 });

--- a/common/js/src/app-utils.js
+++ b/common/js/src/app-utils.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,5 +31,4 @@ const GSC = GoogleSmartCard;
 GSC.AppUtils.enableSelfAutoLoading = function() {
   chrome.runtime.onStartup.addListener(goog.functions.NULL);
 };
-
 });  // goog.scope

--- a/common/js/src/background-page-unload-preventing/background-page-unload-preventing.js
+++ b/common/js/src/background-page-unload-preventing/background-page-unload-preventing.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,9 +59,8 @@ GSC.BackgroundPageUnloadPreventing.enable = function() {
 };
 
 function createIFrameElement() {
-  const iframe = goog.dom.createDom('iframe', {
-    'src': 'background-page-unload-preventing-iframe.html'
-  });
+  const iframe = goog.dom.createDom(
+      'iframe', {'src': 'background-page-unload-preventing-iframe.html'});
   GSC.Logging.checkWithLogger(logger, document.body);
   document.body.appendChild(iframe);
 }
@@ -81,7 +81,7 @@ function connectListener(port) {
       GSC.Logging.failWithLogger(
           logger,
           'Unexpectedly received a message from the message port from the ' +
-          'iframe');
+              'iframe');
     });
   }
 }
@@ -89,5 +89,4 @@ function connectListener(port) {
 function suspendListener() {
   GSC.Logging.failWithLogger(logger, 'Suspend event was received');
 }
-
 });  // goog.scope

--- a/common/js/src/background-page-unload-preventing/iframe-main.js
+++ b/common/js/src/background-page-unload-preventing/iframe-main.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,7 +55,6 @@ port.onMessage.addListener(function() {
   GSC.Logging.failWithLogger(
       logger,
       'Unexpectedly received a message through the message port from the ' +
-      'background page');
+          'background page');
 });
-
 });  // goog.scope

--- a/common/js/src/clipboard.js
+++ b/common/js/src/clipboard.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,5 +55,4 @@ GSC.Clipboard.copyToClipboard = function(text) {
   logger.fine('Copied text of length ' + text.length + ' to clipboard');
   return true;
 };
-
 });  // goog.scope

--- a/common/js/src/container-helpers-unittest.js
+++ b/common/js/src/container-helpers-unittest.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2018 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,8 +35,7 @@ goog.exportSymbol('testBuildObjectFromMap', function() {
       buildObjectFromMap(new Map([['key1', 'value1'], ['key2', 'value2']])),
       {key1: 'value1', key2: 'value2'});
   // Test cases where keys and/or values are not strings.
-  assertObjectEquals(
-      buildObjectFromMap(new Map([['key', 123]])), {key: 123});
+  assertObjectEquals(buildObjectFromMap(new Map([['key', 123]])), {key: 123});
   assertObjectEquals(
       buildObjectFromMap(new Map([[123, 'value']])), {123: 'value'});
   assertObjectEquals(
@@ -82,5 +82,4 @@ goog.exportSymbol('testSubstituteArrayBuffersRecursively', function() {
   assertEquals(substituteArrayBuffersRecursively(parseInt), parseInt);
   assertEquals(substituteArrayBuffersRecursively(Array), Array);
 });
-
 });  // goog.scope

--- a/common/js/src/container-helpers.js
+++ b/common/js/src/container-helpers.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2018 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,8 +34,9 @@ const GSC = GoogleSmartCard;
 GSC.ContainerHelpers.buildObjectFromMap = function(map) {
   let obj = {};
   for (let [key, value] of map) {
-    GSC.Logging.check(typeof key === 'string' || typeof key === 'number',
-                      'Invalid type for object key');
+    GSC.Logging.check(
+        typeof key === 'string' || typeof key === 'number',
+        'Invalid type for object key');
     obj[key] = value;
   }
   return obj;
@@ -64,5 +66,4 @@ GSC.ContainerHelpers.substituteArrayBuffersRecursively = function(value) {
   }
   return value;
 };
-
 });  // goog.scope

--- a/common/js/src/deferred-processor.js
+++ b/common/js/src/deferred-processor.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -92,8 +93,8 @@ const DeferredProcessor = GSC.DeferredProcessor;
 
 goog.inherits(DeferredProcessor, goog.Disposable);
 
-DeferredProcessor.prototype.logger = GSC.Logging.getScopedLogger(
-    'DeferredProcessor');
+DeferredProcessor.prototype.logger =
+    GSC.Logging.getScopedLogger('DeferredProcessor');
 
 /**
  * This structure is used to store the jobs in a queue.
@@ -196,5 +197,4 @@ DeferredProcessor.prototype.flushEnqueuedJobs_ = function() {
   GSC.Logging.checkWithLogger(this.logger, this.isCurrentlyFlushingJobs_);
   this.isCurrentlyFlushingJobs_ = false;
 };
-
 });  // goog.scope

--- a/common/js/src/executable-module/emscripten-module.js
+++ b/common/js/src/executable-module/emscripten-module.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2020 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -81,13 +82,15 @@ EmscriptenModule.prototype.getLogger = function() {
 
 /** @override */
 EmscriptenModule.prototype.startLoading = function() {
-  this.load_().then(() => {
-    this.loadPromiseResolver_.resolve();
-  }, (e) => {
-    this.logger_.warning('Failed to load the Emscripten module: ' + e);
-    this.dispose();
-    this.loadPromiseResolver_.reject(e);
-  });
+  this.load_().then(
+      () => {
+        this.loadPromiseResolver_.resolve();
+      },
+      (e) => {
+        this.logger_.warning('Failed to load the Emscripten module: ' + e);
+        this.dispose();
+        this.loadPromiseResolver_.reject(e);
+      });
 };
 
 /** @override */
@@ -144,8 +147,9 @@ EmscriptenModule.prototype.load_ = async function() {
   // side and is used for exchanging messages with it. By convention (see the
   // entry_point_emscripten.cc files), the class is named GoogleSmartCardModule.
   const GoogleSmartCardModule = emscriptenApiModule['GoogleSmartCardModule'];
-  GSC.Logging.checkWithLogger(this.logger_, GoogleSmartCardModule,
-                              'GoogleSmartCardModule class not defined');
+  GSC.Logging.checkWithLogger(
+      this.logger_, GoogleSmartCardModule,
+      'GoogleSmartCardModule class not defined');
   this.googleSmartCardModule_ = new GoogleSmartCardModule((message) => {
     this.messageChannel_.onMessageFromModule(message);
   });
@@ -247,8 +251,8 @@ EmscriptenModuleMessageChannel.prototype.disposeInternal = function() {
  * @param {?} googleSmartCardModule
  * @package
  */
-EmscriptenModuleMessageChannel.prototype.onModuleCreated =
-    function(googleSmartCardModule) {
+EmscriptenModuleMessageChannel.prototype.onModuleCreated = function(
+    googleSmartCardModule) {
   this.googleSmartCardModule_ = googleSmartCardModule;
   // Send all previously enqueued messages. Note that, in theory, new items
   // might be added to the array while we're iterating over it, which should be
@@ -262,8 +266,8 @@ EmscriptenModuleMessageChannel.prototype.onModuleCreated =
  * @param {?} message
  * @package
  */
-EmscriptenModuleMessageChannel.prototype.onMessageFromModule =
-    function(message) {
+EmscriptenModuleMessageChannel.prototype.onMessageFromModule = function(
+    message) {
   const typedMessage = GSC.TypedMessage.parseTypedMessage(message);
   if (!typedMessage) {
     GSC.Logging.fail(
@@ -284,5 +288,4 @@ EmscriptenModuleMessageChannel.prototype.sendNow_ = function(message) {
   // Closure Compiler doesn't rename this method call.
   this.googleSmartCardModule_['postMessage'](message);
 };
-
 });  // goog.scope

--- a/common/js/src/executable-module/executable-module.js
+++ b/common/js/src/executable-module/executable-module.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2020 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,7 +59,7 @@ const TOOLCHAIN = goog.define('GoogleSmartCard.ExecutableModule.TOOLCHAIN', '');
 GSC.Logging.check(
     Object.values(GSC.ExecutableModule.Toolchain).includes(TOOLCHAIN),
     'Unexpected value of GoogleSmartCard.ExecutableModule.TOOLCHAIN: ' +
-    '`${TOOLCHAIN}`');
+        '`${TOOLCHAIN}`');
 /**
  * The toolchain that is used for building the executable module. This constant
  * is coming from the build scripts, which take it from the "TOOLCHAIN"
@@ -66,8 +67,8 @@ GSC.Logging.check(
  * @type {!ExecutableModule.Toolchain}
  * @const
  */
-ExecutableModule.TOOLCHAIN = /** @type {!ExecutableModule.Toolchain} */ (
-    TOOLCHAIN);
+ExecutableModule.TOOLCHAIN =
+    /** @type {!ExecutableModule.Toolchain} */ (TOOLCHAIN);
 
 /**
  * @abstract
@@ -99,5 +100,4 @@ ExecutableModule.prototype.getLoadPromise = function() {};
  * @return {!goog.messaging.AbstractChannel}
  */
 ExecutableModule.prototype.getMessageChannel = function() {};
-
 });  // goog.scope

--- a/common/js/src/fixed-size-integer-unittest.js
+++ b/common/js/src/fixed-size-integer-unittest.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,5 +36,4 @@ goog.exportSymbol('testCastToInt32', function() {
   assertEquals(-0x80000000, castToInt32(-0x80000000));
   assertEquals(-0x7FFFFFFF, castToInt32(0x80000001));
 });
-
 });  // goog.scope

--- a/common/js/src/fixed-size-integer.js
+++ b/common/js/src/fixed-size-integer.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,5 +31,4 @@ const GSC = GoogleSmartCard;
 GSC.FixedSizeInteger.castToInt32 = function(value) {
   return goog.math.Integer.fromNumber(value).toInt();
 };
-
 });  // goog.scope

--- a/common/js/src/i18n-unittest.js
+++ b/common/js/src/i18n-unittest.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2020 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -152,5 +153,4 @@ goog.exportSymbol('testI18n', {
     checkSpanNodeTranslated();
   },
 });
-
 });  // goog.scope

--- a/common/js/src/i18n.js
+++ b/common/js/src/i18n.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,15 +44,13 @@ const I18N_TITLE_ATTRIBUTE = 'data-title';
 function transformElement(element, attribute, transformFunction) {
   const i18nId = element.getAttribute(attribute);
   GSC.Logging.checkWithLogger(
-      logger,
-      i18nId,
+      logger, i18nId,
       'Failed to get attribute [' + attribute +
-      '] for element: ' + element.outerHTML);
+          '] for element: ' + element.outerHTML);
 
   const translatedText = chrome.i18n.getMessage(i18nId);
   GSC.Logging.checkWithLogger(
-      logger,
-      translatedText,
+      logger, translatedText,
       'Failed to get translation for text with id: ' + i18nId);
 
   transformFunction(element, translatedText);
@@ -69,46 +68,48 @@ function transformAllElements(attribute, transformFunction) {
 }
 
 /**
- * @param {!Element} element 
- * @param {string} translatedText 
+ * @param {!Element} element
+ * @param {string} translatedText
  */
 function applyContentTranslation(element, translatedText) {
-  logger.fine('Translating element.textContent [' + element.outerHTML +
-              '] to "' + translatedText + '"');
+  logger.fine(
+      'Translating element.textContent [' + element.outerHTML + '] to "' +
+      translatedText + '"');
   element.textContent = translatedText;
 }
 
 /**
- * @param {!Element} element 
- * @param {string} translatedText 
+ * @param {!Element} element
+ * @param {string} translatedText
  */
 function applyAriaLabelTranslation(element, translatedText) {
-  logger.fine('Translating element.aria-label [' + element.outerHTML +
-              '] to "' + translatedText + '"');
+  logger.fine(
+      'Translating element.aria-label [' + element.outerHTML + '] to "' +
+      translatedText + '"');
   element.setAttribute('aria-label', translatedText);
 }
 
 /**
- * @param {!Element} element 
- * @param {string} translatedText 
+ * @param {!Element} element
+ * @param {string} translatedText
  */
 function applyTitleTranslation(element, translatedText) {
-  logger.fine('Translating element.title [' + element.outerHTML +
-              '] to "' + translatedText + '"');
+  logger.fine(
+      'Translating element.title [' + element.outerHTML + '] to "' +
+      translatedText + '"');
   element.setAttribute('title', translatedText);
 }
 
-/** 
- * Takes the element passed, replacing element.textContent with 
- * translation if it contains I18N_DATA_ATTRIBUTE, setting aria-label to 
+/**
+ * Takes the element passed, replacing element.textContent with
+ * translation if it contains I18N_DATA_ATTRIBUTE, setting aria-label to
  * translation if it contains I18N_DATA_ARIA_LABEL_ATTRIBUTE, and setting
  * title to translation if it contains I18N_TITLE_ATTRIBUTE.
  * @param {!Element} element
  */
 GSC.I18n.adjustElementTranslation = function(element) {
   if (element.hasAttribute(I18N_DATA_ATTRIBUTE)) {
-    transformElement(
-        element, I18N_DATA_ATTRIBUTE, applyContentTranslation);
+    transformElement(element, I18N_DATA_ATTRIBUTE, applyContentTranslation);
   }
 
   if (element.hasAttribute(I18N_DATA_ARIA_LABEL_ATTRIBUTE)) {
@@ -117,25 +118,21 @@ GSC.I18n.adjustElementTranslation = function(element) {
   }
 
   if (element.hasAttribute(I18N_TITLE_ATTRIBUTE)) {
-    transformElement(
-        element, I18N_TITLE_ATTRIBUTE, applyTitleTranslation);
+    transformElement(element, I18N_TITLE_ATTRIBUTE, applyTitleTranslation);
   }
 };
 
 /**
- * Applies adjustElementTranslation() to all HTML elements in the current 
+ * Applies adjustElementTranslation() to all HTML elements in the current
  * document. Used for translation that plays nice with Chromevox (accessibility
  * tool).
  */
 GSC.I18n.adjustAllElementsTranslation = function() {
-  transformAllElements(
-      I18N_DATA_ATTRIBUTE, applyContentTranslation);
+  transformAllElements(I18N_DATA_ATTRIBUTE, applyContentTranslation);
 
   transformAllElements(
       I18N_DATA_ARIA_LABEL_ATTRIBUTE, applyAriaLabelTranslation);
 
-  transformAllElements(
-      I18N_TITLE_ATTRIBUTE, applyTitleTranslation);
+  transformAllElements(I18N_TITLE_ATTRIBUTE, applyTitleTranslation);
 };
-
 });  // goog.scope

--- a/common/js/src/json.js
+++ b/common/js/src/json.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,5 +43,4 @@ GSC.Json.parse = function(jsonString) {
     return goog.Promise.reject(exc);
   }
 };
-
 });  // goog.scope

--- a/common/js/src/logging/crash-loop-detection-unittest.js
+++ b/common/js/src/logging/crash-loop-detection-unittest.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2020 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,8 +27,8 @@ const GSC = GoogleSmartCard;
 const CrashLoopDetection = GSC.Logging.CrashLoopDetection;
 
 const SOME_DATE = new Date(
-    /*year=*/2001, /*monthIndex=*/2, /*day=*/3, /*hours=*/4, /*minutes=*/5,
-    /*seconds=*/6, /*milliseconds=*/7);
+    /*year=*/ 2001, /*monthIndex=*/ 2, /*day=*/ 3, /*hours=*/ 4, /*minutes=*/ 5,
+    /*seconds=*/ 6, /*milliseconds=*/ 7);
 
 const propertyReplacer = new goog.testing.PropertyReplacer;
 
@@ -56,9 +57,8 @@ function stubDateNow() {
  */
 function stubChromeStorageLocalGet(key, callback) {
   if (simulateStorageGetFailure) {
-    propertyReplacer.set(chrome, 'runtime', {
-      'lastError': {'message': 'Error'}
-    });
+    propertyReplacer.set(
+        chrome, 'runtime', {'lastError': {'message': 'Error'}});
     callback();
     propertyReplacer.set(chrome, 'runtime', {'lastError': undefined});
     return;
@@ -76,9 +76,8 @@ function stubChromeStorageLocalGet(key, callback) {
  */
 function stubChromeStorageLocalSet(items, callback) {
   if (simulateStorageSetFailure) {
-    propertyReplacer.set(chrome, 'runtime', {
-      'lastError': {'message': 'Error'}
-    });
+    propertyReplacer.set(
+        chrome, 'runtime', {'lastError': {'message': 'Error'}});
     callback();
     propertyReplacer.set(chrome, 'runtime', {'lastError': undefined});
     return;
@@ -94,10 +93,10 @@ goog.exportSymbol('testCrashLoopDetection', {
     currentDate = SOME_DATE;
     currentStorage = {};
     propertyReplacer.set(Date, 'now', stubDateNow);
-    propertyReplacer.set(chrome, 'storage', {'local': {
-      'get': stubChromeStorageLocalGet,
-      'set': stubChromeStorageLocalSet
-    }});
+    propertyReplacer.set(chrome, 'storage', {
+      'local':
+          {'get': stubChromeStorageLocalGet, 'set': stubChromeStorageLocalSet}
+    });
     propertyReplacer.set(chrome, 'runtime', {'lastError': undefined});
   },
 
@@ -110,8 +109,8 @@ goog.exportSymbol('testCrashLoopDetection', {
   testSingleCrash: function() {
     return CrashLoopDetection.handleImminentCrash().then((isInCrashLoop) => {
       assertFalse(isInCrashLoop);
-      assertObjectEquals({'crash_timestamps': [SOME_DATE.getTime()]},
-                         currentStorage);
+      assertObjectEquals(
+          {'crash_timestamps': [SOME_DATE.getTime()]}, currentStorage);
     });
   },
 
@@ -131,8 +130,8 @@ goog.exportSymbol('testCrashLoopDetection', {
     currentStorage = {'crash_timestamps': [ONE_HOUR_AGO]};
     return CrashLoopDetection.handleImminentCrash().then((isInCrashLoop) => {
       assertFalse(isInCrashLoop);
-      assertObjectEquals({'crash_timestamps': [SOME_DATE.getTime()]},
-                         currentStorage);
+      assertObjectEquals(
+          {'crash_timestamps': [SOME_DATE.getTime()]}, currentStorage);
     });
   },
 
@@ -143,9 +142,9 @@ goog.exportSymbol('testCrashLoopDetection', {
     currentStorage = {'crash_timestamps': [ONE_SECOND_AGO]};
     return CrashLoopDetection.handleImminentCrash().then((isInCrashLoop) => {
       assertFalse(isInCrashLoop);
-      assertObjectEquals({
-        'crash_timestamps': [ONE_SECOND_AGO, SOME_DATE.getTime()]
-      }, currentStorage);
+      assertObjectEquals(
+          {'crash_timestamps': [ONE_SECOND_AGO, SOME_DATE.getTime()]},
+          currentStorage);
     });
   },
 
@@ -218,8 +217,8 @@ goog.exportSymbol('testCrashLoopDetection', {
     return CrashLoopDetection.handleImminentCrash().then((isInCrashLoop) => {
       assertFalse(isInCrashLoop);
       // Bad data got overwritten in the storage.
-      assertObjectEquals({'crash_timestamps': [SOME_DATE.getTime()]},
-                         currentStorage);
+      assertObjectEquals(
+          {'crash_timestamps': [SOME_DATE.getTime()]}, currentStorage);
     });
   },
 
@@ -241,5 +240,4 @@ goog.exportSymbol('testCrashLoopDetection', {
     });
   },
 });
-
 });  // goog.scope

--- a/common/js/src/logging/crash-loop-detection.js
+++ b/common/js/src/logging/crash-loop-detection.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2020 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,13 +74,15 @@ GSC.Logging.CrashLoopDetection.handleImminentCrash = function() {
     return Promise.reject(new Error('Already crashing'));
   crashing = true;
 
-  return loadRecentCrashTimestamps().then(recentCrashTimestamps => {
-    return storeNewCrashTimestamps(recentCrashTimestamps);
-  }).then(newCrashTimestamps => {
-    const isInCrashLoop =
-        newCrashTimestamps.length >= CRASH_LOOP_THRESHOLD_COUNT;
-    return Promise.resolve(isInCrashLoop);
-  });
+  return loadRecentCrashTimestamps()
+      .then(recentCrashTimestamps => {
+        return storeNewCrashTimestamps(recentCrashTimestamps);
+      })
+      .then(newCrashTimestamps => {
+        const isInCrashLoop =
+            newCrashTimestamps.length >= CRASH_LOOP_THRESHOLD_COUNT;
+        return Promise.resolve(isInCrashLoop);
+      });
 };
 
 /**
@@ -130,13 +133,13 @@ function storeNewCrashTimestamps(recentCrashTimestamps) {
   const minTimestampToKeep = currentTimestamp - CRASH_LOOP_WINDOW_MILLISECONDS;
   let newCrashTimestamps = recentCrashTimestamps.filter(crashTimestamp => {
     return minTimestampToKeep <= crashTimestamp &&
-           crashTimestamp <= currentTimestamp;
+        crashTimestamp <= currentTimestamp;
   });
   // Sanitization: Drop extra items beyond the |CRASH_LOOP_THRESHOLD_COUNT-1|
   // ones, in order to avoid any risk of the storage growing beyond all bounds.
   if (newCrashTimestamps.length >= CRASH_LOOP_THRESHOLD_COUNT) {
-    newCrashTimestamps = newCrashTimestamps.slice(
-        -CRASH_LOOP_THRESHOLD_COUNT + 1);
+    newCrashTimestamps =
+        newCrashTimestamps.slice(-CRASH_LOOP_THRESHOLD_COUNT + 1);
   }
   newCrashTimestamps.push(currentTimestamp);
 
@@ -162,5 +165,4 @@ function storeNewCrashTimestamps(recentCrashTimestamps) {
 }
 
 function ignoreChromeRuntimeLastError() {}
-
 });  // goog.scope

--- a/common/js/src/logging/debug-dump-unittest.js
+++ b/common/js/src/logging/debug-dump-unittest.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2017 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,18 +46,19 @@ goog.exportSymbol('testDebugDump', function() {
 
   assertEquals('[0x01, "foo", [0x02, 0x03], []]', dump([1, 'foo', [2, 3], []]));
 
-  assertEquals('ArrayBuffer[0x01, 0xFF]',
-               dump(new Uint8Array([1, 255]).buffer));
+  assertEquals(
+      'ArrayBuffer[0x01, 0xFF]', dump(new Uint8Array([1, 255]).buffer));
 
-  assertEquals('Map{0x01: 0x02, 0x03: "foo", "bar": {}, {}: 0x04}',
-               dump(new Map([[1, 2], [3, 'foo'], ['bar', {}], [{}, 4]])));
+  assertEquals(
+      'Map{0x01: 0x02, 0x03: "foo", "bar": {}, {}: 0x04}',
+      dump(new Map([[1, 2], [3, 'foo'], ['bar', {}], [{}, 4]])));
 
   assertEquals('Set{0x01, 0x02}', dump(new Set([1, 2])));
 
   assertEquals('{}', dump({}));
   assertEquals('{"a": "b", "c": [0x01, "d"]}', dump({'a': 'b', 'c': [1, 'd']}));
 
-  assertEquals('<Function>', dump(function(){}));
+  assertEquals('<Function>', dump(function() {}));
 
   assertEquals('<Document>', dump(document));
   assertEquals('<Window>', dump(window));
@@ -64,5 +66,4 @@ goog.exportSymbol('testDebugDump', function() {
   assertEquals('<NodeList>', dump(document.body.childNodes));
   assertEquals('<HTMLCollection>', dump(document.body.children));
 });
-
 });  // goog.scope

--- a/common/js/src/logging/debug-dump.js
+++ b/common/js/src/logging/debug-dump.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -106,7 +107,7 @@ function dumpNumber(value) {
   const hexValue = value.toString(16).toUpperCase();
   const expectedHexLength = bitLength / 4;
   return '0x' + goog.string.repeat('0', expectedHexLength - hexValue.length) +
-         hexValue;
+      hexValue;
 }
 
 /**
@@ -260,5 +261,4 @@ GSC.DebugDump.debugDump = function(value) {
   else
     return '<stripped value>';
 };
-
 });  // goog.scope

--- a/common/js/src/logging/log-buffer-forwarder.js
+++ b/common/js/src/logging/log-buffer-forwarder.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2020 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -124,8 +125,8 @@ LogBufferForwarder.prototype.onLogRecordObserved_ = function(
       this.ignoredLoggerNames_.has(logRecord.getLoggerName())) {
     return;
   }
-  const formattedLogRecord = GSC.LogFormatting.formatLogRecord(
-      documentLocation, logRecord);
+  const formattedLogRecord =
+      GSC.LogFormatting.formatLogRecord(documentLocation, logRecord);
   if (!this.messageChannel_) {
     this.postponedLogRecords_.add(formattedLogRecord);
     return;
@@ -149,5 +150,4 @@ LogBufferForwarder.prototype.sendLogRecord_ = function(formattedLogRecord) {
 
   this.logCapturingEnabled_ = true;
 };
-
 });

--- a/common/js/src/logging/log-buffer.js
+++ b/common/js/src/logging/log-buffer.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -78,8 +79,8 @@ GSC.LogBuffer = function(capacity) {
    * @type {!goog.structs.CircularBuffer.<string>}
    * @private
    */
-  this.formattedLogsSuffix_ = new goog.structs.CircularBuffer(
-      capacity - this.logsPrefixCapacity_);
+  this.formattedLogsSuffix_ =
+      new goog.structs.CircularBuffer(capacity - this.logsPrefixCapacity_);
 };
 
 const LogBuffer = GSC.LogBuffer;
@@ -147,8 +148,7 @@ LogBuffer.State.prototype.getAsText = function() {
 };
 
 goog.exportProperty(
-    LogBuffer.State.prototype,
-    'getAsText',
+    LogBuffer.State.prototype, 'getAsText',
     LogBuffer.State.prototype.getAsText);
 
 /**
@@ -162,8 +162,7 @@ goog.exportProperty(
  */
 LogBuffer.prototype.getState = function() {
   return new LogBuffer.State(
-      this.size_,
-      goog.array.clone(this.formattedLogsPrefix_),
+      this.size_, goog.array.clone(this.formattedLogsPrefix_),
       this.size_ - this.formattedLogsPrefix_.length -
           this.formattedLogsSuffix_.getCount(),
       this.formattedLogsSuffix_.getValues());
@@ -208,5 +207,4 @@ LogBuffer.prototype.onLogRecordObserved_ = function(
     this.formattedLogsSuffix_.add(formattedLogRecord);
   ++this.size_;
 };
-
 });  // goog.scope

--- a/common/js/src/logging/log-formatting.js
+++ b/common/js/src/logging/log-formatting.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2020 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,8 +65,8 @@ function getFormattedDocumentLocation(documentLocation, isCompact) {
  */
 function prefixLogRecord(documentLocation, logRecord, isCompact) {
   const loggerNameParts = [];
-  const formattedDocumentLocation = getFormattedDocumentLocation(
-      documentLocation, isCompact);
+  const formattedDocumentLocation =
+      getFormattedDocumentLocation(documentLocation, isCompact);
   if (formattedDocumentLocation)
     loggerNameParts.push(formattedDocumentLocation);
   if (logRecord.getLoggerName())
@@ -73,11 +74,8 @@ function prefixLogRecord(documentLocation, logRecord, isCompact) {
   const prefixedLoggerName = loggerNameParts.join('.');
 
   return new goog.log.LogRecord(
-      logRecord.getLevel(),
-      logRecord.getMessage(),
-      prefixedLoggerName,
-      logRecord.getMillis(),
-      logRecord.getSequenceNumber());
+      logRecord.getLevel(), logRecord.getMessage(), prefixedLoggerName,
+      logRecord.getMillis(), logRecord.getSequenceNumber());
 }
 
 /**
@@ -88,8 +86,8 @@ function prefixLogRecord(documentLocation, logRecord, isCompact) {
  * @return {string}
  */
 GSC.LogFormatting.formatLogRecord = function(documentLocation, logRecord) {
-  return textFormatter.formatRecord(prefixLogRecord(
-      documentLocation, logRecord, /*isCompact=*/false));
+  return textFormatter.formatRecord(
+      prefixLogRecord(documentLocation, logRecord, /*isCompact=*/ false));
 };
 
 /**
@@ -104,8 +102,7 @@ GSC.LogFormatting.formatLogRecord = function(documentLocation, logRecord) {
  */
 GSC.LogFormatting.formatLogRecordCompact = function(
     documentLocation, logRecord) {
-  return textFormatter.formatRecord(prefixLogRecord(
-      documentLocation, logRecord, /*isCompact=*/true));
+  return textFormatter.formatRecord(
+      prefixLogRecord(documentLocation, logRecord, /*isCompact=*/ true));
 };
-
 });

--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -105,7 +106,8 @@ const rootLogger =
  * @type {!goog.log.Logger}
  */
 const logger = GSC.Logging.USE_SCOPED_LOGGERS ?
-    goog.asserts.assert(goog.log.getLogger(LOGGER_SCOPE)) : rootLogger;
+    goog.asserts.assert(goog.log.getLogger(LOGGER_SCOPE)) :
+    rootLogger;
 
 /** @type {boolean} */
 let wasLoggingSetUp = false;
@@ -135,8 +137,9 @@ GSC.Logging.setupLogging = function() {
   setupConsoleLogging();
   setupRootLoggerLevel();
 
-  logger.fine('Logging was set up with level=' + ROOT_LOGGER_LEVEL.name +
-              ' and enabled logging to JS console');
+  logger.fine(
+      'Logging was set up with level=' + ROOT_LOGGER_LEVEL.name +
+      ' and enabled logging to JS console');
 
   setupLogBuffer();
 };
@@ -179,8 +182,7 @@ GSC.Logging.getScopedLogger = function(name, opt_level) {
  * @param {!goog.log.Level=} opt_level
  * @return {!goog.log.Logger}
  */
-GSC.Logging.getChildLogger = function(
-    parentLogger, relativeName, opt_level) {
+GSC.Logging.getChildLogger = function(parentLogger, relativeName, opt_level) {
   return GSC.Logging.getLogger(parentLogger.getName() + '.' + relativeName);
 };
 
@@ -219,8 +221,7 @@ GSC.Logging.check = function(condition, opt_message) {
  * @param {T} condition The condition to check.
  * @param {string=} opt_message Error message in case of failure.
  */
-GSC.Logging.checkWithLogger = function(
-    logger, condition, opt_message) {
+GSC.Logging.checkWithLogger = function(logger, condition, opt_message) {
   if (!condition)
     GSC.Logging.failWithLogger(logger, opt_message);
 };
@@ -271,8 +272,8 @@ GSC.Logging.getLogBuffer = function() {
 function scheduleAppReloadIfAllowed() {
   if (goog.DEBUG || !GSC.Logging.SELF_RELOAD_ON_FATAL_ERROR)
     return;
-  GSC.Logging.CrashLoopDetection.handleImminentCrash().then(
-      function(isInCrashLoop) {
+  GSC.Logging.CrashLoopDetection.handleImminentCrash()
+      .then(function(isInCrashLoop) {
         if (isInCrashLoop) {
           rootLogger.info(
               'Crash loop detected. The application is defunct, but the ' +
@@ -281,7 +282,8 @@ function scheduleAppReloadIfAllowed() {
         }
         rootLogger.info('Reloading the application due to the fatal error...');
         reloadApp();
-      }).catch(function() {
+      })
+      .catch(function() {
         // Don't do anything for repeated crashes within a single run.
       });
 }
@@ -314,8 +316,9 @@ function setupLogBuffer() {
   if (goog.object.containsKey(
           window, GSC.Logging.GLOBAL_LOG_BUFFER_VARIABLE_NAME)) {
     logBuffer = window[GSC.Logging.GLOBAL_LOG_BUFFER_VARIABLE_NAME];
-    logger.fine('Detected an existing log buffer instance, attaching it to ' +
-                'the root logger');
+    logger.fine(
+        'Detected an existing log buffer instance, attaching it to ' +
+        'the root logger');
   } else {
     logBuffer = new GSC.LogBuffer(LOG_BUFFER_CAPACITY);
     window[GSC.Logging.GLOBAL_LOG_BUFFER_VARIABLE_NAME] = logBuffer;
@@ -327,5 +330,4 @@ function setupLogBuffer() {
 }
 
 GSC.Logging.setupLogging();
-
 });  // goog.scope

--- a/common/js/src/messaging/common.js
+++ b/common/js/src/messaging/common.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,5 +68,4 @@ GSC.MessagingCommon.extractKey = function(object, key) {
 
   return GSC.ObjectHelpers.extractKey(object, key);
 };
-
 });  // goog.scope

--- a/common/js/src/messaging/message-channel-pair.js
+++ b/common/js/src/messaging/message-channel-pair.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,7 +55,8 @@ GSC.MessageChannelPair = function() {
    * @private
    */
   this.items_ = [
-      new MessageChannelPairItem(this, 0), new MessageChannelPairItem(this, 1)];
+    new MessageChannelPairItem(this, 0), new MessageChannelPairItem(this, 1)
+  ];
 };
 
 const MessageChannelPair = GSC.MessageChannelPair;
@@ -104,8 +106,8 @@ MessageChannelPair.prototype.sendFrom_ = function(
   const targetItem = this.items_[1 - fromItemIndex];
   // Deliver the message to the target message channel asynchronously, because
   // that's how the real message channels usually work.
-  goog.async.nextTick(targetItem.deliver_.bind(
-      targetItem, serviceName, payload));
+  goog.async.nextTick(
+      targetItem.deliver_.bind(targetItem, serviceName, payload));
 };
 
 /**
@@ -146,5 +148,4 @@ MessageChannelPairItem.prototype.disposeInternal = function() {
 MessageChannelPairItem.prototype.deliver_ = function(serviceName, payload) {
   this.deliver(serviceName, payload);
 };
-
 });  // goog.scope

--- a/common/js/src/messaging/message-channel-pinging.js
+++ b/common/js/src/messaging/message-channel-pinging.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -93,8 +94,8 @@ GSC.MessageChannelPinging.Pinger = function(
       PingResponder.SERVICE_NAME, this.serviceCallback_.bind(this), true);
 
   /** @private */
-  this.onEstablished_ = opt_onEstablished !== undefined ?
-      opt_onEstablished : null;
+  this.onEstablished_ =
+      opt_onEstablished !== undefined ? opt_onEstablished : null;
 
   /**
    * @type {number|null}
@@ -184,8 +185,9 @@ Pinger.prototype.serviceCallback_ = function(messageData) {
   }
   const channelId = messageData[CHANNEL_ID_MESSAGE_KEY];
   if (typeof channelId !== 'number') {
-    this.logger.warning('Received pong message has wrong format: channel id ' +
-                        'is not a number. Disposing...');
+    this.logger.warning(
+        'Received pong message has wrong format: channel id ' +
+        'is not a number. Disposing...');
     this.disposeChannelAndSelf_();
     return;
   }
@@ -200,8 +202,9 @@ Pinger.prototype.serviceCallback_ = function(messageData) {
       this.onEstablished_ = null;
     }
   } else if (this.previousRemoteEndChannelId_ == channelId) {
-    this.logger.finest('Received a pong response with the correct channel ' +
-                       'id, so the remote end considered alive');
+    this.logger.finest(
+        'Received a pong response with the correct channel ' +
+        'id, so the remote end considered alive');
     this.clearTimeoutTimer_();
     this.scheduleTimeoutTimer_();
   } else {
@@ -238,9 +241,7 @@ Pinger.prototype.schedulePostingPingMessage_ = function() {
 Pinger.prototype.scheduleTimeoutTimer_ = function() {
   GSC.Logging.checkWithLogger(this.logger, this.timeoutTimerId_ === null);
   this.timeoutTimerId_ = goog.Timer.callOnce(
-      this.timeoutCallback_.bind(this),
-      Pinger.TIMEOUT_MILLISECONDS,
-      this);
+      this.timeoutCallback_.bind(this), Pinger.TIMEOUT_MILLISECONDS, this);
 };
 
 /** @private */
@@ -255,8 +256,9 @@ Pinger.prototype.clearTimeoutTimer_ = function() {
 Pinger.prototype.timeoutCallback_ = function() {
   if (this.isDisposed())
     return;
-  this.logger.warning('No pong response received in time, the remote end is ' +
-                      'dead. Disposing...');
+  this.logger.warning(
+      'No pong response received in time, the remote end is ' +
+      'dead. Disposing...');
   this.disposeChannelAndSelf_();
 };
 
@@ -280,8 +282,8 @@ GSC.MessageChannelPinging.PingResponder = function(
    * @type {!goog.log.Logger}
    * @const
    */
-  this.logger = GSC.Logging.getChildLogger(
-      parentLogger, PING_RESPONDER_LOGGER_TITLE);
+  this.logger =
+      GSC.Logging.getChildLogger(parentLogger, PING_RESPONDER_LOGGER_TITLE);
 
   /** @private */
   this.messageChannel_ = messageChannel;
@@ -346,5 +348,4 @@ PingResponder.prototype.disposeInternal = function() {
 
   PingResponder.base(this, 'disposeInternal');
 };
-
 });  // goog.scope

--- a/common/js/src/messaging/message-channel-pool.js
+++ b/common/js/src/messaging/message-channel-pool.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -133,5 +134,4 @@ MessageChannelPool.prototype.handleChannelDisposed_ = function(
   }
   this.fireOnUpdateListeners_();
 };
-
 });  // goog.scope

--- a/common/js/src/messaging/mock-port.js
+++ b/common/js/src/messaging/mock-port.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,8 +74,7 @@ MockPort.prototype.disposeInternal = function() {
  */
 MockPort.prototype.fireOnMessage = function(message) {
   GSC.Logging.checkWithLogger(
-      this.logger,
-      !this.isDisposed() && this.isConnected_,
+      this.logger, !this.isDisposed() && this.isConnected_,
       'Trying to fire onMessage for closed mock port');
   for (let listener of this.getListeners_('onMessage'))
     listener(message);

--- a/common/js/src/messaging/port-message-channel-unittest.js
+++ b/common/js/src/messaging/port-message-channel-unittest.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -141,8 +142,10 @@ goog.exportSymbol('testPortMessageChannelMessageSending', function() {
   const mockPort = new GSC.MockPort('mock port');
   setUpPingRespondingForMockPort(mockPort);
   for (let testMessage of TEST_MESSAGES) {
-    mockPort.postMessage(new goog.testing.mockmatchers.ObjectEquals(
-        testMessage.makeMessage())).$once();
+    mockPort
+        .postMessage(new goog.testing.mockmatchers.ObjectEquals(
+            testMessage.makeMessage()))
+        .$once();
   }
   mockPort.postMessage.$replay();
 
@@ -175,8 +178,10 @@ goog.exportSymbol('testPortMessageChannelArrayBufferSending', function() {
       new TypedMessage(MESSAGE_TYPE, EXPECTED_TRANSMITTED_DATA);
 
   const mockPort = new GSC.MockPort('mock port');
-  mockPort.postMessage(new goog.testing.mockmatchers.ObjectEquals(
-      EXPECTED_TRANSMITTED_MESSAGE.makeMessage())).$once();
+  mockPort
+      .postMessage(new goog.testing.mockmatchers.ObjectEquals(
+          EXPECTED_TRANSMITTED_MESSAGE.makeMessage()))
+      .$once();
   mockPort.postMessage.$replay();
 
   const portMessageChannel = new GSC.PortMessageChannel(mockPort.getFakePort());
@@ -206,14 +211,12 @@ goog.exportSymbol('testPortMessageChannelMessageReceiving', function() {
 
     for (let testMessage of TEST_MESSAGES) {
       portMessageChannel.registerService(
-          testMessage.type,
-          function(messageData) {
+          testMessage.type, function(messageData) {
             GSC.Logging.check(goog.isObject(messageData));
             goog.asserts.assert(goog.isObject(messageData));
-            receivedMessages.push(new TypedMessage(
-                testMessage.type, messageData));
-          },
-          true);
+            receivedMessages.push(
+                new TypedMessage(testMessage.type, messageData));
+          }, true);
     }
 
     for (let testMessage of TEST_MESSAGES)

--- a/common/js/src/messaging/port-message-channel.js
+++ b/common/js/src/messaging/port-message-channel.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -184,15 +185,14 @@ PortMessageChannel.prototype.disconnectEventHandler_ = function() {
  * @private
  */
 PortMessageChannel.prototype.messageEventHandler_ = function(message) {
-  this.logger.finest('Received a message: ' +
-                     GSC.DebugDump.debugDump(message));
+  this.logger.finest('Received a message: ' + GSC.DebugDump.debugDump(message));
 
   const typedMessage = GSC.TypedMessage.parseTypedMessage(message);
   if (!typedMessage) {
     GSC.Logging.failWithLogger(
         this.logger,
         'Failed to parse the received message: ' +
-        GSC.DebugDump.debugDump(message));
+            GSC.DebugDump.debugDump(message));
   }
 
   this.deliver(typedMessage.type, typedMessage.data);
@@ -208,7 +208,6 @@ PortMessageChannel.prototype.defaultServiceCallback_ = function(
   GSC.Logging.failWithLogger(
       this.logger,
       'Unhandled message received: serviceName="' + serviceName +
-      '", payload=' + GSC.DebugDump.debugDump(payload));
+          '", payload=' + GSC.DebugDump.debugDump(payload));
 };
-
 });  // goog.scope

--- a/common/js/src/messaging/single-message-based-channel-unittest.js
+++ b/common/js/src/messaging/single-message-based-channel-unittest.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -123,8 +124,8 @@ goog.exportSymbol('testSingleMessageBasedChannelEstablishing', function() {
     testCasePromiseResolver.reject();
   }
 
-  globalChannel = new GSC.SingleMessageBasedChannel(
-      EXTENSION_ID, onChannelEstablished);
+  globalChannel =
+      new GSC.SingleMessageBasedChannel(EXTENSION_ID, onChannelEstablished);
   globalChannel.addOnDisposeCallback(onChannelDisposed);
 
   return testCasePromiseResolver.promise;
@@ -176,8 +177,8 @@ goog.exportSymbol('testSingleMessageBasedChannelSending', function() {
 
   for (const testMessage of TEST_MESSAGES) {
     chrome.runtime.sendMessage(
-        verifyChannelIdMatcher, new goog.testing.mockmatchers.ObjectEquals(
-            testMessage.makeMessage()));
+        verifyChannelIdMatcher,
+        new goog.testing.mockmatchers.ObjectEquals(testMessage.makeMessage()));
     mockedSendMessage.$once();
   }
 
@@ -197,8 +198,8 @@ goog.exportSymbol('testSingleMessageBasedChannelSending', function() {
     testCasePromiseResolver.reject();
   }
 
-  globalChannel = new GSC.SingleMessageBasedChannel(
-      EXTENSION_ID, onChannelEstablished);
+  globalChannel =
+      new GSC.SingleMessageBasedChannel(EXTENSION_ID, onChannelEstablished);
   globalChannel.addOnDisposeCallback(onChannelDisposed);
 
   return testCasePromiseResolver.promise;
@@ -220,15 +221,11 @@ goog.exportSymbol('testSingleMessageBasedChannelReceiving', function() {
     const receivedMessages = [];
 
     for (let testMessage of TEST_MESSAGES) {
-      globalChannel.registerService(
-          testMessage.type,
-          function(messageData) {
-            GSC.Logging.check(goog.isObject(messageData));
-            goog.asserts.assert(goog.isObject(messageData));
-            receivedMessages.push(new TypedMessage(
-                testMessage.type, messageData));
-          },
-          true);
+      globalChannel.registerService(testMessage.type, function(messageData) {
+        GSC.Logging.check(goog.isObject(messageData));
+        goog.asserts.assert(goog.isObject(messageData));
+        receivedMessages.push(new TypedMessage(testMessage.type, messageData));
+      }, true);
     }
 
     for (let testMessage of TEST_MESSAGES) {
@@ -244,8 +241,8 @@ goog.exportSymbol('testSingleMessageBasedChannelReceiving', function() {
     testCasePromiseResolver.reject();
   }
 
-  globalChannel = new GSC.SingleMessageBasedChannel(
-      EXTENSION_ID, onChannelEstablished);
+  globalChannel =
+      new GSC.SingleMessageBasedChannel(EXTENSION_ID, onChannelEstablished);
   globalChannel.addOnDisposeCallback(onChannelDisposed);
 
   return testCasePromiseResolver.promise;
@@ -279,8 +276,9 @@ goog.exportSymbol('testSingleMessageBasedChannelDisposing', function() {
   }
 
   function onChannelDisposed() {
-    assert('Channel wasn\'t successfully established prior to failure',
-           channelEstablished);
+    assert(
+        'Channel wasn\'t successfully established prior to failure',
+        channelEstablished);
     assert(globalChannel.isDisposed());
 
     assertThrows(function() {
@@ -292,11 +290,10 @@ goog.exportSymbol('testSingleMessageBasedChannelDisposing', function() {
     globalChannel.dispose();
   }
 
-  globalChannel = new GSC.SingleMessageBasedChannel(
-      EXTENSION_ID, onChannelEstablished);
+  globalChannel =
+      new GSC.SingleMessageBasedChannel(EXTENSION_ID, onChannelEstablished);
   globalChannel.addOnDisposeCallback(onChannelDisposed);
 
   return testCasePromiseResolver.promise;
 });
-
 });  // goog.scope

--- a/common/js/src/messaging/single-message-based-channel.js
+++ b/common/js/src/messaging/single-message-based-channel.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -114,15 +115,14 @@ SingleMessageBasedChannel.prototype.send = function(serviceName, payload) {
  * @param {*} message
  */
 SingleMessageBasedChannel.prototype.deliverMessage = function(message) {
-  this.logger.finest('Received a message: ' +
-                     GSC.DebugDump.debugDump(message));
+  this.logger.finest('Received a message: ' + GSC.DebugDump.debugDump(message));
 
   const typedMessage = GSC.TypedMessage.parseTypedMessage(message);
   if (!typedMessage) {
     GSC.Logging.failWithLogger(
         this.logger,
         'Failed to parse the received message: ' +
-        GSC.DebugDump.debugDump(message));
+            GSC.DebugDump.debugDump(message));
   }
 
   this.deliver(typedMessage.type, typedMessage.data);
@@ -153,7 +153,7 @@ SingleMessageBasedChannel.prototype.defaultServiceCallback_ = function(
   GSC.Logging.failWithLogger(
       this.logger,
       'Unhandled message received: serviceName="' + serviceName +
-      '", payload=' + GSC.DebugDump.debugDump(payload));
+          '", payload=' + GSC.DebugDump.debugDump(payload));
 };
 
 /** @private */
@@ -163,5 +163,4 @@ SingleMessageBasedChannel.prototype.pingMessageReceivedListener_ = function() {
   if (this.shouldPingOnPing_)
     this.pinger_.postPingMessage();
 };
-
 });  // goog.scope

--- a/common/js/src/messaging/typed-message.js
+++ b/common/js/src/messaging/typed-message.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,8 +57,7 @@ const TypedMessage = GSC.TypedMessage;
  * @return {TypedMessage?}
  */
 TypedMessage.parseTypedMessage = function(message) {
-  if (!goog.isObject(message) ||
-      goog.object.getCount(message) != 2 ||
+  if (!goog.isObject(message) || goog.object.getCount(message) != 2 ||
       !goog.object.containsKey(message, TYPE_MESSAGE_KEY) ||
       typeof message[TYPE_MESSAGE_KEY] !== 'string' ||
       !goog.object.containsKey(message, DATA_MESSAGE_KEY) ||
@@ -75,5 +75,4 @@ TypedMessage.prototype.makeMessage = function() {
   return goog.object.create(
       TYPE_MESSAGE_KEY, this.type, DATA_MESSAGE_KEY, this.data);
 };
-
 });  // goog.scope

--- a/common/js/src/nacl-module/nacl-module-log-messages-receiver.js
+++ b/common/js/src/nacl-module/nacl-module-log-messages-receiver.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -93,8 +94,7 @@ NaclModuleLogMessagesReceiver.prototype.extractLogMessageLevel_ = function(
 
   const result = goog.log.Level.getPredefinedLevel(value);
   GSC.Logging.checkWithLogger(
-      this.logger,
-      result,
+      this.logger, result,
       'Unknown log level specified in the received message: "' + value + '"');
   goog.asserts.assert(result);
 

--- a/common/js/src/nacl-module/nacl-module-messaging-channel.js
+++ b/common/js/src/nacl-module/nacl-module-messaging-channel.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -105,11 +106,12 @@ NaclModuleMessageChannel.prototype.messageEventListener_ = function(message) {
     GSC.Logging.failWithLogger(
         this.logger_,
         'Failed to parse message received from NaCl module: ' +
-        GSC.DebugDump.debugDump(messageData));
+            GSC.DebugDump.debugDump(messageData));
   }
 
-  this.logger_.finest('Received a message from NaCl module: ' +
-                      GSC.DebugDump.debugDump(messageData));
+  this.logger_.finest(
+      'Received a message from NaCl module: ' +
+      GSC.DebugDump.debugDump(messageData));
   this.deliver(typedMessage.type, typedMessage.data);
 };
 
@@ -119,7 +121,6 @@ NaclModuleMessageChannel.prototype.defaultServiceCallback_ = function(
   GSC.Logging.failWithLogger(
       this.logger_,
       'Unhandled message received from NaCl module: serviceName="' +
-      serviceName + '", payload=' + GSC.DebugDump.debugDump(payload));
+          serviceName + '", payload=' + GSC.DebugDump.debugDump(payload));
 };
-
 });  // goog.scope

--- a/common/js/src/nacl-module/nacl-module.js
+++ b/common/js/src/nacl-module/nacl-module.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,8 +67,8 @@ GSC.NaclModule = function(naclModulePath, type, logModulePath = false) {
    * @type {!goog.log.Logger}
    * @const @private
    */
-  this.logger_ = GSC.Logging.getChildLogger(
-      messagesReceiverLogger, LOGGER_TITLE);
+  this.logger_ =
+      GSC.Logging.getChildLogger(messagesReceiverLogger, LOGGER_TITLE);
 
   /**
    * @type {string}
@@ -97,8 +98,8 @@ GSC.NaclModule = function(naclModulePath, type, logModulePath = false) {
    * @type {!GSC.NaclModuleMessageChannel}
    * @private
    */
-  this.messageChannel_ = new GSC.NaclModuleMessageChannel(
-      this.element_, this.logger_);
+  this.messageChannel_ =
+      new GSC.NaclModuleMessageChannel(this.element_, this.logger_);
 
   /** @type {!GSC.NaclModuleLogMessagesReceiver} */
   this.logMessagesReceiver = new GSC.NaclModuleLogMessagesReceiver(
@@ -169,12 +170,9 @@ NaclModule.prototype.disposeInternal = function() {
 NaclModule.prototype.createElement_ = function() {
   const mimeType = this.getMimeType_();
   this.logger_.fine('Preparing NaCl embed (MIME type: "' + mimeType + '")...');
-  return goog.dom.createDom('embed', {
-    'type': mimeType,
-    'width': 0,
-    'height': 0,
-    'src': this.naclModulePath
-  });
+  return goog.dom.createDom(
+      'embed',
+      {'type': mimeType, 'width': 0, 'height': 0, 'src': this.naclModulePath});
 };
 
 /**
@@ -223,8 +221,9 @@ NaclModule.prototype.loadEventListener_ = function() {
 NaclModule.prototype.abortEventListener_ = function() {
   if (this.isDisposed())
     return;
-  this.logger_.severe('NaCl module load was aborted with the following ' +
-                      'message: ' + this.element_['lastError']);
+  this.logger_.severe(
+      'NaCl module load was aborted with the following ' +
+      'message: ' + this.element_['lastError']);
   this.dispose();
 };
 
@@ -232,8 +231,9 @@ NaclModule.prototype.abortEventListener_ = function() {
 NaclModule.prototype.errorEventListener_ = function() {
   if (this.isDisposed())
     return;
-  this.logger_.severe('Failed to load NaCl module with the following ' +
-                      'message: ' + this.element_['lastError']);
+  this.logger_.severe(
+      'Failed to load NaCl module with the following ' +
+      'message: ' + this.element_['lastError']);
   this.dispose();
 };
 
@@ -252,5 +252,4 @@ NaclModule.prototype.forceElementLoading_ = function() {
   // crbug.com/350445).
   this.element_.offsetTop = this.element_.offsetTop;
 };
-
 });  // goog.scope

--- a/common/js/src/object-helpers.js
+++ b/common/js/src/object-helpers.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,10 +45,9 @@ GSC.ObjectHelpers.extractKey = function(object, key) {
     GSC.Logging.failWithLogger(
         LOGGER,
         'Key "' + key + '" not present in object ' +
-        GSC.DebugDump.debugDump(object));
+            GSC.DebugDump.debugDump(object));
   }
 
   return object[key];
 };
-
 });  // goog.scope

--- a/common/js/src/popup-window/client.js
+++ b/common/js/src/popup-window/client.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -65,8 +66,9 @@ GSC.PopupWindow.Client.showWindow = function() {
 GSC.PopupWindow.Client.resolveModalDialog = function(result) {
   const callback = GSC.PopupWindow.Client.getData()['resolveModalDialog'];
   GSC.Logging.checkWithLogger(logger, callback);
-  logger.fine('The modal dialog is resolved with the following result: ' +
-              GSC.DebugDump.debugDump(result));
+  logger.fine(
+      'The modal dialog is resolved with the following result: ' +
+      GSC.DebugDump.debugDump(result));
   callback(result);
   closeWindow();
 };
@@ -80,8 +82,8 @@ GSC.PopupWindow.Client.resolveModalDialog = function(result) {
 GSC.PopupWindow.Client.rejectModalDialog = function(error) {
   const callback = GSC.PopupWindow.Client.getData()['rejectModalDialog'];
   GSC.Logging.checkWithLogger(logger, callback);
-  logger.fine('The modal dialog is rejected with the following error: ' +
-              error);
+  logger.fine(
+      'The modal dialog is rejected with the following error: ' + error);
   callback(error);
   closeWindow();
 };
@@ -119,8 +121,7 @@ GSC.PopupWindow.Client.setWindowHeightToFitContent = function() {
  */
 GSC.PopupWindow.Client.setupClosingOnEscape = function() {
   goog.events.listen(
-      document,
-      goog.events.EventType.KEYDOWN,
+      document, goog.events.EventType.KEYDOWN,
       documentClosingOnEscapeKeyDownListener);
   logger.fine('ESC key press handler was set up');
 };
@@ -150,5 +151,4 @@ function documentClosingOnEscapeKeyDownListener(event) {
 function windowCloseDialogRejectionListener() {
   GSC.PopupWindow.Client.rejectModalDialog(new Error('Dialog was closed'));
 }
-
 });  // goog.scope

--- a/common/js/src/popup-window/server.js
+++ b/common/js/src/popup-window/server.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -60,21 +61,21 @@ GSC.PopupWindow.Server.createWindow = function(
     createdWindowExtends['passedData'] = opt_data;
 
   logger.fine(
-      'Creating a popup window with url="' + url + '", options=' +
-      GSC.DebugDump.debugDump(createWindowOptions) + ', data=' +
-      GSC.DebugDump.debugDump(opt_data));
+      'Creating a popup window with url="' + url +
+      '", options=' + GSC.DebugDump.debugDump(createWindowOptions) +
+      ', data=' + GSC.DebugDump.debugDump(opt_data));
 
   /** @preserveTry */
   try {
     chrome.app.window.create(
-        url,
-        createWindowOptions,
+        url, createWindowOptions,
         createWindowCallback.bind(null, createdWindowExtends));
   } catch (exc) {
     GSC.Logging.failWithLogger(
         logger,
         'Failed to create the popup window with URL "' + url + '" and ' +
-        'options ' + GSC.DebugDump.debugDump(createWindowOptions) + ': ' + exc);
+            'options ' + GSC.DebugDump.debugDump(createWindowOptions) + ': ' +
+            exc);
   }
 };
 
@@ -96,7 +97,7 @@ GSC.PopupWindow.Server.runModalDialog = function(
         logger,
         !goog.object.containsKey(opt_createWindowOptionsOverrides, 'id'),
         '"id" window option is disallowed for the modal dialogs (as this ' +
-        'option may result in not creating the new modal dialog)');
+            'option may result in not creating the new modal dialog)');
     Object.assign(createWindowOptions, opt_createWindowOptionsOverrides);
   }
 
@@ -133,5 +134,4 @@ function createWindowCallback(createdWindowExtends, createdWindow) {
       GSC.DebugDump.debugDump(createdWindowExtends));
   Object.assign(createdWindowScope, createdWindowExtends);
 }
-
 });  // goog.scope

--- a/common/js/src/promise-helpers.js
+++ b/common/js/src/promise-helpers.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,5 +37,4 @@ const GSC = GoogleSmartCard;
 GSC.PromiseHelpers.suppressUnhandledRejectionError = function(promise) {
   promise.thenCatch(function() {});
 };
-
 });  // goog.scope

--- a/common/js/src/random.js
+++ b/common/js/src/random.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,5 +43,4 @@ GSC.Random.randomIntegerNumber = function() {
   });
   return result;
 };
-
 });  // goog.scope

--- a/common/js/src/requesting/remote-call-message.js
+++ b/common/js/src/requesting/remote-call-message.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -80,9 +81,7 @@ RemoteCallMessage.parseRequestPayload = function(requestPayload) {
  */
 RemoteCallMessage.prototype.makeRequestPayload = function() {
   return goog.object.create(
-      FUNCTION_NAME_MESSAGE_KEY,
-      this.functionName,
-      ARGUMENTS_MESSAGE_KEY,
+      FUNCTION_NAME_MESSAGE_KEY, this.functionName, ARGUMENTS_MESSAGE_KEY,
       this.functionArguments);
 };
 
@@ -96,10 +95,9 @@ RemoteCallMessage.prototype.makeRequestPayload = function() {
  */
 RemoteCallMessage.prototype.getDebugRepresentation = function() {
   return goog.string.subs(
-      '%s(%s)',
-      this.functionName,
-      goog.iter.join(goog.iter.map(
-          this.functionArguments, GSC.DebugDump.debugDump), ', '));
+      '%s(%s)', this.functionName,
+      goog.iter.join(
+          goog.iter.map(this.functionArguments, GSC.DebugDump.debugDump),
+          ', '));
 };
-
 });  // goog.scope

--- a/common/js/src/requesting/request-receiver.js
+++ b/common/js/src/requesting/request-receiver.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -121,7 +122,7 @@ RequestReceiver.prototype.requestMessageReceivedListener_ = function(
       GSC.Logging.failWithLogger(
           this.logger,
           'Failed to parse the received request message: ' +
-          GSC.DebugDump.debugDump(messageData));
+              GSC.DebugDump.debugDump(messageData));
     }
   }
 
@@ -153,10 +154,10 @@ RequestReceiver.prototype.responseResolvedListener_ = function(
 
   this.logger.fine(
       'Sending the successful response for the request with identifier ' +
-      requestMessageData.requestId + ', the response is: ' +
-      GSC.DebugDump.debugDump(payload));
-  this.sendResponse_(new ResponseMessageData(
-      requestMessageData.requestId, payload));
+      requestMessageData.requestId +
+      ', the response is: ' + GSC.DebugDump.debugDump(payload));
+  this.sendResponse_(
+      new ResponseMessageData(requestMessageData.requestId, payload));
 };
 
 /**

--- a/common/js/src/requesting/requester-message.js
+++ b/common/js/src/requesting/requester-message.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -110,9 +111,7 @@ RequestMessageData.parseMessageData = function(messageData) {
  */
 RequestMessageData.prototype.makeMessageData = function() {
   return goog.object.create(
-      REQUEST_ID_MESSAGE_KEY,
-      this.requestId,
-      PAYLOAD_MESSAGE_KEY,
+      REQUEST_ID_MESSAGE_KEY, this.requestId, PAYLOAD_MESSAGE_KEY,
       this.payload);
 };
 
@@ -142,8 +141,8 @@ const ResponseMessageData = RequesterMessage.ResponseMessageData;
  * @type {!goog.log.Logger}
  * @const
  */
-ResponseMessageData.prototype.logger = GSC.Logging.getScopedLogger(
-    'RequesterMessage.ResponseMessageData');
+ResponseMessageData.prototype.logger =
+    GSC.Logging.getScopedLogger('RequesterMessage.ResponseMessageData');
 
 /**
  * @return {boolean}
@@ -211,5 +210,4 @@ ResponseMessageData.prototype.makeMessageData = function() {
   }
   return goog.object.create(args);
 };
-
 });  // goog.scope

--- a/common/js/src/requesting/requester-unittest.js
+++ b/common/js/src/requesting/requester-unittest.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2018 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -156,8 +157,6 @@ goog.exportSymbol('testRequester_disposed', function() {
 
   return requestPromise.then(() => {
     fail('Unexpected success');
-  }, () => {
-  });
+  }, () => {});
 });
-
 });  // goog.scope

--- a/common/js/src/requesting/requester.js
+++ b/common/js/src/requesting/requester.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -223,8 +224,8 @@ Requester.prototype.resolveRequest_ = function(requestId, payload) {
  * @private
  */
 Requester.prototype.rejectRequest_ = function(requestId, errorMessage) {
-  this.logger.fine('The request with identifier ' + requestId + ' failed: ' +
-                   errorMessage);
+  this.logger.fine(
+      'The request with identifier ' + requestId + ' failed: ' + errorMessage);
   this.popRequestPromiseResolver_(requestId).reject(new Error(errorMessage));
 };
 

--- a/example_cpp_smart_card_client_app/src/background.js
+++ b/example_cpp_smart_card_client_app/src/background.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -141,8 +142,9 @@ function createExecutableModule() {
     case GSC.ExecutableModule.Toolchain.EMSCRIPTEN:
       return new GSC.EmscriptenModule('executable_module');
   }
-  GSC.Logging.fail(`Cannot load executable module: unknown toolchain ` +
-                   `${GSC.ExecutableModule.TOOLCHAIN}`);
+  GSC.Logging.fail(
+      `Cannot load executable module: unknown toolchain ` +
+      `${GSC.ExecutableModule.TOOLCHAIN}`);
   goog.asserts.fail();
 }
 
@@ -213,5 +215,4 @@ chrome.app.runtime.onLaunched.addListener(() => {
 
 // Automatically load the App (in the background) with Chrome startup.
 GSC.AppUtils.enableSelfAutoLoading();
-
 });  // goog.scope

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog-backend.js
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog-backend.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2020 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,9 +45,7 @@ const PIN_DIALOG_URL = 'built-in-pin-dialog.html';
 
 const PIN_DIALOG_WINDOW_OPTIONS_OVERRIDES = {
   'alwaysOnTop': false,
-  'innerBounds': {
-    'width': 230
-  }
+  'innerBounds': {'width': 230}
 };
 
 const GSC = GoogleSmartCard;
@@ -91,13 +90,15 @@ function handleRequest(payload) {
 
   const promiseResolver = goog.Promise.withResolver();
 
-  pinPromise.then(function(pin) {
-    logger.info('PIN dialog finished successfully');
-    promiseResolver.resolve(createResponseMessagePayload(pin));
-  }, function(error) {
-    logger.info('PIN dialog finished with error: ' + error);
-    promiseResolver.reject(error);
-  });
+  pinPromise.then(
+      function(pin) {
+        logger.info('PIN dialog finished successfully');
+        promiseResolver.resolve(createResponseMessagePayload(pin));
+      },
+      function(error) {
+        logger.info('PIN dialog finished with error: ' + error);
+        promiseResolver.reject(error);
+      });
 
   return promiseResolver.promise;
 }
@@ -105,5 +106,4 @@ function handleRequest(payload) {
 function createResponseMessagePayload(pin) {
   return goog.object.create(PIN_MESSAGE_KEY, pin);
 }
-
 });  // goog.scope

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog-main.js
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog-main.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2020 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,13 +42,12 @@ function okClickListener() {
 }
 
 function cancelClickListener() {
-  GSC.PopupWindow.Client.rejectModalDialog(new Error(
-      'PIN dialog was canceled'));
+  GSC.PopupWindow.Client.rejectModalDialog(
+      new Error('PIN dialog was canceled'));
 }
 
 goog.events.listen(goog.dom.getElement('ok'), 'click', okClickListener);
 goog.events.listen(goog.dom.getElement('cancel'), 'click', cancelClickListener);
 
 GSC.PopupWindow.Client.prepareAndShowAsModalDialog();
-
 });  // goog.scope

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-integrationtest.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-integrationtest.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2020 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,14 +35,16 @@ const CertificateProviderBridge = SmartCardClientApp.CertificateProviderBridge;
 const FAKE_CERT_1_DER = new Uint8Array([1, 2, 3]);
 const FAKE_CERT_1_ALGORITHMS = ['RSASSA_PKCS1_v1_5_SHA256'];
 const FAKE_CERT_2_DER = new Uint8Array([4]);
-const FAKE_CERT_2_ALGORITHMS = [
-    'RSASSA_PKCS1_v1_5_SHA512', 'RSASSA_PKCS1_v1_5_SHA1'];
+const FAKE_CERT_2_ALGORITHMS =
+    ['RSASSA_PKCS1_v1_5_SHA512', 'RSASSA_PKCS1_v1_5_SHA1'];
 
 /** @type {GSC.IntegrationTestController?} */
 let testController;
 /** @type {CertificateProviderBridge.Backend?} */
 let bridgeBackend;
-/** @type {!goog.promise.Resolver<!chrome.certificateProvider.SetCertificatesDetails>} */
+/**
+ * @type {!goog.promise.Resolver<!chrome.certificateProvider.SetCertificatesDetails>}
+ */
 let setCertificatesApiExpectation;
 
 /**
@@ -77,10 +80,10 @@ goog.exportSymbol('testChromeCertificateProviderApiBridge', {
   setUp: function() {
     testController = new GSC.IntegrationTestController();
     return testController.initAsync().then(() => {
-      bridgeBackend = new CertificateProviderBridge.Backend(
-          testController.naclModule);
+      bridgeBackend =
+          new CertificateProviderBridge.Backend(testController.naclModule);
       return testController.setUpCppHelper(
-        'ChromeCertificateProviderApiBridge', /*helperArgument=*/{});
+          'ChromeCertificateProviderApiBridge', /*helperArgument=*/ {});
     });
   },
 
@@ -94,7 +97,7 @@ goog.exportSymbol('testChromeCertificateProviderApiBridge', {
     setUpApiStubs();
     testController.sendMessageToCppHelper(
         'ChromeCertificateProviderApiBridge',
-        /*messageForHelper=*/'setCertificates_empty');
+        /*messageForHelper=*/ 'setCertificates_empty');
     return setCertificatesApiExpectation.promise.then((details) => {
       assertObjectEquals(details, {'clientCertificates': []});
     });
@@ -105,22 +108,27 @@ goog.exportSymbol('testChromeCertificateProviderApiBridge', {
     // Just verify that no crash happens.
     return testController.sendMessageToCppHelper(
         'ChromeCertificateProviderApiBridge',
-        /*messageForHelper=*/'setCertificates_empty');
+        /*messageForHelper=*/ 'setCertificates_empty');
   },
 
   testSetCertificates_fakeCerts: function() {
     setUpApiStubs();
     testController.sendMessageToCppHelper(
         'ChromeCertificateProviderApiBridge',
-        /*messageForHelper=*/'setCertificates_fakeCerts');
+        /*messageForHelper=*/ 'setCertificates_fakeCerts');
     return setCertificatesApiExpectation.promise.then((details) => {
-      assertObjectEquals(details, {'clientCertificates': [{
-        'certificateChain': [FAKE_CERT_1_DER.buffer],
-        'supportedAlgorithms': FAKE_CERT_1_ALGORITHMS
-      }, {
-        'certificateChain': [FAKE_CERT_2_DER.buffer],
-        'supportedAlgorithms': FAKE_CERT_2_ALGORITHMS
-      }]});
+      assertObjectEquals(details, {
+        'clientCertificates': [
+          {
+            'certificateChain': [FAKE_CERT_1_DER.buffer],
+            'supportedAlgorithms': FAKE_CERT_1_ALGORITHMS
+          },
+          {
+            'certificateChain': [FAKE_CERT_2_DER.buffer],
+            'supportedAlgorithms': FAKE_CERT_2_ALGORITHMS
+          }
+        ]
+      });
     });
   },
 
@@ -129,8 +137,7 @@ goog.exportSymbol('testChromeCertificateProviderApiBridge', {
     // Just verify that no crash happens.
     return testController.sendMessageToCppHelper(
         'ChromeCertificateProviderApiBridge',
-        /*messageForHelper=*/'setCertificates_empty');
+        /*messageForHelper=*/ 'setCertificates_empty');
   },
 });
-
 });  // goog.scope

--- a/example_cpp_smart_card_client_app/src/window.js
+++ b/example_cpp_smart_card_client_app/src/window.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2020 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,7 +50,7 @@ logger.info('The main window is created');
 const executableModuleMessageChannel =
     /** @type {!goog.messaging.MessageChannel} */
     (GSC.ObjectHelpers.extractKey(
-         GSC.PopupWindow.Client.getData(), 'executableModuleMessageChannel'));
+        GSC.PopupWindow.Client.getData(), 'executableModuleMessageChannel'));
 
 // Load the localized strings into the HTML elements.
 GSC.I18n.adjustAllElementsTranslation();
@@ -76,12 +77,10 @@ function displayOutputMessage(text) {
 
 // Set up UI event listeners.
 goog.events.listen(
-    goog.dom.getElement('close-window'),
-    goog.events.EventType.CLICK,
+    goog.dom.getElement('close-window'), goog.events.EventType.CLICK,
     onCloseWindowClicked);
 goog.events.listen(
-    goog.dom.getElement('run-test'),
-    goog.events.EventType.CLICK,
+    goog.dom.getElement('run-test'), goog.events.EventType.CLICK,
     onRunTestClicked);
 
 // Handle messages from the executable module.
@@ -93,7 +92,7 @@ executableModuleMessageChannel.registerService('ui', (payload) => {
 
   if (payload['output_message'])
     displayOutputMessage(payload['output_message']);
-}, /*opt_objectPayload=*/true);
+}, /*opt_objectPayload=*/ true);
 
 // Unregister from receiving messages from the module when our window is closed.
 chrome.app.window.current().onClosed.addListener(() => {
@@ -102,5 +101,4 @@ chrome.app.window.current().onClosed.addListener(() => {
 
 // Show the window, after all the initialization above has been done.
 GSC.PopupWindow.Client.showWindow();
-
 });  // goog.scope

--- a/example_js_smart_card_client_app/src/background.js
+++ b/example_js_smart_card_client_app/src/background.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -126,13 +127,16 @@ function work(api) {
   function runPcscLiteDemo(callback) {
     logger.info('Starting PC/SC-Lite demo...');
     GSC.PcscLiteClient.Demo.logger.setLevel(goog.log.Level.FINE);
-    GSC.PcscLiteClient.Demo.run(api, function() {
-      logger.info('PC/SC-Lite demo successfully finished');
-      callback();
-    }, function() {
-      logger.warning('PC/SC-Lite demo failed');
-      callback();
-    });
+    GSC.PcscLiteClient.Demo.run(
+        api,
+        function() {
+          logger.info('PC/SC-Lite demo successfully finished');
+          callback();
+        },
+        function() {
+          logger.warning('PC/SC-Lite demo failed');
+          callback();
+        });
   }
 
   function runPinDialogDemo() {
@@ -170,5 +174,4 @@ initializeContext();
 GSC.AppUtils.enableSelfAutoLoading();
 
 GSC.BackgroundPageUnloadPreventing.enable();
-
 });  // goog.scope

--- a/example_js_smart_card_client_app/src/pin-dialog/pin-dialog-main.js
+++ b/example_js_smart_card_client_app/src/pin-dialog/pin-dialog-main.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,13 +42,12 @@ function okClickListener() {
 }
 
 function cancelClickListener() {
-  GSC.PopupWindow.Client.rejectModalDialog(new Error(
-      'PIN dialog was canceled'));
+  GSC.PopupWindow.Client.rejectModalDialog(
+      new Error('PIN dialog was canceled'));
 }
 
 goog.events.listen(goog.dom.getElement('ok'), 'click', okClickListener);
 goog.events.listen(goog.dom.getElement('cancel'), 'click', cancelClickListener);
 
 GSC.PopupWindow.Client.prepareAndShowAsModalDialog();
-
 });  // goog.scope

--- a/example_js_smart_card_client_app/src/pin-dialog/pin-dialog-server.js
+++ b/example_js_smart_card_client_app/src/pin-dialog/pin-dialog-server.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,5 +37,4 @@ SmartCardClientApp.PinDialog.Server.requestPin = function() {
   return GSC.PopupWindow.Server.runModalDialog(
       PIN_DIALOG_URL, PIN_DIALOG_WINDOW_OPTIONS_OVERRIDES);
 };
-
 });  // goog.scope

--- a/example_js_standalone_smart_card_client_app/background.js
+++ b/example_js_standalone_smart_card_client_app/background.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2017 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,8 +64,8 @@ function onInitializationSucceeded(constructedApi) {
 function establishContext() {
   console.log('Establishing PC/SC-Lite context...');
   api.SCardEstablishContext(
-      GoogleSmartCard.PcscLiteClient.API.SCARD_SCOPE_SYSTEM, null, null).then(
-      function(result) {
+         GoogleSmartCard.PcscLiteClient.API.SCARD_SCOPE_SYSTEM, null, null)
+      .then(function(result) {
         result.get(onContextEstablished, onPcscLiteError);
       }, onRequestFailed);
 }
@@ -102,8 +103,8 @@ function onPcscLiteError(errorCode) {
 
 /** @param {*} error The exception that happened during the request. */
 function onRequestFailed(error) {
-  console.warn('Failed to perform request to the Smart Card Connector app: ' +
-               error);
+  console.warn(
+      'Failed to perform request to the Smart Card Connector app: ' + error);
 }
 
 initialize();

--- a/example_js_standalone_smart_card_client_library/exports.js
+++ b/example_js_standalone_smart_card_client_library/exports.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,48 +40,37 @@ goog.exportSymbol('goog.log.LogRecord', goog.log.LogRecord);
 goog.exportProperty(
     goog.log.LogRecord.prototype, 'reset', goog.log.LogRecord.prototype.reset);
 goog.exportProperty(
-    goog.log.LogRecord.prototype,
-    'getLoggerName',
+    goog.log.LogRecord.prototype, 'getLoggerName',
     goog.log.LogRecord.prototype.getLoggerName);
 goog.exportProperty(
-    goog.log.LogRecord.prototype,
-    'getException',
+    goog.log.LogRecord.prototype, 'getException',
     goog.log.LogRecord.prototype.getException);
 goog.exportProperty(
-    goog.log.LogRecord.prototype,
-    'setException',
+    goog.log.LogRecord.prototype, 'setException',
     goog.log.LogRecord.prototype.setException);
 goog.exportProperty(
-    goog.log.LogRecord.prototype,
-    'setLoggerName',
+    goog.log.LogRecord.prototype, 'setLoggerName',
     goog.log.LogRecord.prototype.setLoggerName);
 goog.exportProperty(
-    goog.log.LogRecord.prototype,
-    'getLevel',
+    goog.log.LogRecord.prototype, 'getLevel',
     goog.log.LogRecord.prototype.getLevel);
 goog.exportProperty(
-    goog.log.LogRecord.prototype,
-    'setLevel',
+    goog.log.LogRecord.prototype, 'setLevel',
     goog.log.LogRecord.prototype.setLevel);
 goog.exportProperty(
-    goog.log.LogRecord.prototype,
-    'getMessage',
+    goog.log.LogRecord.prototype, 'getMessage',
     goog.log.LogRecord.prototype.getMessage);
 goog.exportProperty(
-    goog.log.LogRecord.prototype,
-    'setMessage',
+    goog.log.LogRecord.prototype, 'setMessage',
     goog.log.LogRecord.prototype.setMessage);
 goog.exportProperty(
-    goog.log.LogRecord.prototype,
-    'getMillis',
+    goog.log.LogRecord.prototype, 'getMillis',
     goog.log.LogRecord.prototype.getMillis);
 goog.exportProperty(
-    goog.log.LogRecord.prototype,
-    'setMillis',
+    goog.log.LogRecord.prototype, 'setMillis',
     goog.log.LogRecord.prototype.setMillis);
 goog.exportProperty(
-    goog.log.LogRecord.prototype,
-    'getSequenceNumber',
+    goog.log.LogRecord.prototype, 'getSequenceNumber',
     goog.log.LogRecord.prototype.getSequenceNumber);
 
 goog.exportSymbol('goog.log.Level', goog.log.Level);
@@ -99,8 +89,7 @@ goog.exportProperty(
 goog.exportProperty(
     goog.log.Level, 'getPredefinedLevel', goog.log.Level.getPredefinedLevel);
 goog.exportProperty(
-    goog.log.Level,
-    'getPredefinedLevelByValue',
+    goog.log.Level, 'getPredefinedLevelByValue',
     goog.log.Level.getPredefinedLevelByValue);
 goog.exportProperty(
     goog.log.Level, 'getPredefinedLevel', goog.log.Level.getPredefinedLevel);
@@ -119,38 +108,31 @@ goog.exportProperty(
 goog.exportProperty(
     goog.log.Logger.prototype, 'getName', goog.log.Logger.prototype.getName);
 goog.exportProperty(
-    goog.log.Logger.prototype,
-    'addHandler',
+    goog.log.Logger.prototype, 'addHandler',
     goog.log.Logger.prototype.addHandler);
 goog.exportProperty(
-    goog.log.Logger.prototype,
-    'removeHandler',
+    goog.log.Logger.prototype, 'removeHandler',
     goog.log.Logger.prototype.removeHandler);
 goog.exportProperty(
-    goog.log.Logger.prototype,
-    'getParent',
+    goog.log.Logger.prototype, 'getParent',
     goog.log.Logger.prototype.getParent);
 goog.exportProperty(
-    goog.log.Logger.prototype,
-    'getChildren',
+    goog.log.Logger.prototype, 'getChildren',
     goog.log.Logger.prototype.getChildren);
 goog.exportProperty(
     goog.log.Logger.prototype, 'setLevel', goog.log.Logger.prototype.setLevel);
 goog.exportProperty(
     goog.log.Logger.prototype, 'getLevel', goog.log.Logger.prototype.getLevel);
 goog.exportProperty(
-    goog.log.Logger.prototype,
-    'getEffectiveLevel',
+    goog.log.Logger.prototype, 'getEffectiveLevel',
     goog.log.Logger.prototype.getEffectiveLevel);
 goog.exportProperty(
-    goog.log.Logger.prototype,
-    'isLoggable',
+    goog.log.Logger.prototype, 'isLoggable',
     goog.log.Logger.prototype.isLoggable);
 goog.exportProperty(
     goog.log.Logger.prototype, 'log', goog.log.Logger.prototype.log);
 goog.exportProperty(
-    goog.log.Logger.prototype,
-    'getLogRecord',
+    goog.log.Logger.prototype, 'getLogRecord',
     goog.log.Logger.prototype.getLogRecord);
 goog.exportProperty(
     goog.log.Logger.prototype, 'shout', goog.log.Logger.prototype.shout);
@@ -169,8 +151,7 @@ goog.exportProperty(
 goog.exportProperty(
     goog.log.Logger.prototype, 'finest', goog.log.Logger.prototype.finest);
 goog.exportProperty(
-    goog.log.Logger.prototype,
-    'logRecord',
+    goog.log.Logger.prototype, 'logRecord',
     goog.log.Logger.prototype.logRecord);
 
 goog.exportSymbol('goog.Promise', goog.Promise);
@@ -183,8 +164,7 @@ goog.exportProperty(
     goog.Promise, 'firstFulfilled', goog.Promise.firstFulfilled);
 goog.exportProperty(goog.Promise, 'withResolver', goog.Promise.withResolver);
 goog.exportProperty(
-    goog.Promise,
-    'setUnhandledRejectionHandler',
+    goog.Promise, 'setUnhandledRejectionHandler',
     goog.Promise.setUnhandledRejectionHandler);
 goog.exportProperty(
     goog.Promise, 'CancellationError', goog.Promise.CancellationError);
@@ -201,35 +181,28 @@ goog.exportProperty(
 
 goog.exportSymbol('goog.Disposable', goog.Disposable);
 goog.exportProperty(
-    goog.Disposable.prototype,
-    'isDisposed',
+    goog.Disposable.prototype, 'isDisposed',
     goog.Disposable.prototype.isDisposed);
 goog.exportProperty(
     goog.Disposable.prototype, 'dispose', goog.Disposable.prototype.dispose);
 goog.exportProperty(
-    goog.Disposable.prototype,
-    'addOnDisposeCallback',
+    goog.Disposable.prototype, 'addOnDisposeCallback',
     goog.Disposable.prototype.addOnDisposeCallback);
 
 goog.exportSymbol(
     'goog.messaging.AbstractChannel', goog.messaging.AbstractChannel);
 goog.exportProperty(
-    goog.messaging.AbstractChannel.prototype,
-    'connect',
+    goog.messaging.AbstractChannel.prototype, 'connect',
     goog.messaging.AbstractChannel.prototype.connect);
 goog.exportProperty(
-    goog.messaging.AbstractChannel.prototype,
-    'isConnected',
+    goog.messaging.AbstractChannel.prototype, 'isConnected',
     goog.messaging.AbstractChannel.prototype.isConnected);
 goog.exportProperty(
-    goog.messaging.AbstractChannel.prototype,
-    'registerService',
+    goog.messaging.AbstractChannel.prototype, 'registerService',
     goog.messaging.AbstractChannel.prototype.registerService);
 goog.exportProperty(
-    goog.messaging.AbstractChannel.prototype,
-    'registerDefaultService',
+    goog.messaging.AbstractChannel.prototype, 'registerDefaultService',
     goog.messaging.AbstractChannel.prototype.registerDefaultService);
 goog.exportProperty(
-    goog.messaging.AbstractChannel.prototype,
-    'send',
+    goog.messaging.AbstractChannel.prototype, 'send',
     goog.messaging.AbstractChannel.prototype.send);

--- a/smart_card_connector_app/src/background-main-window-managing.js
+++ b/smart_card_connector_app/src/background-main-window-managing.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2018 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,10 +40,7 @@ const WINDOW_OPTIONS = {
   'frame': 'none',
   'hidden': true,
   'id': WINDOW_ID,
-  'innerBounds': {
-    'width': 530,
-    'height': 430
-  },
+  'innerBounds': {'width': 530, 'height': 430},
   'resizable': false
 };
 
@@ -58,5 +56,4 @@ GSC.ConnectorApp.Background.MainWindowManaging.openWindowDueToUserRequest =
     function(windowData) {
   GSC.PopupWindow.Server.createWindow(WINDOW_URL, WINDOW_OPTIONS, windowData);
 };
-
 });  // goog.scope

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -80,8 +81,9 @@ function createExecutableModule() {
     case GSC.ExecutableModule.Toolchain.EMSCRIPTEN:
       return new GSC.EmscriptenModule('executable_module');
   }
-  GSC.Logging.fail(`Cannot load executable module: unknown toolchain ` +
-                   `${GSC.ExecutableModule.TOOLCHAIN}`);
+  GSC.Logging.fail(
+      `Cannot load executable module: unknown toolchain ` +
+      `${GSC.ExecutableModule.TOOLCHAIN}`);
   goog.asserts.fail();
 }
 
@@ -112,8 +114,11 @@ const chromeLoginStateHook = new GSC.Libusb.ChromeLoginStateHook();
 libusbChromeUsbBackend.addRequestSuccessHook(
     chromeLoginStateHook.getRequestSuccessHook());
 // Start the backend regardless of whether the hook initialization succeeded.
-chromeLoginStateHook.getHookReadyPromise().then(() => {}, () => {}).then(
-    function() { libusbChromeUsbBackend.startProcessingEvents(); });
+chromeLoginStateHook.getHookReadyPromise()
+    .then(() => {}, () => {})
+    .then(function() {
+      libusbChromeUsbBackend.startProcessingEvents();
+    });
 
 const pcscLiteReadinessTracker =
     new GSC.PcscLiteServerClientsManagement.ReadinessTracker(
@@ -124,8 +129,7 @@ const readerTrackerMessageChannelPair = new GSC.MessageChannelPair;
 createClientHandler(readerTrackerMessageChannelPair.getFirst(), undefined);
 const readerTracker = new GSC.PcscLiteServer.ReaderTracker(
     executableModule.getMessageChannel(),
-    readerTrackerMessageChannelPair.getSecond(),
-    executableModule.getLogger());
+    readerTrackerMessageChannelPair.getSecond(), executableModule.getLogger());
 
 executableModule.startLoading();
 
@@ -174,8 +178,9 @@ function externalConnectionListener(port) {
   logger.fine('Received onConnectExternal event');
   const portMessageChannel = new GSC.PortMessageChannel(port);
   if (portMessageChannel.extensionId === null) {
-    logger.warning('Ignoring the external connection as there is no sender ' +
-                   'extension id specified');
+    logger.warning(
+        'Ignoring the external connection as there is no sender ' +
+        'extension id specified');
     return;
   }
   messageChannelPool.addChannel(
@@ -192,8 +197,9 @@ function externalConnectionListener(port) {
 function externalMessageListener(message, sender) {
   logger.fine('Received onMessageExternal event');
   if (sender.id === undefined) {
-    logger.warning('Ignoring the external message as there is no sender ' +
-                   'extension id specified');
+    logger.warning(
+        'Ignoring the external message as there is no sender ' +
+        'extension id specified');
     return;
   }
   let channel = getOrCreateSingleMessageBasedChannel(sender.id);
@@ -286,7 +292,7 @@ function makeDataForMainWindow() {
     'readerTrackerSubscriber':
         readerTracker.addOnUpdateListener.bind(readerTracker),
     'readerTrackerUnsubscriber':
-        readerTracker.removeOnUpdateListener.bind(readerTracker)};
+        readerTracker.removeOnUpdateListener.bind(readerTracker)
+  };
 }
-
 });  // goog.scope

--- a/smart_card_connector_app/src/window-about-showing.js
+++ b/smart_card_connector_app/src/window-about-showing.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,10 +31,7 @@ goog.scope(function() {
 const ABOUT_WINDOW_URL = 'about-window.html';
 const ABOUT_WINDOW_OPTIONS = {
   'id': 'about-window',
-  'innerBounds': {
-    'width': 700,
-    'height': 500
-  }
+  'innerBounds': {'width': 700, 'height': 500}
 };
 
 const GSC = GoogleSmartCard;
@@ -55,5 +53,4 @@ GSC.ConnectorApp.Window.AboutShowing.initialize = function() {
   goog.events.listen(
       openAboutElement, goog.events.EventType.CLICK, openAboutClickListener);
 };
-
 });  // goog.scope

--- a/smart_card_connector_app/src/window-apps-displaying.js
+++ b/smart_card_connector_app/src/window-apps-displaying.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -83,8 +84,9 @@ function updateAppView(knownAppsPromise, appIds, knownApps) {
 function onUpdateListener(appListArg) {
   const appList = goog.array.clone(appListArg);
   goog.array.sort(appList);
-  logger.fine('Application list updated, refreshing the view. ' +
-              'New list of id\'s: ' + GSC.DebugDump.dump(appList));
+  logger.fine(
+      'Application list updated, refreshing the view. ' +
+      'New list of id\'s: ' + GSC.DebugDump.dump(appList));
 
   const knownAppsPromise = knownAppsRegistry.tryGetByIds(appList);
   lastKnownAppsPromise = knownAppsPromise;
@@ -94,7 +96,8 @@ function onUpdateListener(appListArg) {
         updateAppView(knownAppsPromise, appList, knownApps);
       },
       function(error) {
-        if (!updateAppView(knownAppsPromise, appList, null)) return;
+        if (!updateAppView(knownAppsPromise, appList, null))
+          return;
 
         logger.warning('Couldn\'t resolve appList: ' + error);
       });

--- a/smart_card_connector_app/src/window-devices-displaying.js
+++ b/smart_card_connector_app/src/window-devices-displaying.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,7 +67,7 @@ const addDeviceElement =
     /** @type {!Element} */ (goog.dom.getElement('add-device'));
 
 /**
- * @param {!Array.<!GSC.PcscLiteServer.ReaderInfo>} readers 
+ * @param {!Array.<!GSC.PcscLiteServer.ReaderInfo>} readers
  */
 function onReadersChanged(readers) {
   displayReaderList(readers);
@@ -77,8 +78,9 @@ function onReadersChanged(readers) {
  * @param {!Array.<!GSC.PcscLiteServer.ReaderInfo>} readers
  */
 function displayReaderList(readers) {
-  logger.info('Displaying ' + readers.length + ' card reader(s): ' +
-              GSC.DebugDump.dump(readers));
+  logger.info(
+      'Displaying ' + readers.length +
+      ' card reader(s): ' + GSC.DebugDump.dump(readers));
   goog.dom.removeChildren(readersListElement);
 
   for (let reader of readers) {
@@ -123,7 +125,7 @@ function makeReaderNameForDisplaying(readerName) {
 }
 
 /**
- * @param {!GSC.PcscLiteServer.ReaderInfo} reader 
+ * @param {!GSC.PcscLiteServer.ReaderInfo} reader
  * @return {string}
  */
 function getTooltipText(reader) {
@@ -131,7 +133,8 @@ function getTooltipText(reader) {
     case GSC.PcscLiteServer.ReaderStatus.INIT:
       return 'initReaderTooltip';
     case GSC.PcscLiteServer.ReaderStatus.SUCCESS:
-      if (reader['isCardPresent']) return 'successCardTooltip';
+      if (reader['isCardPresent'])
+        return 'successCardTooltip';
       return 'successReaderTooltip';
     case GSC.PcscLiteServer.ReaderStatus.FAILURE:
       return 'failureReaderTooltip';
@@ -142,7 +145,7 @@ function getTooltipText(reader) {
 }
 
 /**
- * @param {number} readersCount 
+ * @param {number} readersCount
  */
 function updateAddDeviceButtonText(readersCount) {
   if (readersCount == 0) {
@@ -169,8 +172,9 @@ function addDeviceClickListener(e) {
  * @param {!Array.<!chrome.usb.Device>} devices
  */
 function getUserSelectedDevicesCallback(devices) {
-  logger.fine('USB selection dialog finished, ' + devices.length + ' devices ' +
-              'were chosen');
+  logger.fine(
+      'USB selection dialog finished, ' + devices.length + ' devices ' +
+      'were chosen');
 }
 
 GSC.ConnectorApp.Window.DevicesDisplaying.initialize = function() {
@@ -181,7 +185,7 @@ GSC.ConnectorApp.Window.DevicesDisplaying.initialize = function() {
   const readerTrackerSubscriber =
       /** @type {function(function(!Array.<!GSC.PcscLiteServer.ReaderInfo>))} */
       (GSC.ObjectHelpers.extractKey(
-           GSC.PopupWindow.Client.getData(), 'readerTrackerSubscriber'));
+          GSC.PopupWindow.Client.getData(), 'readerTrackerSubscriber'));
   // Start tracking the current list of readers.
   readerTrackerSubscriber(onReadersChanged);
 
@@ -192,7 +196,7 @@ GSC.ConnectorApp.Window.DevicesDisplaying.initialize = function() {
   const readerTrackerUnsubscriber =
       /** @type {function(function(!Array.<!GSC.PcscLiteServer.ReaderInfo>))} */
       (GSC.ObjectHelpers.extractKey(
-           GSC.PopupWindow.Client.getData(), 'readerTrackerUnsubscriber'));
+          GSC.PopupWindow.Client.getData(), 'readerTrackerUnsubscriber'));
   // Stop tracking the current list of readers when our window gets closed.
   chrome.app.window.current().onClosed.addListener(function() {
     readerTrackerUnsubscriber(onReadersChanged);
@@ -201,5 +205,4 @@ GSC.ConnectorApp.Window.DevicesDisplaying.initialize = function() {
   goog.events.listen(
       addDeviceElement, goog.events.EventType.CLICK, addDeviceClickListener);
 };
-
 });  // goog.scope

--- a/smart_card_connector_app/src/window-help-showing.js
+++ b/smart_card_connector_app/src/window-help-showing.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2020 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,7 @@
  */
 
 /**
- * @fileoverview This script implements showing the Help Article in a browser 
+ * @fileoverview This script implements showing the Help Article in a browser
  * window.
  */
 
@@ -44,7 +45,6 @@ function openHelpClickListener(event) {
 
 GSC.ConnectorApp.Window.HelpShowing.initialize = function() {
   goog.events.listen(
-      openHelpElement, goog.events.EventType.CLICK, openHelpClickListener);  
+      openHelpElement, goog.events.EventType.CLICK, openHelpClickListener);
 };
-
 });  // goog.scope

--- a/smart_card_connector_app/src/window-logs-exporting.js
+++ b/smart_card_connector_app/src/window-logs-exporting.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -95,5 +96,4 @@ GSC.ConnectorApp.Window.LogsExporting.initialize = function() {
   goog.events.listen(
       exportLogsElement, goog.events.EventType.CLICK, exportLogsClickListener);
 };
-
 });  // goog.scope

--- a/smart_card_connector_app/src/window-main.js
+++ b/smart_card_connector_app/src/window-main.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,8 +45,7 @@ const logger = GSC.Logging.getScopedLogger('ConnectorApp.MainWindow');
 logger.info('The main window is created');
 
 goog.events.listen(
-    goog.dom.getElement('close-window'),
-    goog.events.EventType.CLICK,
+    goog.dom.getElement('close-window'), goog.events.EventType.CLICK,
     closeWindowClickListener);
 
 GSC.ConnectorApp.Window.AboutShowing.initialize();
@@ -69,12 +69,12 @@ function displayNonChromeOsWarningIfNeeded() {
     /** @type {string} */
     const os = platformInfo['os'];
     if (os != 'cros') {
-      logger.info('Displaying the warning regarding non-Chrome OS system ' +
-                  '(the current OS is "' + os + '")');
+      logger.info(
+          'Displaying the warning regarding non-Chrome OS system ' +
+          '(the current OS is "' + os + '")');
       goog.dom.classlist.remove(
           goog.dom.getElement('non-chrome-os-warning'), 'hidden');
     }
   });
 }
-
 });  // goog.scope

--- a/third_party/libusb/webport/src/chrome_usb/chrome-login-state-hook.js
+++ b/third_party/libusb/webport/src/chrome_usb/chrome-login-state-hook.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2019 Google Inc.
  *
  * This library is free software; you can redistribute it and/or
@@ -45,27 +46,27 @@ const GSC = GoogleSmartCard;
  * @constructor
  */
 GSC.Libusb.ChromeLoginStateHook = function() {
-  /** 
+  /**
    * @type {boolean}
-   * @private  
+   * @private
    */
   this.simulateDevicesAbsent_ = false;
-  /** 
+  /**
    * @type {!Function}
-   * @private 
+   * @private
    */
   this.boundOnGotSessionState_ = this.onGotSessionState_.bind(this);
-  /** 
+  /**
    * @type {!goog.promise.Resolver}
-   * @private 
+   * @private
    */
   this.hookIsReadyResolver_ = goog.Promise.withResolver();
   if (chrome.loginState) {
     chrome.loginState.getProfileType(this.onGotProfileType_.bind(this));
   } else {
     this.logger.warning(
-        'chrome.loginState API is not available. This app might require a '
-        + 'newer version of Chrome.');
+        'chrome.loginState API is not available. This app might require a ' +
+        'newer version of Chrome.');
     this.hookIsReadyResolver_.reject();
   }
 };
@@ -78,8 +79,8 @@ goog.inherits(ChromeLoginStateHook, goog.Disposable);
  * @type {!goog.log.Logger}
  * @const
  */
-ChromeLoginStateHook.prototype.logger = GSC.Logging.getScopedLogger(
-  'Libusb.LoginStateHook');
+ChromeLoginStateHook.prototype.logger =
+    GSC.Logging.getScopedLogger('Libusb.LoginStateHook');
 
 /** @override */
 ChromeLoginStateHook.prototype.disposeInternal = function() {
@@ -96,7 +97,7 @@ ChromeLoginStateHook.prototype.disposeInternal = function() {
 /**
  * @return {function(string, !Array): !Array}
  * @public
- */ 
+ */
 ChromeLoginStateHook.prototype.getRequestSuccessHook = function() {
   return this.requestSuccessHook_.bind(this);
 };
@@ -104,12 +105,12 @@ ChromeLoginStateHook.prototype.getRequestSuccessHook = function() {
 /**
  * @return {!goog.Promise}
  * @public
- */ 
+ */
 ChromeLoginStateHook.prototype.getHookReadyPromise = function() {
   return this.hookIsReadyResolver_.promise;
 };
 
- /**
+/**
  * @param {!chrome.loginState.ProfileType} profileType
  * @private
  */
@@ -128,16 +129,16 @@ ChromeLoginStateHook.prototype.onGotProfileType_ = function(profileType) {
  * @param {!chrome.loginState.SessionState} sessionState
  * @private
  */
-ChromeLoginStateHook.prototype.onGotSessionState_ = function(
-    sessionState) {
+ChromeLoginStateHook.prototype.onGotSessionState_ = function(sessionState) {
   goog.asserts.assert(chrome.loginState);
-  if (sessionState === chrome.loginState.SessionState.IN_LOCK_SCREEN
-      && !this.simulateDevicesAbsent_) {
-    this.logger.info("No longer showing USB devices.");
+  if (sessionState === chrome.loginState.SessionState.IN_LOCK_SCREEN &&
+      !this.simulateDevicesAbsent_) {
+    this.logger.info('No longer showing USB devices.');
     this.simulateDevicesAbsent_ = true;
-  } else if (sessionState !== chrome.loginState.SessionState.IN_LOCK_SCREEN
-             && this.simulateDevicesAbsent_) {
-    this.logger.info("Showing USB devices.");
+  } else if (
+      sessionState !== chrome.loginState.SessionState.IN_LOCK_SCREEN &&
+      this.simulateDevicesAbsent_) {
+    this.logger.info('Showing USB devices.');
     this.simulateDevicesAbsent_ = false;
   }
   // All calls after the first one to resolve() will be ignored.
@@ -157,14 +158,12 @@ ChromeLoginStateHook.prototype.onSessionStateChanged_ = function() {
  * @return {!Array} new callResults
  * @private
  */
-ChromeLoginStateHook.prototype.requestSuccessHook_ = function(functionName, 
-                                                              callResults) {
+ChromeLoginStateHook.prototype.requestSuccessHook_ = function(
+    functionName, callResults) {
   if (this.simulateDevicesAbsent_ &&
-      (functionName === 'getDevices' ||
-       functionName === 'getConfigurations')) {
+      (functionName === 'getDevices' || functionName === 'getConfigurations')) {
     return [[]];
   }
   return callResults;
 };
-
 });  // goog.scope

--- a/third_party/libusb/webport/src/chrome_usb/chrome-usb-backend.js
+++ b/third_party/libusb/webport/src/chrome_usb/chrome-usb-backend.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc.
  *
  * This library is free software; you can redistribute it and/or
@@ -54,28 +55,28 @@ GSC.Libusb.ChromeUsbBackend = function(naclModuleMessageChannel) {
       REQUESTER_NAME, naclModuleMessageChannel, this.handleRequest_.bind(this));
   this.startObservingDevices_();
 
-  /** 
+  /**
    * @type {!Array<function(string, !Array): !Array>}
    * Array of hooks that are called on every successful API request.
-   * @private  
+   * @private
    */
   this.requestSuccessHooks_ = [];
 
-  /** 
+  /**
    * @type {!goog.promise.Resolver}
    * Gets resolved once setup is complete and API requests can be processed.
-   * @private  
+   * @private
    */
   this.setupDonePromiseResolver_ = goog.Promise.withResolver();
 
-  /** 
+  /**
    * @type {!GoogleSmartCard.DeferredProcessor}
    * Queue of API requests that are not yet processed because setup is still in
    * progress.
-   * @private  
+   * @private
    */
-  this.deferredProcessor_ = new GSC.DeferredProcessor(
-      this.setupDonePromiseResolver_.promise);
+  this.deferredProcessor_ =
+      new GSC.DeferredProcessor(this.setupDonePromiseResolver_.promise);
 };
 
 const ChromeUsbBackend = GSC.Libusb.ChromeUsbBackend;
@@ -84,8 +85,8 @@ const ChromeUsbBackend = GSC.Libusb.ChromeUsbBackend;
  * @type {!goog.log.Logger}
  * @const
  */
-ChromeUsbBackend.prototype.logger = GSC.Logging.getScopedLogger(
-    'Libusb.ChromeUsbBackend');
+ChromeUsbBackend.prototype.logger =
+    GSC.Logging.getScopedLogger('Libusb.ChromeUsbBackend');
 
 /**
  * Adds a function hook that is called whenever a request is resolved
@@ -102,10 +103,9 @@ ChromeUsbBackend.prototype.addRequestSuccessHook = function(hook) {
  * @param {function(string, !Array): !Array} hook
  */
 ChromeUsbBackend.prototype.removeRequestSuccessHook = function(hook) {
-  this.requestSuccessHooks_ = this.requestSuccessHooks_.filter(
-      function(value) {
-        return value !== hook; 
-      });
+  this.requestSuccessHooks_ = this.requestSuccessHooks_.filter(function(value) {
+    return value !== hook;
+  });
 };
 
 /**
@@ -151,9 +151,12 @@ ChromeUsbBackend.prototype.logCurrentDevices_ = function() {
  * @private
  */
 ChromeUsbBackend.prototype.logDevices_ = function(devices) {
-  goog.array.sortByKey(devices, function(device) { return device.device; });
-  this.logger.info(devices.length + ' USB device(s) available: ' +
-                   GSC.DebugDump.dump(devices));
+  goog.array.sortByKey(devices, function(device) {
+    return device.device;
+  });
+  this.logger.info(
+      devices.length +
+      ' USB device(s) available: ' + GSC.DebugDump.dump(devices));
 };
 
 /**
@@ -190,9 +193,7 @@ ChromeUsbBackend.prototype.processRequest_ = function(payload) {
   const chromeUsbFunctionArgs = goog.array.concat(
       remoteCallMessage.functionArguments,
       this.chromeUsbApiGenericCallback_.bind(
-          this,
-          debugRepresentation,
-          remoteCallMessage.functionName,
+          this, debugRepresentation, remoteCallMessage.functionName,
           promiseResolver));
 
   /** @preserveTry */
@@ -235,14 +236,11 @@ ChromeUsbBackend.prototype.chromeUsbApiGenericCallback_ = function(
     // lastError flag, that is not suitable for us as we want to distinguish
     // the timeouts from the fatal errors.
     this.reportRequestError_(
-        debugRepresentation,
-        promiseResolver,
+        debugRepresentation, promiseResolver,
         goog.object.get(lastError, 'message', 'Unknown error'));
   } else {
     this.reportRequestSuccess_(
-        debugRepresentation,
-        functionName,
-        promiseResolver,
+        debugRepresentation, functionName, promiseResolver,
         Array.prototype.slice.call(arguments, 3));
   }
 };
@@ -275,8 +273,9 @@ ChromeUsbBackend.prototype.reportRequestError_ = function(
     // done, as it suppresses the useless warning messages.
     this.logger.info('Transfer timed out: ' + debugRepresentation);
   } else {
-    this.logger.warning('API error occurred while calling ' +
-                        debugRepresentation + ': ' + errorMessage);
+    this.logger.warning(
+        'API error occurred while calling ' + debugRepresentation + ': ' +
+        errorMessage);
   }
   promiseResolver.reject(new Error(errorMessage));
 };
@@ -294,9 +293,8 @@ ChromeUsbBackend.prototype.reportRequestSuccess_ = function(
     resultArgs = hook(functionName, resultArgs);
   });
   this.logger.fine(
-      'Results returned by the ' + debugRepresentation + ' call: ' +
-      goog.iter.join(goog.iter.map(resultArgs, debugDump), ', '));
+      'Results returned by the ' + debugRepresentation +
+      ' call: ' + goog.iter.join(goog.iter.map(resultArgs, debugDump), ', '));
   promiseResolver.resolve(resultArgs);
 };
-
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/common/src/constants.js
+++ b/third_party/pcsc-lite/naclport/common/src/constants.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -47,5 +48,4 @@ goog.exportSymbol(
 
 /** @const */
 Constants.REQUESTER_TITLE = 'pcsc_lite_function_call';
-
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/cpp_client/src/nacl-client-backend.js
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/nacl-client-backend.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -117,8 +118,8 @@ const NaclClientBackend = GSC.PcscLiteClient.NaclClientBackend;
  * @type {!goog.log.Logger}
  * @const
  */
-NaclClientBackend.prototype.logger = GSC.Logging.getScopedLogger(
-    'PcscLiteClient.NaclClientBackend');
+NaclClientBackend.prototype.logger =
+    GSC.Logging.getScopedLogger('PcscLiteClient.NaclClientBackend');
 
 /**
  * @param {!Object} payload
@@ -131,16 +132,17 @@ NaclClientBackend.prototype.handleRequest_ = function(payload) {
     GSC.Logging.failWithLogger(
         this.logger,
         'Failed to parse the remote call message: ' +
-        GSC.DebugDump.debugDump(payload));
+            GSC.DebugDump.debugDump(payload));
   }
 
-  this.logger.fine('Received a remote call request: ' +
-                   remoteCallMessage.getDebugRepresentation());
+  this.logger.fine(
+      'Received a remote call request: ' +
+      remoteCallMessage.getDebugRepresentation());
 
   const promiseResolver = goog.Promise.withResolver();
 
-  this.bufferedRequestsQueue_.enqueue(new BufferedRequest(
-      remoteCallMessage, promiseResolver));
+  this.bufferedRequestsQueue_.enqueue(
+      new BufferedRequest(remoteCallMessage, promiseResolver));
 
   // Run the request immediately if the API is already initialized.
   if (this.api_) {
@@ -193,10 +195,10 @@ NaclClientBackend.prototype.initialize_ = function() {
 
   this.logger.fine('Initializing...');
 
-  this.context_ = new GSC.PcscLiteClient.Context(
-      this.clientTitle_, this.serverAppId_);
-  this.context_.addOnInitializedCallback(this.contextInitializedListener_.bind(
-      this));
+  this.context_ =
+      new GSC.PcscLiteClient.Context(this.clientTitle_, this.serverAppId_);
+  this.context_.addOnInitializedCallback(
+      this.contextInitializedListener_.bind(this));
   this.context_.addOnDisposeCallback(this.contextDisposedListener_.bind(this));
   this.context_.initialize();
 };
@@ -251,19 +253,18 @@ NaclClientBackend.prototype.scheduleReinitialization_ = function() {
       ' seconds if new requests will arrive...');
   this.initializationTimerId_ = goog.Timer.callOnce(
       this.reinitializationTimeoutCallback_,
-      REINITIALIZATION_INTERVAL_SECONDS * 1000,
-      this);
+      REINITIALIZATION_INTERVAL_SECONDS * 1000, this);
 };
 
 /** @private */
-NaclClientBackend.prototype.reinitializationTimeoutCallback_ =
-    function() {
+NaclClientBackend.prototype.reinitializationTimeoutCallback_ = function() {
   this.initializationTimerId_ = null;
   if (!this.bufferedRequestsQueue_.isEmpty()) {
     this.initialize_();
   } else {
-    this.logger.finer('Reinitialization timeout passed, but not initializing ' +
-                      'as no new requests arrived');
+    this.logger.finer(
+        'Reinitialization timeout passed, but not initializing ' +
+        'as no new requests arrived');
   }
 };
 
@@ -298,8 +299,9 @@ NaclClientBackend.prototype.rejectAllBufferedRequests_ = function() {
  */
 NaclClientBackend.prototype.startRequest_ = function(
     remoteCallMessage, promiseResolver) {
-  this.logger.fine('Started processing the remote call request: ' +
-                   remoteCallMessage.getDebugRepresentation());
+  this.logger.fine(
+      'Started processing the remote call request: ' +
+      remoteCallMessage.getDebugRepresentation());
 
   GSC.Logging.checkWithLogger(this.logger, this.api_);
 
@@ -323,8 +325,8 @@ NaclClientBackend.prototype.apiMethodResolvedCallback_ = function(
     remoteCallMessage, promiseResolver, apiMethodResult) {
   this.logger.fine(
       'The remote call completed: ' +
-      remoteCallMessage.getDebugRepresentation() + ' with the result: ' +
-      apiMethodResult.getDebugRepresentation());
+      remoteCallMessage.getDebugRepresentation() +
+      ' with the result: ' + apiMethodResult.getDebugRepresentation());
   promiseResolver.resolve(apiMethodResult.responseItems);
 };
 
@@ -357,5 +359,4 @@ NaclClientBackend.prototype.getApiMethod_ = function(methodName) {
   }
   return this.api_[methodName];
 };
-
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/js_client/src/api.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/api.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -106,8 +107,8 @@ GSC.PcscLiteClient.API = function(messageChannel) {
       this.messageChannelDisposedListener_.bind(this));
 
   /** @private */
-  this.requester_ = new GSC.Requester(
-      Constants.REQUESTER_TITLE, this.messageChannel_);
+  this.requester_ =
+      new GSC.Requester(Constants.REQUESTER_TITLE, this.messageChannel_);
 
   this.logger.fine('Initialized');
 };
@@ -584,8 +585,7 @@ goog.exportProperty(
 API.SCARD_E_CERTIFICATE_UNAVAILABLE = castToInt32(0x8010002D);
 
 goog.exportProperty(
-    API,
-    'SCARD_E_CERTIFICATE_UNAVAILABLE',
+    API, 'SCARD_E_CERTIFICATE_UNAVAILABLE',
     API.SCARD_E_CERTIFICATE_UNAVAILABLE);
 
 /**
@@ -1124,8 +1124,8 @@ goog.exportProperty(
     API, 'MAX_BUFFER_SIZE_EXTENDED', API.MAX_BUFFER_SIZE_EXTENDED);
 
 /*
-* Tags for requesting card and reader attributes
-*/
+ * Tags for requesting card and reader attributes
+ */
 
 /**
  * @param {number} class_
@@ -1227,8 +1227,8 @@ goog.exportProperty(API, 'SCARD_CLASS_SYSTEM', API.SCARD_CLASS_SYSTEM);
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_VENDOR_NAME = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_VENDOR_INFO, 0x0100);
+API.SCARD_ATTR_VENDOR_NAME =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_VENDOR_INFO, 0x0100);
 
 goog.exportProperty(API, 'SCARD_ATTR_VENDOR_NAME', API.SCARD_ATTR_VENDOR_NAME);
 
@@ -1237,8 +1237,8 @@ goog.exportProperty(API, 'SCARD_ATTR_VENDOR_NAME', API.SCARD_ATTR_VENDOR_NAME);
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_VENDOR_IFD_TYPE = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_VENDOR_INFO, 0x0101);
+API.SCARD_ATTR_VENDOR_IFD_TYPE =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_VENDOR_INFO, 0x0101);
 
 goog.exportProperty(
     API, 'SCARD_ATTR_VENDOR_IFD_TYPE', API.SCARD_ATTR_VENDOR_IFD_TYPE);
@@ -1249,8 +1249,8 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_VENDOR_IFD_VERSION = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_VENDOR_INFO, 0x0102);
+API.SCARD_ATTR_VENDOR_IFD_VERSION =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_VENDOR_INFO, 0x0102);
 
 goog.exportProperty(
     API, 'SCARD_ATTR_VENDOR_IFD_VERSION', API.SCARD_ATTR_VENDOR_IFD_VERSION);
@@ -1260,12 +1260,11 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_VENDOR_IFD_SERIAL_NO = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_VENDOR_INFO, 0x0103);
+API.SCARD_ATTR_VENDOR_IFD_SERIAL_NO =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_VENDOR_INFO, 0x0103);
 
 goog.exportProperty(
-    API,
-    'SCARD_ATTR_VENDOR_IFD_SERIAL_NO',
+    API, 'SCARD_ATTR_VENDOR_IFD_SERIAL_NO',
     API.SCARD_ATTR_VENDOR_IFD_SERIAL_NO);
 
 /**
@@ -1274,8 +1273,8 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_CHANNEL_ID = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_COMMUNICATIONS, 0x0110);
+API.SCARD_ATTR_CHANNEL_ID =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_COMMUNICATIONS, 0x0110);
 
 goog.exportProperty(API, 'SCARD_ATTR_CHANNEL_ID', API.SCARD_ATTR_CHANNEL_ID);
 
@@ -1284,12 +1283,11 @@ goog.exportProperty(API, 'SCARD_ATTR_CHANNEL_ID', API.SCARD_ATTR_CHANNEL_ID);
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_ASYNC_PROTOCOL_TYPES = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_PROTOCOL, 0x0120);
+API.SCARD_ATTR_ASYNC_PROTOCOL_TYPES =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_PROTOCOL, 0x0120);
 
 goog.exportProperty(
-    API,
-    'SCARD_ATTR_ASYNC_PROTOCOL_TYPES',
+    API, 'SCARD_ATTR_ASYNC_PROTOCOL_TYPES',
     API.SCARD_ATTR_ASYNC_PROTOCOL_TYPES);
 
 /**
@@ -1297,8 +1295,8 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_DEFAULT_CLK = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_PROTOCOL, 0x0121);
+API.SCARD_ATTR_DEFAULT_CLK =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_PROTOCOL, 0x0121);
 
 goog.exportProperty(API, 'SCARD_ATTR_DEFAULT_CLK', API.SCARD_ATTR_DEFAULT_CLK);
 
@@ -1307,8 +1305,7 @@ goog.exportProperty(API, 'SCARD_ATTR_DEFAULT_CLK', API.SCARD_ATTR_DEFAULT_CLK);
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_MAX_CLK = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_PROTOCOL, 0x0122);
+API.SCARD_ATTR_MAX_CLK = API.SCARD_ATTR_VALUE(API.SCARD_CLASS_PROTOCOL, 0x0122);
 
 goog.exportProperty(API, 'SCARD_ATTR_MAX_CLK', API.SCARD_ATTR_MAX_CLK);
 
@@ -1317,8 +1314,8 @@ goog.exportProperty(API, 'SCARD_ATTR_MAX_CLK', API.SCARD_ATTR_MAX_CLK);
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_DEFAULT_DATA_RATE = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_PROTOCOL, 0x0123);
+API.SCARD_ATTR_DEFAULT_DATA_RATE =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_PROTOCOL, 0x0123);
 
 goog.exportProperty(
     API, 'SCARD_ATTR_DEFAULT_DATA_RATE', API.SCARD_ATTR_DEFAULT_DATA_RATE);
@@ -1328,8 +1325,8 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_MAX_DATA_RATE = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_PROTOCOL, 0x0124);
+API.SCARD_ATTR_MAX_DATA_RATE =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_PROTOCOL, 0x0124);
 
 goog.exportProperty(
     API, 'SCARD_ATTR_MAX_DATA_RATE', API.SCARD_ATTR_MAX_DATA_RATE);
@@ -1339,8 +1336,8 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_MAX_IFSD = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_PROTOCOL, 0x0125);
+API.SCARD_ATTR_MAX_IFSD =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_PROTOCOL, 0x0125);
 
 goog.exportProperty(API, 'SCARD_ATTR_MAX_IFSD', API.SCARD_ATTR_MAX_IFSD);
 
@@ -1349,8 +1346,8 @@ goog.exportProperty(API, 'SCARD_ATTR_MAX_IFSD', API.SCARD_ATTR_MAX_IFSD);
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_SYNC_PROTOCOL_TYPES = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_PROTOCOL, 0x0126);
+API.SCARD_ATTR_SYNC_PROTOCOL_TYPES =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_PROTOCOL, 0x0126);
 
 goog.exportProperty(
     API, 'SCARD_ATTR_SYNC_PROTOCOL_TYPES', API.SCARD_ATTR_SYNC_PROTOCOL_TYPES);
@@ -1361,8 +1358,8 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_POWER_MGMT_SUPPORT = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_POWER_MGMT, 0x0131);
+API.SCARD_ATTR_POWER_MGMT_SUPPORT =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_POWER_MGMT, 0x0131);
 
 goog.exportProperty(
     API, 'SCARD_ATTR_POWER_MGMT_SUPPORT', API.SCARD_ATTR_POWER_MGMT_SUPPORT);
@@ -1372,12 +1369,11 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_USER_TO_CARD_AUTH_DEVICE = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_SECURITY, 0x0140);
+API.SCARD_ATTR_USER_TO_CARD_AUTH_DEVICE =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_SECURITY, 0x0140);
 
 goog.exportProperty(
-    API,
-    'SCARD_ATTR_USER_TO_CARD_AUTH_DEVICE',
+    API, 'SCARD_ATTR_USER_TO_CARD_AUTH_DEVICE',
     API.SCARD_ATTR_USER_TO_CARD_AUTH_DEVICE);
 
 /**
@@ -1385,12 +1381,11 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_USER_AUTH_INPUT_DEVICE = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_SECURITY, 0x0142);
+API.SCARD_ATTR_USER_AUTH_INPUT_DEVICE =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_SECURITY, 0x0142);
 
 goog.exportProperty(
-    API,
-    'SCARD_ATTR_USER_AUTH_INPUT_DEVICE',
+    API, 'SCARD_ATTR_USER_AUTH_INPUT_DEVICE',
     API.SCARD_ATTR_USER_AUTH_INPUT_DEVICE);
 
 /**
@@ -1399,8 +1394,8 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_CHARACTERISTICS = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_MECHANICAL, 0x0150);
+API.SCARD_ATTR_CHARACTERISTICS =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_MECHANICAL, 0x0150);
 
 goog.exportProperty(
     API, 'SCARD_ATTR_CHARACTERISTICS', API.SCARD_ATTR_CHARACTERISTICS);
@@ -1410,12 +1405,11 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_CURRENT_PROTOCOL_TYPE = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_IFD_PROTOCOL, 0x0201);
+API.SCARD_ATTR_CURRENT_PROTOCOL_TYPE =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_IFD_PROTOCOL, 0x0201);
 
 goog.exportProperty(
-    API,
-    'SCARD_ATTR_CURRENT_PROTOCOL_TYPE',
+    API, 'SCARD_ATTR_CURRENT_PROTOCOL_TYPE',
     API.SCARD_ATTR_CURRENT_PROTOCOL_TYPE);
 
 /**
@@ -1423,8 +1417,8 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_CURRENT_CLK = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_IFD_PROTOCOL, 0x0202);
+API.SCARD_ATTR_CURRENT_CLK =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_IFD_PROTOCOL, 0x0202);
 
 goog.exportProperty(API, 'SCARD_ATTR_CURRENT_CLK', API.SCARD_ATTR_CURRENT_CLK);
 
@@ -1433,8 +1427,8 @@ goog.exportProperty(API, 'SCARD_ATTR_CURRENT_CLK', API.SCARD_ATTR_CURRENT_CLK);
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_CURRENT_F = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_IFD_PROTOCOL, 0x0203);
+API.SCARD_ATTR_CURRENT_F =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_IFD_PROTOCOL, 0x0203);
 
 goog.exportProperty(API, 'SCARD_ATTR_CURRENT_F', API.SCARD_ATTR_CURRENT_F);
 
@@ -1443,8 +1437,8 @@ goog.exportProperty(API, 'SCARD_ATTR_CURRENT_F', API.SCARD_ATTR_CURRENT_F);
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_CURRENT_D = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_IFD_PROTOCOL, 0x0204);
+API.SCARD_ATTR_CURRENT_D =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_IFD_PROTOCOL, 0x0204);
 
 goog.exportProperty(API, 'SCARD_ATTR_CURRENT_D', API.SCARD_ATTR_CURRENT_D);
 
@@ -1453,8 +1447,8 @@ goog.exportProperty(API, 'SCARD_ATTR_CURRENT_D', API.SCARD_ATTR_CURRENT_D);
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_CURRENT_N = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_IFD_PROTOCOL, 0x0205);
+API.SCARD_ATTR_CURRENT_N =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_IFD_PROTOCOL, 0x0205);
 
 goog.exportProperty(API, 'SCARD_ATTR_CURRENT_N', API.SCARD_ATTR_CURRENT_N);
 
@@ -1463,8 +1457,8 @@ goog.exportProperty(API, 'SCARD_ATTR_CURRENT_N', API.SCARD_ATTR_CURRENT_N);
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_CURRENT_W = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_IFD_PROTOCOL, 0x0206);
+API.SCARD_ATTR_CURRENT_W =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_IFD_PROTOCOL, 0x0206);
 
 goog.exportProperty(API, 'SCARD_ATTR_CURRENT_W', API.SCARD_ATTR_CURRENT_W);
 
@@ -1473,8 +1467,8 @@ goog.exportProperty(API, 'SCARD_ATTR_CURRENT_W', API.SCARD_ATTR_CURRENT_W);
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_CURRENT_IFSC = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_IFD_PROTOCOL, 0x0207);
+API.SCARD_ATTR_CURRENT_IFSC =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_IFD_PROTOCOL, 0x0207);
 
 goog.exportProperty(
     API, 'SCARD_ATTR_CURRENT_IFSC', API.SCARD_ATTR_CURRENT_IFSC);
@@ -1484,8 +1478,8 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_CURRENT_IFSD = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_IFD_PROTOCOL, 0x0208);
+API.SCARD_ATTR_CURRENT_IFSD =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_IFD_PROTOCOL, 0x0208);
 
 goog.exportProperty(
     API, 'SCARD_ATTR_CURRENT_IFSD', API.SCARD_ATTR_CURRENT_IFSD);
@@ -1495,8 +1489,8 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_CURRENT_BWT = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_IFD_PROTOCOL, 0x0209);
+API.SCARD_ATTR_CURRENT_BWT =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_IFD_PROTOCOL, 0x0209);
 
 goog.exportProperty(API, 'SCARD_ATTR_CURRENT_BWT', API.SCARD_ATTR_CURRENT_BWT);
 
@@ -1505,8 +1499,8 @@ goog.exportProperty(API, 'SCARD_ATTR_CURRENT_BWT', API.SCARD_ATTR_CURRENT_BWT);
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_CURRENT_CWT = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_IFD_PROTOCOL, 0x020a);
+API.SCARD_ATTR_CURRENT_CWT =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_IFD_PROTOCOL, 0x020a);
 
 goog.exportProperty(API, 'SCARD_ATTR_CURRENT_CWT', API.SCARD_ATTR_CURRENT_CWT);
 
@@ -1515,12 +1509,11 @@ goog.exportProperty(API, 'SCARD_ATTR_CURRENT_CWT', API.SCARD_ATTR_CURRENT_CWT);
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_CURRENT_EBC_ENCODING = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_IFD_PROTOCOL, 0x020b);
+API.SCARD_ATTR_CURRENT_EBC_ENCODING =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_IFD_PROTOCOL, 0x020b);
 
 goog.exportProperty(
-    API,
-    'SCARD_ATTR_CURRENT_EBC_ENCODING',
+    API, 'SCARD_ATTR_CURRENT_EBC_ENCODING',
     API.SCARD_ATTR_CURRENT_EBC_ENCODING);
 
 /**
@@ -1528,8 +1521,8 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_EXTENDED_BWT = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_IFD_PROTOCOL, 0x020c);
+API.SCARD_ATTR_EXTENDED_BWT =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_IFD_PROTOCOL, 0x020c);
 
 goog.exportProperty(
     API, 'SCARD_ATTR_EXTENDED_BWT', API.SCARD_ATTR_EXTENDED_BWT);
@@ -1539,8 +1532,8 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_ICC_PRESENCE = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_ICC_STATE, 0x0300);
+API.SCARD_ATTR_ICC_PRESENCE =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_ICC_STATE, 0x0300);
 
 goog.exportProperty(
     API, 'SCARD_ATTR_ICC_PRESENCE', API.SCARD_ATTR_ICC_PRESENCE);
@@ -1551,12 +1544,11 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_ICC_INTERFACE_STATUS = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_ICC_STATE, 0x0301);
+API.SCARD_ATTR_ICC_INTERFACE_STATUS =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_ICC_STATE, 0x0301);
 
 goog.exportProperty(
-    API,
-    'SCARD_ATTR_ICC_INTERFACE_STATUS',
+    API, 'SCARD_ATTR_ICC_INTERFACE_STATUS',
     API.SCARD_ATTR_ICC_INTERFACE_STATUS);
 
 /**
@@ -1564,8 +1556,8 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_CURRENT_IO_STATE = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_ICC_STATE, 0x0302);
+API.SCARD_ATTR_CURRENT_IO_STATE =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_ICC_STATE, 0x0302);
 
 goog.exportProperty(
     API, 'SCARD_ATTR_CURRENT_IO_STATE', API.SCARD_ATTR_CURRENT_IO_STATE);
@@ -1575,8 +1567,8 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_ATR_STRING = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_ICC_STATE, 0x0303);
+API.SCARD_ATTR_ATR_STRING =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_ICC_STATE, 0x0303);
 
 goog.exportProperty(API, 'SCARD_ATTR_ATR_STRING', API.SCARD_ATTR_ATR_STRING);
 
@@ -1585,8 +1577,8 @@ goog.exportProperty(API, 'SCARD_ATTR_ATR_STRING', API.SCARD_ATTR_ATR_STRING);
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_ICC_TYPE_PER_ATR = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_ICC_STATE, 0x0304);
+API.SCARD_ATTR_ICC_TYPE_PER_ATR =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_ICC_STATE, 0x0304);
 
 goog.exportProperty(
     API, 'SCARD_ATTR_ICC_TYPE_PER_ATR', API.SCARD_ATTR_ICC_TYPE_PER_ATR);
@@ -1596,8 +1588,8 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_ESC_RESET = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_VENDOR_DEFINED, 0xA000);
+API.SCARD_ATTR_ESC_RESET =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_VENDOR_DEFINED, 0xA000);
 
 goog.exportProperty(API, 'SCARD_ATTR_ESC_RESET', API.SCARD_ATTR_ESC_RESET);
 
@@ -1606,8 +1598,8 @@ goog.exportProperty(API, 'SCARD_ATTR_ESC_RESET', API.SCARD_ATTR_ESC_RESET);
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_ESC_CANCEL = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_VENDOR_DEFINED, 0xA003);
+API.SCARD_ATTR_ESC_CANCEL =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_VENDOR_DEFINED, 0xA003);
 
 goog.exportProperty(API, 'SCARD_ATTR_ESC_CANCEL', API.SCARD_ATTR_ESC_CANCEL);
 
@@ -1616,8 +1608,8 @@ goog.exportProperty(API, 'SCARD_ATTR_ESC_CANCEL', API.SCARD_ATTR_ESC_CANCEL);
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_ESC_AUTHREQUEST = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_VENDOR_DEFINED, 0xA005);
+API.SCARD_ATTR_ESC_AUTHREQUEST =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_VENDOR_DEFINED, 0xA005);
 
 goog.exportProperty(
     API, 'SCARD_ATTR_ESC_AUTHREQUEST', API.SCARD_ATTR_ESC_AUTHREQUEST);
@@ -1627,8 +1619,8 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_MAXINPUT = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_VENDOR_DEFINED, 0xA007);
+API.SCARD_ATTR_MAXINPUT =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_VENDOR_DEFINED, 0xA007);
 
 goog.exportProperty(API, 'SCARD_ATTR_MAXINPUT', API.SCARD_ATTR_MAXINPUT);
 
@@ -1640,8 +1632,8 @@ goog.exportProperty(API, 'SCARD_ATTR_MAXINPUT', API.SCARD_ATTR_MAXINPUT);
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_DEVICE_UNIT = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_SYSTEM, 0x0001);
+API.SCARD_ATTR_DEVICE_UNIT =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_SYSTEM, 0x0001);
 
 goog.exportProperty(API, 'SCARD_ATTR_DEVICE_UNIT', API.SCARD_ATTR_DEVICE_UNIT);
 
@@ -1650,8 +1642,8 @@ goog.exportProperty(API, 'SCARD_ATTR_DEVICE_UNIT', API.SCARD_ATTR_DEVICE_UNIT);
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_DEVICE_IN_USE = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_SYSTEM, 0x0002);
+API.SCARD_ATTR_DEVICE_IN_USE =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_SYSTEM, 0x0002);
 
 goog.exportProperty(
     API, 'SCARD_ATTR_DEVICE_IN_USE', API.SCARD_ATTR_DEVICE_IN_USE);
@@ -1660,48 +1652,44 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_DEVICE_FRIENDLY_NAME_A = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_SYSTEM, 0x0003);
+API.SCARD_ATTR_DEVICE_FRIENDLY_NAME_A =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_SYSTEM, 0x0003);
 
 goog.exportProperty(
-    API,
-    'SCARD_ATTR_DEVICE_FRIENDLY_NAME_A',
+    API, 'SCARD_ATTR_DEVICE_FRIENDLY_NAME_A',
     API.SCARD_ATTR_DEVICE_FRIENDLY_NAME_A);
 
 /**
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_DEVICE_SYSTEM_NAME_A = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_SYSTEM, 0x0004);
+API.SCARD_ATTR_DEVICE_SYSTEM_NAME_A =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_SYSTEM, 0x0004);
 
 goog.exportProperty(
-    API,
-    'SCARD_ATTR_DEVICE_SYSTEM_NAME_A',
+    API, 'SCARD_ATTR_DEVICE_SYSTEM_NAME_A',
     API.SCARD_ATTR_DEVICE_SYSTEM_NAME_A);
 
 /**
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_DEVICE_FRIENDLY_NAME_W = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_SYSTEM, 0x0005);
+API.SCARD_ATTR_DEVICE_FRIENDLY_NAME_W =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_SYSTEM, 0x0005);
 
 goog.exportProperty(
-    API,
-    'SCARD_ATTR_DEVICE_FRIENDLY_NAME_W',
+    API, 'SCARD_ATTR_DEVICE_FRIENDLY_NAME_W',
     API.SCARD_ATTR_DEVICE_FRIENDLY_NAME_W);
 
 /**
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_DEVICE_SYSTEM_NAME_W = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_SYSTEM, 0x0006);
+API.SCARD_ATTR_DEVICE_SYSTEM_NAME_W =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_SYSTEM, 0x0006);
 
 goog.exportProperty(
-    API,
-    'SCARD_ATTR_DEVICE_SYSTEM_NAME_W',
+    API, 'SCARD_ATTR_DEVICE_SYSTEM_NAME_W',
     API.SCARD_ATTR_DEVICE_SYSTEM_NAME_W);
 
 /**
@@ -1709,12 +1697,11 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_SUPRESS_T1_IFS_REQUEST = API.SCARD_ATTR_VALUE(
-    API.SCARD_CLASS_SYSTEM, 0x0007);
+API.SCARD_ATTR_SUPRESS_T1_IFS_REQUEST =
+    API.SCARD_ATTR_VALUE(API.SCARD_CLASS_SYSTEM, 0x0007);
 
 goog.exportProperty(
-    API,
-    'SCARD_ATTR_SUPRESS_T1_IFS_REQUEST',
+    API, 'SCARD_ATTR_SUPRESS_T1_IFS_REQUEST',
     API.SCARD_ATTR_SUPRESS_T1_IFS_REQUEST);
 
 /**
@@ -1722,12 +1709,10 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_DEVICE_FRIENDLY_NAME =
-    API.SCARD_ATTR_DEVICE_FRIENDLY_NAME_W;
+API.SCARD_ATTR_DEVICE_FRIENDLY_NAME = API.SCARD_ATTR_DEVICE_FRIENDLY_NAME_W;
 
 goog.exportProperty(
-    API,
-    'SCARD_ATTR_DEVICE_FRIENDLY_NAME',
+    API, 'SCARD_ATTR_DEVICE_FRIENDLY_NAME',
     API.SCARD_ATTR_DEVICE_FRIENDLY_NAME);
 
 /**
@@ -1735,8 +1720,7 @@ goog.exportProperty(
  * @type {number}
  * @const
  */
-API.SCARD_ATTR_DEVICE_SYSTEM_NAME =
-    API.SCARD_ATTR_DEVICE_SYSTEM_NAME_W;
+API.SCARD_ATTR_DEVICE_SYSTEM_NAME = API.SCARD_ATTR_DEVICE_SYSTEM_NAME_W;
 
 goog.exportProperty(
     API, 'SCARD_ATTR_DEVICE_SYSTEM_NAME', API.SCARD_ATTR_DEVICE_SYSTEM_NAME);
@@ -1848,16 +1832,14 @@ goog.exportProperty(
 API.FEATURE_VERIFY_PIN_DIRECT_APP_ID = 0x0D;
 
 goog.exportProperty(
-    API,
-    'FEATURE_VERIFY_PIN_DIRECT_APP_ID',
+    API, 'FEATURE_VERIFY_PIN_DIRECT_APP_ID',
     API.FEATURE_VERIFY_PIN_DIRECT_APP_ID);
 
 /** @const */
 API.FEATURE_MODIFY_PIN_DIRECT_APP_ID = 0x0E;
 
 goog.exportProperty(
-    API,
-    'FEATURE_MODIFY_PIN_DIRECT_APP_ID',
+    API, 'FEATURE_MODIFY_PIN_DIRECT_APP_ID',
     API.FEATURE_MODIFY_PIN_DIRECT_APP_ID);
 
 /** @const */
@@ -1899,96 +1881,84 @@ goog.exportProperty(API, 'FEATURE_EXECUTE_PACE', API.FEATURE_EXECUTE_PACE);
 API.PCSCv2_PART10_PROPERTY_wLcdLayout = 1;
 
 goog.exportProperty(
-    API,
-    'PCSCv2_PART10_PROPERTY_wLcdLayout',
+    API, 'PCSCv2_PART10_PROPERTY_wLcdLayout',
     API.PCSCv2_PART10_PROPERTY_wLcdLayout);
 
 /** @const */
 API.PCSCv2_PART10_PROPERTY_bEntryValidationCondition = 2;
 
 goog.exportProperty(
-    API,
-    'PCSCv2_PART10_PROPERTY_bEntryValidationCondition',
+    API, 'PCSCv2_PART10_PROPERTY_bEntryValidationCondition',
     API.PCSCv2_PART10_PROPERTY_bEntryValidationCondition);
 
 /** @const */
 API.PCSCv2_PART10_PROPERTY_bTimeOut2 = 3;
 
 goog.exportProperty(
-    API,
-    'PCSCv2_PART10_PROPERTY_bTimeOut2',
+    API, 'PCSCv2_PART10_PROPERTY_bTimeOut2',
     API.PCSCv2_PART10_PROPERTY_bTimeOut2);
 
 /** @const */
 API.PCSCv2_PART10_PROPERTY_wLcdMaxCharacters = 4;
 
 goog.exportProperty(
-    API,
-    'PCSCv2_PART10_PROPERTY_wLcdMaxCharacters',
+    API, 'PCSCv2_PART10_PROPERTY_wLcdMaxCharacters',
     API.PCSCv2_PART10_PROPERTY_wLcdMaxCharacters);
 
 /** @const */
 API.PCSCv2_PART10_PROPERTY_wLcdMaxLines = 5;
 
 goog.exportProperty(
-    API,
-    'PCSCv2_PART10_PROPERTY_wLcdMaxLines',
+    API, 'PCSCv2_PART10_PROPERTY_wLcdMaxLines',
     API.PCSCv2_PART10_PROPERTY_wLcdMaxLines);
 
 /** @const */
 API.PCSCv2_PART10_PROPERTY_bMinPINSize = 6;
 
 goog.exportProperty(
-    API,
-    'PCSCv2_PART10_PROPERTY_bMinPINSize',
+    API, 'PCSCv2_PART10_PROPERTY_bMinPINSize',
     API.PCSCv2_PART10_PROPERTY_bMinPINSize);
 
 /** @const */
 API.PCSCv2_PART10_PROPERTY_bMaxPINSize = 7;
 
 goog.exportProperty(
-    API,
-    'PCSCv2_PART10_PROPERTY_bMaxPINSize',
+    API, 'PCSCv2_PART10_PROPERTY_bMaxPINSize',
     API.PCSCv2_PART10_PROPERTY_bMaxPINSize);
 
 /** @const */
 API.PCSCv2_PART10_PROPERTY_sFirmwareID = 8;
 
 goog.exportProperty(
-    API,
-    'PCSCv2_PART10_PROPERTY_sFirmwareID',
+    API, 'PCSCv2_PART10_PROPERTY_sFirmwareID',
     API.PCSCv2_PART10_PROPERTY_sFirmwareID);
 
 /** @const */
 API.PCSCv2_PART10_PROPERTY_bPPDUSupport = 9;
 
 goog.exportProperty(
-    API,
-    'PCSCv2_PART10_PROPERTY_bPPDUSupport',
+    API, 'PCSCv2_PART10_PROPERTY_bPPDUSupport',
     API.PCSCv2_PART10_PROPERTY_bPPDUSupport);
 
 /** @const */
 API.PCSCv2_PART10_PROPERTY_dwMaxAPDUDataSize = 10;
 
 goog.exportProperty(
-    API,
-    'PCSCv2_PART10_PROPERTY_dwMaxAPDUDataSize',
+    API, 'PCSCv2_PART10_PROPERTY_dwMaxAPDUDataSize',
     API.PCSCv2_PART10_PROPERTY_dwMaxAPDUDataSize);
 
 /** @const */
 API.PCSCv2_PART10_PROPERTY_wIdVendor = 11;
 
 goog.exportProperty(
-    API,
-    'PCSCv2_PART10_PROPERTY_wIdVendor',
+    API, 'PCSCv2_PART10_PROPERTY_wIdVendor',
     API.PCSCv2_PART10_PROPERTY_wIdVendor);
 
 /** @const */
 API.PCSCv2_PART10_PROPERTY_wIdProduct = 12;
 
 goog.exportProperty(
-    API,
-    'PCSCv2_PART10_PROPERTY_wIdProduct',
+    API, 'PCSCv2_PART10_PROPERTY_wIdProduct',
     API.PCSCv2_PART10_PROPERTY_wIdProduct);
 
 /**
@@ -2151,8 +2121,8 @@ goog.exportProperty(API, 'ResultOrErrorCode', API.ResultOrErrorCode);
  * @type {!goog.log.Logger}
  * @const
  */
-API.ResultOrErrorCode.prototype.logger = GSC.Logging.getScopedLogger(
-    'PcscLiteClient.API.ResultOrErrorCode');
+API.ResultOrErrorCode.prototype.logger =
+    GSC.Logging.getScopedLogger('PcscLiteClient.API.ResultOrErrorCode');
 
 /**
  * @param {number} successfulResultItemCount
@@ -2174,8 +2144,7 @@ API.ResultOrErrorCode.prototype.getBase = function(
 };
 
 goog.exportProperty(
-    API.ResultOrErrorCode.prototype,
-    'getBase',
+    API.ResultOrErrorCode.prototype, 'getBase',
     API.ResultOrErrorCode.prototype.getBase);
 
 /**
@@ -2186,8 +2155,7 @@ API.ResultOrErrorCode.prototype.isSuccessful = function() {
 };
 
 goog.exportProperty(
-    API.ResultOrErrorCode.prototype,
-    'isSuccessful',
+    API.ResultOrErrorCode.prototype, 'isSuccessful',
     API.ResultOrErrorCode.prototype.isSuccessful);
 
 /**
@@ -2201,8 +2169,7 @@ API.ResultOrErrorCode.prototype.getResult = function() {
 };
 
 goog.exportProperty(
-    API.ResultOrErrorCode.prototype,
-    'getResult',
+    API.ResultOrErrorCode.prototype, 'getResult',
     API.ResultOrErrorCode.prototype.getResult);
 
 /**
@@ -2221,7 +2188,8 @@ API.ResultOrErrorCode.prototype.getDebugRepresentation = function() {
     // digital signature). The debugDump() function dumps the values only when
     // goog.DEBUG is true, and otherwise shows only the number of values.
     const dumpedItems = this.resultItems && this.resultItems.length ?
-        ' ' + GSC.DebugDump.debugDump(this.resultItems) : '';
+        ' ' + GSC.DebugDump.debugDump(this.resultItems) :
+        '';
     return 'SCARD_S_SUCCESS' + dumpedItems;
   }
   // Dump the error code regardless of whether the mode is Debug or Release,
@@ -2230,8 +2198,7 @@ API.ResultOrErrorCode.prototype.getDebugRepresentation = function() {
 };
 
 goog.exportProperty(
-    API.ResultOrErrorCode.prototype,
-    'getDebugRepresentation',
+    API.ResultOrErrorCode.prototype, 'getDebugRepresentation',
     API.ResultOrErrorCode.prototype.getDebugRepresentation);
 
 
@@ -2245,9 +2212,7 @@ goog.exportProperty(
 API.prototype.pcsc_stringify_error = function(errorCode) {
   const logger = this.logger;
   return this.postRequest_(
-      'pcsc_stringify_error',
-      [errorCode],
-      function(responseItems) {
+      'pcsc_stringify_error', [errorCode], function(responseItems) {
         GSC.Logging.checkWithLogger(logger, responseItems.length == 1);
         GSC.Logging.checkWithLogger(
             logger, typeof responseItems[0] === 'string');
@@ -2256,9 +2221,7 @@ API.prototype.pcsc_stringify_error = function(errorCode) {
 };
 
 goog.exportProperty(
-    API.prototype,
-    'pcsc_stringify_error',
-    API.prototype.pcsc_stringify_error);
+    API.prototype, 'pcsc_stringify_error', API.prototype.pcsc_stringify_error);
 
 /**
  * Creates an Application Context to the PC/SC Resource Manager.
@@ -2296,16 +2259,14 @@ API.prototype.SCardEstablishContext = function(
   if (opt_reserved_2 === undefined)
     opt_reserved_2 = null;
   return this.postRequest_(
-      'SCardEstablishContext',
-      [scope, opt_reserved_1, opt_reserved_2],
+      'SCardEstablishContext', [scope, opt_reserved_1, opt_reserved_2],
       function(responseItems) {
         return new API.SCardEstablishContextResult(responseItems);
       });
 };
 
 goog.exportProperty(
-    API.prototype,
-    'SCardEstablishContext',
+    API.prototype, 'SCardEstablishContext',
     API.prototype.SCardEstablishContext);
 
 /**
@@ -2336,8 +2297,7 @@ API.SCardEstablishContextResult.prototype.get = function(
 };
 
 goog.exportProperty(
-    API.SCardEstablishContextResult.prototype,
-    'get',
+    API.SCardEstablishContextResult.prototype, 'get',
     API.SCardEstablishContextResult.prototype.get);
 
 /**
@@ -2356,17 +2316,13 @@ goog.exportProperty(
  */
 API.prototype.SCardReleaseContext = function(sCardContext) {
   return this.postRequest_(
-      'SCardReleaseContext',
-      [sCardContext],
-      function(responseItems) {
+      'SCardReleaseContext', [sCardContext], function(responseItems) {
         return new API.SCardReleaseContextResult(responseItems);
       });
 };
 
 goog.exportProperty(
-    API.prototype,
-    'SCardReleaseContext',
-    API.prototype.SCardReleaseContext);
+    API.prototype, 'SCardReleaseContext', API.prototype.SCardReleaseContext);
 
 /**
  * Type representing the result of the SCardReleaseContext function call.
@@ -2395,8 +2351,7 @@ API.SCardReleaseContextResult.prototype.get = function(
 };
 
 goog.exportProperty(
-    API.SCardReleaseContextResult.prototype,
-    'get',
+    API.SCardReleaseContextResult.prototype, 'get',
     API.SCardReleaseContextResult.prototype.get);
 
 /**
@@ -2452,8 +2407,7 @@ goog.exportProperty(
 API.prototype.SCardConnect = function(
     sCardContext, reader, shareMode, preferredProtocols) {
   return this.postRequest_(
-      'SCardConnect',
-      [sCardContext, reader, shareMode, preferredProtocols],
+      'SCardConnect', [sCardContext, reader, shareMode, preferredProtocols],
       function(responseItems) {
         return new API.SCardConnectResult(responseItems);
       });
@@ -2488,8 +2442,7 @@ API.SCardConnectResult.prototype.get = function(
 };
 
 goog.exportProperty(
-    API.SCardConnectResult.prototype,
-    'get',
+    API.SCardConnectResult.prototype, 'get',
     API.SCardConnectResult.prototype.get);
 
 /**
@@ -2585,8 +2538,7 @@ API.SCardReconnectResult.prototype.get = function(
 };
 
 goog.exportProperty(
-    API.SCardReconnectResult.prototype,
-    'get',
+    API.SCardReconnectResult.prototype, 'get',
     API.SCardReconnectResult.prototype.get);
 
 /**
@@ -2645,8 +2597,7 @@ API.SCardDisconnectResult.prototype.get = function(
 };
 
 goog.exportProperty(
-    API.SCardDisconnectResult.prototype,
-    'get',
+    API.SCardDisconnectResult.prototype, 'get',
     API.SCardDisconnectResult.prototype.get);
 
 /**
@@ -2679,8 +2630,7 @@ API.prototype.SCardBeginTransaction = function(sCardHandle) {
 };
 
 goog.exportProperty(
-    API.prototype,
-    'SCardBeginTransaction',
+    API.prototype, 'SCardBeginTransaction',
     API.prototype.SCardBeginTransaction);
 
 /**
@@ -2710,8 +2660,7 @@ API.SCardBeginTransactionResult.prototype.get = function(
 };
 
 goog.exportProperty(
-    API.SCardBeginTransactionResult.prototype,
-    'get',
+    API.SCardBeginTransactionResult.prototype, 'get',
     API.SCardBeginTransactionResult.prototype.get);
 
 /**
@@ -2740,8 +2689,7 @@ goog.exportProperty(
  */
 API.prototype.SCardEndTransaction = function(sCardHandle, disposition) {
   return this.postRequest_(
-      'SCardEndTransaction',
-      [sCardHandle, disposition],
+      'SCardEndTransaction', [sCardHandle, disposition],
       function(responseItems) {
         return new API.SCardEndTransactionResult(responseItems);
       });
@@ -2777,8 +2725,7 @@ API.SCardEndTransactionResult.prototype.get = function(
 };
 
 goog.exportProperty(
-    API.SCardEndTransactionResult.prototype,
-    'get',
+    API.SCardEndTransactionResult.prototype, 'get',
     API.SCardEndTransactionResult.prototype.get);
 
 /**
@@ -2847,8 +2794,7 @@ API.SCardStatusResult = function(responseItems) {
   API.SCardStatusResult.base(this, 'constructor', responseItems);
 };
 
-goog.exportProperty(
-    API, 'SCardStatusResult', API.SCardStatusResult);
+goog.exportProperty(API, 'SCardStatusResult', API.SCardStatusResult);
 
 goog.inherits(API.SCardStatusResult, API.ResultOrErrorCode);
 
@@ -2865,8 +2811,7 @@ API.SCardStatusResult.prototype.get = function(
 };
 
 goog.exportProperty(
-    API.SCardStatusResult.prototype,
-    'get',
+    API.SCardStatusResult.prototype, 'get',
     API.SCardStatusResult.prototype.get);
 
 /**
@@ -2942,8 +2887,7 @@ goog.exportProperty(
 API.prototype.SCardGetStatusChange = function(
     sCardContext, timeout, readerStates) {
   return this.postRequest_(
-      'SCardGetStatusChange',
-      [sCardContext, timeout, readerStates],
+      'SCardGetStatusChange', [sCardContext, timeout, readerStates],
       function(responseItems) {
         return new API.SCardGetStatusChangeResult(responseItems);
       });
@@ -2970,7 +2914,8 @@ goog.inherits(API.SCardGetStatusChangeResult, API.ResultOrErrorCode);
 /**
  * @param {function(!Array.<!API.SCARD_READERSTATE_OUT>)=} opt_onSucceeded
  * callback: function(readerStates)
- * @param {function(!API.ERROR_CODE)=} opt_onFailed callback: function(errorCode)
+ * @param {function(!API.ERROR_CODE)=} opt_onFailed callback:
+ *     function(errorCode)
  * @param {*=} opt_context
  */
 API.SCardGetStatusChangeResult.prototype.get = function(
@@ -2979,8 +2924,7 @@ API.SCardGetStatusChangeResult.prototype.get = function(
 };
 
 goog.exportProperty(
-    API.SCardGetStatusChangeResult.prototype,
-    'get',
+    API.SCardGetStatusChangeResult.prototype, 'get',
     API.SCardGetStatusChangeResult.prototype.get);
 
 /**
@@ -3019,8 +2963,7 @@ goog.exportProperty(
  */
 API.prototype.SCardControl = function(sCardHandle, controlCode, dataToSend) {
   return this.postRequest_(
-      'SCardControl',
-      [sCardHandle, controlCode, dataToSend],
+      'SCardControl', [sCardHandle, controlCode, dataToSend],
       function(responseItems) {
         return new API.SCardControlResult(responseItems);
       });
@@ -3055,8 +2998,7 @@ API.SCardControlResult.prototype.get = function(
 };
 
 goog.exportProperty(
-    API.SCardControlResult.prototype,
-    'get',
+    API.SCardControlResult.prototype, 'get',
     API.SCardControlResult.prototype.get);
 
 /**
@@ -3136,9 +3078,7 @@ goog.exportProperty(
  */
 API.prototype.SCardGetAttrib = function(sCardHandle, attrId) {
   return this.postRequest_(
-      'SCardGetAttrib',
-      [sCardHandle, attrId],
-      function(responseItems) {
+      'SCardGetAttrib', [sCardHandle, attrId], function(responseItems) {
         return new API.SCardGetAttribResult(responseItems);
       });
 };
@@ -3172,8 +3112,7 @@ API.SCardGetAttribResult.prototype.get = function(
 };
 
 goog.exportProperty(
-    API.SCardGetAttribResult.prototype,
-    'get',
+    API.SCardGetAttribResult.prototype, 'get',
     API.SCardGetAttribResult.prototype.get);
 
 /**
@@ -3200,9 +3139,7 @@ goog.exportProperty(
  */
 API.prototype.SCardSetAttrib = function(sCardHandle, attrId, attr) {
   return this.postRequest_(
-      'SCardSetAttrib',
-      [sCardHandle, attrId, attr],
-      function(responseItems) {
+      'SCardSetAttrib', [sCardHandle, attrId, attr], function(responseItems) {
         return new API.SCardSetAttribResult(responseItems);
       });
 };
@@ -3236,8 +3173,7 @@ API.SCardSetAttribResult.prototype.get = function(
 };
 
 goog.exportProperty(
-    API.SCardSetAttribResult.prototype,
-    'get',
+    API.SCardSetAttribResult.prototype, 'get',
     API.SCardSetAttribResult.prototype.get);
 
 /**
@@ -3280,16 +3216,14 @@ goog.exportProperty(
  * @return {!goog.Promise.<!API.SCardTransmitResult>}
  */
 API.prototype.SCardTransmit = function(
-    sCardHandle,
-    sendProtocolInformation,
-    dataToSend,
+    sCardHandle, sendProtocolInformation, dataToSend,
     opt_receiveProtocolInformation) {
   return this.postRequest_(
       'SCardTransmit',
-      [sCardHandle,
-       sendProtocolInformation,
-       dataToSend,
-       opt_receiveProtocolInformation],
+      [
+        sCardHandle, sendProtocolInformation, dataToSend,
+        opt_receiveProtocolInformation
+      ],
       function(responseItems) {
         return new API.SCardTransmitResult(responseItems);
       });
@@ -3325,8 +3259,7 @@ API.SCardTransmitResult.prototype.get = function(
 };
 
 goog.exportProperty(
-    API.SCardTransmitResult.prototype,
-    'get',
+    API.SCardTransmitResult.prototype, 'get',
     API.SCardTransmitResult.prototype.get);
 
 /**
@@ -3389,8 +3322,7 @@ API.SCardListReadersResult.prototype.get = function(
 };
 
 goog.exportProperty(
-    API.SCardListReadersResult.prototype,
-    'get',
+    API.SCardListReadersResult.prototype, 'get',
     API.SCardListReadersResult.prototype.get);
 
 /**
@@ -3421,8 +3353,7 @@ API.prototype.SCardListReaderGroups = function(sCardContext) {
 };
 
 goog.exportProperty(
-    API.prototype,
-    'SCardListReaderGroups',
+    API.prototype, 'SCardListReaderGroups',
     API.prototype.SCardListReaderGroups);
 
 /**
@@ -3453,8 +3384,7 @@ API.SCardListReaderGroupsResult.prototype.get = function(
 };
 
 goog.exportProperty(
-    API.SCardListReaderGroupsResult.prototype,
-    'get',
+    API.SCardListReaderGroupsResult.prototype, 'get',
     API.SCardListReaderGroupsResult.prototype.get);
 
 /**
@@ -3490,8 +3420,7 @@ API.SCardCancelResult = function(responseItems) {
   API.SCardCancelResult.base(this, 'constructor', responseItems);
 };
 
-goog.exportProperty(
-    API, 'SCardCancelResult', API.SCardCancelResult);
+goog.exportProperty(API, 'SCardCancelResult', API.SCardCancelResult);
 
 goog.inherits(API.SCardCancelResult, API.ResultOrErrorCode);
 
@@ -3507,8 +3436,7 @@ API.SCardCancelResult.prototype.get = function(
 };
 
 goog.exportProperty(
-    API.SCardCancelResult.prototype,
-    'get',
+    API.SCardCancelResult.prototype, 'get',
     API.SCardCancelResult.prototype.get);
 
 /**
@@ -3565,8 +3493,7 @@ API.SCardIsValidContextResult.prototype.get = function(
 };
 
 goog.exportProperty(
-    API.SCardIsValidContextResult.prototype,
-    'get',
+    API.SCardIsValidContextResult.prototype, 'get',
     API.SCardIsValidContextResult.prototype.get);
 
 
@@ -3600,8 +3527,8 @@ API.prototype.messageChannelDisposedListener_ = function() {
 API.prototype.postRequest_ = function(
     functionName, functionArguments, successfulResultTransformer) {
   if (this.isDisposed()) {
-    return goog.Promise.reject(new Error(
-        'The API instance is already disposed'));
+    return goog.Promise.reject(
+        new Error('The API instance is already disposed'));
   }
   const remoteCallMessage =
       new GSC.RemoteCallMessage(functionName, functionArguments);
@@ -3609,5 +3536,4 @@ API.prototype.postRequest_ = function(
   const promise = this.requester_.postRequest(payload);
   return promise.then(successfulResultTransformer);
 };
-
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/js_client/src/context.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/context.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -107,8 +108,8 @@ goog.exportSymbol('GoogleSmartCard.PcscLiteClient.Context', Context);
  * @type {!goog.log.Logger}
  * @const
  */
-Context.prototype.logger = GSC.Logging.getScopedLogger(
-    'PcscLiteClient.Context');
+Context.prototype.logger =
+    GSC.Logging.getScopedLogger('PcscLiteClient.Context');
 
 goog.exportProperty(Context.prototype, 'logger', Context.prototype.logger);
 
@@ -166,8 +167,7 @@ Context.prototype.addOnInitializedCallback = function(callback) {
 };
 
 goog.exportProperty(
-    Context.prototype,
-    'addOnInitializedCallback',
+    Context.prototype, 'addOnInitializedCallback',
     Context.prototype.addOnInitializedCallback);
 
 /**
@@ -232,5 +232,4 @@ Context.prototype.messageChannelDisposedListener_ = function() {
   this.logger.fine('Message channel was disposed, disposing...');
   this.dispose();
 };
-
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/js_demo/src/demo.js
+++ b/third_party/pcsc-lite/naclport/js_demo/src/demo.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -72,11 +73,10 @@ function startDemo(api, onDemoSucceeded, onDemoFailed) {
 
 function establishContext(api, onDemoSucceeded, onDemoFailed) {
   logger.info('Establishing a context...');
-  api.SCardEstablishContext(API.SCARD_SCOPE_SYSTEM, null, null).then(
-      function(result) {
+  api.SCardEstablishContext(API.SCARD_SCOPE_SYSTEM, null, null)
+      .then(function(result) {
         result.get(
-            onContextEstablished.bind(
-                null, api, onDemoSucceeded, onDemoFailed),
+            onContextEstablished.bind(null, api, onDemoSucceeded, onDemoFailed),
             onPcscLiteError.bind(null, api, onDemoFailed));
       }, onFailure.bind(null, onDemoFailed));
 }
@@ -130,25 +130,16 @@ function waitForReadersChange(
     api, onDemoSucceeded, onDemoFailed, sCardContext) {
   logger.info('Waiting ' + TIMEOUT_SECONDS + ' seconds for readers change...');
   api.SCardGetStatusChange(
-      sCardContext,
-      TIMEOUT_SECONDS * 1000,
-      [API.createSCardReaderStateIn(
-           SPECIAL_READER_NAME, API.SCARD_STATE_UNAWARE, 0xDEADBEEF)]).then(
-          function(result) {
-            result.get(
-                onReadersChanged.bind(
-                    null,
-                    api,
-                    onDemoSucceeded,
-                    onDemoFailed,
-                    sCardContext),
-                onReadersChangeWaitingFailed.bind(
-                    null,
-                    api,
-                    onDemoSucceeded,
-                    onDemoFailed,
-                    sCardContext));
-          }, onFailure.bind(null, onDemoFailed));
+         sCardContext, TIMEOUT_SECONDS * 1000,
+         [API.createSCardReaderStateIn(
+             SPECIAL_READER_NAME, API.SCARD_STATE_UNAWARE, 0xDEADBEEF)])
+      .then(function(result) {
+        result.get(
+            onReadersChanged.bind(
+                null, api, onDemoSucceeded, onDemoFailed, sCardContext),
+            onReadersChangeWaitingFailed.bind(
+                null, api, onDemoSucceeded, onDemoFailed, sCardContext));
+      }, onFailure.bind(null, onDemoFailed));
 }
 
 function onReadersChanged(
@@ -200,8 +191,9 @@ function listReaderGroups(api, onDemoSucceeded, onDemoFailed, sCardContext) {
 
 function onReaderGroupsListed(
     api, onDemoSucceeded, onDemoFailed, sCardContext, readerGroups) {
-  logger.info('Listed reader groups: ' +
-              goog.iter.join(goog.iter.map(readerGroups, dump), ', '));
+  logger.info(
+      'Listed reader groups: ' +
+      goog.iter.join(goog.iter.map(readerGroups, dump), ', '));
   if (!readerGroups) {
     logger.warning('failed: no reader groups found');
     onDemoFailed();
@@ -222,8 +214,8 @@ function listReaders(api, onDemoSucceeded, onDemoFailed, sCardContext) {
 
 function onReadersListed(
     api, onDemoSucceeded, onDemoFailed, sCardContext, readers) {
-  logger.info('Listed readers: ' +
-              goog.iter.join(goog.iter.map(readers, dump), ', '));
+  logger.info(
+      'Listed readers: ' + goog.iter.join(goog.iter.map(readers, dump), ', '));
   if (!readers) {
     logger.warning('failed: no readers found');
     onDemoFailed();
@@ -235,37 +227,25 @@ function onReadersListed(
 
 function waitForCardRemoval(
     api, onDemoSucceeded, onDemoFailed, sCardContext, readerName) {
-  logger.info('Waiting ' + TIMEOUT_SECONDS + ' seconds for card removal ' +
-              'from ' + dump(readerName) + ' reader...');
+  logger.info(
+      'Waiting ' + TIMEOUT_SECONDS + ' seconds for card removal ' +
+      'from ' + dump(readerName) + ' reader...');
   api.SCardGetStatusChange(
-      sCardContext,
-      TIMEOUT_SECONDS * 1000,
-      [API.createSCardReaderStateIn(readerName, API.SCARD_STATE_PRESENT)]).then(
-          function(result) {
-            result.get(
-                onCardRemoved.bind(
-                    null,
-                    api,
-                    onDemoSucceeded,
-                    onDemoFailed,
-                    sCardContext,
-                    readerName),
-                onCardRemovalWaitingFailed.bind(
-                    null,
-                    api,
-                    onDemoSucceeded,
-                    onDemoFailed,
-                    sCardContext,
-                    readerName));
-          }, onFailure.bind(null, onDemoFailed));
+         sCardContext, TIMEOUT_SECONDS * 1000,
+         [API.createSCardReaderStateIn(readerName, API.SCARD_STATE_PRESENT)])
+      .then(function(result) {
+        result.get(
+            onCardRemoved.bind(
+                null, api, onDemoSucceeded, onDemoFailed, sCardContext,
+                readerName),
+            onCardRemovalWaitingFailed.bind(
+                null, api, onDemoSucceeded, onDemoFailed, sCardContext,
+                readerName));
+      }, onFailure.bind(null, onDemoFailed));
 }
 
 function onCardRemoved(
-    api,
-    onDemoSucceeded,
-    onDemoFailed,
-    sCardContext,
-    readerName,
+    api, onDemoSucceeded, onDemoFailed, sCardContext, readerName,
     readerStates) {
   logger.info('Caught card removal: ' + dump(readerStates));
   waitForCardInsertion(
@@ -285,31 +265,23 @@ function onCardRemovalWaitingFailed(
 
 function waitForCardInsertion(
     api, onDemoSucceeded, onDemoFailed, sCardContext, readerName) {
-  logger.info('Waiting ' + TIMEOUT_SECONDS + ' seconds for card insertion ' +
-              'into ' + dump(readerName) + ' reader...');
+  logger.info(
+      'Waiting ' + TIMEOUT_SECONDS + ' seconds for card insertion ' +
+      'into ' + dump(readerName) + ' reader...');
   api.SCardGetStatusChange(
-      sCardContext,
-      TIMEOUT_SECONDS * 1000,
-      [API.createSCardReaderStateIn(readerName, API.SCARD_STATE_EMPTY)]).then(
-          function(result) {
-            result.get(
-                onCardInserted.bind(
-                    null,
-                    api,
-                    onDemoSucceeded,
-                    onDemoFailed,
-                    sCardContext,
-                    readerName),
-                onPcscLiteError.bind(null, api, onDemoFailed));
-          }, onFailure.bind(null, onDemoFailed));
+         sCardContext, TIMEOUT_SECONDS * 1000,
+         [API.createSCardReaderStateIn(readerName, API.SCARD_STATE_EMPTY)])
+      .then(function(result) {
+        result.get(
+            onCardInserted.bind(
+                null, api, onDemoSucceeded, onDemoFailed, sCardContext,
+                readerName),
+            onPcscLiteError.bind(null, api, onDemoFailed));
+      }, onFailure.bind(null, onDemoFailed));
 }
 
 function onCardInserted(
-    api,
-    onDemoSucceeded,
-    onDemoFailed,
-    sCardContext,
-    readerName,
+    api, onDemoSucceeded, onDemoFailed, sCardContext, readerName,
     readerStates) {
   logger.info('Caught card insertion: ' + dump(readerStates));
   waitAndCancel(api, onDemoSucceeded, onDemoFailed, sCardContext, readerName);
@@ -317,31 +289,22 @@ function onCardInserted(
 
 function waitAndCancel(
     api, onDemoSucceeded, onDemoFailed, sCardContext, readerName) {
-  logger.info('Started waiting for card removal from ' + dump(readerName) +
-              ' reader...');
+  logger.info(
+      'Started waiting for card removal from ' + dump(readerName) +
+      ' reader...');
   api.SCardGetStatusChange(
-      sCardContext,
-      TIMEOUT_SECONDS * 1000,
-      [goog.object.create(
-           'reader_name',
-           readerName,
-           'current_state',
-           API.SCARD_STATE_PRESENT)]).then(
-          function(result) {
-            result.get(
-                onCancelingWaitingFinished.bind(
-                    null,
-                    api,
-                    onDemoSucceeded,
-                    onDemoFailed),
-                onCancelingWaitingFailed.bind(
-                    null,
-                    api,
-                    onDemoSucceeded,
-                    onDemoFailed,
-                    sCardContext,
-                    readerName));
-          }, onFailure.bind(null, onDemoFailed));
+         sCardContext, TIMEOUT_SECONDS * 1000,
+         [goog.object.create(
+             'reader_name', readerName, 'current_state',
+             API.SCARD_STATE_PRESENT)])
+      .then(function(result) {
+        result.get(
+            onCancelingWaitingFinished.bind(
+                null, api, onDemoSucceeded, onDemoFailed),
+            onCancelingWaitingFailed.bind(
+                null, api, onDemoSucceeded, onDemoFailed, sCardContext,
+                readerName));
+      }, onFailure.bind(null, onDemoFailed));
   logger.info('Cancelling the waiting...');
   api.SCardCancel(sCardContext).then(function(result) {
     result.get(
@@ -350,12 +313,7 @@ function waitAndCancel(
 }
 
 function onCancelingWaitingFailed(
-    api,
-    onDemoSucceeded,
-    onDemoFailed,
-    sCardContext,
-    readerName,
-    errorCode) {
+    api, onDemoSucceeded, onDemoFailed, sCardContext, readerName, errorCode) {
   if (errorCode != API.SCARD_E_CANCELLED) {
     onPcscLiteError(api, onDemoFailed, errorCode);
     return;
@@ -376,10 +334,9 @@ function onCancelSucceeded() {
 function connect(api, onDemoSucceeded, onDemoFailed, sCardContext, readerName) {
   logger.info('Connecting to the reader ' + dump(readerName) + '...');
   api.SCardConnect(
-      sCardContext,
-      readerName,
-      API.SCARD_SHARE_SHARED,
-      API.SCARD_PROTOCOL_ANY).then(function(result) {
+         sCardContext, readerName, API.SCARD_SHARE_SHARED,
+         API.SCARD_PROTOCOL_ANY)
+      .then(function(result) {
         result.get(
             onConnected.bind(
                 null, api, onDemoSucceeded, onDemoFailed, sCardContext),
@@ -388,15 +345,12 @@ function connect(api, onDemoSucceeded, onDemoFailed, sCardContext, readerName) {
 }
 
 function onConnected(
-    api,
-    onDemoSucceeded,
-    onDemoFailed,
-    sCardContext,
-    sCardHandle,
+    api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle,
     activeProtocol) {
-  logger.info('Successfully connected, handle is: ' + dump(sCardHandle) +
-               ', active protocol is: ' +
-               getProtocolDebugRepresentation(activeProtocol));
+  logger.info(
+      'Successfully connected, handle is: ' + dump(sCardHandle) +
+      ', active protocol is: ' +
+      getProtocolDebugRepresentation(activeProtocol));
   reconnect(api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle);
 }
 
@@ -404,17 +358,12 @@ function reconnect(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle) {
   logger.info('Reconnecting to the card...');
   api.SCardReconnect(
-      sCardHandle,
-      API.SCARD_SHARE_SHARED,
-      API.SCARD_PROTOCOL_ANY,
-      API.SCARD_LEAVE_CARD).then(function(result) {
+         sCardHandle, API.SCARD_SHARE_SHARED, API.SCARD_PROTOCOL_ANY,
+         API.SCARD_LEAVE_CARD)
+      .then(function(result) {
         result.get(
             onReconnected.bind(
-                null,
-                api,
-                onDemoSucceeded,
-                onDemoFailed,
-                sCardContext,
+                null, api, onDemoSucceeded, onDemoFailed, sCardContext,
                 sCardHandle),
             onPcscLiteError.bind(null, api, onDemoFailed));
       }, onFailure.bind(null, onDemoFailed));
@@ -432,85 +381,52 @@ function getStatus(
   api.SCardStatus(sCardHandle).then(function(result) {
     result.get(
         onStatusGot.bind(
-            null,
-            api,
-            onDemoSucceeded,
-            onDemoFailed,
-            sCardContext,
+            null, api, onDemoSucceeded, onDemoFailed, sCardContext,
             sCardHandle),
         onPcscLiteError.bind(null, api, onDemoFailed));
   }, onFailure.bind(null, onDemoFailed));
 }
 
 function onStatusGot(
-    api,
-    onDemoSucceeded,
-    onDemoFailed,
-    sCardContext,
-    sCardHandle,
-    readerName,
-    state,
-    protocol,
-    atr) {
-  logger.info('Card status obtained: reader name is ' + dump(readerName) +
-               ', ' + 'state is ' + dump(state) + ', protocol is ' +
-               getProtocolDebugRepresentation(protocol) + ', atr is ' +
-               dump(atr));
+    api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, readerName,
+    state, protocol, atr) {
+  logger.info(
+      'Card status obtained: reader name is ' + dump(readerName) + ', ' +
+      'state is ' + dump(state) + ', protocol is ' +
+      getProtocolDebugRepresentation(protocol) + ', atr is ' + dump(atr));
   getAttrs(
-      api,
-      onDemoSucceeded,
-      onDemoFailed,
-      sCardContext,
-      sCardHandle,
-      protocol,
+      api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol,
       0);
 }
 
 function getAttrs(
-    api,
-    onDemoSucceeded,
-    onDemoFailed,
-    sCardContext,
-    sCardHandle,
-    protocol,
+    api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol,
     attrIndex) {
   const attrNames = getPcscLiteAttrNames();
   if (attrIndex == attrNames.length) {
     onAttrsGot(
-        api,
-        onDemoSucceeded,
-        onDemoFailed,
-        sCardContext,
-        sCardHandle,
+        api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle,
         protocol);
     return;
   }
   const attrName = attrNames[attrIndex];
   logger.fine('Requesting the ' + dump(attrName) + ' attribute...');
-  api.SCardGetAttrib(
-      sCardHandle, API[attrName]).then(function(result) {
-        result.get(function(attrValue) {
-          logger.info('The ' + dump(attrName) + ' attribute value is: ' +
-                     dump(attrValue));
+  api.SCardGetAttrib(sCardHandle, API[attrName]).then(function(result) {
+    result.get(
+        function(attrValue) {
+          logger.info(
+              'The ' + dump(attrName) +
+              ' attribute value is: ' + dump(attrValue));
           getAttrs(
-              api,
-              onDemoSucceeded,
-              onDemoFailed,
-              sCardContext,
-              sCardHandle,
-              protocol,
-              attrIndex + 1);
-        }, function(error) {
+              api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle,
+              protocol, attrIndex + 1);
+        },
+        function(error) {
           getAttrs(
-              api,
-              onDemoSucceeded,
-              onDemoFailed,
-              sCardContext,
-              sCardHandle,
-              protocol,
-              attrIndex + 1);
+              api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle,
+              protocol, attrIndex + 1);
         });
-      }, onFailure.bind(null, onDemoFailed));
+  }, onFailure.bind(null, onDemoFailed));
 }
 
 function onAttrsGot(
@@ -529,21 +445,11 @@ function setAttr(
       .then(function(result) {
         result.get(
             onAttrSet.bind(
-                null,
-                api,
-                onDemoSucceeded,
-                onDemoFailed,
-                sCardContext,
-                sCardHandle,
-                protocol),
+                null, api, onDemoSucceeded, onDemoFailed, sCardContext,
+                sCardHandle, protocol),
             onAttrSetFailed.bind(
-                null,
-                api,
-                onDemoSucceeded,
-                onDemoFailed,
-                sCardContext,
-                sCardHandle,
-                protocol));
+                null, api, onDemoSucceeded, onDemoFailed, sCardContext,
+                sCardHandle, protocol));
       }, onFailure.bind(null, onDemoFailed));
 }
 
@@ -555,15 +461,11 @@ function onAttrSet(
 }
 
 function onAttrSetFailed(
-    api,
-    onDemoSucceeded,
-    onDemoFailed,
-    sCardContext,
-    sCardHandle,
-    protocol,
+    api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol,
     errorCode) {
-  logger.info('The attribute set was unsuccessful (error code: ' +
-              dump(errorCode) + ')');
+  logger.info(
+      'The attribute set was unsuccessful (error code: ' + dump(errorCode) +
+      ')');
   beginTransaction(
       api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol);
 }
@@ -574,12 +476,7 @@ function beginTransaction(
   api.SCardBeginTransaction(sCardHandle).then(function(result) {
     result.get(
         onTransactionBegun.bind(
-            null,
-            api,
-            onDemoSucceeded,
-            onDemoFailed,
-            sCardContext,
-            sCardHandle,
+            null, api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle,
             protocol),
         onPcscLiteError.bind(null, api, onDemoFailed));
   }, onFailure.bind(null, onDemoFailed));
@@ -595,33 +492,22 @@ function onTransactionBegun(
 function sendControlCommand(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol) {
   logger.info('Sending the CM_IOCTL_GET_FEATURE_REQUEST control command...');
-  api.SCardControl(
-      sCardHandle,
-      API.CM_IOCTL_GET_FEATURE_REQUEST,
-      []).then(function(result) {
+  api.SCardControl(sCardHandle, API.CM_IOCTL_GET_FEATURE_REQUEST, [])
+      .then(function(result) {
         result.get(
             onControlCommandSent.bind(
-                null,
-                api,
-                onDemoSucceeded,
-                onDemoFailed,
-                sCardContext,
-                sCardHandle,
-                protocol),
+                null, api, onDemoSucceeded, onDemoFailed, sCardContext,
+                sCardHandle, protocol),
             onPcscLiteError.bind(null, api, onDemoFailed));
       }, onFailure.bind(null, onDemoFailed));
 }
 
 function onControlCommandSent(
-    api,
-    onDemoSucceeded,
-    onDemoFailed,
-    sCardContext,
-    sCardHandle,
-    protocol,
+    api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol,
     responseData) {
-  logger.info('The CM_IOCTL_GET_FEATURE_REQUEST control command returned: ' +
-              dump(responseData));
+  logger.info(
+      'The CM_IOCTL_GET_FEATURE_REQUEST control command returned: ' +
+      dump(responseData));
   sendTransmitCommand(
       api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol);
 }
@@ -633,33 +519,22 @@ function sendTransmitCommand(
       'Sending the transmit command with "list dir" APDU ' +
       dump(LIST_DIR_APDU) + '...');
   api.SCardTransmit(
-      sCardHandle,
-      protocol == API.SCARD_PROTOCOL_T0 ?
-          API.SCARD_PCI_T0 :
-          API.SCARD_PCI_T1,
-      LIST_DIR_APDU).then(function(result) {
+         sCardHandle,
+         protocol == API.SCARD_PROTOCOL_T0 ? API.SCARD_PCI_T0 :
+                                             API.SCARD_PCI_T1,
+         LIST_DIR_APDU)
+      .then(function(result) {
         result.get(
             onTransmitCommandSent.bind(
-                null,
-                api,
-                onDemoSucceeded,
-                onDemoFailed,
-                sCardContext,
-                sCardHandle,
-                protocol),
+                null, api, onDemoSucceeded, onDemoFailed, sCardContext,
+                sCardHandle, protocol),
             onPcscLiteError.bind(null, api, onDemoFailed));
       }, onFailure.bind(null, onDemoFailed));
 }
 
 function onTransmitCommandSent(
-    api,
-    onDemoSucceeded,
-    onDemoFailed,
-    sCardContext,
-    sCardHandle,
-    protocol,
-    responseProtocolInformation,
-    responseData) {
+    api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol,
+    responseProtocolInformation, responseData) {
   logger.info(
       'The transmit command returned: ' + dump(responseData) + ', the ' +
       'response protocol information is: ' + dump(responseProtocolInformation));
@@ -669,16 +544,11 @@ function onTransmitCommandSent(
 function endTransaction(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle) {
   logger.info('Ending the transaction...');
-  api.SCardEndTransaction(
-      sCardHandle,
-      API.SCARD_LEAVE_CARD).then(function(result) {
+  api.SCardEndTransaction(sCardHandle, API.SCARD_LEAVE_CARD)
+      .then(function(result) {
         result.get(
             onTransactionEnded.bind(
-                null,
-                api,
-                onDemoSucceeded,
-                onDemoFailed,
-                sCardContext,
+                null, api, onDemoSucceeded, onDemoFailed, sCardContext,
                 sCardHandle),
             onPcscLiteError.bind(null, api, onDemoFailed));
       }, onFailure.bind(null, onDemoFailed));
@@ -693,14 +563,12 @@ function onTransactionEnded(
 function disconnect(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle) {
   logger.info('Disconnecting from the reader...');
-  api.SCardDisconnect(
-      sCardHandle,
-      API.SCARD_LEAVE_CARD).then(function(result) {
-        result.get(
-            onDisconnected.bind(
-                null, api, onDemoSucceeded, onDemoFailed, sCardContext),
-            onPcscLiteError.bind(null, api, onDemoFailed));
-      }, onFailure.bind(null, onDemoFailed));
+  api.SCardDisconnect(sCardHandle, API.SCARD_LEAVE_CARD).then(function(result) {
+    result.get(
+        onDisconnected.bind(
+            null, api, onDemoSucceeded, onDemoFailed, sCardContext),
+        onPcscLiteError.bind(null, api, onDemoFailed));
+  }, onFailure.bind(null, onDemoFailed));
 }
 
 function onDisconnected(api, onDemoSucceeded, onDemoFailed, sCardContext) {
@@ -724,12 +592,14 @@ function onContextReleased(api, onDemoSucceeded, onDemoFailed) {
 
 function onPcscLiteError(api, onDemoFailed, errorCode) {
   logger.warning('failed: PC/SC-Lite error: ' + dump(errorCode));
-  api.pcsc_stringify_error(errorCode).then(function(errorText) {
-    logger.warning('PC/SC-Lite error text: ' + errorText);
-    onDemoFailed();
-  }, function() {
-    onDemoFailed();
-  });
+  api.pcsc_stringify_error(errorCode).then(
+      function(errorText) {
+        logger.warning('PC/SC-Lite error text: ' + errorText);
+        onDemoFailed();
+      },
+      function() {
+        onDemoFailed();
+      });
 }
 
 function onFailure(onDemoFailed, error) {
@@ -738,11 +608,9 @@ function onFailure(onDemoFailed, error) {
 }
 
 function getPcscLiteAttrNames() {
-  return goog.array.filter(
-      goog.object.getKeys(API),
-      function(key) {
-        return key.startsWith('SCARD_ATTR_') && key != 'SCARD_ATTR_VALUE';
-      });
+  return goog.array.filter(goog.object.getKeys(API), function(key) {
+    return key.startsWith('SCARD_ATTR_') && key != 'SCARD_ATTR_VALUE';
+  });
 }
 
 function getProtocolDebugRepresentation(protocol) {
@@ -753,5 +621,4 @@ function getProtocolDebugRepresentation(protocol) {
   GSC.Logging.failWithLogger(
       logger, 'Unknown protocol value: ' + dump(protocol));
 }
-
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
+++ b/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -90,8 +91,8 @@ const ReaderInfo = GSC.PcscLiteServer.ReaderInfo;
 GSC.PcscLiteServer.ReaderTracker = function(
     serverMessageChannel, pcscContextMessageChannel, parentLogger) {
   /** @private */
-  this.logger_ = GSC.Logging.getChildLogger(
-      parentLogger, READER_TRACKER_LOGGER_TITLE);
+  this.logger_ =
+      GSC.Logging.getChildLogger(parentLogger, READER_TRACKER_LOGGER_TITLE);
 
   /**
    * @type {!Array.<function(!Array.<!ReaderInfo>)>}
@@ -101,15 +102,13 @@ GSC.PcscLiteServer.ReaderTracker = function(
 
   /** @private */
   this.trackerThroughPcscServerHook_ = new TrackerThroughPcscServerHook(
-      this.logger_,
-      serverMessageChannel,
+      this.logger_, serverMessageChannel,
       this.fireOnUpdateListeners_.bind(this));
 
   /** @private */
   this.trackerThroughPcscApi_ =
       new GSC.PcscLiteClient.ReaderTrackerThroughPcscApi(
-          this.logger_,
-          pcscContextMessageChannel,
+          this.logger_, pcscContextMessageChannel,
           this.fireOnUpdateListeners_.bind(this));
 
   this.logger_.fine('Initialized');
@@ -140,8 +139,9 @@ ReaderTracker.prototype.removeOnUpdateListener = function(listener) {
   if (goog.array.remove(this.updateListeners_, listener)) {
     this.logger_.fine('Removed an update listener');
   } else {
-    this.logger_.warning('Failed to remove an update listener: the passed ' +
-                         'function was not found');
+    this.logger_.warning(
+        'Failed to remove an update listener: the passed ' +
+        'function was not found');
   }
 };
 
@@ -157,13 +157,10 @@ ReaderTracker.prototype.getReaders = function() {
   // Take the information about successfully initialized readers from the PC/SC
   // API.
   const successReaders = goog.array.map(
-      this.trackerThroughPcscApi_.getReaders(),
-      function(reader) {
+      this.trackerThroughPcscApi_.getReaders(), function(reader) {
         return new ReaderInfo(
-            reader.name,
-            ReaderStatus.SUCCESS,
-            /*error=*/undefined,
-            reader.isCardPresent);
+            reader.name, ReaderStatus.SUCCESS,
+            /*error=*/ undefined, reader.isCardPresent);
       });
 
   // Take the information about other readers (i.e. that are either under the
@@ -237,8 +234,10 @@ TrackerThroughPcscServerHook.prototype.getReaders = function() {
   const mappedReaderInfos = goog.array.map(
       ports, this.portToReaderInfoMap_.get, this.portToReaderInfoMap_);
   // Remove null entries, as they correspond to readers that should be hidden.
-  return /** @type {!Array.<!ReaderInfo>} */ (mappedReaderInfos.filter(
-      function(item) { return item !== null; }));
+  return /** @type {!Array.<!ReaderInfo>} */ (
+      mappedReaderInfos.filter(function(item) {
+        return item !== null;
+      }));
 };
 
 /**
@@ -254,12 +253,12 @@ TrackerThroughPcscServerHook.prototype.readerInitAddListener_ = function(
   /** @type {string} */
   const device = GSC.MessagingCommon.extractKey(message, 'device');
 
-  this.logger_.info('A new reader "' + name + '" (port ' + port + ', device "' +
-                    device + '") is being initialized...');
+  this.logger_.info(
+      'A new reader "' + name + '" (port ' + port + ', device "' + device +
+      '") is being initialized...');
 
   GSC.Logging.checkWithLogger(
-      this.logger_,
-      !this.portToReaderInfoMap_.has(port),
+      this.logger_, !this.portToReaderInfoMap_.has(port),
       'Initializing reader which is already present!');
   this.portToReaderInfoMap_.set(port, new ReaderInfo(name, ReaderStatus.INIT));
   this.updateListener_();
@@ -287,22 +286,24 @@ TrackerThroughPcscServerHook.prototype.readerFinishAddListener_ = function(
   const readerTitleForLog =
       '"' + name + '" (port ' + port + ', device "' + device + '")';
   if (returnCode === 0) {
-    this.logger_.info('The reader ' + readerTitleForLog + ' was successfully ' +
-                      'initialized');
+    this.logger_.info(
+        'The reader ' + readerTitleForLog + ' was successfully ' +
+        'initialized');
     readerInfo = new ReaderInfo(name, ReaderStatus.SUCCESS);
   } else if (this.shouldHideFailedReader_(device)) {
-    this.logger_.info('Silent error while initializing the reader ' +
-                      readerTitleForLog + ': error code ' + returnCodeHex +
-                      '. This reader will be hidden from UI.');
+    this.logger_.info(
+        'Silent error while initializing the reader ' + readerTitleForLog +
+        ': error code ' + returnCodeHex +
+        '. This reader will be hidden from UI.');
   } else {
-    this.logger_.warning('Failure while initializing the reader ' +
-                         readerTitleForLog + ': error code ' + returnCodeHex);
+    this.logger_.warning(
+        'Failure while initializing the reader ' + readerTitleForLog +
+        ': error code ' + returnCodeHex);
     readerInfo = new ReaderInfo(name, ReaderStatus.FAILURE, returnCodeHex);
   }
 
   GSC.Logging.checkWithLogger(
-      this.logger_,
-      this.portToReaderInfoMap_.has(port),
+      this.logger_, this.portToReaderInfoMap_.has(port),
       'Finishing initializing reader without present reader!');
 
   // Note that the inserted value may be null, which means that this reader
@@ -327,8 +328,7 @@ TrackerThroughPcscServerHook.prototype.readerRemoveListener_ = function(
       'The reader "' + name + '" (port ' + port + ') was removed');
 
   GSC.Logging.checkWithLogger(
-      this.logger_,
-      this.portToReaderInfoMap_.has(port),
+      this.logger_, this.portToReaderInfoMap_.has(port),
       'Tried removing non-existing reader!');
   this.portToReaderInfoMap_.delete(port);
   this.updateListener_();
@@ -352,5 +352,4 @@ TrackerThroughPcscServerHook.prototype.shouldHideFailedReader_ = function(
   // actually signal about any error.
   return /:[1-9][0-9]*$/.test(device);
 };
-
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -166,9 +167,7 @@ const PermissionsChecking =
  * @extends goog.Disposable
  */
 GSC.PcscLiteServerClientsManagement.ClientHandler = function(
-    serverMessageChannel,
-    serverReadinessTracker,
-    clientMessageChannel,
+    serverMessageChannel, serverReadinessTracker, clientMessageChannel,
     clientAppId) {
   ClientHandler.base(this, 'constructor');
 
@@ -184,14 +183,12 @@ GSC.PcscLiteServerClientsManagement.ClientHandler = function(
    */
   this.logger = GSC.Logging.getScopedLogger(
       'PcscLiteServerClientsManagement.ClientHandler<' +
-      (this.clientAppId_ === null ?
-           'own app' : '"' + this.clientAppId_ + '"') +
+      (this.clientAppId_ === null ? 'own app' : '"' + this.clientAppId_ + '"') +
       ', id=' + this.id + '>');
 
   /** @private */
   this.requestReceiver_ = new GSC.RequestReceiver(
-      GSC.PcscLiteCommon.Constants.REQUESTER_TITLE,
-      clientMessageChannel,
+      GSC.PcscLiteCommon.Constants.REQUESTER_TITLE, clientMessageChannel,
       this.handleRequest_.bind(this));
   this.requestReceiver_.setShouldDisposeOnInvalidMessage(true);
 
@@ -217,8 +214,8 @@ GSC.PcscLiteServerClientsManagement.ClientHandler = function(
   // established and the permission check is resolved.
   /** @private */
   this.deferredProcessor_ = new DeferredProcessor(goog.Promise.all([
-      this.serverReadinessTracker_.promise,
-      this.getPermissionsCheckPromise_()]));
+    this.serverReadinessTracker_.promise, this.getPermissionsCheckPromise_()
+  ]));
 
   this.addChannelDisposedListeners_();
 
@@ -301,20 +298,22 @@ ClientHandler.prototype.disposeInternal = function() {
  */
 ClientHandler.prototype.handleRequest_ = function(payload) {
   if (this.isDisposed()) {
-    return goog.Promise.reject(new Error(
-        'The client handler is already disposed'));
+    return goog.Promise.reject(
+        new Error('The client handler is already disposed'));
   }
 
   const remoteCallMessage = RemoteCallMessage.parseRequestPayload(payload);
   if (!remoteCallMessage) {
-    this.logger.warning('Failed to parse the received request payload: ' +
-                        GSC.DebugDump.debugDump(payload));
-    return goog.Promise.reject(new Error(
-        'Failed to parse the received request payload'));
+    this.logger.warning(
+        'Failed to parse the received request payload: ' +
+        GSC.DebugDump.debugDump(payload));
+    return goog.Promise.reject(
+        new Error('Failed to parse the received request payload'));
   }
 
-  this.logger.fine('Received a remote call request: ' +
-                   remoteCallMessage.getDebugRepresentation());
+  this.logger.fine(
+      'Received a remote call request: ' +
+      remoteCallMessage.getDebugRepresentation());
 
   return this.deferredProcessor_.addJob(
       this.postRequestToServer_.bind(this, remoteCallMessage));
@@ -327,16 +326,20 @@ ClientHandler.prototype.handleRequest_ = function(payload) {
  * @private
  */
 ClientHandler.prototype.getPermissionsCheckPromise_ = function() {
-  return permissionsChecker.check(this.clientAppId_).then(function() {
-    if (this.clientAppId_ !== null) {
-      this.logger.info(
-          'Client was granted permissions to issue PC/SC requests');
-    }
-  }, function(error) {
-    this.logger.warning(
-        'Client permission denied. All PC/SC requests will be rejected');
-    throw error;
-  }, this);
+  return permissionsChecker.check(this.clientAppId_)
+      .then(
+          function() {
+            if (this.clientAppId_ !== null) {
+              this.logger.info(
+                  'Client was granted permissions to issue PC/SC requests');
+            }
+          },
+          function(error) {
+            this.logger.warning(
+                'Client permission denied. All PC/SC requests will be rejected');
+            throw error;
+          },
+          this);
 };
 
 /**
@@ -399,27 +402,34 @@ ClientHandler.prototype.clientMessageChannelDisposedListener_ = function() {
  * @private
  */
 ClientHandler.prototype.postRequestToServer_ = function(remoteCallMessage) {
-  this.logger.fine('Started processing the remote call request: ' +
-                   remoteCallMessage.getDebugRepresentation());
+  this.logger.fine(
+      'Started processing the remote call request: ' +
+      remoteCallMessage.getDebugRepresentation());
 
   this.createServerRequesterIfNeed_();
 
-  return this.serverRequester_.postRequest(
-      remoteCallMessage.makeRequestPayload()).then(function(result) {
-    this.logger.fine(
-        'The remote call request ' +
-        remoteCallMessage.getDebugRepresentation() + ' finished successfully' +
-        (goog.DEBUG ?
-             ' with the following result: ' + GSC.DebugDump.debugDump(result) :
-             ''));
-    return result;
-  }, function(error) {
-    this.logger.warning(
-        'The remote call request ' +
-        remoteCallMessage.getDebugRepresentation() + ' failed with the ' +
-        'following error: ' + error);
-    throw error;
-  }, this);
+  return this.serverRequester_
+      .postRequest(remoteCallMessage.makeRequestPayload())
+      .then(
+          function(result) {
+            this.logger.fine(
+                'The remote call request ' +
+                remoteCallMessage.getDebugRepresentation() +
+                ' finished successfully' +
+                (goog.DEBUG ? ' with the following result: ' +
+                         GSC.DebugDump.debugDump(result) :
+                              ''));
+            return result;
+          },
+          function(error) {
+            this.logger.warning(
+                'The remote call request ' +
+                remoteCallMessage.getDebugRepresentation() +
+                ' failed with the ' +
+                'following error: ' + error);
+            throw error;
+          },
+          this);
 };
 
 /**
@@ -435,8 +445,7 @@ ClientHandler.prototype.createServerRequesterIfNeed_ = function() {
     return;
 
   this.sendServerCreateHandlerMessage_();
-  GSC.Logging.checkWithLogger(
-      this.logger, this.serverMessageChannel_ !== null);
+  GSC.Logging.checkWithLogger(this.logger, this.serverMessageChannel_ !== null);
   goog.asserts.assert(this.serverMessageChannel_);
 
   const requesterTitle =

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/checker.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -82,8 +83,9 @@ Checker.prototype.logger = GSC.Logging.getScopedLogger(
  * @return {!goog.Promise}
  */
 Checker.prototype.check = function(clientAppId) {
-  this.logger.finer('Checking permissions for client App with id ' +
-                    GSC.DebugDump.dump(clientAppId) + '...');
+  this.logger.finer(
+      'Checking permissions for client App with id ' +
+      GSC.DebugDump.dump(clientAppId) + '...');
 
   if (clientAppId === null) {
     this.logger.finer('Granted permissions for client with null App id');
@@ -104,21 +106,26 @@ Checker.prototype.check = function(clientAppId) {
  */
 Checker.prototype.checkByManagedRegistry_ = function(
     clientAppId, checkPromiseResolver) {
-  this.logger.finer('Checking permissions for the client App with id "' +
-                    clientAppId + '" through the managed registry...');
+  this.logger.finer(
+      'Checking permissions for the client App with id "' + clientAppId +
+      '" through the managed registry...');
 
-  this.managedRegistry_.getById(clientAppId).then(
-      function() {
-        this.logger.finer('Granted permissions for client App with id "' +
-                          clientAppId + '" through the managed registry');
-        checkPromiseResolver.resolve();
-      },
-      function() {
-        this.logger.finer('No permissions found for client App with id "' +
-                          clientAppId + '" through the managed registry');
-        this.checkByUserPromptingChecker_(clientAppId, checkPromiseResolver);
-      },
-      this);
+  this.managedRegistry_.getById(clientAppId)
+      .then(
+          function() {
+            this.logger.finer(
+                'Granted permissions for client App with id "' + clientAppId +
+                '" through the managed registry');
+            checkPromiseResolver.resolve();
+          },
+          function() {
+            this.logger.finer(
+                'No permissions found for client App with id "' + clientAppId +
+                '" through the managed registry');
+            this.checkByUserPromptingChecker_(
+                clientAppId, checkPromiseResolver);
+          },
+          this);
 };
 
 /**
@@ -128,8 +135,7 @@ Checker.prototype.checkByManagedRegistry_ = function(
  */
 Checker.prototype.checkByUserPromptingChecker_ = function(
     clientAppId, checkPromiseResolver) {
-  this.userPromptingChecker_.check(clientAppId).then(
-      checkPromiseResolver.resolve, checkPromiseResolver.reject);
+  this.userPromptingChecker_.check(clientAppId)
+      .then(checkPromiseResolver.resolve, checkPromiseResolver.reject);
 };
-
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/known-apps-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/known-apps-registry.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -111,7 +112,7 @@ KnownAppsRegistry.prototype.getById = function(id) {
               'The specified App id is not in the known Apps registry'));
         }
       },
-      function (error) {
+      function(error) {
         promiseResolver.reject(error);
       });
 
@@ -142,8 +143,8 @@ KnownAppsRegistry.prototype.tryGetByIds = function(idList) {
         promiseResolver.resolve(knownApps);
       },
       function() {
-        promiseResolver.reject(new Error(
-            'Failed to load the known Apps registry'));
+        promiseResolver.reject(
+            new Error('Failed to load the known Apps registry'));
       });
 
   return promiseResolver.promise;
@@ -151,8 +152,9 @@ KnownAppsRegistry.prototype.tryGetByIds = function(idList) {
 
 /** @private */
 KnownAppsRegistry.prototype.startLoadingJson_ = function() {
-  this.logger.fine('Loading registry from JSON file (URL: "' +
-                   KNOWN_CLIENT_APPS_JSON_URL + '")...');
+  this.logger.fine(
+      'Loading registry from JSON file (URL: "' + KNOWN_CLIENT_APPS_JSON_URL +
+      '")...');
   goog.net.XhrIo.send(
       KNOWN_CLIENT_APPS_JSON_URL, this.jsonLoadedCallback_.bind(this));
 };
@@ -163,33 +165,35 @@ KnownAppsRegistry.prototype.jsonLoadedCallback_ = function(e) {
   const xhrio = e.target;
 
   if (!xhrio.isSuccess()) {
-    this.promiseResolver_.reject(new Error(
-        'Failed to load the known Apps registry'));
+    this.promiseResolver_.reject(
+        new Error('Failed to load the known Apps registry'));
     GSC.Logging.failWithLogger(
         this.logger,
         'Failed to load the known Apps registry from JSON file (URL: "' +
-        KNOWN_CLIENT_APPS_JSON_URL + '") with the following error: ' +
-        xhrio.getLastError());
+            KNOWN_CLIENT_APPS_JSON_URL +
+            '") with the following error: ' + xhrio.getLastError());
   }
 
   // Note: not using the xhrio.getResponseJson method as it breaks in the Chrome
   // App environment (for details, see the GSC.Json.parse method).
-  GSC.Json.parse(xhrio.getResponseText()).then(
-      function(json) {
-        GSC.Logging.checkWithLogger(this.logger, goog.isObject(json));
-        goog.asserts.assertObject(json);
-        this.parseJsonAndApply_(json);
-      },
-      function(exc) {
-        this.promiseResolver_.reject(new Error(
-            'Failed to load the known Apps registry'));
-        GSC.Logging.failWithLogger(
-            this.logger,
-            'Failed to load the known Apps registry from JSON file (URL: "' +
-            KNOWN_CLIENT_APPS_JSON_URL + '"): parsing failed with the ' +
-            'following error: ' + exc);
-      },
-      this);
+  GSC.Json.parse(xhrio.getResponseText())
+      .then(
+          function(json) {
+            GSC.Logging.checkWithLogger(this.logger, goog.isObject(json));
+            goog.asserts.assertObject(json);
+            this.parseJsonAndApply_(json);
+          },
+          function(exc) {
+            this.promiseResolver_.reject(
+                new Error('Failed to load the known Apps registry'));
+            GSC.Logging.failWithLogger(
+                this.logger,
+                'Failed to load the known Apps registry from JSON file (URL: "' +
+                    KNOWN_CLIENT_APPS_JSON_URL +
+                    '"): parsing failed with the ' +
+                    'following error: ' + exc);
+          },
+          this);
 };
 
 /**
@@ -213,17 +217,18 @@ KnownAppsRegistry.prototype.parseJsonAndApply_ = function(json) {
   }, this);
 
   if (success) {
-    this.logger.fine('Successfully loaded registry from JSON file: ' +
-                     GSC.DebugDump.dump(knownClientApps));
+    this.logger.fine(
+        'Successfully loaded registry from JSON file: ' +
+        GSC.DebugDump.dump(knownClientApps));
     this.promiseResolver_.resolve(knownClientApps);
   } else {
-    this.promiseResolver_.reject(new Error(
-        'Failed to load the known Apps registry'));
+    this.promiseResolver_.reject(
+        new Error('Failed to load the known Apps registry'));
     GSC.Logging.failWithLogger(
         this.logger,
         'Failed to load the known Apps registry from JSON file (URL: "' +
-        KNOWN_CLIENT_APPS_JSON_URL + '"): parsing of some of the items ' +
-        'finished with errors');
+            KNOWN_CLIENT_APPS_JSON_URL + '"): parsing of some of the items ' +
+            'finished with errors');
   }
 };
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -118,11 +119,12 @@ ManagedRegistry.prototype.loadManagedStorage_ = function() {
  * @private
  */
 ManagedRegistry.prototype.managedStorageLoadedCallback_ = function(items) {
-  this.logger.fine('Loaded the following data from the managed storage: ' +
-                   GSC.DebugDump.dump(items));
+  this.logger.fine(
+      'Loaded the following data from the managed storage: ' +
+      GSC.DebugDump.dump(items));
 
-  if (this.setAllowedClientAppIdsFromStorageData_(goog.object.get(
-          items, MANAGED_STORAGE_KEY, []))) {
+  if (this.setAllowedClientAppIdsFromStorageData_(
+          goog.object.get(items, MANAGED_STORAGE_KEY, []))) {
     this.logger.info(
         'Loaded managed storage data with the allowed client App ids: ' +
         GSC.DebugDump.dump(this.allowedClientAppIds_));
@@ -148,8 +150,9 @@ ManagedRegistry.prototype.storageChangedListener_ = function(
     changes, areaName) {
   if (areaName != 'managed')
     return;
-  this.logger.fine('Received the managed storage update event: ' +
-                   GSC.DebugDump.dump(changes));
+  this.logger.fine(
+      'Received the managed storage update event: ' +
+      GSC.DebugDump.dump(changes));
 
   if (changes[MANAGED_STORAGE_KEY]) {
     if (this.setAllowedClientAppIdsFromStorageData_(
@@ -195,5 +198,4 @@ ManagedRegistry.prototype.setAllowedClientAppIdsFromStorageData_ = function(
   this.allowedClientAppIds_ = newAllowedClientAppIds;
   return true;
 };
-
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompt-dialog-main.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompt-dialog-main.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -98,7 +99,7 @@ function prepareMessage() {
 
   const linkElement = goog.dom.getElement('message-app-link');
   goog.dom.setTextContent(linkElement, linkTitle);
-  linkElement["href"] = linkHref;
+  linkElement['href'] = linkHref;
 
   if (!isClientKnown) {
     goog.dom.classlist.add(
@@ -130,5 +131,4 @@ goog.events.listen(
     goog.dom.getElement('close-window'), 'click', closeWindowClickListener);
 
 GSC.PopupWindow.Client.prepareAndShowAsModalDialog();
-
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittest.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2018 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -86,19 +87,20 @@ function setUpKnownAppsRegistryMock(mockControl) {
  */
 function setUpChromeStorageMock(
     mockControl, propertyReplacer, fakeInitialData, expectedDataToBeWritten) {
-  propertyReplacer.set(
-      chrome, 'storage',
-      {local: {
-         get: mockControl.createFunctionMock('chrome.storage.local.get'),
-         set: mockControl.createFunctionMock('chrome.storage.local.set')}});
+  propertyReplacer.set(chrome, 'storage', {
+    local: {
+      get: mockControl.createFunctionMock('chrome.storage.local.get'),
+      set: mockControl.createFunctionMock('chrome.storage.local.set')
+    }
+  });
 
   // Suppress compiler's signature verifications locally, to be able to use
   // mock-specific functionality.
   /** @type {?} */ chrome.storage.local.get;
   /** @type {?} */ chrome.storage.local.set;
 
-  chrome.storage.local.get(STORAGE_KEY, ignoreArgument).$does(
-      function(key, callback) {
+  chrome.storage.local.get(STORAGE_KEY, ignoreArgument)
+      .$does(function(key, callback) {
         callback(fakeInitialData);
       });
 
@@ -137,8 +139,8 @@ function setUpDialogMock(mockControl, mockedBehavior) {
       };
       break;
   }
-  mockedFunction(ignoreArgument, ignoreArgument, ignoreArgument).$does(
-      mockAction);
+  mockedFunction(ignoreArgument, ignoreArgument, ignoreArgument)
+      .$does(mockAction);
 }
 
 /**
@@ -149,11 +151,14 @@ function setUpDialogMock(mockControl, mockedBehavior) {
  * rejected.
  */
 function negatePromise(promise) {
-  return promise.then(function() {
-    fail('Unexpected successful response');
-  }, function() {
-    // Resolve the resulting promise - by simply returning from this callback.
-  });
+  return promise.then(
+      function() {
+        fail('Unexpected successful response');
+      },
+      function() {
+        // Resolve the resulting promise - by simply returning from this
+        // callback.
+      });
 }
 
 /**
@@ -220,95 +225,107 @@ function makeTest(
 }
 
 goog.exportSymbol(
-    'test_UserPromptingChecker_EmptyStorage_UserApproves', makeTest(
-      {}  /* fakeInitialStorageData */,
-      {[STORAGE_KEY]: {[FAKE_APP_1_ID]: true}}
-          /* expectedStorageDataToBeWritten */,
-      MockedDialogBehavior.USER_APPROVES  /* mockedDialogBehavior */,
-      function(userPromptingChecker) {
-        return userPromptingChecker.check(FAKE_APP_1_ID);
-      }));
+    'test_UserPromptingChecker_EmptyStorage_UserApproves',
+    makeTest(
+        {} /* fakeInitialStorageData */, {
+          [STORAGE_KEY]: {[FAKE_APP_1_ID]: true}
+        } /* expectedStorageDataToBeWritten */,
+        MockedDialogBehavior.USER_APPROVES /* mockedDialogBehavior */,
+        function(userPromptingChecker) {
+          return userPromptingChecker.check(FAKE_APP_1_ID);
+        }));
 
 goog.exportSymbol(
-    'test_UserPromptingChecker_EmptyStorage_UserDenies', makeTest(
-      {}  /* fakeInitialStorageData */,
-      null  /* expectedStorageDataToBeWritten */,
-      MockedDialogBehavior.USER_DENIES  /* mockedDialogBehavior */,
-      function(userPromptingChecker) {
-        return negatePromise(userPromptingChecker.check(FAKE_APP_1_ID));
-      }));
+    'test_UserPromptingChecker_EmptyStorage_UserDenies',
+    makeTest(
+        {} /* fakeInitialStorageData */,
+        null /* expectedStorageDataToBeWritten */,
+        MockedDialogBehavior.USER_DENIES /* mockedDialogBehavior */,
+        function(userPromptingChecker) {
+          return negatePromise(userPromptingChecker.check(FAKE_APP_1_ID));
+        }));
 
 goog.exportSymbol(
-    'test_UserPromptingChecker_EmptyStorage_UserCancels', makeTest(
-      {}  /* fakeInitialStorageData */,
-      null  /* expectedStorageDataToBeWritten */,
-      MockedDialogBehavior.USER_CANCELS  /* mockedDialogBehavior */,
-      function(userPromptingChecker) {
-        return negatePromise(userPromptingChecker.check(FAKE_APP_1_ID));
-      }));
+    'test_UserPromptingChecker_EmptyStorage_UserCancels',
+    makeTest(
+        {} /* fakeInitialStorageData */,
+        null /* expectedStorageDataToBeWritten */,
+        MockedDialogBehavior.USER_CANCELS /* mockedDialogBehavior */,
+        function(userPromptingChecker) {
+          return negatePromise(userPromptingChecker.check(FAKE_APP_1_ID));
+        }));
 
 goog.exportSymbol(
-    'test_UserPromptingChecker_AlreadyInStorage_OneItem', makeTest(
-      {[STORAGE_KEY]: {[FAKE_APP_1_ID]: true}}  /* fakeInitialStorageData */,
-      null  /* expectedStorageDataToBeWritten */,
-      MockedDialogBehavior.NOT_RUN  /* mockedDialogBehavior */,
-      function(userPromptingChecker) {
-        return userPromptingChecker.check(FAKE_APP_1_ID);
-      }));
+    'test_UserPromptingChecker_AlreadyInStorage_OneItem',
+    makeTest(
+        {[STORAGE_KEY]: {[FAKE_APP_1_ID]: true}} /* fakeInitialStorageData */,
+        null /* expectedStorageDataToBeWritten */,
+        MockedDialogBehavior.NOT_RUN /* mockedDialogBehavior */,
+        function(userPromptingChecker) {
+          return userPromptingChecker.check(FAKE_APP_1_ID);
+        }));
 
 goog.exportSymbol(
-    'test_UserPromptingChecker_AlreadyInStorage_TwoItems', makeTest(
-      {[STORAGE_KEY]: {[FAKE_APP_1_ID]: true, [FAKE_APP_2_ID]: true}}
-          /* fakeInitialStorageData */,
-      null  /* expectedStorageDataToBeWritten */,
-      MockedDialogBehavior.NOT_RUN  /* mockedDialogBehavior */,
-      function(userPromptingChecker) {
-        return goog.Promise.all([
+    'test_UserPromptingChecker_AlreadyInStorage_TwoItems',
+    makeTest(
+        {
+          [STORAGE_KEY]: {[FAKE_APP_1_ID]: true, [FAKE_APP_2_ID]: true}
+        } /* fakeInitialStorageData */,
+        null /* expectedStorageDataToBeWritten */,
+        MockedDialogBehavior.NOT_RUN /* mockedDialogBehavior */,
+        function(userPromptingChecker) {
+          return goog.Promise.all([
             userPromptingChecker.check(FAKE_APP_1_ID),
-            userPromptingChecker.check(FAKE_APP_2_ID)]);
-      }));
+            userPromptingChecker.check(FAKE_APP_2_ID)
+          ]);
+        }));
 
 goog.exportSymbol(
-    'test_UserPromptingChecker_OtherInStorage_UserApproves', makeTest(
-      {[STORAGE_KEY]: {[FAKE_APP_1_ID]: true}}  /* fakeInitialStorageData */,
-      {[STORAGE_KEY]: {[FAKE_APP_1_ID]: true, [FAKE_APP_2_ID] : true}}
-          /* expectedStorageDataToBeWritten */,
-      MockedDialogBehavior.USER_APPROVES  /* mockedDialogBehavior */,
-      function(userPromptingChecker) {
-        return userPromptingChecker.check(FAKE_APP_2_ID);
-      }));
+    'test_UserPromptingChecker_OtherInStorage_UserApproves',
+    makeTest(
+        {[STORAGE_KEY]: {[FAKE_APP_1_ID]: true}} /* fakeInitialStorageData */, {
+          [STORAGE_KEY]: {[FAKE_APP_1_ID]: true, [FAKE_APP_2_ID]: true}
+        } /* expectedStorageDataToBeWritten */,
+        MockedDialogBehavior.USER_APPROVES /* mockedDialogBehavior */,
+        function(userPromptingChecker) {
+          return userPromptingChecker.check(FAKE_APP_2_ID);
+        }));
 
 // Regression test for issue #57.
 goog.exportSymbol(
-    'test_UserPromptingChecker_CorruptedStorage_NonObject', makeTest(
-      {[STORAGE_KEY]: 'foo'}  /* fakeInitialStorageData */,
-      {[STORAGE_KEY]: {[FAKE_APP_1_ID]: true}}
-          /* expectedStorageDataToBeWritten */,
-      MockedDialogBehavior.USER_APPROVES  /* mockedDialogBehavior */,
-      function(userPromptingChecker) {
-        return userPromptingChecker.check(FAKE_APP_1_ID);
-      }));
+    'test_UserPromptingChecker_CorruptedStorage_NonObject',
+    makeTest(
+        {[STORAGE_KEY]: 'foo'} /* fakeInitialStorageData */, {
+          [STORAGE_KEY]: {[FAKE_APP_1_ID]: true}
+        } /* expectedStorageDataToBeWritten */,
+        MockedDialogBehavior.USER_APPROVES /* mockedDialogBehavior */,
+        function(userPromptingChecker) {
+          return userPromptingChecker.check(FAKE_APP_1_ID);
+        }));
 
 // Regression test for issue #57.
 goog.exportSymbol(
-    'test_UserPromptingChecker_CorruptedStorage_BadItem', makeTest(
-      {[STORAGE_KEY]: {[FAKE_APP_1_ID]: 'foo'}}  /* fakeInitialStorageData */,
-      {[STORAGE_KEY]: {[FAKE_APP_1_ID]: true}}
-          /* expectedStorageDataToBeWritten */,
-      MockedDialogBehavior.USER_APPROVES  /* mockedDialogBehavior */,
-      function(userPromptingChecker) {
-        return userPromptingChecker.check(FAKE_APP_1_ID);
-      }));
+    'test_UserPromptingChecker_CorruptedStorage_BadItem',
+    makeTest(
+        {[STORAGE_KEY]: {[FAKE_APP_1_ID]: 'foo'}} /* fakeInitialStorageData */,
+        {
+          [STORAGE_KEY]: {[FAKE_APP_1_ID]: true}
+        } /* expectedStorageDataToBeWritten */,
+        MockedDialogBehavior.USER_APPROVES /* mockedDialogBehavior */,
+        function(userPromptingChecker) {
+          return userPromptingChecker.check(FAKE_APP_1_ID);
+        }));
 
 // Regression test for issue #57.
 goog.exportSymbol(
-    'test_UserPromptingChecker_CorruptedStorage_BadOtherItem', makeTest(
-      {[STORAGE_KEY]: {[FAKE_APP_1_ID]: true, [FAKE_APP_2_ID]: 'foo'}}
-          /* fakeInitialStorageData */,
-      null  /* expectedStorageDataToBeWritten */,
-      MockedDialogBehavior.NOT_RUN  /* mockedDialogBehavior */,
-      function(userPromptingChecker) {
-        return userPromptingChecker.check(FAKE_APP_1_ID);
-      }));
-
+    'test_UserPromptingChecker_CorruptedStorage_BadOtherItem',
+    makeTest(
+        {
+          [STORAGE_KEY]: {[FAKE_APP_1_ID]: true, [FAKE_APP_2_ID]: 'foo'}
+        } /* fakeInitialStorageData */,
+        null /* expectedStorageDataToBeWritten */,
+        MockedDialogBehavior.NOT_RUN /* mockedDialogBehavior */,
+        function(userPromptingChecker) {
+          return userPromptingChecker.check(FAKE_APP_1_ID);
+        }));
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -97,8 +98,8 @@ UserPromptingChecker.prototype.logger = GSC.Logging.getScopedLogger(
  * @return {!goog.Promise}
  */
 UserPromptingChecker.prototype.check = function(clientAppId) {
-  this.logger.finest('Checking permissions for client App with id "' +
-                     clientAppId + '"...');
+  this.logger.finest(
+      'Checking permissions for client App with id "' + clientAppId + '"...');
 
   const existingPromise = this.checkPromiseMap_.get(clientAppId);
   if (existingPromise !== undefined) {
@@ -167,8 +168,9 @@ UserPromptingChecker.prototype.localStorageLoadedCallback_ = function(items) {
   const storedUserSelections = this.parseLocalStorageUserSelections_(items);
   const itemsForLog = [];
   storedUserSelections.forEach(function(userSelection, extensionId) {
-    itemsForLog.push((userSelection ? 'allow' : 'deny') + ' for extension "' +
-                     extensionId + '"');
+    itemsForLog.push(
+        (userSelection ? 'allow' : 'deny') + ' for extension "' + extensionId +
+        '"');
   });
   this.logger.info(
       'Loaded local storage data with the stored user selections: ' +
@@ -214,11 +216,15 @@ UserPromptingChecker.prototype.parseLocalStorageUserSelections_ = function(
  */
 UserPromptingChecker.prototype.promptUser_ = function(
     clientAppId, promiseResolver) {
-  this.knownAppsRegistry_.getById(clientAppId).then(function(knownApp) {
-    this.promptUserForKnownApp_(clientAppId, knownApp, promiseResolver);
-  }, function() {
-    this.promptUserForUnknownApp_(clientAppId, promiseResolver);
-  }, this);
+  this.knownAppsRegistry_.getById(clientAppId)
+      .then(
+          function(knownApp) {
+            this.promptUserForKnownApp_(clientAppId, knownApp, promiseResolver);
+          },
+          function() {
+            this.promptUserForUnknownApp_(clientAppId, promiseResolver);
+          },
+          this);
 };
 
 /**
@@ -232,11 +238,13 @@ UserPromptingChecker.prototype.promptUserForKnownApp_ = function(
   this.logger.info(
       'Showing the user prompt for the known client App with id "' +
       clientAppId + '" and name "' + knownApp.name + '"...');
-  this.runPromptDialog_(clientAppId, {
-    'is_client_known': true,
-    'client_app_id': clientAppId,
-    'client_app_name': knownApp.name
-  }, promiseResolver);
+  this.runPromptDialog_(
+      clientAppId, {
+        'is_client_known': true,
+        'client_app_id': clientAppId,
+        'client_app_name': knownApp.name
+      },
+      promiseResolver);
 };
 
 /**
@@ -250,8 +258,7 @@ UserPromptingChecker.prototype.promptUserForUnknownApp_ = function(
       'Showing the warning user prompt for the unknown client App with id "' +
       clientAppId + '"...');
   this.runPromptDialog_(
-      clientAppId,
-      {'is_client_known': false, 'client_app_id': clientAppId},
+      clientAppId, {'is_client_known': false, 'client_app_id': clientAppId},
       promiseResolver);
 };
 
@@ -266,36 +273,41 @@ UserPromptingChecker.prototype.runPromptDialog_ = function(
   const dialogPromise = GSC.PopupWindow.Server.runModalDialog(
       USER_PROMPT_DIALOG_URL, USER_PROMPT_DIALOG_WINDOW_OPTIONS_OVERRIDES,
       userPromptDialogData);
-  dialogPromise.then(function(dialogResult) {
-    if (dialogResult) {
-      this.logger.info('Granted permission to client App with id "' +
-                       clientAppId + '" based on the "grant" user selection');
-      this.storeUserSelection_(clientAppId, true);
-      promiseResolver.resolve();
-    } else {
-      this.logger.info('Rejected permission to client App with id "' +
-                       clientAppId + '" based on the "reject" user selection');
-      this.storeUserSelection_(clientAppId, false);
-      promiseResolver.reject(new Error(
-          'Reject permission based on the "reject" user selection'));
-    }
-  }, function() {
-    this.logger.info(
-        'Rejected permission to client App with id "' + clientAppId +
-        '" because of the user cancellation of the prompt dialog');
-    this.storeUserSelection_(clientAppId, false);
-    promiseResolver.reject(new Error(
-        'Rejected permission because of the user cancellation of the prompt ' +
-        'dialog'));
-  }, this);
+  dialogPromise.then(
+      function(dialogResult) {
+        if (dialogResult) {
+          this.logger.info(
+              'Granted permission to client App with id "' + clientAppId +
+              '" based on the "grant" user selection');
+          this.storeUserSelection_(clientAppId, true);
+          promiseResolver.resolve();
+        } else {
+          this.logger.info(
+              'Rejected permission to client App with id "' + clientAppId +
+              '" based on the "reject" user selection');
+          this.storeUserSelection_(clientAppId, false);
+          promiseResolver.reject(new Error(
+              'Reject permission based on the "reject" user selection'));
+        }
+      },
+      function() {
+        this.logger.info(
+            'Rejected permission to client App with id "' + clientAppId +
+            '" because of the user cancellation of the prompt dialog');
+        this.storeUserSelection_(clientAppId, false);
+        promiseResolver.reject(new Error(
+            'Rejected permission because of the user cancellation of the prompt ' +
+            'dialog'));
+      },
+      this);
 };
 
 /**
  * @param {string} clientAppId
  * @param {boolean} userSelection
  */
-UserPromptingChecker.prototype.storeUserSelection_ =
-    function(clientAppId, userSelection) {
+UserPromptingChecker.prototype.storeUserSelection_ = function(
+    clientAppId, userSelection) {
   // Don't remember negative user selections persistently.
   if (!userSelection)
     return;
@@ -338,5 +350,4 @@ UserPromptingChecker.prototype.notifyAboutRejectionOfUnknownApp_ = function(
     clientAppId) {
   // TODO: implement showing rich notifications to the user here
 };
-
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/readiness-tracker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/readiness-tracker.js
@@ -1,4 +1,5 @@
-/** @license
+/**
+ * @license
  * Copyright 2016 Google Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -88,8 +89,9 @@ GSC.PcscLiteServerClientsManagement.ReadinessTracker = function(
   naclModuleMessageChannel.addOnDisposeCallback(
       this.messageChannelDisposedListener_.bind(this));
 
-  this.logger_.fine('Waiting for the "' + SERVICE_NAME + '" message from the ' +
-                    'NaCl module...');
+  this.logger_.fine(
+      'Waiting for the "' + SERVICE_NAME + '" message from the ' +
+      'NaCl module...');
 };
 
 const ReadinessTracker = GSC.PcscLiteServerClientsManagement.ReadinessTracker;
@@ -99,8 +101,8 @@ goog.inherits(ReadinessTracker, goog.Disposable);
 /** @override */
 ReadinessTracker.prototype.disposeInternal = function() {
   this.isPromiseResolved_ = true;
-  this.promiseResolver_.reject(new Error(
-      'The readiness tracker is disposed of'));
+  this.promiseResolver_.reject(
+      new Error('The readiness tracker is disposed of'));
   ReadinessTracker.base(this, 'disposeInternal');
 };
 
@@ -121,9 +123,8 @@ ReadinessTracker.prototype.messageChannelDisposedListener_ = function() {
       'Failed while waiting for the PC/SC-Lite server successful start: the ' +
       'message channel was disposed of');
   this.isPromiseResolved_ = true;
-  this.promiseResolver_.reject(new Error(
-      'The NaCl module message channel was disposed'));
+  this.promiseResolver_.reject(
+      new Error('The NaCl module message channel was disposed'));
   this.dispose();
 };
-
 });  // goog.scope


### PR DESCRIPTION
Reformat all JavaScript code written in this repository to use the
clang-format's "Chromium" formatting style.

This is intended to be a non-functional change that contributes
to the effort tracked by #264.