### PR TITLE
[WIP] Add single-message-based comm into the JS example

### DIFF
--- a/common/js/src/messaging/single-message-based-channel.js
+++ b/common/js/src/messaging/single-message-based-channel.js
@@ -90,6 +90,9 @@ const SingleMessageBasedChannel = GSC.SingleMessageBasedChannel;
 
 goog.inherits(SingleMessageBasedChannel, goog.messaging.AbstractChannel);
 
+goog.exportSymbol(
+    'GoogleSmartCard.SingleMessageBasedChannel', SingleMessageBasedChannel);
+
 /**
  * @override
  * @param {string} serviceName

--- a/example_js_standalone_smart_card_client_library/Makefile
+++ b/example_js_standalone_smart_card_client_library/Makefile
@@ -34,6 +34,7 @@ JS_COMPILER_INPUT_PATHS := \
 JS_COMPILER_TARGET_NAMESPACES := \
 	GoogleSmartCard.PcscLiteClient.API \
 	GoogleSmartCard.PcscLiteClient.Context \
+	GoogleSmartCard.SingleMessageBasedChannel \
 
 JS_COMPILER_OUTPUT_FILE_NAME := google-smart-card-client-library.js
 


### PR DESCRIPTION
Extend the example_js_standalone_smart_card_client_app to also use
single-messaging channel instead of the (default) port-based messaging.

This is WIP as we probably still want to use the port-based messaging by
default, and leave the single-messaging channel for other scenarios.