### PR TITLE
Add missing @private

### DIFF
--- a/common/js/src/messaging/mock-port.js
+++ b/common/js/src/messaging/mock-port.js
@@ -38,7 +38,7 @@ const GSC = GoogleSmartCard;
 GSC.MockPort = function(opt_name) {
   MockPort.base(this, 'constructor');
 
-  /** @const */
+  /** @private @const */
   this.name_ = opt_name;
 
   /** @type {?} */

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/readiness-tracker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/readiness-tracker.js
@@ -80,7 +80,7 @@ GSC.PcscLiteServerClientsManagement.ReadinessTracker = function(
 
   /**
    * Whether the promise is resolved (either fulfilled or rejected).
-   * @type {boolean}
+   * @type {boolean} @private
    */
   this.isPromiseResolved_ = false;
 


### PR DESCRIPTION
Fix a couple of occasions in the JavaScript code where a private member
wasn't marked as such (via @private).

This is expected to be a non-function change, which contributes to the
refactoring effort tracked by #264.