### PR TITLE
app/extension conditions in manifest.json.template

### DIFF
--- a/smart_card_connector_app/build/Makefile
+++ b/smart_card_connector_app/build/Makefile
@@ -109,7 +109,8 @@ $(OUT_DIR_PATH)/manifest.json: $(SOURCES_PATH)/create_app_manifest.py $(SOURCES_
 	$(SOURCES_PATH)/create_app_manifest.py \
 		--manifest-template-path="$(SOURCES_PATH)/manifest.json.template" \
 		--ccid-supported-readers-config-path="$(CCID_SUPPORTED_READERS_CONFIG_PATH)" \
-		--target-file-path="$(OUT_DIR_PATH)/manifest.json"
+		--target-file-path="$(OUT_DIR_PATH)/manifest.json" \
+		--enable-condition="PACKAGING=$(PACKAGING)"
 
 generate_out: $(OUT_DIR_PATH)/manifest.json
 

--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -4,13 +4,17 @@
   "short_name": "__MSG_appShortName__",
   "description": "__MSG_appDesc__",
   "version": "1.3.5.0",
+${if PACKAGING=app}
   "app": {
+${endif}
     "background": {
       "persistent": false,
       "scripts": [
         "background.js"
       ]
+${if PACKAGING=app}
     }
+${endif}
   },
   "minimum_chrome_version": "48",
   "default_locale": "en",


### PR DESCRIPTION
Add the support of conditionals into the Connector's
manifest.json.template, allowing to switch between extension- and
app-specific blocks in this file depending on the PACKAGING build
variable.

Do this by introducing a simple "${if ...} ... ${endif}" syntax into
create_app_manifest.py, with the regexp-based implementation. The
implementation is very basic and, e.g., doesn't support nested
conditions.

This contributes to the app-to-extension migration effort, in particular
task #379.