### PR TITLE
Switch known_client_apps.json to origins

### DIFF
--- a/smart_card_connector_app/src/window-apps-displaying.js
+++ b/smart_card_connector_app/src/window-apps-displaying.js
@@ -24,6 +24,7 @@ goog.provide('GoogleSmartCard.ConnectorApp.Window.AppsDisplaying');
 
 goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
+goog.require('GoogleSmartCard.MessagingOrigin');
 goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientInfo');
 goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientsRegistry');
 goog.require('goog.Promise');

--- a/smart_card_connector_app/src/window-apps-displaying.js
+++ b/smart_card_connector_app/src/window-apps-displaying.js
@@ -24,8 +24,8 @@ goog.provide('GoogleSmartCard.ConnectorApp.Window.AppsDisplaying');
 
 goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
-goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.KnownApp');
-goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.KnownAppsRegistry');
+goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientInfo');
+goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientsRegistry');
 goog.require('goog.Promise');
 goog.require('goog.array');
 goog.require('goog.asserts');
@@ -36,9 +36,7 @@ goog.require('goog.log.Logger');
 goog.scope(function() {
 
 const GSC = GoogleSmartCard;
-const PermissionsChecking =
-    GSC.PcscLiteServerClientsManagement.PermissionsChecking;
-const KnownApp = PermissionsChecking.KnownApp;
+const TrustedClientInfo = GSC.PcscLiteServer.TrustedClientInfo;
 
 /** @type {!goog.log.Logger} */
 const logger = GSC.Logging.getScopedLogger('ConnectorApp.MainWindow');
@@ -47,21 +45,22 @@ const logger = GSC.Logging.getScopedLogger('ConnectorApp.MainWindow');
 const appListElement =
     /** @type {!Element} */ (goog.dom.getElement('app-list'));
 
-const knownAppsRegistry = new PermissionsChecking.KnownAppsRegistry();
+const trustedClientsRegistry = new GSC.PcscLiteServer.TrustedClientsRegistry();
 
 /**
- * @type {goog.Promise.<!Array.<!KnownApp>>?}
+ * @type {goog.Promise.<!Array.<!TrustedClientInfo>>?}
  */
-let lastKnownAppsPromise = null;
+let lastTrustedClientInfosPromise = null;
 
 /**
- * @param {!goog.Promise.<!Array.<!KnownApp>>} knownAppsPromise
+ * @param {!goog.Promise.<!Array.<!TrustedClientInfo>>}
+ *     trustedClientInfosPromise
  * @param {!Array.<string>} appIds
- * @param {Array.<!KnownApp>?} knownApps
+ * @param {Array.<!TrustedClientInfo>?} trustedClientInfos
  * @return {boolean}
  */
-function updateAppView(knownAppsPromise, appIds, knownApps) {
-  if (knownAppsPromise !== lastKnownAppsPromise)
+function updateAppView(trustedClientInfosPromise, appIds, trustedClientInfos) {
+  if (trustedClientInfosPromise !== lastTrustedClientInfosPromise)
     return false;
 
   GSC.Logging.checkWithLogger(logger, appListElement !== null);
@@ -70,8 +69,9 @@ function updateAppView(knownAppsPromise, appIds, knownApps) {
   goog.dom.removeChildren(appListElement);
 
   for (let i = 0; i < appIds.length; i++) {
-    const text =
-        knownApps && knownApps[i] ? knownApps[i].name : '<' + appIds[i] + '>';
+    const text = trustedClientInfos && trustedClientInfos[i] ?
+        trustedClientInfos[i].name :
+        '<' + appIds[i] + '>';
     const newElement = goog.dom.createDom('li', undefined, text);
     goog.dom.append(appListElement, newElement);
   }
@@ -80,28 +80,29 @@ function updateAppView(knownAppsPromise, appIds, knownApps) {
 }
 
 /**
- * @param {!Array.<string>} appListArg
+ * @param {!Array.<string>} appList
  */
-function onUpdateListener(appListArg) {
-  const appList = goog.array.clone(appListArg);
-  goog.array.sort(appList);
+function onUpdateListener(appList) {
+  const originList = appList.map(GSC.MessagingOrigin.getFromExtensionId);
+  goog.array.sort(originList);
   goog.log.fine(
       logger,
       'Application list updated, refreshing the view. ' +
-          'New list of id\'s: ' + GSC.DebugDump.dump(appList));
+          'New list of origins: ' + GSC.DebugDump.dump(originList));
 
-  const knownAppsPromise = knownAppsRegistry.tryGetByIds(appList);
-  lastKnownAppsPromise = knownAppsPromise;
+  const trustedClientInfosPromise =
+      trustedClientsRegistry.tryGetByOrigins(originList);
+  lastTrustedClientInfosPromise = trustedClientInfosPromise;
 
-  knownAppsPromise.then(
-      function(knownApps) {
-        updateAppView(knownAppsPromise, appList, knownApps);
+  trustedClientInfosPromise.then(
+      function(trustedClientInfos) {
+        updateAppView(trustedClientInfosPromise, appList, trustedClientInfos);
       },
       function(error) {
-        if (!updateAppView(knownAppsPromise, appList, null))
+        if (!updateAppView(trustedClientInfosPromise, appList, null))
           return;
 
-        goog.log.warning(logger, 'Couldn\'t resolve appList: ' + error);
+        goog.log.warning(logger, 'Couldn\'t resolve origins: ' + error);
       });
 }
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/known_client_apps.json
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/known_client_apps.json
@@ -1,71 +1,71 @@
 {
-  "dojmlffgommefdofbfdajjpgjgjoffjo": {
+  "chrome-extension://dojmlffgommefdofbfdajjpgjgjoffjo": {
     "name": "Charismathics Smart Card Middleware"
   },
-  "haeblkpifdemlfnkogkipmghfcbonief": {
+  "chrome-extension://haeblkpifdemlfnkogkipmghfcbonief": {
     "name": "CSSI Smart Card Middleware"
   },
-  "omlchkeefdkmmdndbpbhaapnnemfkobc": {
+  "chrome-extension://omlchkeefdkmmdndbpbhaapnnemfkobc": {
     "name": "Charismathics Smart Card Middleware"
   },
-  "haiffjcadagjlijoggckpgfnoeiflnem": {
+  "chrome-extension://haiffjcadagjlijoggckpgfnoeiflnem": {
     "name": "Citrix Workspace"
   },
-  "pckbpdplfajmgaipljfamclkinbjdnma": {
+  "chrome-extension://pckbpdplfajmgaipljfamclkinbjdnma": {
     "name": "VMware Horizon Client"
   },
-  "lpimdiknnpijeigckalekdccibdmeojg": {
+  "chrome-extension://lpimdiknnpijeigckalekdccibdmeojg": {
     "name": "CACKey"
   },
-  "lbfgjakkeeccemhonnolnmglmfmccaag": {
+  "chrome-extension://lbfgjakkeeccemhonnolnmglmfmccaag": {
     "name": "Citrix Workspace - EAR"
   },
-  "kdndmepchimlohdcdkokdddpbnniijoa": {
+  "chrome-extension://kdndmepchimlohdcdkokdddpbnniijoa": {
     "name": "Citrix Workspace - Internal Build"
   },
-  "djkkpfimmenglkapoanbonjbpgbkckag": {
+  "chrome-extension://djkkpfimmenglkapoanbonjbpgbkckag": {
     "name": "BAIMobile Sample Access PKCS11"
   },
-  "oamoafgijflmdhpnmhgmmappcibfinbo": {
+  "chrome-extension://oamoafgijflmdhpnmhgmmappcibfinbo": {
     "name": "BAIMobile Sample Access PKCS11"
   },
-  "cndpbhkcfblfaciifcmnknlkjobidkjo": {
+  "chrome-extension://cndpbhkcfblfaciifcmnknlkjobidkjo": {
     "name": "Gemalto Smart Card Middleware"
   },
-  "odnooafmbfjkpbgdpjlkofbgnfanpicf": {
+  "chrome-extension://odnooafmbfjkpbgdpjlkofbgnfanpicf": {
     "name": "Gemalto SConnect"
   },
-  "bglhmjfplikpjnfoegeomebmfnkjomhe": {
+  "chrome-extension://bglhmjfplikpjnfoegeomebmfnkjomhe": {
     "name": "VMware Horizon Client - Internal"
   },
-  "fdlpibjfnlhnmeckjjhfiejfdghkmkdm": {
+  "chrome-extension://fdlpibjfnlhnmeckjjhfiejfdghkmkdm": {
     "name": "Xtralogic RDP Client"
   },
-  "hlbkkfgplamgidcmijjcglabmiekfech": {
+  "chrome-extension://hlbkkfgplamgidcmijjcglabmiekfech": {
     "name": "smart-pass"
   },
-  "pnhechapfaindjhompbnflcldabbghjo": {
+  "chrome-extension://pnhechapfaindjhompbnflcldabbghjo": {
     "name": "Secure Shell App"
   },
-  "okddffdblfhhnmhodogpojmfkjmhinfp": {
+  "chrome-extension://okddffdblfhhnmhodogpojmfkjmhinfp": {
     "name": "Secure Shell App (dev)"
   },
-  "iodihamcpbpeioajjeobimgagajmlibd": {
+  "chrome-extension://iodihamcpbpeioajjeobimgagajmlibd": {
     "name": "Secure Shell Extension"
   },
-  "algkcnfjnajfhgimadimbjhmpaeohhln": {
+  "chrome-extension://algkcnfjnajfhgimadimbjhmpaeohhln": {
     "name": "Secure Shell Extension (dev)"
   },
-  "njjeilfpkekklihppohcbbanjlcibolf": {
+  "chrome-extension://njjeilfpkekklihppohcbbanjlcibolf": {
     "name": "Xtralogic RDP Client (Stable Channel)"
   },
-  "ekdokegjbgedabpeokeonakhdbagjokj": {
+  "chrome-extension://ekdokegjbgedabpeokeonakhdbagjokj": {
     "name": "Xtralogic RDP Client (Beta Channel)"
   },
-  "ooiklbnjmhbcgemelgfhaeaocllobloj": {
+  "chrome-extension://ooiklbnjmhbcgemelgfhaeaocllobloj": {
     "name": "Mosh"
   },
-  "ppkfnjlimknmjoaemnpidmdlfchhehel": {
+  "chrome-extension://ppkfnjlimknmjoaemnpidmdlfchhehel": {
     "name": "VMware Horizon Client"
   }
 }

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
@@ -205,7 +205,7 @@ TrustedClientsRegistry.prototype.parseJsonAndApply_ = function(json) {
   const originToInfoMap = new Map;
   let success = true;
   goog.object.forEach(json, function(value, key) {
-    const info = this.tryParseInfoJson_(key, value);
+    const info = this.tryParseTrustedClientInfo_(key, value);
     if (info) {
       originToInfoMap.set(info.origin, info);
     } else {
@@ -240,7 +240,8 @@ TrustedClientsRegistry.prototype.parseJsonAndApply_ = function(json) {
  * @return {TrustedClientInfo?}
  * @private
  */
-TrustedClientsRegistry.prototype.tryParseInfoJson_ = function(key, value) {
+TrustedClientsRegistry.prototype.tryParseTrustedClientInfo_ = function(
+    key, value) {
   if (!goog.isObject(value))
     return null;
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
@@ -30,10 +30,8 @@ goog.provide('GoogleSmartCard.PcscLiteServer.TrustedClientInfo');
 goog.provide('GoogleSmartCard.PcscLiteServer.TrustedClientsRegistry');
 
 goog.require('GoogleSmartCard.DebugDump');
-goog.require('GoogleSmartCard.ExtensionId');
 goog.require('GoogleSmartCard.Json');
 goog.require('GoogleSmartCard.Logging');
-goog.require('GoogleSmartCard.MessagingOrigin');
 goog.require('goog.Promise');
 goog.require('goog.asserts');
 goog.require('goog.log');

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
@@ -31,7 +31,8 @@ goog.provide('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsCheckin
 goog.require('GoogleSmartCard.ContainerHelpers');
 goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
-goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.KnownAppsRegistry');
+goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientInfo');
+goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientsRegistry');
 goog.require('GoogleSmartCard.PopupOpener');
 goog.require('goog.Promise');
 goog.require('goog.iter');
@@ -64,7 +65,7 @@ const PermissionsChecking =
  */
 PermissionsChecking.UserPromptingChecker = function() {
   /** @private @const */
-  this.knownAppsRegistry_ = new PermissionsChecking.KnownAppsRegistry;
+  this.trustedClientsRegistry_ = new GSC.PcscLiteServer.TrustedClientsRegistry;
 
   /** @type {!goog.promise.Resolver.<!Map.<string,boolean>>} @private @const */
   this.localStoragePromiseResolver_ = goog.Promise.withResolver();
@@ -129,7 +130,6 @@ UserPromptingChecker.prototype.check = function(clientAppId) {
                 this.logger,
                 'Rejected permission to client App with id "' + clientAppId +
                     '" due to the stored user selection');
-            this.notifyAboutRejectionByStoredSelection_(clientAppId);
             promiseResolver.reject(new Error(
                 'Rejected permission due to the stored user selection'));
           }
@@ -222,13 +222,15 @@ UserPromptingChecker.prototype.parseLocalStorageUserSelections_ = function(
  */
 UserPromptingChecker.prototype.promptUser_ = function(
     clientAppId, promiseResolver) {
-  this.knownAppsRegistry_.getById(clientAppId)
+  const clientOrigin = GSC.MessagingOrigin.getFromExtensionId(clientAppId);
+  this.trustedClientsRegistry_.getByOrigin(clientOrigin)
       .then(
-          function(knownApp) {
-            this.promptUserForKnownApp_(clientAppId, knownApp, promiseResolver);
+          function(trustedClient) {
+            this.promptUserForTrustedClient_(
+                clientAppId, trustedClient, promiseResolver);
           },
           function() {
-            this.promptUserForUnknownApp_(clientAppId, promiseResolver);
+            this.promptUserForUntrustedClient_(clientAppId, promiseResolver);
           },
           this);
 };
@@ -253,21 +255,21 @@ function getNameToShowForUnknownClient(clientAppId) {
 
 /**
  * @param {string} clientAppId
- * @param {!PermissionsChecking.KnownApp} knownApp
+ * @param {!GSC.PcscLiteServer.TrustedClientInfo} trustedClientInfo
  * @param {!goog.promise.Resolver} promiseResolver
  * @private
  */
-UserPromptingChecker.prototype.promptUserForKnownApp_ = function(
-    clientAppId, knownApp, promiseResolver) {
+UserPromptingChecker.prototype.promptUserForTrustedClient_ = function(
+    clientAppId, trustedClientInfo, promiseResolver) {
   goog.log.info(
       this.logger,
-      'Showing the user prompt for the known client App with id "' +
-          clientAppId + '" and name "' + knownApp.name + '"...');
+      'Showing the user prompt for the trusted client App with id "' +
+          clientAppId + '" and name "' + trustedClientInfo.name + '"...');
   this.runPromptDialog_(
       clientAppId, {
         'is_client_known': true,
         'client_info_link': getClientInfoLink(clientAppId),
-        'client_name': knownApp.name
+        'client_name': trustedClientInfo.name
       },
       promiseResolver);
 };
@@ -277,11 +279,11 @@ UserPromptingChecker.prototype.promptUserForKnownApp_ = function(
  * @param {!goog.promise.Resolver} promiseResolver
  * @private
  */
-UserPromptingChecker.prototype.promptUserForUnknownApp_ = function(
+UserPromptingChecker.prototype.promptUserForUntrustedClient_ = function(
     clientAppId, promiseResolver) {
   goog.log.info(
       this.logger,
-      'Showing the warning user prompt for the unknown client App with id "' +
+      'Showing the warning user prompt for the untrusted client App with id "' +
           clientAppId + '"...');
   this.runPromptDialog_(
       clientAppId, {
@@ -369,21 +371,5 @@ UserPromptingChecker.prototype.storeUserSelection_ = function(
             'Failed to store the user selection in the local storage');
       },
       this);
-};
-
-/**
- * @param {string} clientAppId
- */
-UserPromptingChecker.prototype.notifyAboutRejectionByStoredSelection_ =
-    function(clientAppId) {
-  // TODO: implement showing rich notifications to the user here
-};
-
-/**
- * @param {string} clientAppId
- */
-UserPromptingChecker.prototype.notifyAboutRejectionOfUnknownApp_ = function(
-    clientAppId) {
-  // TODO: implement showing rich notifications to the user here
 };
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
@@ -31,6 +31,7 @@ goog.provide('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsCheckin
 goog.require('GoogleSmartCard.ContainerHelpers');
 goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
+goog.require('GoogleSmartCard.MessagingOrigin');
 goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientInfo');
 goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientsRegistry');
 goog.require('GoogleSmartCard.PopupOpener');


### PR DESCRIPTION
Switch the JSON config that describes all client applications that are
"trusted" to list origins instead of extension IDs. This change is part
of the general plan to switch to origins, allowing us to support
requests from web pages in the same way as how we supported them from
extensions.

Also rename a few source files and classes to better reflect the new
function: "KnownApp" => "TrustedClientInfo", "KnownAppsRegistry" =>
"TrustedClientsRegistry". We don't rename the JSON config since it'll
break github links in various old docs and conversations.

This is a preparatory commit for the effort tracked by #377: supporting
PC/SC requests from web pages.