### PR TITLE
Fix ArrayBuffer bug in single-message-based comm

### DIFF
--- a/common/js/src/messaging/single-message-based-channel.js
+++ b/common/js/src/messaging/single-message-based-channel.js
@@ -99,7 +99,10 @@ SingleMessageBasedChannel.prototype.send = function(serviceName, payload) {
   GSC.Logging.checkWithLogger(this.logger, goog.isObject(payload));
   goog.asserts.assertObject(payload);
 
-  const typedMessage = new GSC.TypedMessage(serviceName, payload);
+  const normalizedPayload =
+      GSC.ContainerHelpers.substituteArrayBuffersRecursively(payload);
+
+  const typedMessage = new GSC.TypedMessage(serviceName, normalizedPayload);
   const message = typedMessage.makeMessage();
   goog.log.log(
       this.logger, goog.log.Level.FINEST,

--- a/common/js/src/messaging/single-message-based-channel.js
+++ b/common/js/src/messaging/single-message-based-channel.js
@@ -24,6 +24,7 @@
 
 goog.provide('GoogleSmartCard.SingleMessageBasedChannel');
 
+goog.require('GoogleSmartCard.ContainerHelpers');
 goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.MessageChannelPinging.PingResponder');


### PR DESCRIPTION
Fix the issue with incorrect serialization of byte fields when using
single-message-based communication channels. The root cause is that
we did internal migration in the Smart Card Connector app to start using
ArrayBuffers for representing such fields, however due to the
cross-extension messages not supporting them we needed to transform this
into integer arrays before sending this. While #226 did this for
port-based communications, the single-message-based communication left
broken, resulting in some fields, like "atr", being received as "{}"
instead of the array of integer-bytes.

This fixes #393.