### PR TITLE
Differentiate app-/extension-specific permissions

### DIFF
--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -25,14 +25,16 @@ ${endif}
     "managed_schema": "managed_storage_schema.json"
   },
   "permissions": [
+${if PACKAGING=app}
     "alwaysOnTopWindows",
     "browser",
-    "loginState",
     "usb",
     {
       "usbDevices": [
 ${usb_devices}
       ]
-    }
+    },
+${endif}
+    "loginState"
   ]
 }


### PR DESCRIPTION
Change the Connector's manifest.json.template to only request the
App-specific permissions in the "app" packaging mode. This allows to
avoid warnings in Chrome when loading the "extension" version.

This contributes to the app-to-extension migration effort, in particular
task #383.