### PR TITLE
Switch PortMessageChannel JS class to origins

### DIFF
--- a/common/js/src/messaging/port-message-channel.js
+++ b/common/js/src/messaging/port-message-channel.js
@@ -29,6 +29,7 @@ goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.MessageChannelPinging.PingResponder');
 goog.require('GoogleSmartCard.MessageChannelPinging.Pinger');
+goog.require('GoogleSmartCard.MessagingOrigin');
 goog.require('GoogleSmartCard.TypedMessage');
 goog.require('goog.asserts');
 goog.require('goog.log');
@@ -67,7 +68,8 @@ GSC.PortMessageChannel = function(port, opt_onEstablished) {
   this.port_ = port;
 
   /** @type {string|null} @const */
-  this.extensionId = this.getPortExtensionId_(port);
+  this.messagingOrigin =
+      GSC.MessagingOrigin.getFromChromeMessageSender(port.sender);
 
   /**
    * @type {!goog.log.Logger}
@@ -75,7 +77,9 @@ GSC.PortMessageChannel = function(port, opt_onEstablished) {
    */
   this.logger = GSC.Logging.getScopedLogger(
       'PortMessageChannel<"' + port.name + '"' +
-      (this.extensionId === null ? '' : ', id="' + this.extensionId + '"') +
+      (this.messagingOrigin === null ?
+           '' :
+           ', sender="' + this.messagingOrigin + '"') +
       '>');
 
   /** @private */
@@ -149,27 +153,6 @@ PortMessageChannel.prototype.disposeInternal = function() {
   goog.log.fine(this.logger, 'Disposed');
 
   PortMessageChannel.base(this, 'disposeInternal');
-};
-
-/**
- * @param {!Port} port
- * @return {string|null}
- * @private
- */
-PortMessageChannel.prototype.getPortExtensionId_ = function(port) {
-  if (!goog.object.containsKey(port, 'sender'))
-    return null;
-  const sender = port['sender'];
-  if (sender === undefined)
-    return null;
-  GSC.Logging.checkWithLogger(this.logger, goog.isObject(sender));
-  if (!goog.object.containsKey(sender, 'id'))
-    return null;
-  const senderId = sender['id'];
-  if (senderId === undefined)
-    return null;
-  GSC.Logging.checkWithLogger(this.logger, typeof senderId === 'string');
-  return senderId;
 };
 
 /** @private */

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -27,6 +27,7 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.MessageChannelPair');
 goog.require('GoogleSmartCard.MessageChannelPool');
 goog.require('GoogleSmartCard.MessagingCommon');
+goog.require('GoogleSmartCard.MessagingOrigin');
 goog.require('GoogleSmartCard.NaclModule');
 goog.require('GoogleSmartCard.Packaging');
 goog.require('GoogleSmartCard.PcscLiteServer.ReaderTracker');

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -183,17 +183,20 @@ function connectionListener(port) {
 function externalConnectionListener(port) {
   goog.log.fine(logger, 'Received onConnectExternal event');
   const portMessageChannel = new GSC.PortMessageChannel(port);
-  if (portMessageChannel.extensionId === null) {
+  if (portMessageChannel.messagingOrigin === null) {
     goog.log.warning(
         logger,
-        'Ignoring the external connection as there is no sender ' +
-            'extension id specified');
+        'Ignoring the external connection as there is no sender specified');
     return;
   }
-  messageChannelPool.addChannel(
-      portMessageChannel.extensionId, portMessageChannel);
+  // TODO(#377): Switch to using origins everywhere.
+  const extensionId = GSC.MessagingOrigin.extractExtensionId(
+      portMessageChannel.messagingOrigin);
+  goog.asserts.assert(extensionId);
+
+  messageChannelPool.addChannel(extensionId, portMessageChannel);
   GSC.MessagingCommon.setNonFatalDefaultServiceCallback(portMessageChannel);
-  createClientHandler(portMessageChannel, portMessageChannel.extensionId);
+  createClientHandler(portMessageChannel, extensionId);
 }
 
 /**


### PR DESCRIPTION
Refactor the class to use a more generic notion of "origins" instead of
"extension IDs".

This is a preparatory commit for the effort tracked by #377: supporting
PC/SC requests from web pages.