### PR TITLE
Update Emscripten to 2.0.31

### DIFF
--- a/env/constants.sh
+++ b/env/constants.sh
@@ -18,7 +18,7 @@
 DEPOT_TOOLS_REPOSITORY_URL="https://chromium.googlesource.com/chromium/tools/depot_tools.git"
 
 EMSCRIPTEN_SDK_REPOSITORY_URL="https://github.com/emscripten-core/emsdk.git"
-EMSCRIPTEN_VERSION="2.0.24"
+EMSCRIPTEN_VERSION="2.0.31"
 
 NACL_SDK_VERSION="47"
 


### PR DESCRIPTION
Uprev the pinned third-party dependency - Emscripten - to 2.0.31. This
version brings a few bugfixes, including a long-awaited by us fix for
the printf thread-unsafety.

This commit contributes to the WebAssembly build infrastructure tracked
by #177.