### PR TITLE
Emulate pipe() IPC function

### DIFF
--- a/common/cpp/build/tests/Makefile
+++ b/common/cpp/build/tests/Makefile
@@ -25,6 +25,7 @@ SOURCES_PATH := $(ROOT_SOURCES_PATH)/$(ROOT_SOURCES_SUBDIR)
 
 SOURCES := \
 	$(SOURCES_PATH)/formatting_unittest.cc \
+	$(SOURCES_PATH)/ipc_emulation_unittest.cc \
 	$(SOURCES_PATH)/logging/hex_dumping_unittest.cc \
 	$(SOURCES_PATH)/messaging/typed_message_router_unittest.cc \
 	$(SOURCES_PATH)/numeric_conversions_unittest.cc \

--- a/common/cpp/src/google_smart_card_common/ipc_emulation.cc
+++ b/common/cpp/src/google_smart_card_common/ipc_emulation.cc
@@ -92,9 +92,6 @@ class IpcEmulation::InMemoryFile final {
       GOOGLE_SMART_CARD_WARN_UNUSED_RESULT {
     GOOGLE_SMART_CARD_CHECK(!timeout_milliseconds ||
                             *timeout_milliseconds >= 0);
-    auto wait_criteria = [this]() {
-      return is_closed_ || !read_buffer_.empty();
-    };
     std::unique_lock<std::mutex> lock(mutex_);
     return WaitUntilCanBeReadLocked(timeout_milliseconds, lock);
   }

--- a/common/cpp/src/google_smart_card_common/ipc_emulation.cc
+++ b/common/cpp/src/google_smart_card_common/ipc_emulation.cc
@@ -102,7 +102,7 @@ class IpcEmulation::InMemoryFile final {
   IpcEmulation::ReadResult Read(uint8_t* buffer, int64_t* in_out_size)
       GOOGLE_SMART_CARD_WARN_UNUSED_RESULT {
     GOOGLE_SMART_CARD_CHECK(buffer);
-    GOOGLE_SMART_CARD_CHECK(*in_out_size > 0);
+    GOOGLE_SMART_CARD_CHECK(*in_out_size >= 0);
     std::unique_lock<std::mutex> lock(mutex_);
     if (is_closed_)
       return IpcEmulation::ReadResult::kNoSuchFile;

--- a/common/cpp/src/google_smart_card_common/ipc_emulation.cc
+++ b/common/cpp/src/google_smart_card_common/ipc_emulation.cc
@@ -14,6 +14,8 @@
 
 #include <google_smart_card_common/ipc_emulation.h>
 
+#include <errno.h>
+
 #include <algorithm>
 #include <chrono>
 #include <condition_variable>
@@ -36,10 +38,13 @@ IpcEmulation* g_ipc_emulation = nullptr;
 
 class IpcEmulation::InMemoryFile final {
  public:
-  explicit InMemoryFile(int file_descriptor)
-      : file_descriptor_(file_descriptor) {
-    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "An in-memory file "
-                                << file_descriptor << " was created";
+  InMemoryFile(int file_descriptor, bool reads_should_block)
+      : file_descriptor_(file_descriptor),
+        reads_should_block_(reads_should_block) {
+    GOOGLE_SMART_CARD_LOG_DEBUG
+        << kLoggingPrefix << "A "
+        << (reads_should_block_ ? "blocking" : "non-blocking")
+        << " in-memory file " << file_descriptor << " was created";
   }
 
   InMemoryFile(const InMemoryFile&) = delete;
@@ -57,10 +62,10 @@ class IpcEmulation::InMemoryFile final {
     GOOGLE_SMART_CARD_CHECK(!other_end.expired());
     GOOGLE_SMART_CARD_CHECK(other_end_.expired());
     other_end_ = other_end;
-    GOOGLE_SMART_CARD_LOG_DEBUG
-        << kLoggingPrefix << "The in-memory file " << file_descriptor()
-        << " connected to the in-memory file "
-        << other_end_.lock()->file_descriptor();
+    GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "The in-memory file "
+                                << file_descriptor()
+                                << " connected to the in-memory file "
+                                << other_end_.lock()->file_descriptor();
   }
 
   void Close() {
@@ -91,18 +96,7 @@ class IpcEmulation::InMemoryFile final {
       return is_closed_ || !read_buffer_.empty();
     };
     std::unique_lock<std::mutex> lock(mutex_);
-    if (timeout_milliseconds) {
-      condition_.wait_for(lock,
-                          std::chrono::milliseconds(*timeout_milliseconds),
-                          wait_criteria);
-    } else {
-      condition_.wait(lock, wait_criteria);
-    }
-    if (is_closed_)
-      return IpcEmulation::WaitResult::kNoSuchFile;
-    if (read_buffer_.empty())
-      return IpcEmulation::WaitResult::kTimeout;
-    return IpcEmulation::WaitResult::kSuccess;
+    return WaitUntilCanBeReadLocked(timeout_milliseconds, lock);
   }
 
   IpcEmulation::ReadResult Read(uint8_t* buffer, int64_t* in_out_size)
@@ -112,6 +106,21 @@ class IpcEmulation::InMemoryFile final {
     std::unique_lock<std::mutex> lock(mutex_);
     if (is_closed_)
       return IpcEmulation::ReadResult::kNoSuchFile;
+    if (!*in_out_size)
+      return IpcEmulation::ReadResult::kSuccess;
+    if (reads_should_block_) {
+      const IpcEmulation::WaitResult wait_result =
+          WaitUntilCanBeReadLocked(/*timeout_milliseconds=*/{}, lock);
+      switch (wait_result) {
+        case IpcEmulation::WaitResult::kSuccess:
+          // Proceed to copying the bytes.
+          break;
+        case IpcEmulation::WaitResult::kNoSuchFile:
+          return IpcEmulation::ReadResult::kNoSuchFile;
+        case IpcEmulation::WaitResult::kTimeout:
+          GOOGLE_SMART_CARD_NOTREACHED;
+      }
+    }
     if (read_buffer_.empty())
       return IpcEmulation::ReadResult::kNoData;
     *in_out_size =
@@ -145,7 +154,28 @@ class IpcEmulation::InMemoryFile final {
     return true;
   }
 
+  IpcEmulation::WaitResult WaitUntilCanBeReadLocked(
+      optional<int64_t> timeout_milliseconds,
+      std::unique_lock<std::mutex>& lock) GOOGLE_SMART_CARD_WARN_UNUSED_RESULT {
+    auto wait_criteria = [this]() {
+      return is_closed_ || !read_buffer_.empty();
+    };
+    if (timeout_milliseconds) {
+      condition_.wait_for(lock,
+                          std::chrono::milliseconds(*timeout_milliseconds),
+                          wait_criteria);
+    } else {
+      condition_.wait(lock, wait_criteria);
+    }
+    if (is_closed_)
+      return IpcEmulation::WaitResult::kNoSuchFile;
+    if (read_buffer_.empty())
+      return IpcEmulation::WaitResult::kTimeout;
+    return IpcEmulation::WaitResult::kSuccess;
+  }
+
   const int file_descriptor_;
+  const bool reads_should_block_;
   mutable std::mutex mutex_;
   std::condition_variable condition_;
   bool is_closed_ = false;
@@ -160,19 +190,28 @@ void IpcEmulation::CreateGlobalInstance() {
 }
 
 // static
+void IpcEmulation::DestroyGlobalInstanceForTesting() {
+  delete g_ipc_emulation;
+  g_ipc_emulation = nullptr;
+}
+
+// static
 IpcEmulation* IpcEmulation::GetInstance() {
   GOOGLE_SMART_CARD_CHECK(g_ipc_emulation);
   return g_ipc_emulation;
 }
 
 void IpcEmulation::CreateInMemoryFilePair(int* file_descriptor_1,
-                                          int* file_descriptor_2) {
+                                          int* file_descriptor_2,
+                                          bool reads_should_block) {
   GOOGLE_SMART_CARD_CHECK(file_descriptor_1);
   GOOGLE_SMART_CARD_CHECK(file_descriptor_2);
   *file_descriptor_1 = GenerateNewFileDescriptor();
   *file_descriptor_2 = GenerateNewFileDescriptor();
-  std::shared_ptr<InMemoryFile> file_1(new InMemoryFile(*file_descriptor_1));
-  std::shared_ptr<InMemoryFile> file_2(new InMemoryFile(*file_descriptor_2));
+  std::shared_ptr<InMemoryFile> file_1(
+      new InMemoryFile(*file_descriptor_1, reads_should_block));
+  std::shared_ptr<InMemoryFile> file_2(
+      new InMemoryFile(*file_descriptor_2, reads_should_block));
   file_1->SetOtherEnd(file_2);
   file_2->SetOtherEnd(file_1);
   AddFile(std::move(file_1));
@@ -196,6 +235,8 @@ bool IpcEmulation::CloseInMemoryFile(int file_descriptor) {
 bool IpcEmulation::WriteToInMemoryFile(int file_descriptor,
                                        const uint8_t* data,
                                        int64_t size) {
+  GOOGLE_SMART_CARD_CHECK(data);
+  GOOGLE_SMART_CARD_CHECK(size >= 0);
   const std::shared_ptr<InMemoryFile> file =
       FindFileByDescriptor(file_descriptor);
   if (!file)
@@ -217,12 +258,15 @@ IpcEmulation::ReadResult IpcEmulation::ReadFromInMemoryFile(
     int file_descriptor,
     uint8_t* buffer,
     int64_t* in_out_size) {
+  GOOGLE_SMART_CARD_CHECK(buffer);
+  GOOGLE_SMART_CARD_CHECK(in_out_size);
+  GOOGLE_SMART_CARD_CHECK(*in_out_size >= 0);
   const std::shared_ptr<InMemoryFile> file =
       FindFileByDescriptor(file_descriptor);
   if (!file)
     return ReadResult::kNoSuchFile;
   ReadResult read_result = file->Read(buffer, in_out_size);
-  GOOGLE_SMART_CARD_CHECK(*in_out_size > 0);
+  GOOGLE_SMART_CARD_CHECK(*in_out_size >= 0);
   return read_result;
 }
 
@@ -256,5 +300,49 @@ std::shared_ptr<IpcEmulation::InMemoryFile> IpcEmulation::FindFileByDescriptor(
     return {};
   return iter->second;
 }
+
+extern "C" {
+
+int GoogleSmartCardIpcEmulationPipe(int pipefd[2]) {
+  IpcEmulation::GetInstance()->CreateInMemoryFilePair(
+      &pipefd[0], &pipefd[1], /*reads_should_block=*/true);
+  return 0;
+}
+
+ssize_t GoogleSmartCardIpcEmulationWrite(int fd,
+                                         const void* buf,
+                                         size_t count) {
+  if (!IpcEmulation::GetInstance()->WriteToInMemoryFile(
+          fd, static_cast<const uint8_t*>(buf), count)) {
+    errno = EBADF;
+    return -1;
+  }
+  return count;
+}
+
+ssize_t GoogleSmartCardIpcEmulationRead(int fd, void* buf, size_t count) {
+  int64_t in_out_count = count;
+  IpcEmulation::ReadResult read_result =
+      IpcEmulation::GetInstance()->ReadFromInMemoryFile(
+          fd, static_cast<uint8_t*>(buf), &in_out_count);
+  switch (read_result) {
+    case IpcEmulation::ReadResult::kSuccess:
+      return in_out_count;
+    case IpcEmulation::ReadResult::kNoSuchFile:
+      errno = EBADF;
+      return -1;
+    case IpcEmulation::ReadResult::kNoData:
+      return 0;
+  }
+}
+
+int GoogleSmartCardIpcEmulationClose(int fd) {
+  if (IpcEmulation::GetInstance()->CloseInMemoryFile(fd))
+    return 0;
+  errno = EBADF;
+  return -1;
+}
+
+}  // extern "C"
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/ipc_emulation.h
+++ b/common/cpp/src/google_smart_card_common/ipc_emulation.h
@@ -143,7 +143,7 @@ extern "C" {
 //
 // The background is that the standard library implementation of `pipe()` under
 // Emscripten has poor semantics: it always creates a nonblocking pipe, despite
-// that the `O_NONBLOCK` flag is not passed (and ).
+// that the `O_NONBLOCK` flag is not passed.
 int GoogleSmartCardIpcEmulationPipe(int pipefd[2]);
 
 // Fake implementation of `write()`.

--- a/third_party/pcsc-lite/naclport/server/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server/build/Makefile
@@ -98,7 +98,6 @@ PCSC_LITE_SERVER_SOURCES := \
 	$(PCSC_LITE_SOURCES_PATH)/atrhandler.c \
 	$(PCSC_LITE_SOURCES_PATH)/error.c \
 	$(PCSC_LITE_SOURCES_PATH)/eventhandler.c \
-	$(PCSC_LITE_SOURCES_PATH)/hotplug_libusb.c \
 	$(PCSC_LITE_SOURCES_PATH)/ifdwrapper.c \
 	$(PCSC_LITE_SOURCES_PATH)/prothandler.c \
 	$(PCSC_LITE_SOURCES_PATH)/utils.c \
@@ -171,6 +170,25 @@ PCSC_LITE_SERVER_READERFACTORY_CPPFLAGS := \
 
 $(foreach src,$(PCSC_LITE_SERVER_READERFACTORY_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_READERFACTORY_CPPFLAGS))))
 
+# Special group just for hotplug_libusb.c.
+PCSC_LITE_SERVER_HOTPLUG_LIBUSB_SOURCES := \
+	$(PCSC_LITE_SOURCES_PATH)/hotplug_libusb.c \
+
+# * mock out the pipe(), read(), write() and close() standard library functions
+#   with our fake implementations, since the standard pipe() has poor semantics
+#   under Emscripten (it always creates a nonblocking pipe, even when there's no
+#   O_NONBLOCK flag specified); read() and close() need to be mocked out, since
+#   our fake pipe() implementation returns fake file descriptors (based on
+#   simple counters).
+PCSC_LITE_SERVER_HOTPLUG_LIBUSB_CPPFLAGS := \
+	$(PCSC_LITE_SERVER_CPPFLAGS) \
+	-Dclose=GoogleSmartCardIpcEmulationClose \
+	-Dpipe=GoogleSmartCardIpcEmulationPipe \
+	-Dread=GoogleSmartCardIpcEmulationRead \
+	-Dwrite=GoogleSmartCardIpcEmulationWrite \
+
+$(foreach src,$(PCSC_LITE_SERVER_HOTPLUG_LIBUSB_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_HOTPLUG_LIBUSB_CPPFLAGS))))
+
 # List of the original PC/SC-Lite client library source files to be compiled
 PCSC_LITE_CLIENT_SOURCES := \
 	$(PCSC_LITE_SOURCES_PATH)/winscard_clnt.c \
@@ -211,6 +229,7 @@ SOURCES := \
 	$(PCSC_LITE_SERVER_SOURCES) \
 	$(PCSC_LITE_SERVER_SVC_SOURCES) \
 	$(PCSC_LITE_SERVER_DEBUGLOG_SOURCES) \
+	$(PCSC_LITE_SERVER_HOTPLUG_LIBUSB_SOURCES) \
 	$(PCSC_LITE_CLIENT_SOURCES) \
 	$(PCSC_LITE_SERVER_NACL_SOURCES) \
 	$(PCSC_LITE_SERVER_READERFACTORY_SOURCES) \

--- a/third_party/pcsc-lite/naclport/server/src/winscard_msg_nacl.cc
+++ b/third_party/pcsc-lite/naclport/server/src/winscard_msg_nacl.cc
@@ -89,7 +89,8 @@ INTERNAL int ClientSetupSession(uint32_t* pdwClientID) {
   int client_socket_file_descriptor;
   int server_socket_file_descriptor;
   IpcEmulation::GetInstance()->CreateInMemoryFilePair(
-      &client_socket_file_descriptor, &server_socket_file_descriptor);
+      &client_socket_file_descriptor, &server_socket_file_descriptor,
+      /*reads_should_block=*/false);
   *pdwClientID = static_cast<uint32_t>(client_socket_file_descriptor);
 
   // Another end of the created socket pair is passed to the daemon main run


### PR DESCRIPTION
Add a fake implementation of the pipe() function, in order to work
around the Emscripten issue with all pipes being created as
non-blocking - which is a non-standard behavior that was causing crashes
inside the PC/SC-Lite daemon.

Also wire up this fake pipe() implementation, together with
corresponding fake write()/read()/close(), with the third-party code in
hotplug_libusb.c, by redefining the standard names to our own helpers.
This is hacky, but allows to not maintain complex patches that'd need to
be reapplied to the upstream.

This commit contributes to the WebAssembly migration effort, tracked by
issue #233.