### PR TITLE
Generalize PC/SC permission prompt

### DIFF
--- a/smart_card_connector_app/src/_locales/en/messages.json
+++ b/smart_card_connector_app/src/_locales/en/messages.json
@@ -119,43 +119,29 @@
     "message": "BLOCK",
     "description": "\"Block\" button title in the PC/SC-Lite client handling user prompt dialog"
   },
-  "pcscClientHandlingUserPromptDialogMessagePrefix": {
-    "message": "The app",
-    "description": "The prefix of the message displayed in the PC/SC-Lite client handling user prompt dialog, when the App is in the bundled list of the known Apps"
-  },
-  "pcscClientHandlingUserPromptDialogMessageAppNamePart": {
-    "message": "\"$appName$\"",
-    "description": "The App name part of the message displayed in the PC/SC-Lite client handling user prompt dialog, when the App is in the bundled list of the known Apps",
+  "pcscClientHandlingUserPromptDialogMessageClientNamePart": {
+    "message": "\"$clientName$\"",
+    "description": "The name part of the message displayed in the PC/SC-Lite client handling user prompt dialog, when the client is in the bundled list of the known clients",
     "placeholders": {
-      "appName": {
+      "clientName": {
         "content": "$1",
-        "example": "Some App"
+        "example": "Some Application"
       }
     }
   },
   "pcscClientHandlingUserPromptDialogMessageSuffix": {
-    "message": "is trying to access the Smart Card Connector. Would you like to grant this app permission to access Smart card readers?",
-    "description": "The suffix of the message displayed in the PC/SC-Lite client handling user prompt dialog, when the App is in the bundled list of the known Apps"
+    "message": "is trying to access the Smart Card Connector. Would you like to grant it permission to access Smart card readers?",
+    "description": "The suffix of the message displayed in the PC/SC-Lite client handling user prompt dialog, when the client is in the bundled list of the known clients"
   },
-  "pcscClientHandlingUserPromptDialogWarningMessageForUnknownApp": {
-    "message": "For developers only - don't grant access to unknown apps unless you know what you are doing!",
-    "description": "The warning message displayed in the PC/SC-Lite client handling user prompt dialog, when the App is not in the bundled list of the known Apps"
+  "pcscClientHandlingUserPromptDialogWarningMessageForUnknownClient": {
+    "message": "Don't grant access to unknown applications unless you know what you are doing!",
+    "description": "The warning message displayed in the PC/SC-Lite client handling user prompt dialog, when the client is not in the bundled list of the known clients"
   },
-  "pcscClientHandlingUserPromptDialogMessagePrefixForUnknownApp": {
-    "message": "The app from unknown vendor",
-    "description": "The prefix of the message displayed in the PC/SC-Lite client handling user prompt dialog, when the App is not in the bundled list of the known Apps. This message will never be used in the production version"
+  "pcscClientHandlingUserPromptDialogMessagePrefixForUnknownClient": {
+    "message": "The application from unknown vendor",
+    "description": "The prefix of the message displayed in the PC/SC-Lite client handling user prompt dialog, when the client is not in the bundled list of the known clients. This message will never be used in the production version"
   },
-  "pcscClientHandlingUserPromptDialogMessageAppIdPartForUnknownApp": {
-    "message": "(app id: \"$appId$\")",
-    "description": "The App id part of the message displayed in the PC/SC-Lite client handling user prompt dialog, when the App is not in the bundled list of the known Apps. This message will never be used in the production version",
-    "placeholders": {
-      "appId": {
-        "content": "$1",
-        "example": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-      }
-    }
-  },
-  "pcscClientHandlingUserPromptDialogMessageSuffixForUnknownApp": {
+  "pcscClientHandlingUserPromptDialogMessageSuffixForUnknownClient": {
     "message": "is trying to access the Smart Card Connector. Would you like to grant this app permission to access Smart card readers?",
     "description": "The suffix of the message displayed in the PC/SC-Lite client handling user prompt dialog, when the App is not in the bundled list of the known Apps. This message will never be used in the production version"
   },

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompt-dialog-main.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompt-dialog-main.js
@@ -52,7 +52,6 @@ goog.require('goog.string');
 
 goog.scope(function() {
 
-const APP_LINK_TEMPLATE = 'https://chrome.google.com/webstore/detail/%s';
 const UNTRUSTED_CLASS = 'untrusted';
 
 const GSC = GoogleSmartCard;
@@ -69,37 +68,20 @@ function prepareMessage() {
   GSC.Logging.checkWithLogger(logger, typeof isClientKnown === 'boolean');
   goog.asserts.assertBoolean(isClientKnown);
 
-  const clientAppId = data['client_app_id'];
-  GSC.Logging.checkWithLogger(logger, typeof clientAppId === 'string');
-  goog.asserts.assertString(clientAppId);
+  const clientInfoLink = data['client_info_link'];
+  GSC.Logging.checkWithLogger(logger, typeof clientInfoLink === 'string');
+  goog.asserts.assertString(clientInfoLink);
 
-  const clientAppName = data['client_app_name'];
-  if (isClientKnown) {
-    GSC.Logging.checkWithLogger(logger, typeof clientAppName === 'string');
-    goog.asserts.assertString(clientAppName);
-  } else {
-    GSC.Logging.checkWithLogger(
-        logger,
-        clientAppName === undefined || typeof clientAppName === 'string');
-    goog.asserts.assert(
-        clientAppName === undefined || typeof clientAppName === 'string');
-  }
+  const clientName = data['client_name'];
+  GSC.Logging.checkWithLogger(logger, typeof clientName === 'string');
+  goog.asserts.assertString(clientName);
 
-  let linkTitle;
-  if (isClientKnown) {
-    linkTitle = chrome.i18n.getMessage(
-        'pcscClientHandlingUserPromptDialogMessageAppNamePart', clientAppName);
-  } else {
-    linkTitle = chrome.i18n.getMessage(
-        'pcscClientHandlingUserPromptDialogMessageAppIdPartForUnknownApp',
-        clientAppId);
-  }
-
-  const linkHref = goog.string.subs(APP_LINK_TEMPLATE, clientAppId);
+  const linkTitle = chrome.i18n.getMessage(
+      'pcscClientHandlingUserPromptDialogMessageClientNamePart', clientName);
 
   const linkElement = goog.dom.getElement('message-app-link');
   goog.dom.setTextContent(linkElement, linkTitle);
-  linkElement['href'] = linkHref;
+  linkElement['href'] = clientInfoLink;
 
   if (!isClientKnown) {
     goog.dom.classlist.add(

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompt-dialog.css
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompt-dialog.css
@@ -85,7 +85,7 @@ body {
 }
 
 #warning-message::after {
-  content: "__MSG_pcscClientHandlingUserPromptDialogWarningMessageForUnknownApp__";
+  content: "__MSG_pcscClientHandlingUserPromptDialogWarningMessageForUnknownClient__";
 }
 
 #message {
@@ -94,12 +94,8 @@ body {
   padding: 20px 16px 0 0;
 }
 
-#message-prefix::after {
-  content: "__MSG_pcscClientHandlingUserPromptDialogMessagePrefix__";
-}
-
 #message-prefix.untrusted::after {
-  content: "__MSG_pcscClientHandlingUserPromptDialogMessagePrefixForUnknownApp__";
+  content: "__MSG_pcscClientHandlingUserPromptDialogMessagePrefixForUnknownClient__";
 }
 
 #message-app-link,
@@ -115,7 +111,7 @@ body {
 }
 
 #message-suffix.untrusted::after {
-  content: "__MSG_pcscClientHandlingUserPromptDialogMessageSuffixForUnknownApp__";
+  content: "__MSG_pcscClientHandlingUserPromptDialogMessageSuffixForUnknownClient__";
 }
 
 #buttons-container {

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
@@ -235,6 +235,24 @@ UserPromptingChecker.prototype.promptUser_ = function(
 
 /**
  * @param {string} clientAppId
+ * @return {string}
+ */
+function getClientInfoLink(clientAppId) {
+  // For extensions/apps, the info link should point to WebStore.
+  return `https://chrome.google.com/webstore/detail/${clientAppId}`;
+}
+
+/**
+ * @param {string} clientAppId
+ * @return {string}
+ */
+function getNameToShowForUnknownClient(clientAppId) {
+  // For unknown extensions/apps, show their ID.
+  return clientAppId;
+}
+
+/**
+ * @param {string} clientAppId
  * @param {!PermissionsChecking.KnownApp} knownApp
  * @param {!goog.promise.Resolver} promiseResolver
  * @private
@@ -248,8 +266,8 @@ UserPromptingChecker.prototype.promptUserForKnownApp_ = function(
   this.runPromptDialog_(
       clientAppId, {
         'is_client_known': true,
-        'client_app_id': clientAppId,
-        'client_app_name': knownApp.name
+        'client_info_link': getClientInfoLink(clientAppId),
+        'client_name': knownApp.name
       },
       promiseResolver);
 };
@@ -266,7 +284,11 @@ UserPromptingChecker.prototype.promptUserForUnknownApp_ = function(
       'Showing the warning user prompt for the unknown client App with id "' +
           clientAppId + '"...');
   this.runPromptDialog_(
-      clientAppId, {'is_client_known': false, 'client_app_id': clientAppId},
+      clientAppId, {
+        'is_client_known': false,
+        'client_info_link': getClientInfoLink(clientAppId),
+        'client_name': getNameToShowForUnknownClient(clientAppId)
+      },
       promiseResolver);
 };
 
@@ -307,8 +329,8 @@ UserPromptingChecker.prototype.runPromptDialog_ = function(
                 '" because of the user cancellation of the prompt dialog');
         this.storeUserSelection_(clientAppId, false);
         promiseResolver.reject(new Error(
-            'Rejected permission because of the user cancellation of the prompt ' +
-            'dialog'));
+            'Rejected permission because of the user cancellation of the ' +
+            'prompt dialog'));
       },
       this);
 };
@@ -326,9 +348,8 @@ UserPromptingChecker.prototype.storeUserSelection_ = function(
   goog.log.info(
       this.logger,
       'Storing user selection of the ' +
-          (userSelection ? 'granted' : 'rejected') +
-          ' permission to client App ' +
-          'with id "' + clientAppId + '"');
+          (userSelection ? 'granted' : 'rejected') + ' permission to client ' +
+          clientAppId);
 
   this.localStoragePromiseResolver_.promise.then(
       function(/** !Map */ storedUserSelections) {


### PR DESCRIPTION
Change the dialog to make it agnostic to whether the client application
is an extension/app or a web page. Also improve the wording.

This is a preparatory commit for the effort tracked by #377: supporting
PC/SC requests from web pages.