### PR TITLE
Replace usages of goog.isArray

### DIFF
--- a/common/js/src/container-helpers.js
+++ b/common/js/src/container-helpers.js
@@ -55,7 +55,7 @@ GSC.ContainerHelpers.substituteArrayBuffersRecursively = function(value) {
     // Convert the array buffer into an array of bytes.
     return Array.from(new Uint8Array(value));
   }
-  if (goog.isArray(value)) {
+  if (Array.isArray(value)) {
     // Recursively process array items.
     return value.map(substituteArrayBuffersRecursively);
   }

--- a/common/js/src/logging/debug-dump.js
+++ b/common/js/src/logging/debug-dump.js
@@ -211,7 +211,7 @@ function dump(value) {
     return dumpNumber(value);
   if (typeof value === 'string')
     return dumpString(value);
-  if (goog.isArray(value))
+  if (Array.isArray(value))
     return dumpArray(value);
   if (goog.isFunction(value))
     return dumpFunction(value);

--- a/common/js/src/requesting/remote-call-message.js
+++ b/common/js/src/requesting/remote-call-message.js
@@ -67,7 +67,7 @@ RemoteCallMessage.parseRequestPayload = function(requestPayload) {
       !goog.object.containsKey(requestPayload, FUNCTION_NAME_MESSAGE_KEY) ||
       typeof requestPayload[FUNCTION_NAME_MESSAGE_KEY] !== 'string' ||
       !goog.object.containsKey(requestPayload, ARGUMENTS_MESSAGE_KEY) ||
-      !goog.isArray(requestPayload[ARGUMENTS_MESSAGE_KEY])) {
+      !Array.isArray(requestPayload[ARGUMENTS_MESSAGE_KEY])) {
     return null;
   }
   return new RemoteCallMessage(

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
@@ -171,7 +171,7 @@ ManagedRegistry.prototype.storageChangedListener_ = function(
  */
 ManagedRegistry.prototype.setAllowedClientAppIdsFromStorageData_ = function(
     storageData) {
-  if (!goog.isArray(storageData)) {
+  if (!Array.isArray(storageData)) {
     this.logger.warning(
         'Failed to load the allowed client App ids data from the managed ' +
         'storage: expected an array, instead got: ' +


### PR DESCRIPTION
Refactor JavaScript code to use Array.isArray() instead of
goog.isArray().

goog.isArray() got deprecated and removed from the recent
versions of the Closure Library.

This contributes to the refactoring effort tracked by #264.