### PR TITLE
Fix missing import

### DIFF
--- a/common/js/src/packaging.js
+++ b/common/js/src/packaging.js
@@ -17,6 +17,8 @@
 
 goog.provide('GoogleSmartCard.Packaging');
 
+goog.require('GoogleSmartCard.Logging');
+
 goog.scope(function() {
 
 const GSC = GoogleSmartCard;


### PR DESCRIPTION
The packaging.js script should import the GoogleSmartCard.Logging
namespace. Closure Compiler doesn't explain about this due to whatever
reason, however it began to produce broken code sometimes, namely code
that throws this exception sometimes:

  Uncaught TypeError: Cannot read properties of undefined (reading
  'check')

Basically, the code from packaging.js uses code from logging.js, but
somehow Closure Compiler misses that and produces the resulting file
with packaging.js coming before logging.js.

This is a follow-up to #380 where packaging.js was originally
introduced, and contributes to the app-to-extension migration effort,
in particular task #379.