### PR TITLE
Replace usages of deprecated Logger methods

### DIFF
--- a/common/js/src/background-page-unload-preventing/background-page-unload-preventing.js
+++ b/common/js/src/background-page-unload-preventing/background-page-unload-preventing.js
@@ -19,6 +19,7 @@ goog.provide('GoogleSmartCard.BackgroundPageUnloadPreventing');
 
 goog.require('GoogleSmartCard.Logging');
 goog.require('goog.dom');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 
 goog.scope(function() {
@@ -45,7 +46,8 @@ let enabled = false;
  */
 GSC.BackgroundPageUnloadPreventing.enable = function() {
   if (enabled) {
-    logger.fine('Trying to enable for the second time. Ignoring this attempt');
+    goog.log.fine(
+        logger, 'Trying to enable for the second time. Ignoring this attempt');
     return;
   }
   enabled = true;
@@ -54,7 +56,7 @@ GSC.BackgroundPageUnloadPreventing.enable = function() {
 
   chrome.runtime.onSuspend.addListener(suspendListener);
 
-  logger.fine('Enabling: creating an iframe...');
+  goog.log.fine(logger, 'Enabling: creating an iframe...');
   createIFrameElement();
 };
 
@@ -70,7 +72,7 @@ function createIFrameElement() {
  */
 function connectListener(port) {
   if (port.name == 'background-page-unload-preventing') {
-    logger.fine('Success: received a port opened by the iframe');
+    goog.log.fine(logger, 'Success: received a port opened by the iframe');
 
     port.onDisconnect.addListener(function() {
       GSC.Logging.failWithLogger(

--- a/common/js/src/background-page-unload-preventing/iframe-main.js
+++ b/common/js/src/background-page-unload-preventing/iframe-main.js
@@ -31,6 +31,7 @@
 goog.provide('GoogleSmartCard.BackgroundPageUnloadPreventing.IFrameMain');
 
 goog.require('GoogleSmartCard.Logging');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 
 goog.scope(function() {
@@ -41,7 +42,7 @@ const GSC = GoogleSmartCard;
 const logger =
     GSC.Logging.getScopedLogger('BackgroundPageUnloadPreventing.IFrame');
 
-logger.fine('Opening a port to the background page...');
+goog.log.fine(logger, 'Opening a port to the background page...');
 /** @type {!Port} */
 const port =
     chrome.runtime.connect({'name': 'background-page-unload-preventing'});

--- a/common/js/src/clipboard.js
+++ b/common/js/src/clipboard.js
@@ -24,6 +24,7 @@ goog.provide('GoogleSmartCard.Clipboard');
 
 goog.require('GoogleSmartCard.Logging');
 goog.require('goog.dom');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 
 goog.scope(function() {
@@ -48,11 +49,13 @@ GSC.Clipboard.copyToClipboard = function(text) {
   document.body.removeChild(element);
 
   if (!success) {
-    logger.severe(
+    goog.log.error(
+        logger,
         'Failed to copy the text of length ' + text.length + ' to clipboard');
     return false;
   }
-  logger.fine('Copied text of length ' + text.length + ' to clipboard');
+  goog.log.fine(
+      logger, 'Copied text of length ' + text.length + ' to clipboard');
   return true;
 };
 });  // goog.scope

--- a/common/js/src/deferred-processor.js
+++ b/common/js/src/deferred-processor.js
@@ -26,6 +26,7 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PromiseHelpers');
 goog.require('goog.Disposable');
 goog.require('goog.Promise');
+goog.require('goog.log');
 goog.require('goog.promise.Resolver');
 goog.require('goog.structs.Queue');
 
@@ -137,7 +138,7 @@ DeferredProcessor.prototype.disposeInternal = function() {
   this.isSettled_ = true;
   this.flushEnqueuedJobs_();
 
-  this.logger.fine('Disposed');
+  goog.log.fine(this.logger, 'Disposed');
 
   DeferredProcessor.base(this, 'disposeInternal');
 };
@@ -149,7 +150,7 @@ DeferredProcessor.prototype.promiseResolvedListener_ = function() {
   if (this.isSettled_)
     return;
   this.isSettled_ = true;
-  this.logger.fine('The awaited promise was resolved');
+  goog.log.fine(this.logger, 'The awaited promise was resolved');
   this.flushEnqueuedJobs_();
 };
 
@@ -157,7 +158,7 @@ DeferredProcessor.prototype.promiseResolvedListener_ = function() {
 DeferredProcessor.prototype.promiseRejectedListener_ = function() {
   if (this.isDisposed())
     return;
-  this.logger.fine('The awaited promise was rejected, disposing...');
+  goog.log.fine(this.logger, 'The awaited promise was rejected, disposing...');
   this.dispose();
 };
 

--- a/common/js/src/executable-module/emscripten-module.js
+++ b/common/js/src/executable-module/emscripten-module.js
@@ -29,6 +29,7 @@ goog.require('GoogleSmartCard.TypedMessage');
 goog.require('goog.Promise');
 goog.require('goog.asserts');
 goog.require('goog.html.TrustedResourceUrl');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 goog.require('goog.net.jsloader');
@@ -87,7 +88,8 @@ EmscriptenModule.prototype.startLoading = function() {
         this.loadPromiseResolver_.resolve();
       },
       (e) => {
-        this.logger_.warning('Failed to load the Emscripten module: ' + e);
+        goog.log.warning(
+            this.logger_, 'Failed to load the Emscripten module: ' + e);
         this.dispose();
         this.loadPromiseResolver_.reject(e);
       });
@@ -105,7 +107,7 @@ EmscriptenModule.prototype.getMessageChannel = function() {
 
 /** @override */
 EmscriptenModule.prototype.disposeInternal = function() {
-  this.logger_.fine('Disposed');
+  goog.log.fine(this.logger_, 'Disposed');
   // Call `delete()` on the C++ object before dropping the reference on it, in
   // order to make the C++ destructor called.
   // Note: The method is accessed using the square bracket notation, to make
@@ -182,7 +184,7 @@ EmscriptenModule.prototype.getEmscriptenApiModuleSettings_ = function() {
  * @private
  */
 EmscriptenModule.prototype.onModuleCrashed_ = function() {
-  this.logger_.severe('The Emscripten module crashed');
+  goog.log.error(this.logger_, 'The Emscripten module crashed');
   this.dispose();
 };
 
@@ -194,7 +196,7 @@ EmscriptenModule.prototype.onModuleCrashed_ = function() {
 EmscriptenModule.prototype.onModuleStdoutReceived_ = function(message) {
   // TODO(#185): Consider downgrading to the "fine" level once structured log
   // messages are received from the module.
-  this.fromModuleMessagesLogger_.info(message);
+  goog.log.info(this.fromModuleMessagesLogger_, message);
 };
 
 /**
@@ -205,7 +207,7 @@ EmscriptenModule.prototype.onModuleStdoutReceived_ = function(message) {
 EmscriptenModule.prototype.onModuleStderrReceived_ = function(message) {
   // TODO(#185): Consider downgrading to the "fine" level once structured log
   // messages are received from the module.
-  this.fromModuleMessagesLogger_.info(message);
+  goog.log.info(this.fromModuleMessagesLogger_, message);
 };
 
 /**

--- a/common/js/src/i18n.js
+++ b/common/js/src/i18n.js
@@ -23,6 +23,7 @@
 goog.provide('GoogleSmartCard.I18n');
 
 goog.require('GoogleSmartCard.Logging');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 
 goog.scope(function() {
@@ -72,9 +73,10 @@ function transformAllElements(attribute, transformFunction) {
  * @param {string} translatedText
  */
 function applyContentTranslation(element, translatedText) {
-  logger.fine(
+  goog.log.fine(
+      logger,
       'Translating element.textContent [' + element.outerHTML + '] to "' +
-      translatedText + '"');
+          translatedText + '"');
   element.textContent = translatedText;
 }
 
@@ -83,9 +85,10 @@ function applyContentTranslation(element, translatedText) {
  * @param {string} translatedText
  */
 function applyAriaLabelTranslation(element, translatedText) {
-  logger.fine(
+  goog.log.fine(
+      logger,
       'Translating element.aria-label [' + element.outerHTML + '] to "' +
-      translatedText + '"');
+          translatedText + '"');
   element.setAttribute('aria-label', translatedText);
 }
 
@@ -94,9 +97,10 @@ function applyAriaLabelTranslation(element, translatedText) {
  * @param {string} translatedText
  */
 function applyTitleTranslation(element, translatedText) {
-  logger.fine(
+  goog.log.fine(
+      logger,
       'Translating element.title [' + element.outerHTML + '] to "' +
-      translatedText + '"');
+          translatedText + '"');
   element.setAttribute('title', translatedText);
 }
 

--- a/common/js/src/logging/log-buffer.js
+++ b/common/js/src/logging/log-buffer.js
@@ -26,6 +26,7 @@ goog.require('GoogleSmartCard.LogFormatting');
 goog.require('goog.Disposable');
 goog.require('goog.array');
 goog.require('goog.iter');
+goog.require('goog.log');
 goog.require('goog.log.LogRecord');
 goog.require('goog.log.Logger');
 goog.require('goog.structs.CircularBuffer');
@@ -104,7 +105,8 @@ goog.exportProperty(
  * @param {string} documentLocation
  */
 LogBuffer.prototype.attachToLogger = function(logger, documentLocation) {
-  logger.addHandler(this.onLogRecordObserved_.bind(this, documentLocation));
+  goog.log.addHandler(
+      logger, this.onLogRecordObserved_.bind(this, documentLocation));
 };
 
 goog.exportProperty(

--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -137,9 +137,10 @@ GSC.Logging.setupLogging = function() {
   setupConsoleLogging();
   setupRootLoggerLevel();
 
-  logger.fine(
+  goog.log.fine(
+      logger,
       'Logging was set up with level=' + ROOT_LOGGER_LEVEL.name +
-      ' and enabled logging to JS console');
+          ' and enabled logging to JS console');
 
   setupLogBuffer();
 };
@@ -193,9 +194,9 @@ GSC.Logging.getChildLogger = function(parentLogger, relativeName, opt_level) {
  * @param {!goog.log.Level} boundaryLevel
  */
 GSC.Logging.setLoggerVerbosityAtMost = function(logger, boundaryLevel) {
-  const effectiveLevel = logger.getEffectiveLevel();
+  const effectiveLevel = goog.log.getEffectiveLevel(logger);
   if (!effectiveLevel || effectiveLevel.value < boundaryLevel.value)
-    logger.setLevel(boundaryLevel);
+    goog.log.setLevel(logger, boundaryLevel);
 };
 
 /**
@@ -235,7 +236,7 @@ GSC.Logging.checkWithLogger = function(logger, condition, opt_message) {
  */
 GSC.Logging.fail = function(opt_message) {
   const message = opt_message ? opt_message : 'Failure';
-  rootLogger.severe(message);
+  goog.log.error(rootLogger, message);
   scheduleAppReloadIfAllowed();
   throw new Error(message);
 };
@@ -275,12 +276,14 @@ function scheduleAppReloadIfAllowed() {
   GSC.Logging.CrashLoopDetection.handleImminentCrash()
       .then(function(isInCrashLoop) {
         if (isInCrashLoop) {
-          rootLogger.info(
+          goog.log.info(
+              rootLogger,
               'Crash loop detected. The application is defunct, but the ' +
-              'execution state is kept in order to retain the failure logs.');
+                  'execution state is kept in order to retain the failure logs.');
           return;
         }
-        rootLogger.info('Reloading the application due to the fatal error...');
+        goog.log.info(
+            rootLogger, 'Reloading the application due to the fatal error...');
         reloadApp();
       })
       .catch(function() {
@@ -307,7 +310,7 @@ function setupConsoleLogging() {
 }
 
 function setupRootLoggerLevel() {
-  rootLogger.setLevel(ROOT_LOGGER_LEVEL);
+  goog.log.setLevel(rootLogger, ROOT_LOGGER_LEVEL);
 }
 
 function setupLogBuffer() {
@@ -316,13 +319,15 @@ function setupLogBuffer() {
   if (goog.object.containsKey(
           window, GSC.Logging.GLOBAL_LOG_BUFFER_VARIABLE_NAME)) {
     logBuffer = window[GSC.Logging.GLOBAL_LOG_BUFFER_VARIABLE_NAME];
-    logger.fine(
+    goog.log.fine(
+        logger,
         'Detected an existing log buffer instance, attaching it to ' +
-        'the root logger');
+            'the root logger');
   } else {
     logBuffer = new GSC.LogBuffer(LOG_BUFFER_CAPACITY);
     window[GSC.Logging.GLOBAL_LOG_BUFFER_VARIABLE_NAME] = logBuffer;
-    logger.fine(
+    goog.log.fine(
+        logger,
         'Created a new log buffer instance, attaching it to the root logger');
   }
 

--- a/common/js/src/messaging/common.js
+++ b/common/js/src/messaging/common.js
@@ -25,6 +25,7 @@ goog.provide('GoogleSmartCard.MessagingCommon');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.ObjectHelpers');
 goog.require('goog.asserts');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 
@@ -49,9 +50,10 @@ GSC.MessagingCommon.setNonFatalDefaultServiceCallback = function(channel) {
  * @param {!Object|string} payload
  */
 function nonFatalDefaultServiceCallback(channel, serviceName, payload) {
-  LOGGER.warning(
+  goog.log.warning(
+      LOGGER,
       'Unhandled message received: serviceName="' + serviceName +
-      '", payload=' + GSC.DebugDump.debugDump(payload));
+          '", payload=' + GSC.DebugDump.debugDump(payload));
   channel.dispose();
 }
 

--- a/common/js/src/messaging/message-channel-pinging.js
+++ b/common/js/src/messaging/message-channel-pinging.js
@@ -147,7 +147,7 @@ Pinger.createMessageData = function() {
 Pinger.prototype.postPingMessage = function() {
   if (this.isDisposed())
     return;
-  this.logger.finest('Sending a ping request...');
+  goog.log.log(this.logger, goog.log.Level.FINEST, 'Sending a ping request...');
 
   this.messageChannel_.send(Pinger.SERVICE_NAME, Pinger.createMessageData());
 };
@@ -160,7 +160,7 @@ Pinger.prototype.disposeInternal = function() {
 
   this.messageChannel_ = null;
 
-  this.logger.fine('Disposed');
+  goog.log.fine(this.logger, 'Disposed');
 
   Pinger.base(this, 'disposeInternal');
 };
@@ -177,48 +177,53 @@ Pinger.prototype.serviceCallback_ = function(messageData) {
     return;
 
   if (!goog.object.containsKey(messageData, CHANNEL_ID_MESSAGE_KEY)) {
-    this.logger.warning(
+    goog.log.warning(
+        this.logger,
         'Received pong message has wrong format: no "' +
-        CHANNEL_ID_MESSAGE_KEY + '" field is present. Disposing...');
+            CHANNEL_ID_MESSAGE_KEY + '" field is present. Disposing...');
     this.disposeChannelAndSelf_();
     return;
   }
   const channelId = messageData[CHANNEL_ID_MESSAGE_KEY];
   if (typeof channelId !== 'number') {
-    this.logger.warning(
+    goog.log.warning(
+        this.logger,
         'Received pong message has wrong format: channel id ' +
-        'is not a number. Disposing...');
+            'is not a number. Disposing...');
     this.disposeChannelAndSelf_();
     return;
   }
 
   if (this.previousRemoteEndChannelId_ === null) {
-    this.logger.fine(
+    goog.log.fine(
+        this.logger,
         'Received the first pong response (remote channel id is ' + channelId +
-        '). The message channel is considered established');
+            '). The message channel is considered established');
     this.previousRemoteEndChannelId_ = channelId;
     if (this.onEstablished_) {
       this.onEstablished_();
       this.onEstablished_ = null;
     }
   } else if (this.previousRemoteEndChannelId_ == channelId) {
-    this.logger.finest(
+    goog.log.log(
+        this.logger, goog.log.Level.FINEST,
         'Received a pong response with the correct channel ' +
-        'id, so the remote end considered alive');
+            'id, so the remote end considered alive');
     this.clearTimeoutTimer_();
     this.scheduleTimeoutTimer_();
   } else {
-    this.logger.warning(
+    goog.log.warning(
+        this.logger,
         'Received a pong response with a channel id different from the ' +
-        'expected one (expected ' + this.previousRemoteEndChannelId_ +
-        ', received ' + channelId + '). Disposing...');
+            'expected one (expected ' + this.previousRemoteEndChannelId_ +
+            ', received ' + channelId + '). Disposing...');
     this.disposeChannelAndSelf_();
   }
 };
 
 /** @private */
 Pinger.prototype.disposeChannelAndSelf_ = function() {
-  this.logger.fine('Disposing the message channel and self');
+  goog.log.fine(this.logger, 'Disposing the message channel and self');
   this.messageChannel_.dispose();
   this.dispose();
 };
@@ -256,9 +261,10 @@ Pinger.prototype.clearTimeoutTimer_ = function() {
 Pinger.prototype.timeoutCallback_ = function() {
   if (this.isDisposed())
     return;
-  this.logger.warning(
+  goog.log.warning(
+      this.logger,
       'No pong response received in time, the remote end is ' +
-      'dead. Disposing...');
+          'dead. Disposing...');
   this.disposeChannelAndSelf_();
 };
 
@@ -294,7 +300,8 @@ GSC.MessageChannelPinging.PingResponder = function(
   /** @private */
   this.onPingReceivedListener_ = opt_onPingReceived;
 
-  this.logger.fine(
+  goog.log.fine(
+      this.logger,
       'Initialized (generated channel id is ' + PingResponder.CHANNEL_ID + ')');
 };
 
@@ -328,7 +335,9 @@ PingResponder.prototype.serviceCallback_ = function() {
   if (this.isDisposed())
     return;
 
-  this.logger.finest('Received a ping request, sending pong response...');
+  goog.log.log(
+      this.logger, goog.log.Level.FINEST,
+      'Received a ping request, sending pong response...');
 
   this.messageChannel_.send(
       PingResponder.SERVICE_NAME,
@@ -344,7 +353,7 @@ PingResponder.prototype.disposeInternal = function() {
 
   this.onPingReceivedListener_ = null;
 
-  this.logger.fine('Disposed');
+  goog.log.fine(this.logger, 'Disposed');
 
   PingResponder.base(this, 'disposeInternal');
 };

--- a/common/js/src/messaging/message-channel-pool.js
+++ b/common/js/src/messaging/message-channel-pool.js
@@ -25,6 +25,7 @@ goog.provide('GoogleSmartCard.MessageChannelPool');
 
 goog.require('GoogleSmartCard.Logging');
 goog.require('goog.labs.structs.Multimap');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 
@@ -58,7 +59,7 @@ GSC.MessageChannelPool = function() {
    */
   this.onUpdateListeners_ = [];
 
-  this.logger.fine('Initialized successfully');
+  goog.log.fine(this.logger, 'Initialized successfully');
 };
 
 const MessageChannelPool = GSC.MessageChannelPool;
@@ -90,7 +91,8 @@ MessageChannelPool.prototype.addChannel = function(
     GSC.Logging.failWithLogger(
         this.logger, 'Tried to add a channel that was already present');
   }
-  this.logger.fine('Added a new channel, extension id = ' + extensionId);
+  goog.log.fine(
+      this.logger, 'Added a new channel, extension id = ' + extensionId);
   this.channels_.add(extensionId, messageChannel);
   messageChannel.addOnDisposeCallback(
       this.handleChannelDisposed_.bind(this, extensionId, messageChannel));
@@ -103,7 +105,7 @@ MessageChannelPool.prototype.addChannel = function(
  */
 MessageChannelPool.prototype.addOnUpdateListener = function(
     listener, opt_scope) {
-  this.logger.fine('Added an OnUpdateListener');
+  goog.log.fine(this.logger, 'Added an OnUpdateListener');
   this.onUpdateListeners_.push(
       opt_scope !== undefined ? goog.bind(listener, opt_scope) : listener);
   // Fire it once immediately to update.
@@ -114,7 +116,7 @@ MessageChannelPool.prototype.addOnUpdateListener = function(
  * @private
  */
 MessageChannelPool.prototype.fireOnUpdateListeners_ = function() {
-  this.logger.fine('Firing channel update listeners');
+  goog.log.fine(this.logger, 'Firing channel update listeners');
   for (let listener of this.onUpdateListeners_) {
     listener(this.getExtensionIds());
   }
@@ -127,7 +129,8 @@ MessageChannelPool.prototype.fireOnUpdateListeners_ = function() {
  */
 MessageChannelPool.prototype.handleChannelDisposed_ = function(
     extensionId, messageChannel) {
-  this.logger.fine('Disposed of channel, extension id = ' + extensionId);
+  goog.log.fine(
+      this.logger, 'Disposed of channel, extension id = ' + extensionId);
   if (!this.channels_.remove(extensionId, messageChannel)) {
     GSC.Logging.failWithLogger(
         this.logger, 'Tried to dispose of non-existing channel');

--- a/common/js/src/messaging/port-message-channel.js
+++ b/common/js/src/messaging/port-message-channel.js
@@ -31,6 +31,7 @@ goog.require('GoogleSmartCard.MessageChannelPinging.PingResponder');
 goog.require('GoogleSmartCard.MessageChannelPinging.Pinger');
 goog.require('GoogleSmartCard.TypedMessage');
 goog.require('goog.asserts');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 goog.require('goog.object');
@@ -93,7 +94,7 @@ GSC.PortMessageChannel = function(port, opt_onEstablished) {
   /** @private */
   this.pinger_ = new Pinger(this, this.logger, opt_onEstablished);
 
-  this.logger.fine('Initialized successfully');
+  goog.log.fine(this.logger, 'Initialized successfully');
 };
 
 const PortMessageChannel = GSC.PortMessageChannel;
@@ -110,7 +111,9 @@ PortMessageChannel.prototype.send = function(serviceName, payload) {
 
   const typedMessage = new GSC.TypedMessage(serviceName, normalizedPayload);
   const message = typedMessage.makeMessage();
-  this.logger.finest('Posting a message: ' + GSC.DebugDump.debugDump(message));
+  goog.log.log(
+      this.logger, goog.log.Level.FINEST,
+      'Posting a message: ' + GSC.DebugDump.debugDump(message));
 
   if (this.isDisposed()) {
     GSC.Logging.failWithLogger(
@@ -143,7 +146,7 @@ PortMessageChannel.prototype.disposeInternal = function() {
   this.port_.disconnect();
   this.port_ = null;
 
-  this.logger.fine('Disposed');
+  goog.log.fine(this.logger, 'Disposed');
 
   PortMessageChannel.base(this, 'disposeInternal');
 };
@@ -176,7 +179,8 @@ PortMessageChannel.prototype.disconnectEventHandler_ = function() {
       chrome.runtime.lastError.message) {
     reason = ` due to '${chrome.runtime.lastError.message}'`;
   }
-  this.logger.info(`Message port was disconnected${reason}, disposing...`);
+  goog.log.info(
+      this.logger, `Message port was disconnected${reason}, disposing...`);
   this.dispose();
 };
 
@@ -185,7 +189,9 @@ PortMessageChannel.prototype.disconnectEventHandler_ = function() {
  * @private
  */
 PortMessageChannel.prototype.messageEventHandler_ = function(message) {
-  this.logger.finest('Received a message: ' + GSC.DebugDump.debugDump(message));
+  goog.log.log(
+      this.logger, goog.log.Level.FINEST,
+      'Received a message: ' + GSC.DebugDump.debugDump(message));
 
   const typedMessage = GSC.TypedMessage.parseTypedMessage(message);
   if (!typedMessage) {

--- a/common/js/src/messaging/single-message-based-channel.js
+++ b/common/js/src/messaging/single-message-based-channel.js
@@ -30,6 +30,7 @@ goog.require('GoogleSmartCard.MessageChannelPinging.PingResponder');
 goog.require('GoogleSmartCard.MessageChannelPinging.Pinger');
 goog.require('GoogleSmartCard.TypedMessage');
 goog.require('goog.asserts');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 
@@ -82,7 +83,7 @@ GSC.SingleMessageBasedChannel = function(
   this.pingResponder_ = new PingResponder(
       this, this.logger, this.pingMessageReceivedListener_.bind(this));
 
-  this.logger.fine('Initialized successfully');
+  goog.log.fine(this.logger, 'Initialized successfully');
 };
 
 const SingleMessageBasedChannel = GSC.SingleMessageBasedChannel;
@@ -100,7 +101,9 @@ SingleMessageBasedChannel.prototype.send = function(serviceName, payload) {
 
   const typedMessage = new GSC.TypedMessage(serviceName, payload);
   const message = typedMessage.makeMessage();
-  this.logger.finest('Posting a message: ' + GSC.DebugDump.debugDump(message));
+  goog.log.log(
+      this.logger, goog.log.Level.FINEST,
+      'Posting a message: ' + GSC.DebugDump.debugDump(message));
 
   if (this.isDisposed()) {
     GSC.Logging.failWithLogger(
@@ -115,7 +118,9 @@ SingleMessageBasedChannel.prototype.send = function(serviceName, payload) {
  * @param {*} message
  */
 SingleMessageBasedChannel.prototype.deliverMessage = function(message) {
-  this.logger.finest('Received a message: ' + GSC.DebugDump.debugDump(message));
+  goog.log.log(
+      this.logger, goog.log.Level.FINEST,
+      'Received a message: ' + GSC.DebugDump.debugDump(message));
 
   const typedMessage = GSC.TypedMessage.parseTypedMessage(message);
   if (!typedMessage) {
@@ -138,7 +143,7 @@ SingleMessageBasedChannel.prototype.disposeInternal = function() {
   this.pingResponder_.dispose();
   this.pingResponder_ = null;
 
-  this.logger.fine('Disposed');
+  goog.log.fine(this.logger, 'Disposed');
 
   SingleMessageBasedChannel.base(this, 'disposeInternal');
 };

--- a/common/js/src/nacl-module/nacl-module-log-messages-receiver.js
+++ b/common/js/src/nacl-module/nacl-module-log-messages-receiver.js
@@ -73,8 +73,8 @@ NaclModuleLogMessagesReceiver.prototype.onMessageReceived_ = function(
   GSC.Logging.checkWithLogger(this.logger, goog.isObject(messageData));
   goog.asserts.assertObject(messageData);
 
-  this.logger.log(
-      this.extractLogMessageLevel_(messageData),
+  goog.log.log(
+      this.logger, this.extractLogMessageLevel_(messageData),
       this.extractLogMessageText_(messageData));
 };
 

--- a/common/js/src/nacl-module/nacl-module-messaging-channel.js
+++ b/common/js/src/nacl-module/nacl-module-messaging-channel.js
@@ -28,6 +28,7 @@ goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.TypedMessage');
 goog.require('goog.asserts');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 
@@ -66,7 +67,7 @@ GSC.NaclModuleMessageChannel = function(naclModuleElement, parentLogger) {
 
   this.registerDefaultService(this.defaultServiceCallback_.bind(this));
 
-  this.logger_.fine('Initialized');
+  goog.log.fine(this.logger_, 'Initialized');
 };
 
 const NaclModuleMessageChannel = GSC.NaclModuleMessageChannel;
@@ -81,7 +82,8 @@ NaclModuleMessageChannel.prototype.send = function(serviceName, payload) {
   const message = typedMessage.makeMessage();
   if (this.isDisposed())
     return;
-  this.logger_.finest(
+  goog.log.log(
+      this.logger_, goog.log.Level.FINEST,
       'Sending message to NaCl module: ' + GSC.DebugDump.debugDump(message));
   this.naclModuleElement_['postMessage'](message);
 };
@@ -109,9 +111,10 @@ NaclModuleMessageChannel.prototype.messageEventListener_ = function(message) {
             GSC.DebugDump.debugDump(messageData));
   }
 
-  this.logger_.finest(
+  goog.log.log(
+      this.logger_, goog.log.Level.FINEST,
       'Received a message from NaCl module: ' +
-      GSC.DebugDump.debugDump(messageData));
+          GSC.DebugDump.debugDump(messageData));
   this.deliver(typedMessage.type, typedMessage.data);
 };
 

--- a/common/js/src/nacl-module/nacl-module.js
+++ b/common/js/src/nacl-module/nacl-module.js
@@ -31,6 +31,7 @@ goog.require('GoogleSmartCard.TypedMessage');
 goog.require('goog.Promise');
 goog.require('goog.dom');
 goog.require('goog.events');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 
 goog.scope(function() {
@@ -128,7 +129,7 @@ NaclModule.prototype.getLogger = function() {
 
 /** @override */
 NaclModule.prototype.startLoading = function() {
-  this.logger_.info('Loading NaCl module...');
+  goog.log.info(this.logger_, 'Loading NaCl module...');
   GSC.Logging.checkWithLogger(this.logger_, !this.element_.parentNode);
   GSC.Logging.checkWithLogger(this.logger_, document.body);
   document.body.appendChild(this.element_);
@@ -158,7 +159,7 @@ NaclModule.prototype.disposeInternal = function() {
 
   this.loadPromiseResolver_.reject(new Error('Disposed'));
 
-  this.logger_.fine('Disposed');
+  goog.log.fine(this.logger_, 'Disposed');
 
   NaclModule.base(this, 'disposeInternal');
 };
@@ -169,7 +170,8 @@ NaclModule.prototype.disposeInternal = function() {
  */
 NaclModule.prototype.createElement_ = function() {
   const mimeType = this.getMimeType_();
-  this.logger_.fine('Preparing NaCl embed (MIME type: "' + mimeType + '")...');
+  goog.log.fine(
+      this.logger_, 'Preparing NaCl embed (MIME type: "' + mimeType + '")...');
   return goog.dom.createDom(
       'embed',
       {'type': mimeType, 'width': 0, 'height': 0, 'src': this.naclModulePath});
@@ -213,7 +215,7 @@ NaclModule.prototype.addStatusEventListeners_ = function() {
 NaclModule.prototype.loadEventListener_ = function() {
   if (this.isDisposed())
     return;
-  this.logger_.info('Successfully loaded NaCl module');
+  goog.log.info(this.logger_, 'Successfully loaded NaCl module');
   this.loadPromiseResolver_.resolve();
 };
 
@@ -221,9 +223,10 @@ NaclModule.prototype.loadEventListener_ = function() {
 NaclModule.prototype.abortEventListener_ = function() {
   if (this.isDisposed())
     return;
-  this.logger_.severe(
+  goog.log.error(
+      this.logger_,
       'NaCl module load was aborted with the following ' +
-      'message: ' + this.element_['lastError']);
+          'message: ' + this.element_['lastError']);
   this.dispose();
 };
 
@@ -231,9 +234,10 @@ NaclModule.prototype.abortEventListener_ = function() {
 NaclModule.prototype.errorEventListener_ = function() {
   if (this.isDisposed())
     return;
-  this.logger_.severe(
+  goog.log.error(
+      this.logger_,
       'Failed to load NaCl module with the following ' +
-      'message: ' + this.element_['lastError']);
+          'message: ' + this.element_['lastError']);
   this.dispose();
 };
 
@@ -241,7 +245,7 @@ NaclModule.prototype.errorEventListener_ = function() {
 NaclModule.prototype.crashEventListener_ = function() {
   if (this.isDisposed())
     return;
-  this.logger_.severe('The NaCl module has crashed');
+  goog.log.error(this.logger_, 'The NaCl module has crashed');
   this.dispose();
 };
 

--- a/common/js/src/popup-window/client.js
+++ b/common/js/src/popup-window/client.js
@@ -31,6 +31,7 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
 goog.require('goog.events.KeyCodes');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.object');
 
@@ -53,7 +54,7 @@ GSC.PopupWindow.Client.getData = function() {
  * Shows the window.
  */
 GSC.PopupWindow.Client.showWindow = function() {
-  logger.fine('Showing the window...');
+  goog.log.fine(logger, 'Showing the window...');
   chrome.app.window.current().show();
 };
 
@@ -66,9 +67,10 @@ GSC.PopupWindow.Client.showWindow = function() {
 GSC.PopupWindow.Client.resolveModalDialog = function(result) {
   const callback = GSC.PopupWindow.Client.getData()['resolveModalDialog'];
   GSC.Logging.checkWithLogger(logger, callback);
-  logger.fine(
+  goog.log.fine(
+      logger,
       'The modal dialog is resolved with the following result: ' +
-      GSC.DebugDump.debugDump(result));
+          GSC.DebugDump.debugDump(result));
   callback(result);
   closeWindow();
 };
@@ -82,7 +84,8 @@ GSC.PopupWindow.Client.resolveModalDialog = function(result) {
 GSC.PopupWindow.Client.rejectModalDialog = function(error) {
   const callback = GSC.PopupWindow.Client.getData()['rejectModalDialog'];
   GSC.Logging.checkWithLogger(logger, callback);
-  logger.fine(
+  goog.log.fine(
+      logger,
       'The modal dialog is rejected with the following error: ' + error);
   callback(error);
   closeWindow();
@@ -110,7 +113,8 @@ GSC.PopupWindow.Client.setWindowHeightToFitContent = function() {
       logger,
       wholeContentHeight !== undefined &&
           typeof wholeContentHeight === 'number');
-  logger.fine('Resizing the window size to ' + wholeContentHeight + 'px');
+  goog.log.fine(
+      logger, 'Resizing the window size to ' + wholeContentHeight + 'px');
   chrome.app.window.current().innerBounds.height = wholeContentHeight;
 };
 
@@ -123,7 +127,7 @@ GSC.PopupWindow.Client.setupClosingOnEscape = function() {
   goog.events.listen(
       document, goog.events.EventType.KEYDOWN,
       documentClosingOnEscapeKeyDownListener);
-  logger.fine('ESC key press handler was set up');
+  goog.log.fine(logger, 'ESC key press handler was set up');
 };
 
 /**
@@ -137,13 +141,13 @@ GSC.PopupWindow.Client.setupRejectionOnWindowClose = function() {
 };
 
 function closeWindow() {
-  logger.fine('Closing the window...');
+  goog.log.fine(logger, 'Closing the window...');
   chrome.app.window.current().close();
 }
 
 function documentClosingOnEscapeKeyDownListener(event) {
   if (event.keyCode == goog.events.KeyCodes.ESC) {
-    logger.fine('ESC key press received, the window will be closed');
+    goog.log.fine(logger, 'ESC key press received, the window will be closed');
     closeWindow();
   }
 }

--- a/common/js/src/popup-window/server.js
+++ b/common/js/src/popup-window/server.js
@@ -25,6 +25,7 @@ goog.provide('GoogleSmartCard.PopupWindow.Server');
 goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
 goog.require('goog.Promise');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.object');
 
@@ -60,10 +61,11 @@ GSC.PopupWindow.Server.createWindow = function(
   if (opt_data !== undefined)
     createdWindowExtends['passedData'] = opt_data;
 
-  logger.fine(
+  goog.log.fine(
+      logger,
       'Creating a popup window with url="' + url +
-      '", options=' + GSC.DebugDump.debugDump(createWindowOptions) +
-      ', data=' + GSC.DebugDump.debugDump(opt_data));
+          '", options=' + GSC.DebugDump.debugDump(createWindowOptions) +
+          ', data=' + GSC.DebugDump.debugDump(opt_data));
 
   /** @preserveTry */
   try {
@@ -128,10 +130,11 @@ function createWindowCallback(createdWindowExtends, createdWindow) {
 
   const createdWindowScope = createdWindow['contentWindow'];
 
-  logger.finer(
+  goog.log.log(
+      logger, goog.log.Level.FINER,
       'The popup window callback is executed, injecting the following data ' +
-      'into the created window: ' +
-      GSC.DebugDump.debugDump(createdWindowExtends));
+          'into the created window: ' +
+          GSC.DebugDump.debugDump(createdWindowExtends));
   Object.assign(createdWindowScope, createdWindowExtends);
 }
 });  // goog.scope

--- a/common/js/src/requesting/request-receiver.js
+++ b/common/js/src/requesting/request-receiver.js
@@ -29,6 +29,7 @@ goog.require('GoogleSmartCard.RequesterMessage.RequestMessageData');
 goog.require('GoogleSmartCard.RequesterMessage.ResponseMessageData');
 goog.require('goog.Promise');
 goog.require('goog.asserts');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 
@@ -112,10 +113,12 @@ RequestReceiver.prototype.requestMessageReceivedListener_ = function(
   const requestMessageData = RequestMessageData.parseMessageData(messageData);
   if (requestMessageData === null) {
     if (this.shouldDisposeOnInvalidMessage_) {
-      this.logger.warning(
+      goog.log.warning(
+          this.logger,
           'Failed to parse the received request message: ' +
-          GSC.DebugDump.debugDump(messageData) + ', disposing of the message ' +
-          'channel...');
+              GSC.DebugDump.debugDump(messageData) +
+              ', disposing of the message ' +
+              'channel...');
       this.messageChannel_.dispose();
       return;
     } else {
@@ -126,10 +129,11 @@ RequestReceiver.prototype.requestMessageReceivedListener_ = function(
     }
   }
 
-  this.logger.fine(
+  goog.log.fine(
+      this.logger,
       'Received a request with identifier ' + requestMessageData.requestId +
-      ', the payload is: ' +
-      GSC.DebugDump.debugDump(requestMessageData.payload));
+          ', the payload is: ' +
+          GSC.DebugDump.debugDump(requestMessageData.payload));
 
   const promise = this.requestHandler_(requestMessageData.payload);
   promise.then(
@@ -145,17 +149,20 @@ RequestReceiver.prototype.requestMessageReceivedListener_ = function(
 RequestReceiver.prototype.responseResolvedListener_ = function(
     requestMessageData, payload) {
   if (this.messageChannel_.isDisposed()) {
-    this.logger.warning(
+    goog.log.warning(
+        this.logger,
         'Ignoring the successful response for the request with identifier ' +
-        requestMessageData.requestId + ' due to the disposal of the message ' +
-        'channel');
+            requestMessageData.requestId +
+            ' due to the disposal of the message ' +
+            'channel');
     return;
   }
 
-  this.logger.fine(
+  goog.log.fine(
+      this.logger,
       'Sending the successful response for the request with identifier ' +
-      requestMessageData.requestId +
-      ', the response is: ' + GSC.DebugDump.debugDump(payload));
+          requestMessageData.requestId +
+          ', the response is: ' + GSC.DebugDump.debugDump(payload));
   this.sendResponse_(
       new ResponseMessageData(requestMessageData.requestId, payload));
 };
@@ -168,17 +175,20 @@ RequestReceiver.prototype.responseResolvedListener_ = function(
 RequestReceiver.prototype.responseRejectedListener_ = function(
     requestMessageData, error) {
   if (this.messageChannel_.isDisposed()) {
-    this.logger.warning(
+    goog.log.warning(
+        this.logger,
         'Ignoring the failure response for the request with identifier ' +
-        requestMessageData.requestId + ' due to the disposal of the message ' +
-        'channel');
+            requestMessageData.requestId +
+            ' due to the disposal of the message ' +
+            'channel');
     return;
   }
 
   const stringifiedError = String(error);
-  this.logger.fine(
+  goog.log.fine(
+      this.logger,
       'Sending the failure response for the request with identifier ' +
-      requestMessageData.requestId + ', the error is: ' + stringifiedError);
+          requestMessageData.requestId + ', the error is: ' + stringifiedError);
   this.sendResponse_(new ResponseMessageData(
       requestMessageData.requestId, undefined, stringifiedError));
 };

--- a/common/js/src/requesting/requester.js
+++ b/common/js/src/requesting/requester.js
@@ -33,6 +33,7 @@ goog.require('goog.Promise');
 goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.iter');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 goog.require('goog.promise.Resolver');
@@ -106,9 +107,10 @@ goog.inherits(Requester, goog.Disposable);
 Requester.prototype.postRequest = function(payload) {
   const requestId = this.requestIdGenerator_.next();
 
-  this.logger.fine(
+  goog.log.fine(
+      this.logger,
       'Starting a request with identifier ' + requestId +
-      ', the payload is: ' + GSC.DebugDump.debugDump(payload));
+          ', the payload is: ' + GSC.DebugDump.debugDump(payload));
 
   const promiseResolver = goog.Promise.withResolver();
 
@@ -146,7 +148,7 @@ Requester.prototype.disposeInternal = function() {
 
   this.messageChannel_ = null;
 
-  this.logger.fine('Disposed');
+  goog.log.fine(this.logger, 'Disposed');
 
   Requester.base(this, 'disposeInternal');
 };
@@ -168,7 +170,7 @@ Requester.prototype.addChannelDisposedListener_ = function() {
 Requester.prototype.channelDisposedListener_ = function() {
   if (this.isDisposed())
     return;
-  this.logger.info('Message channel was disposed, disposing...');
+  goog.log.info(this.logger, 'Message channel was disposed, disposing...');
   this.dispose();
 };
 
@@ -212,9 +214,10 @@ Requester.prototype.responseMessageReceivedListener_ = function(messageData) {
  * @private
  */
 Requester.prototype.resolveRequest_ = function(requestId, payload) {
-  this.logger.fine(
+  goog.log.fine(
+      this.logger,
       'The request with identifier ' + requestId + ' succeeded with the ' +
-      'following result: ' + GSC.DebugDump.debugDump(payload));
+          'following result: ' + GSC.DebugDump.debugDump(payload));
   this.popRequestPromiseResolver_(requestId).resolve(payload);
 };
 
@@ -224,7 +227,8 @@ Requester.prototype.resolveRequest_ = function(requestId, payload) {
  * @private
  */
 Requester.prototype.rejectRequest_ = function(requestId, errorMessage) {
-  this.logger.fine(
+  goog.log.fine(
+      this.logger,
       'The request with identifier ' + requestId + ' failed: ' + errorMessage);
   this.popRequestPromiseResolver_(requestId).reject(new Error(errorMessage));
 };

--- a/example_cpp_smart_card_client_app/src/background.js
+++ b/example_cpp_smart_card_client_app/src/background.js
@@ -60,6 +60,7 @@ goog.require('GoogleSmartCard.PopupWindow.Server');
 goog.require('SmartCardClientApp.BuiltInPinDialog.Backend');
 goog.require('SmartCardClientApp.CertificateProviderBridge.Backend');
 goog.require('goog.asserts');
+goog.require('goog.log');
 goog.require('goog.log.Level');
 goog.require('goog.log.Logger');
 
@@ -124,11 +125,12 @@ const logger = GSC.Logging.getLogger(
 
 const extensionManifest = chrome.runtime.getManifest();
 const formattedStartupTime = (new Date()).toLocaleString();
-logger.info(
+goog.log.info(
+    logger,
     `The extension (id "${chrome.runtime.id}", version ` +
-    `${extensionManifest.version}) background script started. Browser ` +
-    `version: "${window.navigator.appVersion}". System time: ` +
-    `"${formattedStartupTime}"`);
+        `${extensionManifest.version}) background script started. Browser ` +
+        `version: "${window.navigator.appVersion}". System time: ` +
+        `"${formattedStartupTime}"`);
 
 /**
  * Loads the binary executable module depending on the toolchain configuration.

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog-backend.js
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog-backend.js
@@ -29,6 +29,7 @@ goog.provide('SmartCardClientApp.BuiltInPinDialog.Backend');
 goog.require('GoogleSmartCard.PopupWindow.Server');
 goog.require('GoogleSmartCard.RequestReceiver');
 goog.require('goog.Promise');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 goog.require('goog.object');
@@ -83,7 +84,7 @@ const Backend = SmartCardClientApp.BuiltInPinDialog.Backend;
  * @return {!goog.Promise}
  */
 function handleRequest(payload) {
-  logger.info('Starting PIN dialog...');
+  goog.log.info(logger, 'Starting PIN dialog...');
 
   const pinPromise = GSC.PopupWindow.Server.runModalDialog(
       PIN_DIALOG_URL, PIN_DIALOG_WINDOW_OPTIONS_OVERRIDES);
@@ -92,11 +93,11 @@ function handleRequest(payload) {
 
   pinPromise.then(
       function(pin) {
-        logger.info('PIN dialog finished successfully');
+        goog.log.info(logger, 'PIN dialog finished successfully');
         promiseResolver.resolve(createResponseMessagePayload(pin));
       },
       function(error) {
-        logger.info('PIN dialog finished with error: ' + error);
+        goog.log.info(logger, 'PIN dialog finished with error: ' + error);
         promiseResolver.reject(error);
       });
 

--- a/example_cpp_smart_card_client_app/src/window.js
+++ b/example_cpp_smart_card_client_app/src/window.js
@@ -28,6 +28,7 @@ goog.require('GoogleSmartCard.PopupWindow.Client');
 goog.require('goog.dom');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
+goog.require('goog.log');
 goog.require('goog.log.Level');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.MessageChannel');
@@ -43,7 +44,7 @@ const logger = GSC.Logging.getLogger(
     'SmartCardClientAppWindow',
     goog.DEBUG ? goog.log.Level.FINE : goog.log.Level.INFO);
 
-logger.info('The main window is created');
+goog.log.info(logger, 'The main window is created');
 
 // Obtain the message channel that is used for communication with the executable
 // module.

--- a/example_js_smart_card_client_app/src/background.js
+++ b/example_js_smart_card_client_app/src/background.js
@@ -95,7 +95,7 @@ function initializeContext() {
  * client API requests.
  */
 function contextInitializedListener(api) {
-  logger.info('Successfully connected to the server app');
+  goog.log.info(logger, 'Successfully connected to the server app');
   work(api);
 }
 
@@ -107,7 +107,7 @@ function contextInitializedListener(api) {
  * becomes disposed at this point (if not disposed yet).
  */
 function contextDisposedListener() {
-  logger.warning('Connection to the server app was shut down');
+  goog.log.warning(logger, 'Connection to the server app was shut down');
   context = null;
   stopWork();
 }
@@ -125,29 +125,30 @@ function work(api) {
   //
 
   function runPcscLiteDemo(callback) {
-    logger.info('Starting PC/SC-Lite demo...');
-    GSC.PcscLiteClient.Demo.logger.setLevel(goog.log.Level.FINE);
+    goog.log.info(logger, 'Starting PC/SC-Lite demo...');
+    goog.log.setLevel(logger, goog.log.Level.FINE);
     GSC.PcscLiteClient.Demo.run(
         api,
         function() {
-          logger.info('PC/SC-Lite demo successfully finished');
+          goog.log.info(logger, 'PC/SC-Lite demo successfully finished');
           callback();
         },
         function() {
-          logger.warning('PC/SC-Lite demo failed');
+          goog.log.warning(logger, 'PC/SC-Lite demo failed');
           callback();
         });
   }
 
   function runPinDialogDemo() {
-    logger.info('Starting PIN dialog demo...');
+    goog.log.info(logger, 'Starting PIN dialog demo...');
     const pinPromise = SmartCardClientApp.PinDialog.Server.requestPin();
     pinPromise.then(
         function(pin) {
-          logger.info('PIN dialog demo finished: received PIN "' + pin + '"');
+          goog.log.info(
+              logger, 'PIN dialog demo finished: received PIN "' + pin + '"');
         },
         function(error) {
-          logger.info('PIN dialog demo finished: ' + error);
+          goog.log.info(logger, 'PIN dialog demo finished: ' + error);
         });
   }
 

--- a/example_js_smart_card_client_app/src/background.js
+++ b/example_js_smart_card_client_app/src/background.js
@@ -126,7 +126,7 @@ function work(api) {
 
   function runPcscLiteDemo(callback) {
     goog.log.info(logger, 'Starting PC/SC-Lite demo...');
-    goog.log.setLevel(logger, goog.log.Level.FINE);
+    goog.log.setLevel(GSC.PcscLiteClient.Demo.logger, goog.log.Level.FINE);
     GSC.PcscLiteClient.Demo.run(
         api,
         function() {

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -102,9 +102,7 @@ if (logBufferForwarderToNaclModule) {
     // while sending messages to it, in order to avoid duplication and/or
     // infinite recursion.
     logBufferForwarderToNaclModule.ignoreLogger(
-        executableModule.logMessagesReceiver.goog.log.getName(
-            logger,
-            ));
+        executableModule.logMessagesReceiver.logger.getName());
     // Start forwarding all future log messages collected on the JS side, but
     // also immediately post the messages that have been accumulated so far.
     logBufferForwarderToNaclModule.startForwarding(

--- a/smart_card_connector_app/src/window-apps-displaying.js
+++ b/smart_card_connector_app/src/window-apps-displaying.js
@@ -30,6 +30,7 @@ goog.require('goog.Promise');
 goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.dom');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 
 goog.scope(function() {
@@ -84,9 +85,10 @@ function updateAppView(knownAppsPromise, appIds, knownApps) {
 function onUpdateListener(appListArg) {
   const appList = goog.array.clone(appListArg);
   goog.array.sort(appList);
-  logger.fine(
+  goog.log.fine(
+      logger,
       'Application list updated, refreshing the view. ' +
-      'New list of id\'s: ' + GSC.DebugDump.dump(appList));
+          'New list of id\'s: ' + GSC.DebugDump.dump(appList));
 
   const knownAppsPromise = knownAppsRegistry.tryGetByIds(appList);
   lastKnownAppsPromise = knownAppsPromise;
@@ -99,12 +101,12 @@ function onUpdateListener(appListArg) {
         if (!updateAppView(knownAppsPromise, appList, null))
           return;
 
-        logger.warning('Couldn\'t resolve appList: ' + error);
+        goog.log.warning(logger, 'Couldn\'t resolve appList: ' + error);
       });
 }
 
 GSC.ConnectorApp.Window.AppsDisplaying.initialize = function() {
-  logger.fine('Registering listener on connected apps update');
+  goog.log.fine(logger, 'Registering listener on connected apps update');
   // FIXME(emaxx): Do unsubscription too.
   // FIXME(emaxx): Use GSC.ObjectHelpers.extractKey to ensure that the expected
   // object is passed to the window.

--- a/smart_card_connector_app/src/window-devices-displaying.js
+++ b/smart_card_connector_app/src/window-devices-displaying.js
@@ -32,6 +32,7 @@ goog.require('goog.dom');
 goog.require('goog.dom.dataset');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.string');
 
@@ -78,9 +79,10 @@ function onReadersChanged(readers) {
  * @param {!Array.<!GSC.PcscLiteServer.ReaderInfo>} readers
  */
 function displayReaderList(readers) {
-  logger.info(
+  goog.log.info(
+      logger,
       'Displaying ' + readers.length +
-      ' card reader(s): ' + GSC.DebugDump.dump(readers));
+          ' card reader(s): ' + GSC.DebugDump.dump(readers));
   goog.dom.removeChildren(readersListElement);
 
   for (let reader of readers) {
@@ -115,9 +117,10 @@ function makeReaderNameForDisplaying(readerName) {
     if (goog.string.endsWith(readerName, suffixToRemove)) {
       const newReaderName =
           readerName.substr(0, readerName.length - suffixToRemove.length);
-      logger.fine(
+      goog.log.fine(
+          logger,
           'Transformed reader name "' + readerName + '" into "' +
-          newReaderName + '"');
+              newReaderName + '"');
       return newReaderName;
     }
   }
@@ -162,7 +165,7 @@ function updateAddDeviceButtonText(readersCount) {
 function addDeviceClickListener(e) {
   e.preventDefault();
 
-  logger.fine('Running USB devices selection dialog...');
+  goog.log.fine(logger, 'Running USB devices selection dialog...');
   chrome.usb.getUserSelectedDevices(
       {'multiple': true, 'filters': USB_DEVICE_FILTERS},
       getUserSelectedDevicesCallback);
@@ -172,9 +175,10 @@ function addDeviceClickListener(e) {
  * @param {!Array.<!chrome.usb.Device>} devices
  */
 function getUserSelectedDevicesCallback(devices) {
-  logger.fine(
+  goog.log.fine(
+      logger,
       'USB selection dialog finished, ' + devices.length + ' devices ' +
-      'were chosen');
+          'were chosen');
 }
 
 GSC.ConnectorApp.Window.DevicesDisplaying.initialize = function() {

--- a/smart_card_connector_app/src/window-logs-exporting.js
+++ b/smart_card_connector_app/src/window-logs-exporting.js
@@ -28,6 +28,7 @@ goog.require('goog.Timer');
 goog.require('goog.dom');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 
 goog.scope(function() {
@@ -68,10 +69,11 @@ function exportLogsClickListener(e) {
 function exportLogs() {
   const logBufferState = GSC.Logging.getLogBuffer().getState();
   const dumpedLogs = logBufferState.getAsText();
-  logger.fine(
+  goog.log.fine(
+      logger,
       'Prepared a (possibly truncated) dump of ' + logBufferState['logCount'] +
-      ' log messages from the log buffer, the dump size is ' +
-      dumpedLogs.length + ' characters');
+          ' log messages from the log buffer, the dump size is ' +
+          dumpedLogs.length + ' characters');
   const copyingSuccess = GSC.Clipboard.copyToClipboard(dumpedLogs);
 
   if (copyingSuccess) {

--- a/smart_card_connector_app/src/window-main.js
+++ b/smart_card_connector_app/src/window-main.js
@@ -33,6 +33,7 @@ goog.require('goog.dom');
 goog.require('goog.dom.classlist');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 
 goog.scope(function() {
@@ -42,7 +43,7 @@ const GSC = GoogleSmartCard;
 /** @type {!goog.log.Logger} */
 const logger = GSC.Logging.getScopedLogger('ConnectorApp.MainWindow');
 
-logger.info('The main window is created');
+goog.log.info(logger, 'The main window is created');
 
 goog.events.listen(
     goog.dom.getElement('close-window'), goog.events.EventType.CLICK,
@@ -69,9 +70,10 @@ function displayNonChromeOsWarningIfNeeded() {
     /** @type {string} */
     const os = platformInfo['os'];
     if (os != 'cros') {
-      logger.info(
+      goog.log.info(
+          logger,
           'Displaying the warning regarding non-Chrome OS system ' +
-          '(the current OS is "' + os + '")');
+              '(the current OS is "' + os + '")');
       goog.dom.classlist.remove(
           goog.dom.getElement('non-chrome-os-warning'), 'hidden');
     }

--- a/third_party/libusb/webport/src/chrome_usb/chrome-login-state-hook.js
+++ b/third_party/libusb/webport/src/chrome_usb/chrome-login-state-hook.js
@@ -29,6 +29,7 @@ goog.require('goog.asserts');
 goog.require('goog.array');
 goog.require('goog.Disposable');
 goog.require('goog.iter');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 goog.require('goog.object');
@@ -64,9 +65,10 @@ GSC.Libusb.ChromeLoginStateHook = function() {
   if (chrome.loginState) {
     chrome.loginState.getProfileType(this.onGotProfileType_.bind(this));
   } else {
-    this.logger.warning(
+    goog.log.warning(
+        this.logger,
         'chrome.loginState API is not available. This app might require a ' +
-        'newer version of Chrome.');
+            'newer version of Chrome.');
     this.hookIsReadyResolver_.reject();
   }
 };
@@ -89,7 +91,7 @@ ChromeLoginStateHook.prototype.disposeInternal = function() {
         this.boundOnGotSessionState_);
   }
 
-  this.logger.fine('Disposed');
+  goog.log.fine(this.logger, 'Disposed');
 
   ChromeLoginStateHook.base(this, 'disposeInternal');
 };
@@ -133,12 +135,12 @@ ChromeLoginStateHook.prototype.onGotSessionState_ = function(sessionState) {
   goog.asserts.assert(chrome.loginState);
   if (sessionState === chrome.loginState.SessionState.IN_LOCK_SCREEN &&
       !this.simulateDevicesAbsent_) {
-    this.logger.info('No longer showing USB devices.');
+    goog.log.info(this.logger, 'No longer showing USB devices.');
     this.simulateDevicesAbsent_ = true;
   } else if (
       sessionState !== chrome.loginState.SessionState.IN_LOCK_SCREEN &&
       this.simulateDevicesAbsent_) {
-    this.logger.info('Showing USB devices.');
+    goog.log.info(this.logger, 'Showing USB devices.');
     this.simulateDevicesAbsent_ = false;
   }
   // All calls after the first one to resolve() will be ignored.

--- a/third_party/libusb/webport/src/chrome_usb/chrome-usb-backend.js
+++ b/third_party/libusb/webport/src/chrome_usb/chrome-usb-backend.js
@@ -29,6 +29,7 @@ goog.require('goog.asserts');
 goog.require('goog.array');
 goog.require('goog.functions');
 goog.require('goog.iter');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 goog.require('goog.object');
@@ -129,7 +130,8 @@ ChromeUsbBackend.prototype.startObservingDevices_ = function() {
  * @private
  */
 ChromeUsbBackend.prototype.deviceAddedListener_ = function(device) {
-  this.logger.fine('A USB device was added: ' + GSC.DebugDump.dump(device));
+  goog.log.fine(
+      this.logger, 'A USB device was added: ' + GSC.DebugDump.dump(device));
   this.logCurrentDevices_();
 };
 
@@ -138,7 +140,8 @@ ChromeUsbBackend.prototype.deviceAddedListener_ = function(device) {
  * @private
  */
 ChromeUsbBackend.prototype.deviceRemovedListener_ = function(device) {
-  this.logger.fine('A USB device was removed: ' + GSC.DebugDump.dump(device));
+  goog.log.fine(
+      this.logger, 'A USB device was removed: ' + GSC.DebugDump.dump(device));
   this.logCurrentDevices_();
 };
 
@@ -155,9 +158,10 @@ ChromeUsbBackend.prototype.logDevices_ = function(devices) {
   goog.array.sortByKey(devices, function(device) {
     return device.device;
   });
-  this.logger.info(
+  goog.log.info(
+      this.logger,
       devices.length +
-      ' USB device(s) available: ' + GSC.DebugDump.dump(devices));
+          ' USB device(s) available: ' + GSC.DebugDump.dump(devices));
 };
 
 /**
@@ -185,7 +189,8 @@ ChromeUsbBackend.prototype.processRequest_ = function(payload) {
 
   const debugRepresentation =
       'chrome.usb.' + remoteCallMessage.getDebugRepresentation();
-  this.logger.fine('Received a remote call request: ' + debugRepresentation);
+  goog.log.fine(
+      this.logger, 'Received a remote call request: ' + debugRepresentation);
 
   const promiseResolver = goog.Promise.withResolver();
 
@@ -254,9 +259,10 @@ ChromeUsbBackend.prototype.chromeUsbApiGenericCallback_ = function(
  */
 ChromeUsbBackend.prototype.reportRequestException_ = function(
     debugRepresentation, promiseResolver, exc) {
-  this.logger.warning(
+  goog.log.warning(
+      this.logger,
       'JavaScript exception was thrown while calling ' + debugRepresentation +
-      ': ' + exc);
+          ': ' + exc);
   promiseResolver.reject(exc);
 };
 
@@ -272,11 +278,12 @@ ChromeUsbBackend.prototype.reportRequestError_ = function(
     // FIXME(emaxx): Remove this special branch here once the USB transfer
     // timeouts support is implemented. This branch is useful before this is
     // done, as it suppresses the useless warning messages.
-    this.logger.info('Transfer timed out: ' + debugRepresentation);
+    goog.log.info(this.logger, 'Transfer timed out: ' + debugRepresentation);
   } else {
-    this.logger.warning(
+    goog.log.warning(
+        this.logger,
         'API error occurred while calling ' + debugRepresentation + ': ' +
-        errorMessage);
+            errorMessage);
   }
   promiseResolver.reject(new Error(errorMessage));
 };
@@ -293,9 +300,10 @@ ChromeUsbBackend.prototype.reportRequestSuccess_ = function(
   this.requestSuccessHooks_.forEach(function(hook) {
     resultArgs = hook(functionName, resultArgs);
   });
-  this.logger.fine(
-      'Results returned by the ' + debugRepresentation +
-      ' call: ' + goog.iter.join(goog.iter.map(resultArgs, debugDump), ', '));
+  goog.log.fine(
+      this.logger,
+      'Results returned by the ' + debugRepresentation + ' call: ' +
+          goog.iter.join(goog.iter.map(resultArgs, debugDump), ', '));
   promiseResolver.resolve(resultArgs);
 };
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/js_client/src/api.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/api.js
@@ -60,6 +60,7 @@ goog.require('goog.Promise');
 goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.async.nextTick');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 
@@ -110,7 +111,7 @@ GSC.PcscLiteClient.API = function(messageChannel) {
   this.requester_ =
       new GSC.Requester(Constants.REQUESTER_TITLE, this.messageChannel_);
 
-  this.logger.fine('Initialized');
+  goog.log.fine(this.logger, 'Initialized');
 };
 
 const API = GSC.PcscLiteClient.API;
@@ -3504,7 +3505,7 @@ API.prototype.disposeInternal = function() {
 
   this.messageChannel_ = null;
 
-  this.logger.fine('Disposed');
+  goog.log.fine(this.logger, 'Disposed');
 
   API.base(this, 'disposeInternal');
 };
@@ -3513,7 +3514,7 @@ API.prototype.disposeInternal = function() {
 API.prototype.messageChannelDisposedListener_ = function() {
   if (this.isDisposed())
     return;
-  this.logger.info('Message channel was disposed, disposing...');
+  goog.log.info(this.logger, 'Message channel was disposed, disposing...');
   this.dispose();
 };
 

--- a/third_party/pcsc-lite/naclport/js_client/src/context.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/context.js
@@ -36,6 +36,7 @@ goog.require('goog.Disposable');
 goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.async.nextTick');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 
@@ -95,7 +96,7 @@ GSC.PcscLiteClient.Context = function(clientTitle, opt_serverAppId) {
    */
   this.onInitializedCallbacks_ = [];
 
-  this.logger.fine('Constructed');
+  goog.log.fine(this.logger, 'Constructed');
 };
 
 const Context = GSC.PcscLiteClient.Context;
@@ -127,12 +128,13 @@ Context.prototype.initialize = function(opt_messageChannel) {
     this.channel_ = opt_messageChannel;
     goog.async.nextTick(this.messageChannelEstablishedListener_, this);
   } else {
-    this.logger.fine(
+    goog.log.fine(
+        this.logger,
         'Opening a connection to the server app ' +
-        (this.serverAppId_ !== undefined ?
-             '(extension id is "' + this.serverAppId_ + '")' :
-             '(which is the own app)') +
-        '...');
+            (this.serverAppId_ !== undefined ?
+                 '(extension id is "' + this.serverAppId_ + '")' :
+                 '(which is the own app)') +
+            '...');
     const connectInfo = {'name': this.clientTitle};
     let port;
     if (this.serverAppId_ !== undefined) {
@@ -203,7 +205,7 @@ Context.prototype.disposeInternal = function() {
     this.channel_ = null;
   }
 
-  this.logger.fine('Disposed');
+  goog.log.fine(this.logger, 'Disposed');
 
   Context.base(this, 'disposeInternal');
 };
@@ -213,7 +215,7 @@ Context.prototype.messageChannelEstablishedListener_ = function() {
   if (this.isDisposed() || this.channel_.isDisposed())
     return;
 
-  this.logger.fine('Message channel was established successfully');
+  goog.log.fine(this.logger, 'Message channel was established successfully');
 
   GSC.Logging.checkWithLogger(this.logger, this.api === null);
   GSC.Logging.checkWithLogger(this.logger, this.channel_ !== null);
@@ -229,7 +231,7 @@ Context.prototype.messageChannelEstablishedListener_ = function() {
 
 /** @private */
 Context.prototype.messageChannelDisposedListener_ = function() {
-  this.logger.fine('Message channel was disposed, disposing...');
+  goog.log.fine(this.logger, 'Message channel was disposed, disposing...');
   this.dispose();
 };
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/js_client/src/reader-tracker-through-pcsc-api.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/reader-tracker-through-pcsc-api.js
@@ -29,6 +29,7 @@ goog.require('GoogleSmartCard.PcscLiteClient.Context');
 goog.require('goog.array');
 goog.require('goog.async.nextTick');
 goog.require('goog.iter');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 goog.require('goog.object');
@@ -118,7 +119,7 @@ ReaderTrackerThroughPcscApi.prototype.getReaders = function() {
  */
 ReaderTrackerThroughPcscApi.prototype.startStatusTracking_ = function(
     pcscContextMessageChannel) {
-  this.logger_.fine('Started tracking through PC/SC API');
+  goog.log.fine(this.logger_, 'Started tracking through PC/SC API');
 
   const promise =
       this.makeApiPromise_(pcscContextMessageChannel).then(function(api) {
@@ -206,9 +207,10 @@ ReaderTrackerThroughPcscApi.prototype.startStatusTrackingWithApi_ = function(
 ReaderTrackerThroughPcscApi.prototype.addPromiseErrorHandler_ = function(
     promise) {
   promise.thenCatch(function(error) {
-    this.logger_.warning(
+    goog.log.warning(
+        this.logger_,
         'Stopped tracking through PC/SC API: ' +
-        (/** @type {{message:string}} */ (error)).message);
+            (/** @type {{message:string}} */ (error)).message);
     this.updateResult_([]);
   }, this);
 };
@@ -315,10 +317,11 @@ ReaderTrackerThroughPcscApi.prototype.makeReaderStatesPromise_ = function(
                 promiseResolver.resolve.bind(promiseResolver),
                 function(errorCode) {
                   if (errorCode == API.SCARD_E_UNKNOWN_READER) {
-                    this.logger_.warning(
+                    goog.log.warning(
+                        this.logger_,
                         'Getting the statuses of the readers from PC/SC finished ' +
-                        'unsuccessfully due to removal of the tracked reader. A ' +
-                        'retry will be attempted after some delay');
+                            'unsuccessfully due to removal of the tracked reader. A ' +
+                            'retry will be attempted after some delay');
                     promiseResolver.resolve(null);
                   } else {
                     promiseResolver.reject(new Error(
@@ -386,9 +389,10 @@ ReaderTrackerThroughPcscApi.prototype.makeReaderStatesChangePromise_ = function(
   readerStatesIn.push(new API.SCARD_READERSTATE_IN(
       '\\\\?PnP?\\Notification', API.SCARD_STATE_UNAWARE));
 
-  this.logger_.fine(
+  goog.log.fine(
+      this.logger_,
       'Waiting for the reader statuses change from PC/SC with the following ' +
-      'data: ' + GSC.DebugDump.dump(readerStatesIn) + '...');
+          'data: ' + GSC.DebugDump.dump(readerStatesIn) + '...');
 
   api.SCardGetStatusChange(
          sCardContext, READER_STATUS_QUERY_TIMEOUT_MILLISECONDS, readerStatesIn)
@@ -396,21 +400,24 @@ ReaderTrackerThroughPcscApi.prototype.makeReaderStatesChangePromise_ = function(
           function(result) {
             result.get(
                 function(readerStatesOut) {
-                  this.logger_.fine(
+                  goog.log.fine(
+                      this.logger_,
                       'Received a reader statuses change event from PC/SC: ' +
-                      GSC.DebugDump.dump(readerStatesOut));
+                          GSC.DebugDump.dump(readerStatesOut));
                   promiseResolver.resolve();
                 },
                 function(errorCode) {
                   if (errorCode == API.SCARD_E_TIMEOUT) {
-                    this.logger_.fine(
+                    goog.log.fine(
+                        this.logger_,
                         'No reader statuses changes were reported by PC/SC ' +
-                        'within the timeout');
+                            'within the timeout');
                     promiseResolver.resolve();
                   } else if (errorCode == API.SCARD_E_UNKNOWN_READER) {
-                    this.logger_.warning(
+                    goog.log.warning(
+                        this.logger_,
                         'Waiting for the reader statuses changes from PC/SC finished ' +
-                        'unsuccessfully due to removal of the tracked reader');
+                            'unsuccessfully due to removal of the tracked reader');
                     promiseResolver.resolve();
                   } else {
                     promiseResolver.reject(new Error(
@@ -445,10 +452,11 @@ ReaderTrackerThroughPcscApi.prototype.updateResult_ = function(result) {
     return '"' + readerInfo.name + '"' +
         (readerInfo.isCardPresent ? ' (with inserted card)' : '');
   });
-  this.logger_.info(
+  goog.log.info(
+      this.logger_,
       'Information about readers returned by PC/SC: ' +
-      (dumpedResults.length ? goog.iter.join(dumpedResults, ', ') :
-                              'no readers'));
+          (dumpedResults.length ? goog.iter.join(dumpedResults, ', ') :
+                                  'no readers'));
 
   this.result_ = result;
   this.updateListener_();

--- a/third_party/pcsc-lite/naclport/js_demo/src/demo.js
+++ b/third_party/pcsc-lite/naclport/js_demo/src/demo.js
@@ -38,6 +38,7 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PcscLiteClient.API');
 goog.require('goog.array');
 goog.require('goog.iter');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.object');
 
@@ -72,7 +73,7 @@ function startDemo(api, onDemoSucceeded, onDemoFailed) {
 }
 
 function establishContext(api, onDemoSucceeded, onDemoFailed) {
-  logger.info('Establishing a context...');
+  goog.log.info(logger, 'Establishing a context...');
   api.SCardEstablishContext(API.SCARD_SCOPE_SYSTEM, null, null)
       .then(function(result) {
         result.get(
@@ -83,12 +84,12 @@ function establishContext(api, onDemoSucceeded, onDemoFailed) {
 
 function onContextEstablished(
     api, onDemoSucceeded, onDemoFailed, sCardContext) {
-  logger.info('Established a new context: ' + dump(sCardContext));
+  goog.log.info(logger, 'Established a new context: ' + dump(sCardContext));
   validateContext(api, onDemoSucceeded, onDemoFailed, sCardContext);
 }
 
 function validateContext(api, onDemoSucceeded, onDemoFailed, sCardContext) {
-  logger.info('Validating the context...');
+  goog.log.info(logger, 'Validating the context...');
   api.SCardIsValidContext(sCardContext).then(function(result) {
     result.get(
         onContextValidated.bind(
@@ -98,13 +99,13 @@ function validateContext(api, onDemoSucceeded, onDemoFailed, sCardContext) {
 }
 
 function onContextValidated(api, onDemoSucceeded, onDemoFailed, sCardContext) {
-  logger.info('Context checked successfully');
+  goog.log.info(logger, 'Context checked successfully');
   validateInvalidContext(api, onDemoSucceeded, onDemoFailed, sCardContext);
 }
 
 function validateInvalidContext(
     api, onDemoSucceeded, onDemoFailed, sCardContext) {
-  logger.info('Validating an invalid context...');
+  goog.log.info(logger, 'Validating an invalid context...');
   api.SCardIsValidContext(sCardContext + 1).then(function(result) {
     result.get(
         onInvalidContextAccepted.bind(
@@ -116,19 +117,20 @@ function validateInvalidContext(
 
 function onInvalidContextAccepted(
     api, onDemoSucceeded, onDemoFailed, sCardContext) {
-  logger.warning('failed: the invalid context was accepted');
+  goog.log.warning(logger, 'failed: the invalid context was accepted');
   onDemoFailed();
 }
 
 function onInvalidContextRejected(
     api, onDemoSucceeded, onDemoFailed, sCardContext) {
-  logger.info('OK, the invalid context was rejected');
+  goog.log.info(logger, 'OK, the invalid context was rejected');
   waitForReadersChange(api, onDemoSucceeded, onDemoFailed, sCardContext);
 }
 
 function waitForReadersChange(
     api, onDemoSucceeded, onDemoFailed, sCardContext) {
-  logger.info('Waiting ' + TIMEOUT_SECONDS + ' seconds for readers change...');
+  goog.log.info(
+      logger, 'Waiting ' + TIMEOUT_SECONDS + ' seconds for readers change...');
   api.SCardGetStatusChange(
          sCardContext, TIMEOUT_SECONDS * 1000,
          [API.createSCardReaderStateIn(
@@ -145,27 +147,29 @@ function waitForReadersChange(
 function onReadersChanged(
     api, onDemoSucceeded, onDemoFailed, sCardContext, readerStates) {
   if (readerStates.length != 1) {
-    logger.warning('failed: returned invalid number of reader states');
+    goog.log.warning(
+        logger, 'failed: returned invalid number of reader states');
     onDemoFailed();
     return;
   }
   if (readerStates[0]['reader_name'] != SPECIAL_READER_NAME) {
-    logger.warning('failed: returned wrong reader name');
+    goog.log.warning(logger, 'failed: returned wrong reader name');
     onDemoFailed();
     return;
   }
   if (readerStates[0]['user_data'] != 0xDEADBEEF) {
-    logger.warning('failed: returned wrong reader name');
+    goog.log.warning(logger, 'failed: returned wrong reader name');
     onDemoFailed();
     return;
   }
   if (!(readerStates[0]['event_state'] & API.SCARD_STATE_CHANGED)) {
-    logger.warning(
+    goog.log.warning(
+        logger,
         'failed: returned current state mask without SCARD_STATE_CHANGED bit');
     onDemoFailed();
     return;
   }
-  logger.info('Caught readers change: ' + dump(readerStates));
+  goog.log.info(logger, 'Caught readers change: ' + dump(readerStates));
   listReaderGroups(api, onDemoSucceeded, onDemoFailed, sCardContext);
 }
 
@@ -175,12 +179,12 @@ function onReadersChangeWaitingFailed(
     onPcscLiteError(api, onDemoFailed, errorCode);
     return;
   }
-  logger.info('No readers change events were caught');
+  goog.log.info(logger, 'No readers change events were caught');
   listReaderGroups(api, onDemoSucceeded, onDemoFailed, sCardContext);
 }
 
 function listReaderGroups(api, onDemoSucceeded, onDemoFailed, sCardContext) {
-  logger.info('Listing reader groups...');
+  goog.log.info(logger, 'Listing reader groups...');
   api.SCardListReaderGroups(sCardContext).then(function(result) {
     result.get(
         onReaderGroupsListed.bind(
@@ -191,11 +195,12 @@ function listReaderGroups(api, onDemoSucceeded, onDemoFailed, sCardContext) {
 
 function onReaderGroupsListed(
     api, onDemoSucceeded, onDemoFailed, sCardContext, readerGroups) {
-  logger.info(
+  goog.log.info(
+      logger,
       'Listed reader groups: ' +
-      goog.iter.join(goog.iter.map(readerGroups, dump), ', '));
+          goog.iter.join(goog.iter.map(readerGroups, dump), ', '));
   if (!readerGroups) {
-    logger.warning('failed: no reader groups found');
+    goog.log.warning(logger, 'failed: no reader groups found');
     onDemoFailed();
     return;
   }
@@ -203,7 +208,7 @@ function onReaderGroupsListed(
 }
 
 function listReaders(api, onDemoSucceeded, onDemoFailed, sCardContext) {
-  logger.info('Listing readers...');
+  goog.log.info(logger, 'Listing readers...');
   api.SCardListReaders(sCardContext, null).then(function(result) {
     result.get(
         onReadersListed.bind(
@@ -214,10 +219,11 @@ function listReaders(api, onDemoSucceeded, onDemoFailed, sCardContext) {
 
 function onReadersListed(
     api, onDemoSucceeded, onDemoFailed, sCardContext, readers) {
-  logger.info(
+  goog.log.info(
+      logger,
       'Listed readers: ' + goog.iter.join(goog.iter.map(readers, dump), ', '));
   if (!readers) {
-    logger.warning('failed: no readers found');
+    goog.log.warning(logger, 'failed: no readers found');
     onDemoFailed();
     return;
   }
@@ -227,9 +233,10 @@ function onReadersListed(
 
 function waitForCardRemoval(
     api, onDemoSucceeded, onDemoFailed, sCardContext, readerName) {
-  logger.info(
+  goog.log.info(
+      logger,
       'Waiting ' + TIMEOUT_SECONDS + ' seconds for card removal ' +
-      'from ' + dump(readerName) + ' reader...');
+          'from ' + dump(readerName) + ' reader...');
   api.SCardGetStatusChange(
          sCardContext, TIMEOUT_SECONDS * 1000,
          [API.createSCardReaderStateIn(readerName, API.SCARD_STATE_PRESENT)])
@@ -247,7 +254,7 @@ function waitForCardRemoval(
 function onCardRemoved(
     api, onDemoSucceeded, onDemoFailed, sCardContext, readerName,
     readerStates) {
-  logger.info('Caught card removal: ' + dump(readerStates));
+  goog.log.info(logger, 'Caught card removal: ' + dump(readerStates));
   waitForCardInsertion(
       api, onDemoSucceeded, onDemoFailed, sCardContext, readerName);
 }
@@ -258,16 +265,17 @@ function onCardRemovalWaitingFailed(
     onPcscLiteError(api, onDemoFailed, errorCode);
     return;
   }
-  logger.info('No card removal events were caught');
+  goog.log.info(logger, 'No card removal events were caught');
   waitForCardInsertion(
       api, onDemoSucceeded, onDemoFailed, sCardContext, readerName);
 }
 
 function waitForCardInsertion(
     api, onDemoSucceeded, onDemoFailed, sCardContext, readerName) {
-  logger.info(
+  goog.log.info(
+      logger,
       'Waiting ' + TIMEOUT_SECONDS + ' seconds for card insertion ' +
-      'into ' + dump(readerName) + ' reader...');
+          'into ' + dump(readerName) + ' reader...');
   api.SCardGetStatusChange(
          sCardContext, TIMEOUT_SECONDS * 1000,
          [API.createSCardReaderStateIn(readerName, API.SCARD_STATE_EMPTY)])
@@ -283,15 +291,16 @@ function waitForCardInsertion(
 function onCardInserted(
     api, onDemoSucceeded, onDemoFailed, sCardContext, readerName,
     readerStates) {
-  logger.info('Caught card insertion: ' + dump(readerStates));
+  goog.log.info(logger, 'Caught card insertion: ' + dump(readerStates));
   waitAndCancel(api, onDemoSucceeded, onDemoFailed, sCardContext, readerName);
 }
 
 function waitAndCancel(
     api, onDemoSucceeded, onDemoFailed, sCardContext, readerName) {
-  logger.info(
+  goog.log.info(
+      logger,
       'Started waiting for card removal from ' + dump(readerName) +
-      ' reader...');
+          ' reader...');
   api.SCardGetStatusChange(
          sCardContext, TIMEOUT_SECONDS * 1000,
          [goog.object.create(
@@ -305,7 +314,7 @@ function waitAndCancel(
                 null, api, onDemoSucceeded, onDemoFailed, sCardContext,
                 readerName));
       }, onFailure.bind(null, onDemoFailed));
-  logger.info('Cancelling the waiting...');
+  goog.log.info(logger, 'Cancelling the waiting...');
   api.SCardCancel(sCardContext).then(function(result) {
     result.get(
         onCancelSucceeded, onPcscLiteError.bind(null, api, onDemoFailed));
@@ -322,17 +331,18 @@ function onCancelingWaitingFailed(
 }
 
 function onCancelingWaitingFinished(api, onDemoSucceeded, onDemoFailed) {
-  logger.warning(
+  goog.log.warning(
+      logger,
       'failed: the waiting finished successfully despite the cancellation');
   onDemoFailed();
 }
 
 function onCancelSucceeded() {
-  logger.info('Successfully initiated cancelling of the waiting');
+  goog.log.info(logger, 'Successfully initiated cancelling of the waiting');
 }
 
 function connect(api, onDemoSucceeded, onDemoFailed, sCardContext, readerName) {
-  logger.info('Connecting to the reader ' + dump(readerName) + '...');
+  goog.log.info(logger, 'Connecting to the reader ' + dump(readerName) + '...');
   api.SCardConnect(
          sCardContext, readerName, API.SCARD_SHARE_SHARED,
          API.SCARD_PROTOCOL_ANY)
@@ -347,16 +357,17 @@ function connect(api, onDemoSucceeded, onDemoFailed, sCardContext, readerName) {
 function onConnected(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle,
     activeProtocol) {
-  logger.info(
+  goog.log.info(
+      logger,
       'Successfully connected, handle is: ' + dump(sCardHandle) +
-      ', active protocol is: ' +
-      getProtocolDebugRepresentation(activeProtocol));
+          ', active protocol is: ' +
+          getProtocolDebugRepresentation(activeProtocol));
   reconnect(api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle);
 }
 
 function reconnect(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle) {
-  logger.info('Reconnecting to the card...');
+  goog.log.info(logger, 'Reconnecting to the card...');
   api.SCardReconnect(
          sCardHandle, API.SCARD_SHARE_SHARED, API.SCARD_PROTOCOL_ANY,
          API.SCARD_LEAVE_CARD)
@@ -371,13 +382,13 @@ function reconnect(
 
 function onReconnected(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle) {
-  logger.info('Successfully reconnected');
+  goog.log.info(logger, 'Successfully reconnected');
   getStatus(api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle);
 }
 
 function getStatus(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle) {
-  logger.info('Obtaining card status...');
+  goog.log.info(logger, 'Obtaining card status...');
   api.SCardStatus(sCardHandle).then(function(result) {
     result.get(
         onStatusGot.bind(
@@ -390,10 +401,11 @@ function getStatus(
 function onStatusGot(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, readerName,
     state, protocol, atr) {
-  logger.info(
+  goog.log.info(
+      logger,
       'Card status obtained: reader name is ' + dump(readerName) + ', ' +
-      'state is ' + dump(state) + ', protocol is ' +
-      getProtocolDebugRepresentation(protocol) + ', atr is ' + dump(atr));
+          'state is ' + dump(state) + ', protocol is ' +
+          getProtocolDebugRepresentation(protocol) + ', atr is ' + dump(atr));
   getAttrs(
       api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol,
       0);
@@ -410,13 +422,14 @@ function getAttrs(
     return;
   }
   const attrName = attrNames[attrIndex];
-  logger.fine('Requesting the ' + dump(attrName) + ' attribute...');
+  goog.log.fine(logger, 'Requesting the ' + dump(attrName) + ' attribute...');
   api.SCardGetAttrib(sCardHandle, API[attrName]).then(function(result) {
     result.get(
         function(attrValue) {
-          logger.info(
+          goog.log.info(
+              logger,
               'The ' + dump(attrName) +
-              ' attribute value is: ' + dump(attrValue));
+                  ' attribute value is: ' + dump(attrValue));
           getAttrs(
               api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle,
               protocol, attrIndex + 1);
@@ -439,7 +452,8 @@ function setAttr(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol) {
   const ATTR_NAME = 'SCARD_ATTR_DEVICE_FRIENDLY_NAME_A';
   const ATTR_VALUE = [0x54, 0x65, 0x73, 0x74];
-  logger.info(
+  goog.log.info(
+      logger,
       'Setting the ' + dump(ATTR_NAME) + ' attribute to ' + dump(ATTR_VALUE));
   api.SCardSetAttrib(sCardHandle, API[ATTR_NAME], ATTR_VALUE)
       .then(function(result) {
@@ -455,7 +469,7 @@ function setAttr(
 
 function onAttrSet(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol) {
-  logger.info('The attribute was set successfully');
+  goog.log.info(logger, 'The attribute was set successfully');
   beginTransaction(
       api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol);
 }
@@ -463,16 +477,17 @@ function onAttrSet(
 function onAttrSetFailed(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol,
     errorCode) {
-  logger.info(
+  goog.log.info(
+      logger,
       'The attribute set was unsuccessful (error code: ' + dump(errorCode) +
-      ')');
+          ')');
   beginTransaction(
       api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol);
 }
 
 function beginTransaction(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol) {
-  logger.info('Beginning transaction...');
+  goog.log.info(logger, 'Beginning transaction...');
   api.SCardBeginTransaction(sCardHandle).then(function(result) {
     result.get(
         onTransactionBegun.bind(
@@ -484,14 +499,15 @@ function beginTransaction(
 
 function onTransactionBegun(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol) {
-  logger.info('Transaction begun successfully');
+  goog.log.info(logger, 'Transaction begun successfully');
   sendControlCommand(
       api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol);
 }
 
 function sendControlCommand(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol) {
-  logger.info('Sending the CM_IOCTL_GET_FEATURE_REQUEST control command...');
+  goog.log.info(
+      logger, 'Sending the CM_IOCTL_GET_FEATURE_REQUEST control command...');
   api.SCardControl(sCardHandle, API.CM_IOCTL_GET_FEATURE_REQUEST, [])
       .then(function(result) {
         result.get(
@@ -505,9 +521,10 @@ function sendControlCommand(
 function onControlCommandSent(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol,
     responseData) {
-  logger.info(
+  goog.log.info(
+      logger,
       'The CM_IOCTL_GET_FEATURE_REQUEST control command returned: ' +
-      dump(responseData));
+          dump(responseData));
   sendTransmitCommand(
       api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol);
 }
@@ -515,9 +532,10 @@ function onControlCommandSent(
 function sendTransmitCommand(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol) {
   const LIST_DIR_APDU = [0x00, 0xA4, 0x00, 0x00, 0x02, 0x3F, 0x00, 0x00];
-  logger.info(
+  goog.log.info(
+      logger,
       'Sending the transmit command with "list dir" APDU ' +
-      dump(LIST_DIR_APDU) + '...');
+          dump(LIST_DIR_APDU) + '...');
   api.SCardTransmit(
          sCardHandle,
          protocol == API.SCARD_PROTOCOL_T0 ? API.SCARD_PCI_T0 :
@@ -535,15 +553,17 @@ function sendTransmitCommand(
 function onTransmitCommandSent(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol,
     responseProtocolInformation, responseData) {
-  logger.info(
+  goog.log.info(
+      logger,
       'The transmit command returned: ' + dump(responseData) + ', the ' +
-      'response protocol information is: ' + dump(responseProtocolInformation));
+          'response protocol information is: ' +
+          dump(responseProtocolInformation));
   endTransaction(api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle);
 }
 
 function endTransaction(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle) {
-  logger.info('Ending the transaction...');
+  goog.log.info(logger, 'Ending the transaction...');
   api.SCardEndTransaction(sCardHandle, API.SCARD_LEAVE_CARD)
       .then(function(result) {
         result.get(
@@ -556,13 +576,13 @@ function endTransaction(
 
 function onTransactionEnded(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle) {
-  logger.info('Transaction ended successfully');
+  goog.log.info(logger, 'Transaction ended successfully');
   disconnect(api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle);
 }
 
 function disconnect(
     api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle) {
-  logger.info('Disconnecting from the reader...');
+  goog.log.info(logger, 'Disconnecting from the reader...');
   api.SCardDisconnect(sCardHandle, API.SCARD_LEAVE_CARD).then(function(result) {
     result.get(
         onDisconnected.bind(
@@ -572,12 +592,12 @@ function disconnect(
 }
 
 function onDisconnected(api, onDemoSucceeded, onDemoFailed, sCardContext) {
-  logger.info('Disconnected successfully');
+  goog.log.info(logger, 'Disconnected successfully');
   releaseContext(api, onDemoSucceeded, onDemoFailed, sCardContext);
 }
 
 function releaseContext(api, onDemoSucceeded, onDemoFailed, sCardContext) {
-  logger.info('Releasing the context...');
+  goog.log.info(logger, 'Releasing the context...');
   api.SCardReleaseContext(sCardContext).then(function(result) {
     result.get(
         onContextReleased.bind(null, api, onDemoSucceeded, onDemoFailed),
@@ -586,15 +606,15 @@ function releaseContext(api, onDemoSucceeded, onDemoFailed, sCardContext) {
 }
 
 function onContextReleased(api, onDemoSucceeded, onDemoFailed) {
-  logger.info('Released the context');
+  goog.log.info(logger, 'Released the context');
   onDemoSucceeded();
 }
 
 function onPcscLiteError(api, onDemoFailed, errorCode) {
-  logger.warning('failed: PC/SC-Lite error: ' + dump(errorCode));
+  goog.log.warning(logger, 'failed: PC/SC-Lite error: ' + dump(errorCode));
   api.pcsc_stringify_error(errorCode).then(
       function(errorText) {
-        logger.warning('PC/SC-Lite error text: ' + errorText);
+        goog.log.warning(logger, 'PC/SC-Lite error text: ' + errorText);
         onDemoFailed();
       },
       function() {
@@ -603,7 +623,7 @@ function onPcscLiteError(api, onDemoFailed, errorCode) {
 }
 
 function onFailure(onDemoFailed, error) {
-  logger.warning('failed: ' + error);
+  goog.log.warning(logger, 'failed: ' + error);
   onDemoFailed();
 }
 

--- a/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
+++ b/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
@@ -33,6 +33,7 @@ goog.require('GoogleSmartCard.TypedMessage');
 goog.require('goog.Promise');
 goog.require('goog.Timer');
 goog.require('goog.array');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 goog.require('goog.promise.Resolver');
@@ -111,7 +112,7 @@ GSC.PcscLiteServer.ReaderTracker = function(
           this.logger_, pcscContextMessageChannel,
           this.fireOnUpdateListeners_.bind(this));
 
-  this.logger_.fine('Initialized');
+  goog.log.fine(this.logger_, 'Initialized');
 };
 
 const ReaderTracker = GSC.PcscLiteServer.ReaderTracker;
@@ -126,7 +127,7 @@ const ReaderTracker = GSC.PcscLiteServer.ReaderTracker;
  */
 ReaderTracker.prototype.addOnUpdateListener = function(listener) {
   this.updateListeners_.push(listener);
-  this.logger_.fine('Added an update listener');
+  goog.log.fine(this.logger_, 'Added an update listener');
 
   listener(this.getReaders());
 };
@@ -137,11 +138,12 @@ ReaderTracker.prototype.addOnUpdateListener = function(listener) {
  */
 ReaderTracker.prototype.removeOnUpdateListener = function(listener) {
   if (goog.array.remove(this.updateListeners_, listener)) {
-    this.logger_.fine('Removed an update listener');
+    goog.log.fine(this.logger_, 'Removed an update listener');
   } else {
-    this.logger_.warning(
+    goog.log.warning(
+        this.logger_,
         'Failed to remove an update listener: the passed ' +
-        'function was not found');
+            'function was not found');
   }
 };
 
@@ -179,9 +181,10 @@ ReaderTracker.prototype.getReaders = function() {
  */
 ReaderTracker.prototype.fireOnUpdateListeners_ = function() {
   const readers = this.getReaders();
-  this.logger_.fine(
+  goog.log.fine(
+      this.logger_,
       'Firing readers updated listeners with data ' +
-      GSC.DebugDump.dump(readers));
+          GSC.DebugDump.dump(readers));
   for (let listener of this.updateListeners_) {
     listener(readers);
   }
@@ -253,9 +256,10 @@ TrackerThroughPcscServerHook.prototype.readerInitAddListener_ = function(
   /** @type {string} */
   const device = GSC.MessagingCommon.extractKey(message, 'device');
 
-  this.logger_.info(
+  goog.log.info(
+      this.logger_,
       'A new reader "' + name + '" (port ' + port + ', device "' + device +
-      '") is being initialized...');
+          '") is being initialized...');
 
   GSC.Logging.checkWithLogger(
       this.logger_, !this.portToReaderInfoMap_.has(port),
@@ -286,19 +290,22 @@ TrackerThroughPcscServerHook.prototype.readerFinishAddListener_ = function(
   const readerTitleForLog =
       '"' + name + '" (port ' + port + ', device "' + device + '")';
   if (returnCode === 0) {
-    this.logger_.info(
+    goog.log.info(
+        this.logger_,
         'The reader ' + readerTitleForLog + ' was successfully ' +
-        'initialized');
+            'initialized');
     readerInfo = new ReaderInfo(name, ReaderStatus.SUCCESS);
   } else if (this.shouldHideFailedReader_(device)) {
-    this.logger_.info(
+    goog.log.info(
+        this.logger_,
         'Silent error while initializing the reader ' + readerTitleForLog +
-        ': error code ' + returnCodeHex +
-        '. This reader will be hidden from UI.');
+            ': error code ' + returnCodeHex +
+            '. This reader will be hidden from UI.');
   } else {
-    this.logger_.warning(
+    goog.log.warning(
+        this.logger_,
         'Failure while initializing the reader ' + readerTitleForLog +
-        ': error code ' + returnCodeHex);
+            ': error code ' + returnCodeHex);
     readerInfo = new ReaderInfo(name, ReaderStatus.FAILURE, returnCodeHex);
   }
 
@@ -324,7 +331,8 @@ TrackerThroughPcscServerHook.prototype.readerRemoveListener_ = function(
   /** @type {number} */
   const port = GSC.MessagingCommon.extractKey(message, 'port');
 
-  this.logger_.info(
+  goog.log.info(
+      this.logger_,
       'The reader "' + name + '" (port ' + port + ') was removed');
 
   GSC.Logging.checkWithLogger(

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
@@ -42,6 +42,7 @@ goog.require('goog.Promise');
 goog.require('goog.asserts');
 goog.require('goog.iter');
 goog.require('goog.iter.Iterator');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 goog.require('goog.object');
@@ -219,7 +220,7 @@ GSC.PcscLiteServerClientsManagement.ClientHandler = function(
 
   this.addChannelDisposedListeners_();
 
-  this.logger.fine('Initialized');
+  goog.log.fine(this.logger, 'Initialized');
 };
 
 const ClientHandler = GSC.PcscLiteServerClientsManagement.ClientHandler;
@@ -285,7 +286,7 @@ ClientHandler.prototype.disposeInternal = function() {
 
   this.requestReceiver_ = null;
 
-  this.logger.fine('Disposed');
+  goog.log.fine(this.logger, 'Disposed');
 
   ClientHandler.base(this, 'disposeInternal');
 };
@@ -304,16 +305,18 @@ ClientHandler.prototype.handleRequest_ = function(payload) {
 
   const remoteCallMessage = RemoteCallMessage.parseRequestPayload(payload);
   if (!remoteCallMessage) {
-    this.logger.warning(
+    goog.log.warning(
+        this.logger,
         'Failed to parse the received request payload: ' +
-        GSC.DebugDump.debugDump(payload));
+            GSC.DebugDump.debugDump(payload));
     return goog.Promise.reject(
         new Error('Failed to parse the received request payload'));
   }
 
-  this.logger.fine(
+  goog.log.fine(
+      this.logger,
       'Received a remote call request: ' +
-      remoteCallMessage.getDebugRepresentation());
+          remoteCallMessage.getDebugRepresentation());
 
   return this.deferredProcessor_.addJob(
       this.postRequestToServer_.bind(this, remoteCallMessage));
@@ -330,12 +333,14 @@ ClientHandler.prototype.getPermissionsCheckPromise_ = function() {
       .then(
           function() {
             if (this.clientAppId_ !== null) {
-              this.logger.info(
+              goog.log.info(
+                  this.logger,
                   'Client was granted permissions to issue PC/SC requests');
             }
           },
           function(error) {
-            this.logger.warning(
+            goog.log.warning(
+                this.logger,
                 'Client permission denied. All PC/SC requests will be rejected');
             throw error;
           },
@@ -364,7 +369,8 @@ ClientHandler.prototype.addChannelDisposedListeners_ = function() {
 ClientHandler.prototype.serverMessageChannelDisposedListener_ = function() {
   if (this.isDisposed())
     return;
-  this.logger.warning('Server message channel was disposed, disposing...');
+  goog.log.warning(
+      this.logger, 'Server message channel was disposed, disposing...');
 
   // Note: this assignment is important because it prevents from sending of any
   // messages through the server message channel, which is normally happening
@@ -386,9 +392,9 @@ ClientHandler.prototype.clientMessageChannelDisposedListener_ = function() {
     return;
   const logMessage = 'Client message channel was disposed, disposing...';
   if (this.clientAppId_ === null)
-    this.logger.fine(logMessage);
+    goog.log.fine(this.logger, logMessage);
   else
-    this.logger.info(logMessage);
+    goog.log.info(this.logger, logMessage);
   this.dispose();
 };
 
@@ -402,9 +408,10 @@ ClientHandler.prototype.clientMessageChannelDisposedListener_ = function() {
  * @private
  */
 ClientHandler.prototype.postRequestToServer_ = function(remoteCallMessage) {
-  this.logger.fine(
+  goog.log.fine(
+      this.logger,
       'Started processing the remote call request: ' +
-      remoteCallMessage.getDebugRepresentation());
+          remoteCallMessage.getDebugRepresentation());
 
   this.createServerRequesterIfNeed_();
 
@@ -412,21 +419,23 @@ ClientHandler.prototype.postRequestToServer_ = function(remoteCallMessage) {
       .postRequest(remoteCallMessage.makeRequestPayload())
       .then(
           function(result) {
-            this.logger.fine(
+            goog.log.fine(
+                this.logger,
                 'The remote call request ' +
-                remoteCallMessage.getDebugRepresentation() +
-                ' finished successfully' +
-                (goog.DEBUG ? ' with the following result: ' +
-                         GSC.DebugDump.debugDump(result) :
-                              ''));
+                    remoteCallMessage.getDebugRepresentation() +
+                    ' finished successfully' +
+                    (goog.DEBUG ? ' with the following result: ' +
+                             GSC.DebugDump.debugDump(result) :
+                                  ''));
             return result;
           },
           function(error) {
-            this.logger.warning(
+            goog.log.warning(
+                this.logger,
                 'The remote call request ' +
-                remoteCallMessage.getDebugRepresentation() +
-                ' failed with the ' +
-                'following error: ' + error);
+                    remoteCallMessage.getDebugRepresentation() +
+                    ' failed with the ' +
+                    'following error: ' + error);
             throw error;
           },
           this);

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/checker.js
@@ -33,6 +33,7 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.ManagedRegistry');
 goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.UserPromptingChecker');
 goog.require('goog.Promise');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.promise.Resolver');
 
@@ -83,12 +84,15 @@ Checker.prototype.logger = GSC.Logging.getScopedLogger(
  * @return {!goog.Promise}
  */
 Checker.prototype.check = function(clientAppId) {
-  this.logger.finer(
+  goog.log.log(
+      this.logger, goog.log.Level.FINER,
       'Checking permissions for client App with id ' +
-      GSC.DebugDump.dump(clientAppId) + '...');
+          GSC.DebugDump.dump(clientAppId) + '...');
 
   if (clientAppId === null) {
-    this.logger.finer('Granted permissions for client with null App id');
+    goog.log.log(
+        this.logger, goog.log.Level.FINER,
+        'Granted permissions for client with null App id');
     return goog.Promise.resolve();
   }
 
@@ -106,22 +110,25 @@ Checker.prototype.check = function(clientAppId) {
  */
 Checker.prototype.checkByManagedRegistry_ = function(
     clientAppId, checkPromiseResolver) {
-  this.logger.finer(
+  goog.log.log(
+      this.logger, goog.log.Level.FINER,
       'Checking permissions for the client App with id "' + clientAppId +
-      '" through the managed registry...');
+          '" through the managed registry...');
 
   this.managedRegistry_.getById(clientAppId)
       .then(
           function() {
-            this.logger.finer(
+            goog.log.log(
+                this.logger, goog.log.Level.FINER,
                 'Granted permissions for client App with id "' + clientAppId +
-                '" through the managed registry');
+                    '" through the managed registry');
             checkPromiseResolver.resolve();
           },
           function() {
-            this.logger.finer(
+            goog.log.log(
+                this.logger, goog.log.Level.FINER,
                 'No permissions found for client App with id "' + clientAppId +
-                '" through the managed registry');
+                    '" through the managed registry');
             this.checkByUserPromptingChecker_(
                 clientAppId, checkPromiseResolver);
           },

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/known-apps-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/known-apps-registry.js
@@ -34,6 +34,7 @@ goog.require('GoogleSmartCard.Json');
 goog.require('GoogleSmartCard.Logging');
 goog.require('goog.Promise');
 goog.require('goog.asserts');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.net.XhrIo');
 goog.require('goog.object');
@@ -152,9 +153,10 @@ KnownAppsRegistry.prototype.tryGetByIds = function(idList) {
 
 /** @private */
 KnownAppsRegistry.prototype.startLoadingJson_ = function() {
-  this.logger.fine(
+  goog.log.fine(
+      this.logger,
       'Loading registry from JSON file (URL: "' + KNOWN_CLIENT_APPS_JSON_URL +
-      '")...');
+          '")...');
   goog.net.XhrIo.send(
       KNOWN_CLIENT_APPS_JSON_URL, this.jsonLoadedCallback_.bind(this));
 };
@@ -209,17 +211,19 @@ KnownAppsRegistry.prototype.parseJsonAndApply_ = function(json) {
     if (knownApp) {
       knownClientApps.set(knownApp.id, knownApp);
     } else {
-      this.logger.warning(
+      goog.log.warning(
+          this.logger,
           'Failed to parse the following known Apps registry JSON item: key="' +
-          key + '", value=' + GSC.DebugDump.dump(value));
+              key + '", value=' + GSC.DebugDump.dump(value));
       success = false;
     }
   }, this);
 
   if (success) {
-    this.logger.fine(
+    goog.log.fine(
+        this.logger,
         'Successfully loaded registry from JSON file: ' +
-        GSC.DebugDump.dump(knownClientApps));
+            GSC.DebugDump.dump(knownClientApps));
     this.promiseResolver_.resolve(knownClientApps);
   } else {
     this.promiseResolver_.reject(

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
@@ -31,6 +31,7 @@ goog.provide('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsCheckin
 goog.require('GoogleSmartCard.Logging');
 goog.require('goog.Promise');
 goog.require('goog.array');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.object');
 goog.require('goog.promise.Resolver');
@@ -107,9 +108,10 @@ ManagedRegistry.prototype.getById = function(clientAppId) {
 
 /** @private */
 ManagedRegistry.prototype.loadManagedStorage_ = function() {
-  this.logger.fine(
+  goog.log.fine(
+      this.logger,
       'Loading managed storage data with the allowed client App ids (the key ' +
-      'is "' + MANAGED_STORAGE_KEY + '")...');
+          'is "' + MANAGED_STORAGE_KEY + '")...');
   chrome.storage.managed.get(
       MANAGED_STORAGE_KEY, this.managedStorageLoadedCallback_.bind(this));
 };
@@ -119,15 +121,17 @@ ManagedRegistry.prototype.loadManagedStorage_ = function() {
  * @private
  */
 ManagedRegistry.prototype.managedStorageLoadedCallback_ = function(items) {
-  this.logger.fine(
+  goog.log.fine(
+      this.logger,
       'Loaded the following data from the managed storage: ' +
-      GSC.DebugDump.dump(items));
+          GSC.DebugDump.dump(items));
 
   if (this.setAllowedClientAppIdsFromStorageData_(
           goog.object.get(items, MANAGED_STORAGE_KEY, []))) {
-    this.logger.info(
+    goog.log.info(
+        this.logger,
         'Loaded managed storage data with the allowed client App ids: ' +
-        GSC.DebugDump.dump(this.allowedClientAppIds_));
+            GSC.DebugDump.dump(this.allowedClientAppIds_));
     this.managedStoragePromiseResolver_.resolve();
   } else {
     this.managedStoragePromiseResolver_.reject(new Error(
@@ -150,16 +154,18 @@ ManagedRegistry.prototype.storageChangedListener_ = function(
     changes, areaName) {
   if (areaName != 'managed')
     return;
-  this.logger.fine(
+  goog.log.fine(
+      this.logger,
       'Received the managed storage update event: ' +
-      GSC.DebugDump.dump(changes));
+          GSC.DebugDump.dump(changes));
 
   if (changes[MANAGED_STORAGE_KEY]) {
     if (this.setAllowedClientAppIdsFromStorageData_(
             goog.object.get(changes[MANAGED_STORAGE_KEY], 'newValue', []))) {
-      this.logger.info(
+      goog.log.info(
+          this.logger,
           'Loaded the updated managed storage data with the allowed client ' +
-          'App ids: ' + GSC.DebugDump.dump(this.allowedClientAppIds_));
+              'App ids: ' + GSC.DebugDump.dump(this.allowedClientAppIds_));
     }
   }
 };
@@ -172,10 +178,11 @@ ManagedRegistry.prototype.storageChangedListener_ = function(
 ManagedRegistry.prototype.setAllowedClientAppIdsFromStorageData_ = function(
     storageData) {
   if (!Array.isArray(storageData)) {
-    this.logger.warning(
+    goog.log.warning(
+        this.logger,
         'Failed to load the allowed client App ids data from the managed ' +
-        'storage: expected an array, instead got: ' +
-        GSC.DebugDump.dump(storageData));
+            'storage: expected an array, instead got: ' +
+            GSC.DebugDump.dump(storageData));
     return false;
   }
 
@@ -183,10 +190,11 @@ ManagedRegistry.prototype.setAllowedClientAppIdsFromStorageData_ = function(
   let success = true;
   goog.array.forEach(/** @type {!Array} */ (storageData), function(item) {
     if (typeof item !== 'string') {
-      this.logger.warning(
+      goog.log.warning(
+          this.logger,
           'Failed to load the allowed client App id from the managed ' +
-          'storage item: expected a string, instead got: ' +
-          GSC.DebugDump.dump(item));
+              'storage item: expected a string, instead got: ' +
+              GSC.DebugDump.dump(item));
       success = false;
       return;
     }

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/readiness-tracker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/readiness-tracker.js
@@ -32,6 +32,7 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PromiseHelpers');
 goog.require('goog.Disposable');
 goog.require('goog.Promise');
+goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 goog.require('goog.promise.Resolver');
@@ -89,9 +90,10 @@ GSC.PcscLiteServerClientsManagement.ReadinessTracker = function(
   naclModuleMessageChannel.addOnDisposeCallback(
       this.messageChannelDisposedListener_.bind(this));
 
-  this.logger_.fine(
+  goog.log.fine(
+      this.logger_,
       'Waiting for the "' + SERVICE_NAME + '" message from the ' +
-      'NaCl module...');
+          'NaCl module...');
 };
 
 const ReadinessTracker = GSC.PcscLiteServerClientsManagement.ReadinessTracker;
@@ -110,7 +112,7 @@ ReadinessTracker.prototype.disposeInternal = function() {
 ReadinessTracker.prototype.serviceCallback_ = function() {
   if (this.isPromiseResolved_)
     return;
-  this.logger_.info('PC/SC-Lite server has started successfully');
+  goog.log.info(this.logger_, 'PC/SC-Lite server has started successfully');
   this.isPromiseResolved_ = true;
   this.promiseResolver_.resolve();
 };
@@ -119,9 +121,10 @@ ReadinessTracker.prototype.serviceCallback_ = function() {
 ReadinessTracker.prototype.messageChannelDisposedListener_ = function() {
   if (this.isPromiseResolved_)
     return;
-  this.logger_.warning(
+  goog.log.warning(
+      this.logger_,
       'Failed while waiting for the PC/SC-Lite server successful start: the ' +
-      'message channel was disposed of');
+          'message channel was disposed of');
   this.isPromiseResolved_ = true;
   this.promiseResolver_.reject(
       new Error('The NaCl module message channel was disposed'));


### PR DESCRIPTION
Refactor JavaScript code to stop using deprecated methods
of goog.log.Logger objects, and switch to their replacement
analogs - which are mostly static methods in the goog.log
namespace.

Doing this refactoring resolves one of blockers that doesn't
allow us to switch to the latest Closure Library version, which
has the deprecated logger methods already deleted.