### PR TITLE
Use "mimicking" ID for Connector in Debug builds

### DIFF
--- a/smart_card_connector_app/build/Makefile
+++ b/smart_card_connector_app/build/Makefile
@@ -110,6 +110,7 @@ $(OUT_DIR_PATH)/manifest.json: $(SOURCES_PATH)/create_app_manifest.py $(SOURCES_
 		--manifest-template-path="$(SOURCES_PATH)/manifest.json.template" \
 		--ccid-supported-readers-config-path="$(CCID_SUPPORTED_READERS_CONFIG_PATH)" \
 		--target-file-path="$(OUT_DIR_PATH)/manifest.json" \
+		--enable-condition="CONFIG=$(CONFIG)" \
 		--enable-condition="PACKAGING=$(PACKAGING)"
 
 generate_out: $(OUT_DIR_PATH)/manifest.json

--- a/smart_card_connector_app/src/create_app_manifest.py
+++ b/smart_card_connector_app/src/create_app_manifest.py
@@ -162,7 +162,7 @@ def main():
       dest='target_file')
   args_parser.add_argument(
       '--enable-condition',
-      nargs='+',
+      action='append',
       dest='enabled_conditions')
   args = args_parser.parse_args()
 

--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -1,4 +1,7 @@
 {
+${if CONFIG=Debug}
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlc6hy5++uljMusXcpXspmA3UH5t9ppVHj3FfxvVMPOFX0RLrDvXtfH3f/TkdyPsAzk1QDDQ1++lDatRa3xc4rOGa2ynXljOR9y6rWoqB5wwMOjB42AWSVZWNwpccRsYkMhML5s7uur+B4SERWeMasXuJUhTPweS48Mz0mvp9wZMQB9+xPNm93iUeUZvVtB63ksibx5B3UJUCBz1wSUXLnEoTjy6TR9XsQ+boZlRsk/jY79A+iMQZw72QBBXvWSfJRaeDj266Dz+Jyp0h4lxZJjg/pnL0Rp5s0zlhlSNm6zyrQ6lWMzagjP/2G95LWMNvLTE95oKqhP4hNaxYrI/pUQIDAQAB",
+${endif}
   "manifest_version": 2,
   "name": "__MSG_appName__",
   "short_name": "__MSG_appShortName__",


### PR DESCRIPTION
When building the Smart Card Connector in CONFIG=Debug, automatically
append the "key" property with the real Smart Card Connector's public
key.

This is useful in development and manual testing scenarios, since it
allows to load the just-built application under the production extension
ID ("khpfeaanjngmcnplbdlpegiifgpfgdco").