### PR TITLE
Replace usages of goog.isFunction

### DIFF
--- a/common/js/src/container-helpers.js
+++ b/common/js/src/container-helpers.js
@@ -18,6 +18,7 @@
 goog.provide('GoogleSmartCard.ContainerHelpers');
 
 goog.require('GoogleSmartCard.Logging');
+goog.require('goog.functions');
 goog.require('goog.object');
 
 goog.scope(function() {
@@ -59,7 +60,7 @@ GSC.ContainerHelpers.substituteArrayBuffersRecursively = function(value) {
     // Recursively process array items.
     return value.map(substituteArrayBuffersRecursively);
   }
-  if (goog.isObject(value) && !goog.isFunction(value) &&
+  if (goog.isObject(value) && !goog.functions.isFunction(value) &&
       !ArrayBuffer.isView(value)) {
     // This is a dictionary-like object; process it recursively.
     return goog.object.map(value, substituteArrayBuffersRecursively);

--- a/common/js/src/logging/debug-dump.js
+++ b/common/js/src/logging/debug-dump.js
@@ -24,6 +24,7 @@ goog.provide('GoogleSmartCard.DebugDump');
 
 goog.require('goog.Disposable');
 goog.require('goog.array');
+goog.require('goog.functions');
 goog.require('goog.iter');
 goog.require('goog.json');
 goog.require('goog.math');
@@ -213,7 +214,7 @@ function dump(value) {
     return dumpString(value);
   if (Array.isArray(value))
     return dumpArray(value);
-  if (goog.isFunction(value))
+  if (goog.functions.isFunction(value))
     return dumpFunction(value);
   if (value instanceof ArrayBuffer)
     return dumpArrayBuffer(value);

--- a/common/js/src/messaging/mock-port.js
+++ b/common/js/src/messaging/mock-port.js
@@ -20,6 +20,7 @@ goog.provide('GoogleSmartCard.MockPort');
 goog.require('GoogleSmartCard.Logging');
 goog.require('goog.Disposable');
 goog.require('goog.events.ListenerMap');
+goog.require('goog.functions');
 goog.require('goog.testing');
 
 goog.setTestOnly();
@@ -157,7 +158,7 @@ MockPort.prototype.removeListener_ = function(type, callback) {
 MockPort.prototype.getListeners_ = function(type) {
   const result = [];
   for (let listenerKey of this.listenerMap_.getListeners(type, false)) {
-    if (goog.isFunction(listenerKey.listener))
+    if (goog.functions.isFunction(listenerKey.listener))
       result.push(listenerKey.listener);
   }
   return result;

--- a/third_party/libusb/webport/src/chrome_usb/chrome-usb-backend.js
+++ b/third_party/libusb/webport/src/chrome_usb/chrome-usb-backend.js
@@ -27,6 +27,7 @@ goog.require('GoogleSmartCard.RequestReceiver');
 goog.require('goog.Promise');
 goog.require('goog.asserts');
 goog.require('goog.array');
+goog.require('goog.functions');
 goog.require('goog.iter');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
@@ -213,7 +214,7 @@ ChromeUsbBackend.prototype.processRequest_ = function(payload) {
  */
 ChromeUsbBackend.prototype.getChromeUsbFunction_ = function(functionName) {
   if (!goog.object.containsKey(chrome.usb, functionName) ||
-      !goog.isFunction(chrome.usb[functionName])) {
+      !goog.functions.isFunction(chrome.usb[functionName])) {
     GSC.Logging.failWithLogger(
         this.logger,
         'Unknown chrome.usb API function requested: ' + functionName);

--- a/third_party/pcsc-lite/naclport/cpp_client/src/nacl-client-backend.js
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/nacl-client-backend.js
@@ -37,6 +37,7 @@ goog.require('GoogleSmartCard.RemoteCallMessage');
 goog.require('GoogleSmartCard.RequestReceiver');
 goog.require('goog.Promise');
 goog.require('goog.Timer');
+goog.require('goog.functions');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 goog.require('goog.object');
@@ -352,7 +353,7 @@ NaclClientBackend.prototype.apiMethodRejectedCallback_ = function(
 NaclClientBackend.prototype.getApiMethod_ = function(methodName) {
   GSC.Logging.checkWithLogger(this.logger, this.api_);
   if (!goog.object.containsKey(this.api_, methodName) ||
-      !goog.isFunction(this.api_[methodName])) {
+      !goog.functions.isFunction(this.api_[methodName])) {
     GSC.Logging.failWithLogger(
         this.logger,
         'Unknown PC/SC-Lite Client API method requested: ' + methodName);


### PR DESCRIPTION
Refactor JavaScript code to use goog.functions.isFunction()
instead of goog.isFunction().

goog.isFunction() got deprecated and removed from the recent
versions of the Closure Library; for whatever reason, they decided to
add a synonym "goog.functions.isFunction".

This change contributes to the refactoring effort tracked by #264.