### PR TITLE
[usb] Rename LibusbOverChromeUsbGlobal

### DIFF
--- a/smart_card_connector_app/build/executable_module/Makefile
+++ b/smart_card_connector_app/build/executable_module/Makefile
@@ -55,8 +55,8 @@ LIBS := \
 DEPS :=
 
 CXXFLAGS := \
+	-I$(ROOT_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
-	-I$(ROOT_PATH)/third_party/libusb/webport/src \
 	-I$(ROOT_PATH)/third_party/pcsc-lite/naclport/server/src \
 	-I$(ROOT_PATH)/third_party/pcsc-lite/naclport/server_clients_management/src \
 	-Wall \

--- a/smart_card_connector_app/src/application.cc
+++ b/smart_card_connector_app/src/application.cc
@@ -25,10 +25,11 @@
 #include <google_smart_card_common/unique_ptr_utils.h>
 #include <google_smart_card_common/value.h>
 #include <google_smart_card_common/value_conversion.h>
-#include <google_smart_card_libusb/global.h>
 #include <google_smart_card_pcsc_lite_server/global.h>
 #include <google_smart_card_pcsc_lite_server_clients_management/backend.h>
 #include <google_smart_card_pcsc_lite_server_clients_management/ready_message.h>
+
+#include "third_party/libusb/webport/src/public/libusb_web_port_service.h"
 
 namespace google_smart_card {
 
@@ -39,9 +40,9 @@ Application::Application(
     : global_context_(global_context),
       typed_message_router_(typed_message_router),
       background_initialization_callback_(background_initialization_callback),
-      libusb_over_chrome_usb_global_(
-          MakeUnique<LibusbOverChromeUsbGlobal>(global_context_,
-                                                typed_message_router_)),
+      libusb_web_port_service_(
+          MakeUnique<LibusbWebPortService>(global_context_,
+                                           typed_message_router_)),
       pcsc_lite_server_global_(
           MakeUnique<PcscLiteServerGlobal>(global_context_)) {
   ScheduleServicesInitialization();
@@ -50,8 +51,8 @@ Application::Application(
 Application::~Application() {
   // Intentionally leak objects that might still be used by background threads.
   // Only detach them from `this` and the JavaScript side.
-  libusb_over_chrome_usb_global_->Detach();
-  (void)libusb_over_chrome_usb_global_.release();
+  libusb_web_port_service_->Detach();
+  (void)libusb_web_port_service_.release();
   (void)pcsc_lite_server_global_.release();
 }
 

--- a/smart_card_connector_app/src/application.h
+++ b/smart_card_connector_app/src/application.h
@@ -20,9 +20,10 @@
 
 #include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_libusb/global.h>
 #include <google_smart_card_pcsc_lite_server/global.h>
 #include <google_smart_card_pcsc_lite_server_clients_management/backend.h>
+
+#include "third_party/libusb/webport/src/public/libusb_web_port_service.h"
 
 namespace google_smart_card {
 
@@ -59,7 +60,7 @@ class Application final {
   GlobalContext* const global_context_;
   TypedMessageRouter* const typed_message_router_;
   std::function<void()> background_initialization_callback_;
-  std::unique_ptr<LibusbOverChromeUsbGlobal> libusb_over_chrome_usb_global_;
+  std::unique_ptr<LibusbWebPortService> libusb_web_port_service_;
   std::unique_ptr<PcscLiteServerClientsManagementBackend>
       pcsc_lite_server_clients_management_backend_;
   std::unique_ptr<PcscLiteServerGlobal> pcsc_lite_server_global_;

--- a/third_party/libusb/webport/build/Makefile
+++ b/third_party/libusb/webport/build/Makefile
@@ -39,11 +39,11 @@ C_SOURCES := \
 CXX_SOURCES := \
 	$(LIBUSB_NACL_SOURCES_PATH)/chrome_usb/api_bridge.cc \
 	$(LIBUSB_NACL_SOURCES_PATH)/chrome_usb/types.cc \
-	$(LIBUSB_NACL_SOURCES_PATH)/google_smart_card_libusb/global.cc \
 	$(LIBUSB_NACL_SOURCES_PATH)/libusb_contexts_storage.cc \
 	$(LIBUSB_NACL_SOURCES_PATH)/libusb_opaque_types.cc \
 	$(LIBUSB_NACL_SOURCES_PATH)/libusb_over_chrome_usb.cc \
 	$(LIBUSB_NACL_SOURCES_PATH)/libusb_tracing_wrapper.cc \
+	$(LIBUSB_NACL_SOURCES_PATH)/public/libusb_web_port_service.cc \
 	$(LIBUSB_NACL_SOURCES_PATH)/usb_transfer_destination.cc \
 	$(LIBUSB_NACL_SOURCES_PATH)/usb_transfers_parameters_storage.cc \
 

--- a/third_party/libusb/webport/src/public/libusb_web_port_service.cc
+++ b/third_party/libusb/webport/src/public/libusb_web_port_service.cc
@@ -14,7 +14,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include <google_smart_card_libusb/global.h>
+#include "libusb_web_port_service.h"
 
 #include <utility>
 
@@ -34,7 +34,7 @@ namespace {
 // that is used by the implementation of libusb_* functions in this library.
 google_smart_card::LibusbInterface* g_libusb = nullptr;
 
-google_smart_card::LibusbInterface* GetGlobalLibusb() {
+google_smart_card::LibusbInterface* GetLibusbImpl() {
   GOOGLE_SMART_CARD_CHECK(g_libusb);
   return g_libusb;
 }
@@ -43,7 +43,7 @@ google_smart_card::LibusbInterface* GetGlobalLibusb() {
 
 namespace google_smart_card {
 
-class LibusbOverChromeUsbGlobal::Impl final {
+class LibusbWebPortService::Impl final {
  public:
   Impl(GlobalContext* global_context, TypedMessageRouter* typed_message_router)
       : chrome_usb_api_bridge_(
@@ -75,7 +75,7 @@ class LibusbOverChromeUsbGlobal::Impl final {
   std::unique_ptr<LibusbTracingWrapper> libusb_tracing_wrapper_;
 };
 
-LibusbOverChromeUsbGlobal::LibusbOverChromeUsbGlobal(
+LibusbWebPortService::LibusbWebPortService(
     GlobalContext* global_context,
     TypedMessageRouter* typed_message_router)
     : impl_(MakeUnique<Impl>(global_context, typed_message_router)) {
@@ -83,103 +83,103 @@ LibusbOverChromeUsbGlobal::LibusbOverChromeUsbGlobal(
   g_libusb = impl_->libusb();
 }
 
-LibusbOverChromeUsbGlobal::~LibusbOverChromeUsbGlobal() {
+LibusbWebPortService::~LibusbWebPortService() {
   GOOGLE_SMART_CARD_CHECK(g_libusb == impl_->libusb());
   g_libusb = nullptr;
 }
 
-void LibusbOverChromeUsbGlobal::Detach() {
+void LibusbWebPortService::Detach() {
   impl_->Detach();
 }
 
 }  // namespace google_smart_card
 
 int LIBUSB_CALL libusb_init(libusb_context** ctx) {
-  return GetGlobalLibusb()->LibusbInit(ctx);
+  return GetLibusbImpl()->LibusbInit(ctx);
 }
 
 void LIBUSB_CALL libusb_exit(libusb_context* ctx) {
-  GetGlobalLibusb()->LibusbExit(ctx);
+  GetLibusbImpl()->LibusbExit(ctx);
 }
 
 ssize_t LIBUSB_CALL libusb_get_device_list(libusb_context* ctx,
                                            libusb_device*** list) {
-  return GetGlobalLibusb()->LibusbGetDeviceList(ctx, list);
+  return GetLibusbImpl()->LibusbGetDeviceList(ctx, list);
 }
 
 void LIBUSB_CALL libusb_free_device_list(libusb_device** list,
                                          int unref_devices) {
-  GetGlobalLibusb()->LibusbFreeDeviceList(list, unref_devices);
+  GetLibusbImpl()->LibusbFreeDeviceList(list, unref_devices);
 }
 
 libusb_device* LIBUSB_CALL libusb_ref_device(libusb_device* dev) {
-  return GetGlobalLibusb()->LibusbRefDevice(dev);
+  return GetLibusbImpl()->LibusbRefDevice(dev);
 }
 
 void LIBUSB_CALL libusb_unref_device(libusb_device* dev) {
-  GetGlobalLibusb()->LibusbUnrefDevice(dev);
+  GetLibusbImpl()->LibusbUnrefDevice(dev);
 }
 
 int LIBUSB_CALL
 libusb_get_active_config_descriptor(libusb_device* dev,
                                     libusb_config_descriptor** config) {
-  return GetGlobalLibusb()->LibusbGetActiveConfigDescriptor(dev, config);
+  return GetLibusbImpl()->LibusbGetActiveConfigDescriptor(dev, config);
 }
 
 void LIBUSB_CALL
 libusb_free_config_descriptor(libusb_config_descriptor* config) {
-  return GetGlobalLibusb()->LibusbFreeConfigDescriptor(config);
+  return GetLibusbImpl()->LibusbFreeConfigDescriptor(config);
 }
 
 int LIBUSB_CALL libusb_get_device_descriptor(libusb_device* dev,
                                              libusb_device_descriptor* desc) {
-  return GetGlobalLibusb()->LibusbGetDeviceDescriptor(dev, desc);
+  return GetLibusbImpl()->LibusbGetDeviceDescriptor(dev, desc);
 }
 
 uint8_t LIBUSB_CALL libusb_get_bus_number(libusb_device* dev) {
-  return GetGlobalLibusb()->LibusbGetBusNumber(dev);
+  return GetLibusbImpl()->LibusbGetBusNumber(dev);
 }
 
 uint8_t LIBUSB_CALL libusb_get_device_address(libusb_device* dev) {
-  return GetGlobalLibusb()->LibusbGetDeviceAddress(dev);
+  return GetLibusbImpl()->LibusbGetDeviceAddress(dev);
 }
 
 int LIBUSB_CALL libusb_open(libusb_device* dev, libusb_device_handle** handle) {
-  return GetGlobalLibusb()->LibusbOpen(dev, handle);
+  return GetLibusbImpl()->LibusbOpen(dev, handle);
 }
 
 void LIBUSB_CALL libusb_close(libusb_device_handle* dev_handle) {
-  return GetGlobalLibusb()->LibusbClose(dev_handle);
+  return GetLibusbImpl()->LibusbClose(dev_handle);
 }
 
 int LIBUSB_CALL libusb_claim_interface(libusb_device_handle* dev,
                                        int interface_number) {
-  return GetGlobalLibusb()->LibusbClaimInterface(dev, interface_number);
+  return GetLibusbImpl()->LibusbClaimInterface(dev, interface_number);
 }
 
 int LIBUSB_CALL libusb_release_interface(libusb_device_handle* dev,
                                          int interface_number) {
-  return GetGlobalLibusb()->LibusbReleaseInterface(dev, interface_number);
+  return GetLibusbImpl()->LibusbReleaseInterface(dev, interface_number);
 }
 
 libusb_transfer* LIBUSB_CALL libusb_alloc_transfer(int iso_packets) {
-  return GetGlobalLibusb()->LibusbAllocTransfer(iso_packets);
+  return GetLibusbImpl()->LibusbAllocTransfer(iso_packets);
 }
 
 int LIBUSB_CALL libusb_submit_transfer(libusb_transfer* transfer) {
-  return GetGlobalLibusb()->LibusbSubmitTransfer(transfer);
+  return GetLibusbImpl()->LibusbSubmitTransfer(transfer);
 }
 
 int LIBUSB_CALL libusb_cancel_transfer(libusb_transfer* transfer) {
-  return GetGlobalLibusb()->LibusbCancelTransfer(transfer);
+  return GetLibusbImpl()->LibusbCancelTransfer(transfer);
 }
 
 void LIBUSB_CALL libusb_free_transfer(libusb_transfer* transfer) {
-  GetGlobalLibusb()->LibusbFreeTransfer(transfer);
+  GetLibusbImpl()->LibusbFreeTransfer(transfer);
 }
 
 int LIBUSB_CALL libusb_reset_device(libusb_device_handle* dev) {
-  return GetGlobalLibusb()->LibusbResetDevice(dev);
+  return GetLibusbImpl()->LibusbResetDevice(dev);
 }
 
 int LIBUSB_CALL libusb_control_transfer(libusb_device_handle* dev_handle,
@@ -190,9 +190,9 @@ int LIBUSB_CALL libusb_control_transfer(libusb_device_handle* dev_handle,
                                         unsigned char* data,
                                         uint16_t wLength,
                                         unsigned int timeout) {
-  return GetGlobalLibusb()->LibusbControlTransfer(dev_handle, request_type,
-                                                  bRequest, wValue, wIndex,
-                                                  data, wLength, timeout);
+  return GetLibusbImpl()->LibusbControlTransfer(dev_handle, request_type,
+                                                bRequest, wValue, wIndex, data,
+                                                wLength, timeout);
 }
 
 int LIBUSB_CALL libusb_bulk_transfer(libusb_device_handle* dev_handle,
@@ -201,8 +201,8 @@ int LIBUSB_CALL libusb_bulk_transfer(libusb_device_handle* dev_handle,
                                      int length,
                                      int* actual_length,
                                      unsigned int timeout) {
-  return GetGlobalLibusb()->LibusbBulkTransfer(dev_handle, endpoint, data,
-                                               length, actual_length, timeout);
+  return GetLibusbImpl()->LibusbBulkTransfer(dev_handle, endpoint, data, length,
+                                             actual_length, timeout);
 }
 
 int LIBUSB_CALL libusb_interrupt_transfer(libusb_device_handle* dev_handle,
@@ -211,15 +211,15 @@ int LIBUSB_CALL libusb_interrupt_transfer(libusb_device_handle* dev_handle,
                                           int length,
                                           int* actual_length,
                                           unsigned int timeout) {
-  return GetGlobalLibusb()->LibusbInterruptTransfer(
+  return GetLibusbImpl()->LibusbInterruptTransfer(
       dev_handle, endpoint, data, length, actual_length, timeout);
 }
 
 int LIBUSB_CALL libusb_handle_events(libusb_context* ctx) {
-  return GetGlobalLibusb()->LibusbHandleEvents(ctx);
+  return GetLibusbImpl()->LibusbHandleEvents(ctx);
 }
 
 int LIBUSB_CALL libusb_handle_events_completed(libusb_context* ctx,
                                                int* completed) {
-  return GetGlobalLibusb()->LibusbHandleEventsCompleted(ctx, completed);
+  return GetLibusbImpl()->LibusbHandleEventsCompleted(ctx, completed);
 }

--- a/third_party/libusb/webport/src/public/libusb_web_port_service.h
+++ b/third_party/libusb/webport/src/public/libusb_web_port_service.h
@@ -28,28 +28,27 @@ namespace google_smart_card {
 // the implementation of the global libusb_* functions.
 //
 // All global libusb_* functions are allowed to be called only while the
-// LibusbOverChromeUsbGlobal object exists.
+// LibusbWebPortService object exists.
 //
-// It is allowed to have at most one LibusbOverChromeUsbGlobal constructed at
-// any given moment of time.
+// It is allowed to have at most one LibusbWebPortService constructed at any
+// given moment of time.
 //
 // Note: The class constructor and destructor are not thread-safe against any
 // concurrent libusb_* function calls.
-class LibusbOverChromeUsbGlobal final {
+class LibusbWebPortService final {
  public:
-  LibusbOverChromeUsbGlobal(GlobalContext* global_context,
-                            TypedMessageRouter* typed_message_router);
+  LibusbWebPortService(GlobalContext* global_context,
+                       TypedMessageRouter* typed_message_router);
 
-  LibusbOverChromeUsbGlobal(const LibusbOverChromeUsbGlobal&) = delete;
-  LibusbOverChromeUsbGlobal& operator=(const LibusbOverChromeUsbGlobal&) =
-      delete;
+  LibusbWebPortService(const LibusbWebPortService&) = delete;
+  LibusbWebPortService& operator=(const LibusbWebPortService&) = delete;
 
   // Destroys the self instance and the owned LibusbOverChromeUsb instance.
   //
   // After the destructor is called, any global libusb_* function calls are not
   // allowed (and the still running calls, if any, will introduce undefined
   // behavior).
-  ~LibusbOverChromeUsbGlobal();
+  ~LibusbWebPortService();
 
   // Detaches from the typed message router and the JavaScript side, which
   // prevents making any further requests and prevents waiting for the responses
@@ -68,6 +67,9 @@ class LibusbOverChromeUsbGlobal final {
   void Detach();
 
  private:
+  // Use the "pimpl" pattern, so that other code can include our .h file without
+  // transitively including all of our internal implementation headers (which
+  // would break code isolation and also require special compilation flags).
   class Impl;
 
   std::unique_ptr<Impl> impl_;


### PR DESCRIPTION
Rename LibusbOverChromeUsbGlobal to LibusbWebPortService. Also move it
from "google_smart_card_libusb/global.{h,cc}" to
"public/libusb_web_port_service.{h,cc}", and change files that include
it to specify full path - for making the code easier to follow.

This is a pure refactoring change. It's preparatory work for the WebUSB
support effort tracked by #429.