### PR TITLE
Rename socketpair_emulation=>ipc_emulation & move

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -29,6 +29,7 @@ SOURCES_PATH := $(ROOT_SOURCES_PATH)/$(ROOT_SOURCES_SUBDIR)
 
 SOURCES := \
 	$(SOURCES_PATH)/formatting.cc \
+	$(SOURCES_PATH)/ipc_emulation.cc \
 	$(SOURCES_PATH)/logging/function_call_tracer.cc \
 	$(SOURCES_PATH)/logging/hex_dumping.cc \
 	$(SOURCES_PATH)/logging/logging.cc \

--- a/common/cpp/src/google_smart_card_common/ipc_emulation.h
+++ b/common/cpp/src/google_smart_card_common/ipc_emulation.h
@@ -1,43 +1,25 @@
 // Copyright 2016 Google Inc.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in the
-//    documentation and/or other materials provided with the distribution.
-// 3. The name of the author may not be used to endorse or promote products
-//    derived from this software without specific prior written permission.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
-// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-// IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-// As NaCl/PNaCl currently don't implement the sockets for local inter-process
-// communication (domain PF_UNIX sockets), their replacement with a limited
-// functionality is provided here.
-//
-// It works only within a single NaCl process. The interface is heavily
-// simplified comparing to the original POSIX interface (the family of the
-// following functions: accept, bind, close, connect, fcntl, listen, read,
-// select, socket, etc.).
-//
-// When the PNaCl SDK eventually provides a native implementation of the POSIX
-// domain sockets (see <http://crbug.com/532095>), this emulation library can be
-// dropped.
+// This file provides polyfills for POSIX inter-process communication
+// primitives. As web packaging technologies (WebAssembly, and previously NaCl)
+// don't support multiprocess execution, our polyfills are in-process simulation
+// of these primitives. The polyfills are also severely simplified, with the
+// main objective to address our use cases in this project.
 
-#ifndef GOOGLE_SMART_CARD_THIRD_PARTY_PCSC_LITE_SOCKETPAIR_EMULATION_H_
-#define GOOGLE_SMART_CARD_THIRD_PARTY_PCSC_LITE_SOCKETPAIR_EMULATION_H_
+#ifndef GOOGLE_SMART_CARD_COMMON_IPC_EMULATION_H_
+#define GOOGLE_SMART_CARD_COMMON_IPC_EMULATION_H_
 
 #include <stdint.h>
 
@@ -58,7 +40,7 @@ namespace google_smart_card {
 // be enough for most purposes, given that the generation of a new emulated
 // socket pair is requested only when a client opens a new connection to the
 // server).
-class SocketpairEmulationManager final {
+class IpcEmulationManager final {
  public:
   // Creates a singleton instance of this class.
   //
@@ -67,7 +49,7 @@ class SocketpairEmulationManager final {
   // Returns a previously created singleton instance of this class.
   //
   // Note: This function is not thread-safe!
-  static SocketpairEmulationManager* GetInstance();
+  static IpcEmulationManager* GetInstance();
 
   // Creates a new socket pair, and returns file descriptors corresponding to
   // the both ends.
@@ -124,11 +106,10 @@ class SocketpairEmulationManager final {
  private:
   class Socket;
 
-  SocketpairEmulationManager();
-  SocketpairEmulationManager(const SocketpairEmulationManager&) = delete;
-  SocketpairEmulationManager& operator=(const SocketpairEmulationManager&) =
-      delete;
-  ~SocketpairEmulationManager();
+  IpcEmulationManager();
+  IpcEmulationManager(const IpcEmulationManager&) = delete;
+  IpcEmulationManager& operator=(const IpcEmulationManager&) = delete;
+  ~IpcEmulationManager();
 
   int GenerateNewFileDescriptor();
 
@@ -141,15 +122,15 @@ class SocketpairEmulationManager final {
   std::unordered_map<int, const std::shared_ptr<Socket>> socket_map_;
 };
 
-namespace socketpair_emulation {
+namespace ipc_emulation {
 
 //
 // The following group of functions correspond to the methods of the
-// SocketpairEmulationManager class.
+// IpcEmulationManager class.
 //
-// It is assumed that a global instance of the SocketpairEmulationManager class
-// was previously created (see the
-// SocketpairEmulationManager::CreateGlobalInstance method).
+// It is assumed that a global instance of the IpcEmulationManager class was
+// previously created (see the `IpcEmulationManager::CreateGlobalInstance()`
+// method).
 //
 
 void Create(int* file_descriptor_1, int* file_descriptor_2);
@@ -171,8 +152,8 @@ bool Read(int file_descriptor,
           int64_t* in_out_size,
           bool* is_failure);
 
-}  // namespace socketpair_emulation
+}  // namespace ipc_emulation
 
 }  // namespace google_smart_card
 
-#endif  // GOOGLE_SMART_CARD_THIRD_PARTY_PCSC_LITE_SOCKETPAIR_EMULATION_H_
+#endif  // GOOGLE_SMART_CARD_COMMON_IPC_EMULATION_H_

--- a/third_party/pcsc-lite/naclport/server/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server/build/Makefile
@@ -193,7 +193,6 @@ PCSC_LITE_SERVER_NACL_SOURCES := \
 	$(SOURCES_PATH)/pcscdaemon_nacl.cc \
 	$(SOURCES_PATH)/readerfactory_nacl.cc \
 	$(SOURCES_PATH)/server_sockets_manager.cc \
-	$(SOURCES_PATH)/socketpair_emulation.cc \
 	$(SOURCES_PATH)/sys_nacl.cc \
 	$(SOURCES_PATH)/unistd_nacl.cc \
 	$(SOURCES_PATH)/winscard_msg_nacl.cc \

--- a/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.cc
+++ b/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.cc
@@ -42,13 +42,13 @@ extern "C" {
 #include "winscard_svc.h"
 }
 
+#include <google_smart_card_common/ipc_emulation.h>
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/messaging/typed_message.h>
 #include <google_smart_card_common/value.h>
 #include <google_smart_card_common/value_conversion.h>
 
 #include "server_sockets_manager.h"
-#include "socketpair_emulation.h"
 
 namespace google_smart_card {
 
@@ -167,7 +167,7 @@ const PcscLiteServerGlobal* PcscLiteServerGlobal::GetInstance() {
 void PcscLiteServerGlobal::InitializeAndRunDaemonThread() {
   GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Initialization...";
 
-  SocketpairEmulationManager::CreateGlobalInstance();
+  IpcEmulationManager::CreateGlobalInstance();
   PcscLiteServerSocketsManager::CreateGlobalInstance();
 
   ::SYS_InitRandom();


### PR DESCRIPTION
This refactoring renames the "socketpair emulation" helper to "IPC
emulation", to reflect that we're going to simulate more IPC methods,
those that don't work under Emscripten. Also move it into //common/cpp/,
since there's really nothing PC/SC-Lite-specific about this code.

This commit contributes to the WebAssembly migration effort, tracked by
issue #233.