### PR TITLE
Don't call getBackgroundPage in non-app/extensions

### DIFF
--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -316,6 +316,14 @@ function setupLogBuffer() {
   GSC.LogBuffer.attachBufferToLogger(
       logBuffer, rootLogger, document.location.href);
 
+  if (!chrome || !chrome.runtime || !chrome.runtime.getBackgroundPage) {
+    // We don't know whether we're running inside the background page and
+    // the API for talking to it is unavailable - therefore no action needed,
+    // i.e., our page will continue using our log buffer. This should only
+    // happen in tests or if this code is running outside an app/extension.
+    return;
+  }
+
   // Expose our log buffer in the global window properties. Pages other than the
   // background will use it to access the background page's log buffer - see the
   // code directly below.


### PR DESCRIPTION
Skip calling chrome.runtime.getBackgroundPage() when setting up logging
(originally added in #391), so that this code doesn't throw an exception
when this method is unavailable. This should never happen in production
currently, but might happen if the code is running outside an app/extension.

This contributes to the app-to-extension migration effort, in particular
task #390.