### PR TITLE
Rename {app_building => packaging}_common.mk

### DIFF
--- a/common/make/packaging_common.mk
+++ b/common/make/packaging_common.mk
@@ -14,7 +14,8 @@
 
 
 #
-# This file contains some helper definitions for building Chrome Apps.
+# This file contains some helper definitions for building Chrome
+# Apps/Extensions.
 #
 # common.mk must be included before including this file.
 #
@@ -54,17 +55,18 @@ $(eval $(call CLEAN_RULE,$(APP_RUN_USER_DATA_DIR_PATH)))
 
 
 #
-# Special "package" target that creates a packaged App .CRX file and a .ZIP
-# archive suitable for uploading at Chrome WebStore (see
+# Special "package" target that creates a packaged App/Extension .CRX file and a
+# .ZIP archive suitable for uploading at Chrome WebStore (see
 # <https://developer.chrome.com/webstore/publish>).
 #
-# The ID of the generated App packaged in the .CRX file is controlled by the
-# private key .P8 file. The P8 file, if missing, is automatically generated with
-# some random contents - so, in order to keep ID the same, the P8 file should be
-# preserved.
+# The ID of the generated App/Extension packaged in the .CRX file is controlled
+# by the private key .P8 file. The P8 file, if missing, is automatically
+# generated with some random contents - so, in order to keep ID the same, the P8
+# file should be preserved.
 #
 # The .ZIP archive intended for WebStore, in contrast, has no signature, as
-# WebStore stores the private key internally and signs the App package itself.
+# WebStore stores the private key internally and signs the App/Extension package
+# itself.
 #
 
 .PHONY: package

--- a/example_cpp_smart_card_client_app/build/Makefile
+++ b/example_cpp_smart_card_client_app/build/Makefile
@@ -21,7 +21,7 @@ include $(COMMON_DIR_PATH)/make/js_building_common.mk
 
 include $(COMMON_DIR_PATH)/js/include.mk
 
-include $(COMMON_DIR_PATH)/make/app_building_common.mk
+include $(COMMON_DIR_PATH)/make/packaging_common.mk
 
 include $(COMMON_DIR_PATH)/make/executable_module_recursive_build.mk
 

--- a/example_js_smart_card_client_app/build/Makefile
+++ b/example_js_smart_card_client_app/build/Makefile
@@ -21,7 +21,7 @@ include $(COMMON_DIR_PATH)/make/js_building_common.mk
 
 include $(COMMON_DIR_PATH)/js/include.mk
 
-include $(COMMON_DIR_PATH)/make/app_building_common.mk
+include $(COMMON_DIR_PATH)/make/packaging_common.mk
 
 include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/js_client/include.mk
 include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/js_demo/include.mk

--- a/smart_card_connector_app/build/Makefile
+++ b/smart_card_connector_app/build/Makefile
@@ -14,23 +14,23 @@
 
 
 #
-# This makefile builds the Smart Card Connector app.
+# This makefile builds the Smart Card Connector app/extension.
 #
-# Upon successful build, the resulting app (including all resources that may be
-# needed during run time) is stored under the ./out/ directory.
+# Upon successful build, the resulting app/extension (including all resources
+# that may be needed during run time) is stored under the ./out/ directory.
 #
 # You may use the "make run" command to start an instance of Chrome that would
 # automatically load and run the app.
 #
-# You may also use the "make package" command to build a packaged app .CRX file
-# and a .ZIP archive suitable for uploading at Chrome WebStore. (Please note
-# that in both cases, the resulting app will have an ID different from ID of the
-# app published by Google on Web Store. Only project maintainers who have
-# corresponding access in the Chrome Developer Dashboard can update the app
-# published by Google.)
+# You may also use the "make package" command to build a packaged app/extension
+# .CRX file and a .ZIP archive suitable for uploading at Chrome WebStore.
+# (Please note that in both cases, the resulting app/extension will have an ID
+# different from ID of the app/extension published by Google on Web Store. Only
+# project maintainers who have corresponding access in the Chrome Developer
+# Dashboard can update the app/extension published by Google.)
 #
 # For more details regarding these special make targets, refer to the
-# common/make/app_building_common.mk file.
+# common/make/packaging_common.mk file.
 #
 
 
@@ -42,7 +42,7 @@ include $(COMMON_DIR_PATH)/make/js_building_common.mk
 
 include $(COMMON_DIR_PATH)/js/include.mk
 
-include $(COMMON_DIR_PATH)/make/app_building_common.mk
+include $(COMMON_DIR_PATH)/make/packaging_common.mk
 
 include $(COMMON_DIR_PATH)/make/executable_module_recursive_build.mk
 


### PR DESCRIPTION
Rename the common/make/app_building_common.mk file to
packaging_common.mk, since we're going to add support for other
packaging modes besides the (legacy) Chrome App.

This contributes to the app-to-extension migration effort, in particular
task #379.