### PR TITLE
Add messaging origin helpers

### DIFF
--- a/common/js/src/messaging/messaging-origin-unittest.js
+++ b/common/js/src/messaging/messaging-origin-unittest.js
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2021 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.require('GoogleSmartCard.MessagingOrigin');
+goog.require('goog.testing.jsunit');
+
+goog.setTestOnly();
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+const getFromChromeMessageSender =
+    GSC.MessagingOrigin.getFromChromeMessageSender;
+const getFromExtensionId = GSC.MessagingOrigin.getFromExtensionId;
+const extractExtensionId = GSC.MessagingOrigin.extractExtensionId;
+
+goog.exportSymbol('testGetFromChromeMessageSender', function() {
+  assertNull(getFromChromeMessageSender(undefined));
+
+  const messageSender = /** @type {!MessageSender} */ ({});
+  assertNull(getFromChromeMessageSender(messageSender));
+
+  messageSender.id = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  assertEquals(
+      getFromChromeMessageSender(messageSender),
+      'chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+
+  delete messageSender.id;
+  messageSender.url = 'https://example.org/index.html';
+  assertEquals(
+      getFromChromeMessageSender(messageSender), 'https://example.org');
+
+  messageSender.url = 'http://example.org:8080/#foo=bar';
+  assertEquals(
+      getFromChromeMessageSender(messageSender), 'http://example.org:8080');
+
+  messageSender.url = 'abacaba';
+  assertNull(getFromChromeMessageSender(messageSender));
+});
+
+goog.exportSymbol('testGetFromExtensionId', function() {
+  assertEquals(
+      getFromExtensionId('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+      'chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+});
+
+goog.exportSymbol('testExtractExtensionId', function() {
+  assertEquals(
+      extractExtensionId('chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+
+  assertNull(extractExtensionId('https://example.org'));
+  assertNull(extractExtensionId('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
+  assertNull(extractExtensionId('https://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
+});
+});  // goog.scope

--- a/common/js/src/messaging/messaging-origin.js
+++ b/common/js/src/messaging/messaging-origin.js
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2021 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.provide('GoogleSmartCard.MessagingOrigin');
+
+goog.require('goog.Uri');
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+/** @const */
+GSC.MessagingOrigin.EXTENSION_PROTOCOL = 'chrome-extension:';
+
+/**
+ * Returns an origin that identifies the sender of messages, given the
+ * MessageSender object from the Chrome Extensions API. An example of the origin
+ * is: "https://example.org". Returns null when the origin cannot be identified.
+ * @param {!MessageSender|undefined} messageSender
+ * @return {string|null}
+ */
+GSC.MessagingOrigin.getFromChromeMessageSender = function(messageSender) {
+  if (!messageSender)
+    return null;
+  if (messageSender.id) {
+    // The sender is a Chrome extension/app.
+    return GSC.MessagingOrigin.getFromExtensionId(messageSender.id);
+  }
+  if (messageSender.url) {
+    // The sender is a web page. We're parsing the origin from the "url"
+    // property instead of reading the "origin" property, since in case the
+    // sender is in an iframe we want the iframe's URL.
+    let url;
+    try {
+      url = new URL(messageSender.url);
+    } catch (exc) {
+      // Invalid URLs should never occur in the Chrome's MessageSender fields,
+      // but handle this to be on the safe side.
+      return null;
+    }
+    return url.origin;
+  }
+  // Unknown sender.
+  return null;
+};
+
+/**
+ * Synthesizes an origin that corresponds to the given extension/app ID.
+ * @param {string} extensionId
+ * @return {string}
+ */
+GSC.MessagingOrigin.getFromExtensionId = function(extensionId) {
+  return `${GSC.MessagingOrigin.EXTENSION_PROTOCOL}//${extensionId}`;
+};
+
+/**
+ * Extracts the extension ID from the origin. Returns null when the origin
+ * doesn't refer to an extension/app.
+ * @param {string} messagingOrigin
+ * @return {string|null}
+ */
+GSC.MessagingOrigin.extractExtensionId = function(messagingOrigin) {
+  let url;
+  try {
+    url = new URL(messagingOrigin);
+  } catch (exc) {
+    // Invalid origin.
+    return null;
+  }
+  if (url.protocol !== GSC.MessagingOrigin.EXTENSION_PROTOCOL) {
+    // Origin doesn't refer to an extension/app.
+    return null;
+  }
+  return url.hostname;
+};
+});  // goog.scope


### PR DESCRIPTION
Introduce a concept of a "messaging origin", which is a unique
identifier of a remote endpoint that sends messages to us. Practically,
it's going to be used for identifying which extension or which website
is sending PC/SC commands to us, that is, to the Smart Card Connector.

An origin is a suitable abstraction that allows to make most of code
agnostic to whether the sender is an extension/app or a web page.

This is a preparatory commit for the effort tracked by #377: supporting
PC/SC requests from web pages.