### PR TITLE
Fix GitHub binary preparation script for packaging

### DIFF
--- a/prepare-binaries-for-github-release.py
+++ b/prepare-binaries-for-github-release.py
@@ -44,10 +44,10 @@ BINARY_CONTENTS_RELATIVES_PATHS = [
 # archives, accompanied with the relative target file paths.
 PATHS_TO_COPY = [
   ['example_js_standalone_smart_card_client_library/js_build/'
-   'emscripten_Debug/google-smart-card-client-library.js',
+   'app_emscripten_Debug/google-smart-card-client-library.js',
    'google-smart-card-client-library.debug.js'],
   ['example_js_standalone_smart_card_client_library/js_build/'
-   'emscripten_Release/google-smart-card-client-library.js',
+   'app_emscripten_Release/google-smart-card-client-library.js',
    'google-smart-card-client-library.js'],
 ]
 


### PR DESCRIPTION
Update the prepare-binaries-for-github-release.py script to use the
correct directory name for input artifacts. Since #380, the directory
name has the pattern "$(PACKAGING)_$(TOOLCHAIN)_$(CONFIG)" (e.g.,
"app_pnacl_Release"), meanwhile it used to be just
"$(TOOLCHAIN)_$(CONFIG)".