### PR TITLE
Add helper for checking string being extension ID

### DIFF
--- a/common/js/src/extension-id-unittest.js
+++ b/common/js/src/extension-id-unittest.js
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2021 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.require('GoogleSmartCard.ExtensionId');
+goog.require('goog.testing.jsunit');
+
+goog.setTestOnly();
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+const looksLikeExtensionId = GSC.ExtensionId.looksLikeExtensionId;
+
+goog.exportSymbol('testLooksLikeExtensionId', function() {
+  assertFalse(looksLikeExtensionId(''));
+  assertFalse(looksLikeExtensionId('abc'));
+  assertFalse(looksLikeExtensionId('123'));
+
+  assertTrue(looksLikeExtensionId('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
+  assertTrue(looksLikeExtensionId('khpfeaanjngmcnplbdlpegiifgpfgdco'));
+
+  assertFalse(looksLikeExtensionId('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
+  assertFalse(looksLikeExtensionId('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
+});
+});  // goog.scope

--- a/common/js/src/extension-id.js
+++ b/common/js/src/extension-id.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2021 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.provide('GoogleSmartCard.ExtensionId');
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+/**
+ * Returns whether the given string's format corresponds to the one of the
+ * Extension IDs. This function does NOT guarantee that there's a real-world
+ * extension with this ID.
+ * @param {string} string
+ * @return {boolean}
+ */
+GSC.ExtensionId.looksLikeExtensionId = function(string) {
+  return string.length === 32 && !!string.match(/[a-p]/i);
+};
+
+});  // goog.scope


### PR DESCRIPTION
Add a small helper for checking whether a string is (purely based on its
format) an extension ID.

The plan is to use this helper in follow-ups in order to distinguish
between extension IDs and generic web origins. Specifically, we're
adding the support of receiving smart card commands from web pages,
which means we'll store two kinds of permissions granted by the user:
ones based on Extension IDs and ones based on web origins; when loading
these persisted permissions, we'll need to determine the kind of every
stored item.

This is a preparatory commit for the effort tracked by #377: supporting
PC/SC requests from web pages.