### PR TITLE
Fix data passing from background to popup window

### DIFF
--- a/smart_card_connector_app/src/background-main-window-managing.js
+++ b/smart_card_connector_app/src/background-main-window-managing.js
@@ -50,10 +50,9 @@ const GSC = GoogleSmartCard;
 /**
  * Opens the main window due to user request. Does nothing if the window is
  * already opened.
- * @param {!Object} windowData Data for passing into the created window.
  */
 GSC.ConnectorApp.Background.MainWindowManaging.openWindowDueToUserRequest =
-    function(windowData) {
-  GSC.PopupWindow.Server.createWindow(WINDOW_URL, WINDOW_OPTIONS, windowData);
+    function() {
+  GSC.PopupWindow.Server.createWindow(WINDOW_URL, WINDOW_OPTIONS);
 };
 });  // goog.scope

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -163,8 +163,7 @@ function executableModuleDisposedListener() {
  */
 function launchedListener() {
   goog.log.fine(logger, 'Received onLaunched event, opening window...');
-  GSC.ConnectorApp.Background.MainWindowManaging.openWindowDueToUserRequest(
-      makeDataForMainWindow());
+  GSC.ConnectorApp.Background.MainWindowManaging.openWindowDueToUserRequest();
 }
 
 /**
@@ -292,17 +291,16 @@ function createClientHandler(clientMessageChannel, clientExtensionId) {
 }
 
 /**
- * Creates data for passing into the opened main window.
- * @return {!Object}
+ * Sets global variables to be used by the main window (once it's opened).
  */
-function makeDataForMainWindow() {
-  return {
-    'clientAppListUpdateSubscriber':
-        messageChannelPool.addOnUpdateListener.bind(messageChannelPool),
-    'readerTrackerSubscriber':
-        readerTracker.addOnUpdateListener.bind(readerTracker),
-    'readerTrackerUnsubscriber':
-        readerTracker.removeOnUpdateListener.bind(readerTracker)
-  };
+function exposeGlobalsForMainWindow() {
+  goog.global['googleSmartCard_clientAppListUpdateSubscriber'] =
+      messageChannelPool.addOnUpdateListener.bind(messageChannelPool);
+  goog.global['googleSmartCard_readerTrackerSubscriber'] =
+      readerTracker.addOnUpdateListener.bind(readerTracker);
+  goog.global['googleSmartCard_readerTrackerUnsubscriber'] =
+      readerTracker.removeOnUpdateListener.bind(readerTracker);
 }
+
+exposeGlobalsForMainWindow();
 });  // goog.scope

--- a/smart_card_connector_app/src/window-apps-displaying.js
+++ b/smart_card_connector_app/src/window-apps-displaying.js
@@ -105,15 +105,23 @@ function onUpdateListener(appListArg) {
       });
 }
 
-GSC.ConnectorApp.Window.AppsDisplaying.initialize = function() {
-  goog.log.fine(logger, 'Registering listener on connected apps update');
+/**
+ * @param {!Window=} backgroundPage
+ */
+function initializeWithBackgroundPage(backgroundPage) {
+  GSC.Logging.checkWithLogger(logger, backgroundPage);
+  goog.asserts.assert(backgroundPage);
+
+  goog.log.fine(logger, 'Registering listener on connected clients update');
   // FIXME(emaxx): Do unsubscription too.
-  // FIXME(emaxx): Use GSC.ObjectHelpers.extractKey to ensure that the expected
-  // object is passed to the window.
-  const data =
-      GSC.PopupWindow.Client.getData()['clientAppListUpdateSubscriber'];
-  const clientAppListUpdateSubscriber =
-      /**@type {function(function(!Array.<string>))} */ (data);
-  clientAppListUpdateSubscriber(onUpdateListener);
+  const subscriber =
+      /** @type {function(function(!Array.<string>))} */
+      (GSC.ObjectHelpers.extractKey(
+          backgroundPage, 'googleSmartCard_clientAppListUpdateSubscriber'));
+  subscriber(onUpdateListener);
+}
+
+GSC.ConnectorApp.Window.AppsDisplaying.initialize = function() {
+  chrome.runtime.getBackgroundPage(initializeWithBackgroundPage);
 };
 });  // goog.scope

--- a/smart_card_connector_app/src/window-devices-displaying.js
+++ b/smart_card_connector_app/src/window-devices-displaying.js
@@ -194,7 +194,8 @@ function initializeWithBackgroundPage(backgroundPage) {
    */
   const readerTrackerSubscriber =
       /** @type {function(function(!Array.<!GSC.PcscLiteServer.ReaderInfo>))} */
-      (GSC.ObjectHelpers.extractKey(backgroundPage, 'googleSmartCard_readerTrackerSubscriber'));
+      (GSC.ObjectHelpers.extractKey(
+          backgroundPage, 'googleSmartCard_readerTrackerSubscriber'));
   // Start tracking the current list of readers.
   readerTrackerSubscriber(onReadersChanged);
 

--- a/smart_card_connector_app/src/window-devices-displaying.js
+++ b/smart_card_connector_app/src/window-devices-displaying.js
@@ -181,15 +181,20 @@ function getUserSelectedDevicesCallback(devices) {
           'were chosen');
 }
 
-GSC.ConnectorApp.Window.DevicesDisplaying.initialize = function() {
+/**
+ * @param {!Window=} backgroundPage
+ */
+function initializeWithBackgroundPage(backgroundPage) {
+  GSC.Logging.checkWithLogger(logger, backgroundPage);
+  goog.asserts.assert(backgroundPage);
+
   /**
    * Points to the "addOnUpdateListener" method of the ReaderTracker instance
    * that is owned by the background page.
    */
   const readerTrackerSubscriber =
       /** @type {function(function(!Array.<!GSC.PcscLiteServer.ReaderInfo>))} */
-      (GSC.ObjectHelpers.extractKey(
-          GSC.PopupWindow.Client.getData(), 'readerTrackerSubscriber'));
+      (GSC.ObjectHelpers.extractKey(backgroundPage, 'googleSmartCard_readerTrackerSubscriber'));
   // Start tracking the current list of readers.
   readerTrackerSubscriber(onReadersChanged);
 
@@ -200,11 +205,15 @@ GSC.ConnectorApp.Window.DevicesDisplaying.initialize = function() {
   const readerTrackerUnsubscriber =
       /** @type {function(function(!Array.<!GSC.PcscLiteServer.ReaderInfo>))} */
       (GSC.ObjectHelpers.extractKey(
-          GSC.PopupWindow.Client.getData(), 'readerTrackerUnsubscriber'));
+          backgroundPage, 'googleSmartCard_readerTrackerUnsubscriber'));
   // Stop tracking the current list of readers when our window gets closed.
   chrome.app.window.current().onClosed.addListener(function() {
     readerTrackerUnsubscriber(onReadersChanged);
   });
+}
+
+GSC.ConnectorApp.Window.DevicesDisplaying.initialize = function() {
+  chrome.runtime.getBackgroundPage(initializeWithBackgroundPage);
 
   goog.events.listen(
       addDeviceElement, goog.events.EventType.CLICK, addDeviceClickListener);


### PR DESCRIPTION
Make the data passing (connected readers and connected client
applications) between the Connector's background page and the popup
window work in both "app" and "extension" packaging modes.

This is achieved by changing the mechanism for passing data: instead of
manipulating the popup's global variables (in the
chrome.app.window.create() callback - which was obviously an
App-specific mechanism), let the popup read them from the background
page's globals.

This contributes to the app-to-extension migration effort, in particular
task #383.