### PR TITLE
Clean Emscripten in env/clean.sh

### DIFF
--- a/env/clean.sh
+++ b/env/clean.sh
@@ -21,6 +21,7 @@ set -eu
 PATHS_TO_CLEAN="
   activate
   depot_tools
+  emsdk
   nacl_sdk
   webports
 "


### PR DESCRIPTION
Add a forgotten removal of Emscripten into the env/clean.sh script. It's
intended to clean all artifacts brought in by env/initialize.sh, but we
forgot to add Emscripten into clean.sh when it was added into
initialize.sh.

This fix is attributed to the WebAssembly build infrastructure, that
is tracked by #177.