### PR TITLE
Add missing @const

### DIFF
--- a/common/integration_testing/src/google_smart_card_integration_testing/integration-test-controller.js
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration-test-controller.js
@@ -38,12 +38,12 @@ const INTEGRATION_TEST_NACL_MODULE_REQUESTER_NAME = 'integration_test';
  * @constructor
  */
 GSC.IntegrationTestController = function() {
-  /** @type {!goog.testing.PropertyReplacer} */
+  /** @type {!goog.testing.PropertyReplacer} @const */
   this.propertyReplacer = new goog.testing.PropertyReplacer;
-  /** @type {!GSC.NaclModule} */
+  /** @type {!GSC.NaclModule} @const */
   this.naclModule =
       new GSC.NaclModule(NACL_MODULE_PATH, GSC.NaclModule.Type.PNACL);
-  /** @type {!GSC.Requester} @private */
+  /** @type {!GSC.Requester} @private @const */
   this.naclModuleRequester_ = new GSC.Requester(
       INTEGRATION_TEST_NACL_MODULE_REQUESTER_NAME,
       this.naclModule.getMessageChannel());

--- a/common/js/src/deferred-processor.js
+++ b/common/js/src/deferred-processor.js
@@ -78,10 +78,7 @@ GSC.DeferredProcessor = function(awaitedPromise) {
    */
   this.isCurrentlyFlushingJobs_ = false;
 
-  /**
-   * @type {!goog.structs.Queue.<!Job>}
-   * @private
-   */
+  /** @type {!goog.structs.Queue.<!Job>} @private @const */
   this.jobsQueue_ = new goog.structs.Queue;
 
   awaitedPromise.then(
@@ -105,7 +102,9 @@ DeferredProcessor.prototype.logger =
  * @struct
  */
 function Job(jobFunction, promiseResolver) {
+  /** @const */
   this.jobFunction = jobFunction;
+  /** @const */
   this.promiseResolver = promiseResolver;
 }
 

--- a/common/js/src/logging/log-buffer-forwarder.js
+++ b/common/js/src/logging/log-buffer-forwarder.js
@@ -56,15 +56,9 @@ const POSTPONING_BUFFER_CAPACITY = 100;
  * @constructor
  */
 GSC.LogBufferForwarder = function(logBuffer, messageChannelServiceName) {
-  /**
-   * @type {string}
-   * @private
-   */
+  /** @type {string} @private @const */
   this.messageChannelServiceName_ = messageChannelServiceName;
-  /**
-   * @type {!Set}
-   * @private
-   */
+  /** @type {!Set} @private @const */
   this.ignoredLoggerNames_ = new Set();
   /**
    * @type {?goog.messaging.AbstractChannel}
@@ -76,10 +70,7 @@ GSC.LogBufferForwarder = function(logBuffer, messageChannelServiceName) {
    * @private
    */
   this.logCapturingEnabled_ = true;
-  /**
-   * @type {!goog.structs.CircularBuffer<string>}
-   * @private
-   */
+  /** @type {!goog.structs.CircularBuffer<string>} @private @const */
   this.postponedLogRecords_ = new goog.structs.CircularBuffer();
 
   logBuffer.addObserver(this.onLogRecordObserved_.bind(this));

--- a/common/js/src/logging/log-buffer.js
+++ b/common/js/src/logging/log-buffer.js
@@ -56,18 +56,15 @@ const GSC = GoogleSmartCard;
 GSC.LogBuffer = function(capacity) {
   LogBuffer.base(this, 'constructor');
 
-  /** @private */
+  /** @private @const */
   this.capacity_ = capacity;
 
   /** @private */
   this.size_ = 0;
 
-  /** @private */
+  /** @private @const */
   this.logsPrefixCapacity_ = Math.trunc(capacity / 2);
-  /**
-   * @type {!Array.<string>}
-   * @private
-   */
+  /** @type {!Array.<string>} @private @const */
   this.formattedLogsPrefix_ = [];
   /**
    * @type {!Array.<function(string, !goog.log.LogRecord)>}
@@ -75,10 +72,7 @@ GSC.LogBuffer = function(capacity) {
    */
   this.observers_ = [];
 
-  /**
-   * @type {!goog.structs.CircularBuffer.<string>}
-   * @private
-   */
+  /** @type {!goog.structs.CircularBuffer.<string>} @private @const */
   this.formattedLogsSuffix_ =
       new goog.structs.CircularBuffer(capacity - this.logsPrefixCapacity_);
 };

--- a/common/js/src/messaging/message-channel-pair.js
+++ b/common/js/src/messaging/message-channel-pair.js
@@ -122,7 +122,7 @@ const MessageChannelPairItem = function(messageChannelPair, indexInPair) {
 
   /** @private */
   this.messageChannelPair_ = messageChannelPair;
-  /** @private */
+  /** @private @const */
   this.indexInPair_ = indexInPair;
 };
 

--- a/common/js/src/messaging/message-channel-pool.js
+++ b/common/js/src/messaging/message-channel-pool.js
@@ -48,14 +48,11 @@ GSC.MessageChannelPool = function() {
    *
    * TODO(isandrk): extensionId may be null (extension talks to itself)
    * @type {!goog.labs.structs.Multimap}
-   * @private
+   * @private @const
    */
   this.channels_ = new goog.labs.structs.Multimap;
 
-  /**
-   * @type {!Array.<function(!Array.<string>)>}
-   * @private
-   */
+  /** @type {!Array.<function(!Array.<string>)>} @private @const */
   this.onUpdateListeners_ = [];
 
   this.logger.fine('Initialized successfully');

--- a/common/js/src/messaging/port-message-channel.js
+++ b/common/js/src/messaging/port-message-channel.js
@@ -65,7 +65,7 @@ GSC.PortMessageChannel = function(port, opt_onEstablished) {
    */
   this.port_ = port;
 
-  /** @type {string|null} */
+  /** @type {string|null} @const */
   this.extensionId = this.getPortExtensionId_(port);
 
   /**

--- a/common/js/src/messaging/single-message-based-channel.js
+++ b/common/js/src/messaging/single-message-based-channel.js
@@ -70,7 +70,7 @@ GSC.SingleMessageBasedChannel = function(
   this.logger = GSC.Logging.getScopedLogger(
       'SingleMessageBasedChannel<' + extensionId + '>');
 
-  /** @private */
+  /** @private @const */
   this.shouldPingOnPing_ = !!opt_shouldPingOnPing;
 
   this.registerDefaultService(this.defaultServiceCallback_.bind(this));

--- a/common/js/src/messaging/typed-message.js
+++ b/common/js/src/messaging/typed-message.js
@@ -41,9 +41,9 @@ const GSC = GoogleSmartCard;
  * @constructor
  */
 GSC.TypedMessage = function(type, data) {
-  /** @type {string} */
+  /** @type {string} @const */
   this.type = type;
-  /** @type {!Object} */
+  /** @type {!Object} @const */
   this.data = data;
 };
 

--- a/common/js/src/nacl-module/nacl-module-messaging-channel.js
+++ b/common/js/src/nacl-module/nacl-module-messaging-channel.js
@@ -49,7 +49,7 @@ const GSC = GoogleSmartCard;
 GSC.NaclModuleMessageChannel = function(naclModuleElement, parentLogger) {
   NaclModuleMessageChannel.base(this, 'constructor');
 
-  /** @private */
+  /** @private @const */
   this.logger_ = parentLogger;
 
   /**

--- a/common/js/src/nacl-module/nacl-module.js
+++ b/common/js/src/nacl-module/nacl-module.js
@@ -82,7 +82,7 @@ GSC.NaclModule = function(naclModulePath, type, logModulePath = false) {
    */
   this.type = type;
 
-  /** @private */
+  /** @private @const */
   this.loadPromiseResolver_ = goog.Promise.withResolver();
   GSC.PromiseHelpers.suppressUnhandledRejectionError(
       this.loadPromiseResolver_.promise);

--- a/common/js/src/requesting/remote-call-message.js
+++ b/common/js/src/requesting/remote-call-message.js
@@ -46,9 +46,9 @@ const GSC = GoogleSmartCard;
  * @constructor
  */
 GSC.RemoteCallMessage = function(functionName, functionArguments) {
-  /** @type {string} */
+  /** @type {string} @const */
   this.functionName = functionName;
-  /** @type {!Array.<*>} */
+  /** @type {!Array.<*>} @const */
   this.functionArguments = functionArguments;
 };
 

--- a/common/js/src/requesting/request-receiver.js
+++ b/common/js/src/requesting/request-receiver.js
@@ -60,13 +60,13 @@ GSC.RequestReceiver = function(name, messageChannel, requestHandler) {
    */
   this.logger = GSC.Logging.getScopedLogger('RequestReceiver<"' + name + '">');
 
-  /** @private */
+  /** @private @const */
   this.name_ = name;
 
-  /** @private */
+  /** @private @const */
   this.messageChannel_ = messageChannel;
 
-  /** @private */
+  /** @private @const */
   this.requestHandler_ = requestHandler;
 
   /**

--- a/common/js/src/requesting/requester-message.js
+++ b/common/js/src/requesting/requester-message.js
@@ -78,9 +78,9 @@ RequesterMessage.getResponseMessageType = function(name) {
  * @constructor
  */
 RequesterMessage.RequestMessageData = function(requestId, payload) {
-  /** @type {number} */
+  /** @type {number} @const */
   this.requestId = requestId;
-  /** @type {!Object} */
+  /** @type {!Object} @const */
   this.payload = payload;
 };
 
@@ -124,11 +124,11 @@ RequestMessageData.prototype.makeMessageData = function() {
  */
 RequesterMessage.ResponseMessageData = function(
     requestId, opt_payload, opt_errorMessage) {
-  /** @type {number} */
+  /** @type {number} @const */
   this.requestId = requestId;
-  /** @type {*} */
+  /** @type {*} @const */
   this.payload = opt_payload;
-  /** @type {string|undefined} */
+  /** @type {string|undefined} @const */
   this.errorMessage = opt_errorMessage;
 
   GSC.Logging.checkWithLogger(

--- a/common/js/src/requesting/requester.js
+++ b/common/js/src/requesting/requester.js
@@ -67,13 +67,13 @@ GSC.Requester = function(name, messageChannel) {
    */
   this.logger = GSC.Logging.getScopedLogger('Requester<"' + name + '">');
 
-  /** @private */
+  /** @private @const */
   this.name_ = name;
 
   /** @private */
   this.messageChannel_ = messageChannel;
 
-  /** @private */
+  /** @private @const */
   this.requestIdGenerator_ = goog.iter.count();
 
   /**

--- a/common/make/js_building_common.mk
+++ b/common/make/js_building_common.mk
@@ -110,7 +110,6 @@ JS_BUILD_COMPILATION_FLAGS += \
 	--jscomp_error='*' \
 	--jscomp_off deprecated \
 	--jscomp_off extraRequire \
-	--jscomp_off jsdocMissingConst \
 	--jscomp_off lintChecks \
 	--jscomp_off reportUnknownTypes \
 	--jscomp_off strictMissingProperties \

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
@@ -166,7 +166,7 @@ SmartCardClientApp.CertificateProviderBridge.Backend = function(
   // away.
   this.setupApiListeners_();
 
-  /** @private */
+  /** @private @const */
   this.deferredProcessor_ =
       new GSC.DeferredProcessor(executableModule.getLoadPromise());
   executableModule.addOnDisposeCallback(

--- a/third_party/libusb/webport/src/chrome_usb/chrome-login-state-hook.js
+++ b/third_party/libusb/webport/src/chrome_usb/chrome-login-state-hook.js
@@ -51,15 +51,9 @@ GSC.Libusb.ChromeLoginStateHook = function() {
    * @private
    */
   this.simulateDevicesAbsent_ = false;
-  /**
-   * @type {!Function}
-   * @private
-   */
+  /** @type {!Function} @private @const */
   this.boundOnGotSessionState_ = this.onGotSessionState_.bind(this);
-  /**
-   * @type {!goog.promise.Resolver}
-   * @private
-   */
+  /** @type {!goog.promise.Resolver} @private @const */
   this.hookIsReadyResolver_ = goog.Promise.withResolver();
   if (chrome.loginState) {
     chrome.loginState.getProfileType(this.onGotProfileType_.bind(this));

--- a/third_party/libusb/webport/src/chrome_usb/chrome-usb-backend.js
+++ b/third_party/libusb/webport/src/chrome_usb/chrome-usb-backend.js
@@ -66,7 +66,7 @@ GSC.Libusb.ChromeUsbBackend = function(naclModuleMessageChannel) {
   /**
    * @type {!goog.promise.Resolver}
    * Gets resolved once setup is complete and API requests can be processed.
-   * @private
+   * @private @const
    */
   this.setupDonePromiseResolver_ = goog.Promise.withResolver();
 
@@ -74,7 +74,7 @@ GSC.Libusb.ChromeUsbBackend = function(naclModuleMessageChannel) {
    * @type {!GoogleSmartCard.DeferredProcessor}
    * Queue of API requests that are not yet processed because setup is still in
    * progress.
-   * @private
+   * @private @const
    */
   this.deferredProcessor_ =
       new GSC.DeferredProcessor(this.setupDonePromiseResolver_.promise);

--- a/third_party/pcsc-lite/naclport/cpp_client/src/nacl-client-backend.js
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/nacl-client-backend.js
@@ -75,10 +75,10 @@ const GSC = GoogleSmartCard;
  */
 GSC.PcscLiteClient.NaclClientBackend = function(
     naclModuleMessageChannel, clientTitle, opt_serverAppId) {
-  /** @private */
+  /** @private @const */
   this.clientTitle_ = clientTitle;
 
-  /** @private */
+  /** @private @const */
   this.serverAppId_ = opt_serverAppId;
 
   /**
@@ -93,10 +93,7 @@ GSC.PcscLiteClient.NaclClientBackend = function(
    */
   this.api_ = null;
 
-  /**
-   * @type {!goog.structs.Queue.<!BufferedRequest>}
-   * @private
-   */
+  /** @type {!goog.structs.Queue.<!BufferedRequest>} @private @const */
   this.bufferedRequestsQueue_ = new goog.structs.Queue;
 
   /**
@@ -178,7 +175,9 @@ NaclClientBackend.prototype.handleRequest_ = function(payload) {
  * @constructor
  */
 function BufferedRequest(remoteCallMessage, promiseResolver) {
+  /** @const */
   this.remoteCallMessage = remoteCallMessage;
+  /** @const */
   this.promiseResolver = promiseResolver;
 }
 

--- a/third_party/pcsc-lite/naclport/js_client/src/api.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/api.js
@@ -2094,12 +2094,12 @@ API.ResultOrErrorCode = function(responseItems) {
   /**
    * An array of all values returned from the function call (including the error
    * code).
-   * @type {!Array}
+   * @type {!Array} @const
    */
   this.responseItems = responseItems;
   /**
    * Error code returned by the function call.
-   * @type {!API.ERROR_CODE}
+   * @type {!API.ERROR_CODE} @const
    **/
   this.errorCode = responseItems[0];
   /**
@@ -2108,11 +2108,10 @@ API.ResultOrErrorCode = function(responseItems) {
    *
    * Undefined if there are no result values (i.e. if the function returned only
    * the error code).
-   * @type {!Array|undefined}
+   * @type {!Array|undefined} @const
    */
-  this.resultItems = undefined;
-  if (this.isSuccessful())
-    this.resultItems = goog.array.slice(responseItems, 1);
+  this.resultItems =
+      this.isSuccessful() ? goog.array.slice(responseItems, 1) : undefined;
 };
 
 goog.exportProperty(API, 'ResultOrErrorCode', API.ResultOrErrorCode);

--- a/third_party/pcsc-lite/naclport/js_client/src/reader-tracker-through-pcsc-api.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/reader-tracker-through-pcsc-api.js
@@ -82,10 +82,10 @@ const API = GSC.PcscLiteClient.API;
  */
 GSC.PcscLiteClient.ReaderTrackerThroughPcscApi = function(
     logger, pcscContextMessageChannel, updateListener) {
-  /** @private */
+  /** @private @const */
   this.logger_ = logger;
 
-  /** @private */
+  /** @private @const */
   this.updateListener_ = updateListener;
 
   /**

--- a/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
+++ b/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
@@ -65,13 +65,13 @@ const ReaderStatus = GSC.PcscLiteServer.ReaderStatus;
  */
 GSC.PcscLiteServer.ReaderInfo = function(
     name, status, opt_error, opt_isCardPresent) {
-  /** @type {string} */
+  /** @type {string} @const */
   this['name'] = this.name = name;
-  /** @type {!ReaderStatus} */
+  /** @type {!ReaderStatus} @const */
   this['status'] = this.status = status;
-  /** @type {string|undefined} */
+  /** @type {string|undefined} @const */
   this['error'] = this.error = opt_error;
-  /** @type {boolean} */
+  /** @type {boolean} @const */
   this['isCardPresent'] = this.isCardPresent = !!opt_isCardPresent;
 };
 
@@ -90,22 +90,22 @@ const ReaderInfo = GSC.PcscLiteServer.ReaderInfo;
  */
 GSC.PcscLiteServer.ReaderTracker = function(
     serverMessageChannel, pcscContextMessageChannel, parentLogger) {
-  /** @private */
+  /** @private @const */
   this.logger_ =
       GSC.Logging.getChildLogger(parentLogger, READER_TRACKER_LOGGER_TITLE);
 
   /**
    * @type {!Array.<function(!Array.<!ReaderInfo>)>}
-   * @private
+   * @private @const
    */
   this.updateListeners_ = [];
 
-  /** @private */
+  /** @private @const */
   this.trackerThroughPcscServerHook_ = new TrackerThroughPcscServerHook(
       this.logger_, serverMessageChannel,
       this.fireOnUpdateListeners_.bind(this));
 
-  /** @private */
+  /** @private @const */
   this.trackerThroughPcscApi_ =
       new GSC.PcscLiteClient.ReaderTrackerThroughPcscApi(
           this.logger_, pcscContextMessageChannel,
@@ -197,10 +197,10 @@ ReaderTracker.prototype.fireOnUpdateListeners_ = function() {
  */
 function TrackerThroughPcscServerHook(
     logger, serverMessageChannel, updateListener) {
-  /** @private */
+  /** @private @const */
   this.logger_ = logger;
 
-  /** @private */
+  /** @private @const */
   this.updateListener_ = updateListener;
 
   /**
@@ -210,7 +210,7 @@ function TrackerThroughPcscServerHook(
    * The values can be null, which corresponds to readers that should be hidden
    * from the result.
    * @type {!Map.<number, ReaderInfo?>}
-   * @private
+   * @private @const
    */
   this.portToReaderInfoMap_ = new Map;
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
@@ -171,10 +171,10 @@ GSC.PcscLiteServerClientsManagement.ClientHandler = function(
     clientAppId) {
   ClientHandler.base(this, 'constructor');
 
-  /** @type {number} */
+  /** @type {number} @const */
   this.id = idGenerator.next();
 
-  /** @private */
+  /** @private @const */
   this.clientAppId_ = clientAppId !== undefined ? clientAppId : null;
 
   /**

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/checker.js
@@ -58,9 +58,9 @@ const PermissionsChecking =
  * @constructor
  */
 PermissionsChecking.Checker = function() {
-  /** @private */
+  /** @private @const */
   this.managedRegistry_ = new PermissionsChecking.ManagedRegistry;
-  /** @private */
+  /** @private @const */
   this.userPromptingChecker_ = new PermissionsChecking.UserPromptingChecker;
 };
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/known-apps-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/known-apps-registry.js
@@ -58,7 +58,9 @@ const PermissionsChecking =
  * @constructor
  */
 PermissionsChecking.KnownApp = function(id, name) {
+  /** @const */
   this.id = id;
+  /** @const */
   this.name = name;
 };
 
@@ -73,8 +75,7 @@ const KnownApp = PermissionsChecking.KnownApp;
  */
 PermissionsChecking.KnownAppsRegistry = function() {
   /**
-   * @type {!goog.promise.Resolver.<!Map.<string,!KnownApp>>}
-   * @private
+   * @type {!goog.promise.Resolver.<!Map.<string,!KnownApp>>} @private @const
    */
   this.promiseResolver_ = goog.Promise.withResolver();
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
@@ -49,10 +49,7 @@ const PermissionsChecking =
  * @constructor
  */
 PermissionsChecking.ManagedRegistry = function() {
-  /**
-   * @type {!goog.promise.Resolver}
-   * @private
-   */
+  /** @type {!goog.promise.Resolver} @private @const */
   this.managedStoragePromiseResolver_ = goog.Promise.withResolver();
   /**
    * @type {!Set.<string>}

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
@@ -62,20 +62,14 @@ const PermissionsChecking =
  * @constructor
  */
 PermissionsChecking.UserPromptingChecker = function() {
-  /** @private */
+  /** @private @const */
   this.knownAppsRegistry_ = new PermissionsChecking.KnownAppsRegistry;
 
-  /**
-   * @type {!goog.promise.Resolver.<!Map.<string,boolean>>}
-   * @private
-   */
+  /** @type {!goog.promise.Resolver.<!Map.<string,boolean>>} @private @const */
   this.localStoragePromiseResolver_ = goog.Promise.withResolver();
   this.loadLocalStorage_();
 
-  /**
-   * @type {!Map.<string, !goog.Promise>}
-   * @private
-   */
+  /** @type {!Map.<string, !goog.Promise>} @private @const */
   this.checkPromiseMap_ = new Map;
 };
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/readiness-tracker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/readiness-tracker.js
@@ -64,16 +64,13 @@ GSC.PcscLiteServerClientsManagement.ReadinessTracker = function(
   this.logger_ = GSC.Logging.getScopedLogger(
       'PcscLiteServerClientsManagement.ReadinessTracker');
 
-  /**
-   * @type {!goog.promise.Resolver.<null>}
-   * @private
-   */
+  /** @type {!goog.promise.Resolver.<null>} @private @const */
   this.promiseResolver_ = goog.Promise.withResolver();
 
   /**
    * Promise that is fulfilled once the PC/SC-Lite server gets ready, or is
    * rejected if it failed to initialize.
-   * @type {!goog.Promise}
+   * @type {!goog.Promise} @const
    */
   this.promise = this.promiseResolver_.promise;
   GSC.PromiseHelpers.suppressUnhandledRejectionError(this.promise);


### PR DESCRIPTION
Refactor JavaScript code to specify "@const" for all class attributes
that are never reassigned. Also promote the "jsdocMissingConst" Closure
Compiler diagnostic, which complained about private properties that can
be marked as @const, to be an error.

This is intended to be a non-function change, contributing to the
refactoring effort tracked by #264.