### PR TITLE
[usb] Rename LibusbOverChromeUsb

### DIFF
--- a/third_party/libusb/webport/build/Makefile
+++ b/third_party/libusb/webport/build/Makefile
@@ -40,8 +40,8 @@ CXX_SOURCES := \
 	$(LIBUSB_NACL_SOURCES_PATH)/chrome_usb/api_bridge.cc \
 	$(LIBUSB_NACL_SOURCES_PATH)/chrome_usb/types.cc \
 	$(LIBUSB_NACL_SOURCES_PATH)/libusb_contexts_storage.cc \
+	$(LIBUSB_NACL_SOURCES_PATH)/libusb_js_proxy.cc \
 	$(LIBUSB_NACL_SOURCES_PATH)/libusb_opaque_types.cc \
-	$(LIBUSB_NACL_SOURCES_PATH)/libusb_over_chrome_usb.cc \
 	$(LIBUSB_NACL_SOURCES_PATH)/libusb_tracing_wrapper.cc \
 	$(LIBUSB_NACL_SOURCES_PATH)/public/libusb_web_port_service.cc \
 	$(LIBUSB_NACL_SOURCES_PATH)/usb_transfer_destination.cc \

--- a/third_party/libusb/webport/build/tests/Makefile
+++ b/third_party/libusb/webport/build/tests/Makefile
@@ -24,7 +24,7 @@ include ../../../../../common/cpp_unit_test_runner/include.mk
 SOURCES_PATH := ../../src
 
 SOURCES := \
-	$(SOURCES_PATH)/libusb_over_chrome_usb_unittest.cc \
+	$(SOURCES_PATH)/libusb_js_proxy_unittest.cc \
 
 CXXFLAGS := \
 	-I$(SOURCES_PATH) \

--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -14,7 +14,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include "libusb_over_chrome_usb.h"
+#include "libusb_js_proxy.h"
 
 #include <stdlib.h>
 
@@ -120,16 +120,16 @@ libusb_context* GetLibusbTransferContextChecked(
 
 }  // namespace
 
-LibusbOverChromeUsb::LibusbOverChromeUsb(
+LibusbJsProxy::LibusbJsProxy(
     chrome_usb::ApiBridgeInterface* chrome_usb_api_bridge)
     : chrome_usb_api_bridge_(chrome_usb_api_bridge),
       default_context_(contexts_storage_.CreateContext()) {
   GOOGLE_SMART_CARD_CHECK(chrome_usb_api_bridge_);
 }
 
-LibusbOverChromeUsb::~LibusbOverChromeUsb() = default;
+LibusbJsProxy::~LibusbJsProxy() = default;
 
-int LibusbOverChromeUsb::LibusbInit(libusb_context** ctx) {
+int LibusbJsProxy::LibusbInit(libusb_context** ctx) {
   // If the default context was requested, nothing is done (it's always existing
   // and initialized as long as this class object is alive).
   if (ctx)
@@ -137,15 +137,15 @@ int LibusbOverChromeUsb::LibusbInit(libusb_context** ctx) {
   return LIBUSB_SUCCESS;
 }
 
-void LibusbOverChromeUsb::LibusbExit(libusb_context* ctx) {
+void LibusbJsProxy::LibusbExit(libusb_context* ctx) {
   // If the default context deinitialization was requested, nothing is done
   // (it's always kept initialized as long as this class object is alive).
   if (ctx)
     contexts_storage_.DestroyContext(ctx);
 }
 
-ssize_t LibusbOverChromeUsb::LibusbGetDeviceList(libusb_context* ctx,
-                                                 libusb_device*** list) {
+ssize_t LibusbJsProxy::LibusbGetDeviceList(libusb_context* ctx,
+                                           libusb_device*** list) {
   GOOGLE_SMART_CARD_CHECK(list);
 
   ctx = SubstituteDefaultContextIfNull(ctx);
@@ -154,7 +154,7 @@ ssize_t LibusbOverChromeUsb::LibusbGetDeviceList(libusb_context* ctx,
       chrome_usb_api_bridge_->GetDevices(chrome_usb::GetDevicesOptions());
   if (!result.is_successful()) {
     GOOGLE_SMART_CARD_LOG_WARNING
-        << "LibusbOverChromeUsb::LibusbGetDeviceList request failed: "
+        << "LibusbJsProxy::LibusbGetDeviceList request failed: "
         << result.error_message();
     return LIBUSB_ERROR_OTHER;
   }
@@ -172,8 +172,8 @@ ssize_t LibusbOverChromeUsb::LibusbGetDeviceList(libusb_context* ctx,
   return chrome_usb_devices.size();
 }
 
-void LibusbOverChromeUsb::LibusbFreeDeviceList(libusb_device** list,
-                                               int unref_devices) {
+void LibusbJsProxy::LibusbFreeDeviceList(libusb_device** list,
+                                         int unref_devices) {
   if (!list)
     return;
   if (unref_devices) {
@@ -183,7 +183,7 @@ void LibusbOverChromeUsb::LibusbFreeDeviceList(libusb_device** list,
   delete[] list;
 }
 
-libusb_device* LibusbOverChromeUsb::LibusbRefDevice(libusb_device* dev) {
+libusb_device* LibusbJsProxy::LibusbRefDevice(libusb_device* dev) {
   GOOGLE_SMART_CARD_CHECK(dev);
 
   dev->AddReference();
@@ -191,7 +191,7 @@ libusb_device* LibusbOverChromeUsb::LibusbRefDevice(libusb_device* dev) {
   return dev;
 }
 
-void LibusbOverChromeUsb::LibusbUnrefDevice(libusb_device* dev) {
+void LibusbJsProxy::LibusbUnrefDevice(libusb_device* dev) {
   GOOGLE_SMART_CARD_CHECK(dev);
 
   dev->RemoveReference();
@@ -367,7 +367,7 @@ void FillLibusbConfigDescriptor(
 
 }  // namespace
 
-int LibusbOverChromeUsb::LibusbGetActiveConfigDescriptor(
+int LibusbJsProxy::LibusbGetActiveConfigDescriptor(
     libusb_device* dev,
     libusb_config_descriptor** config) {
   GOOGLE_SMART_CARD_CHECK(dev);
@@ -377,7 +377,7 @@ int LibusbOverChromeUsb::LibusbGetActiveConfigDescriptor(
       chrome_usb_api_bridge_->GetConfigurations(dev->chrome_usb_device());
   if (!result.is_successful()) {
     GOOGLE_SMART_CARD_LOG_WARNING
-        << "LibusbOverChromeUsb::LibusbGetActiveConfigDescriptor request "
+        << "LibusbJsProxy::LibusbGetActiveConfigDescriptor request "
         << "failed: " << result.error_message();
     return LIBUSB_ERROR_OTHER;
   }
@@ -404,7 +404,7 @@ int LibusbOverChromeUsb::LibusbGetActiveConfigDescriptor(
   }
   if (!*config) {
     GOOGLE_SMART_CARD_LOG_WARNING
-        << "LibusbOverChromeUsb::LibusbGetActiveConfigDescriptor request "
+        << "LibusbJsProxy::LibusbGetActiveConfigDescriptor request "
         << "failed: No active config descriptors were returned by chrome.usb "
            "API";
     return LIBUSB_ERROR_OTHER;
@@ -449,7 +449,7 @@ void DestroyLibusbConfigDescriptor(
 
 }  // namespace
 
-void LibusbOverChromeUsb::LibusbFreeConfigDescriptor(
+void LibusbJsProxy::LibusbFreeConfigDescriptor(
     libusb_config_descriptor* config) {
   if (!config)
     return;
@@ -509,9 +509,8 @@ void FillLibusbDeviceDescriptor(const chrome_usb::Device& chrome_usb_device,
 
 }  // namespace
 
-int LibusbOverChromeUsb::LibusbGetDeviceDescriptor(
-    libusb_device* dev,
-    libusb_device_descriptor* desc) {
+int LibusbJsProxy::LibusbGetDeviceDescriptor(libusb_device* dev,
+                                             libusb_device_descriptor* desc) {
   GOOGLE_SMART_CARD_CHECK(dev);
   GOOGLE_SMART_CARD_CHECK(desc);
 
@@ -519,7 +518,7 @@ int LibusbOverChromeUsb::LibusbGetDeviceDescriptor(
   return LIBUSB_SUCCESS;
 }
 
-uint8_t LibusbOverChromeUsb::LibusbGetBusNumber(libusb_device* dev) {
+uint8_t LibusbJsProxy::LibusbGetBusNumber(libusb_device* dev) {
   auto bus_numbers_iterator =
       bus_numbers_.find(dev->chrome_usb_device().device);
   if (bus_numbers_iterator != bus_numbers_.end()) {
@@ -528,7 +527,7 @@ uint8_t LibusbOverChromeUsb::LibusbGetBusNumber(libusb_device* dev) {
   return kDefaultBusNumber;
 }
 
-uint8_t LibusbOverChromeUsb::LibusbGetDeviceAddress(libusb_device* dev) {
+uint8_t LibusbJsProxy::LibusbGetDeviceAddress(libusb_device* dev) {
   GOOGLE_SMART_CARD_CHECK(dev);
 
   const int64_t device_id = dev->chrome_usb_device().device;
@@ -539,8 +538,8 @@ uint8_t LibusbOverChromeUsb::LibusbGetDeviceAddress(libusb_device* dev) {
   return static_cast<uint8_t>(device_id);
 }
 
-int LibusbOverChromeUsb::LibusbOpen(libusb_device* dev,
-                                    libusb_device_handle** handle) {
+int LibusbJsProxy::LibusbOpen(libusb_device* dev,
+                              libusb_device_handle** handle) {
   GOOGLE_SMART_CARD_CHECK(dev);
   GOOGLE_SMART_CARD_CHECK(handle);
 
@@ -548,7 +547,7 @@ int LibusbOverChromeUsb::LibusbOpen(libusb_device* dev,
       chrome_usb_api_bridge_->OpenDevice(dev->chrome_usb_device());
   if (!result.is_successful()) {
     GOOGLE_SMART_CARD_LOG_WARNING
-        << "LibusbOverChromeUsb::LibusbOpen "
+        << "LibusbJsProxy::LibusbOpen "
         << "request failed: " << result.error_message();
     // Modify the devices (fake) bus number that we report so that PCSC will
     // retry to connect to the device once it updates the device list.
@@ -566,7 +565,7 @@ int LibusbOverChromeUsb::LibusbOpen(libusb_device* dev,
   return LIBUSB_SUCCESS;
 }
 
-void LibusbOverChromeUsb::LibusbClose(libusb_device_handle* handle) {
+void LibusbJsProxy::LibusbClose(libusb_device_handle* handle) {
   GOOGLE_SMART_CARD_CHECK(handle);
 
   const RequestResult<chrome_usb::CloseDeviceResult> result =
@@ -582,8 +581,8 @@ void LibusbOverChromeUsb::LibusbClose(libusb_device_handle* handle) {
   delete handle;
 }
 
-int LibusbOverChromeUsb::LibusbClaimInterface(libusb_device_handle* dev,
-                                              int interface_number) {
+int LibusbJsProxy::LibusbClaimInterface(libusb_device_handle* dev,
+                                        int interface_number) {
   GOOGLE_SMART_CARD_CHECK(dev);
 
   const RequestResult<chrome_usb::ClaimInterfaceResult> result =
@@ -591,15 +590,15 @@ int LibusbOverChromeUsb::LibusbClaimInterface(libusb_device_handle* dev,
           dev->chrome_usb_connection_handle(), interface_number);
   if (!result.is_successful()) {
     GOOGLE_SMART_CARD_LOG_WARNING
-        << "LibusbOverChromeUsb::LibusbClaimInterface request failed: "
+        << "LibusbJsProxy::LibusbClaimInterface request failed: "
         << result.error_message();
     return LIBUSB_ERROR_OTHER;
   }
   return LIBUSB_SUCCESS;
 }
 
-int LibusbOverChromeUsb::LibusbReleaseInterface(libusb_device_handle* dev,
-                                                int interface_number) {
+int LibusbJsProxy::LibusbReleaseInterface(libusb_device_handle* dev,
+                                          int interface_number) {
   GOOGLE_SMART_CARD_CHECK(dev);
 
   const RequestResult<chrome_usb::ReleaseInterfaceResult> result =
@@ -607,28 +606,28 @@ int LibusbOverChromeUsb::LibusbReleaseInterface(libusb_device_handle* dev,
           dev->chrome_usb_connection_handle(), interface_number);
   if (!result.is_successful()) {
     GOOGLE_SMART_CARD_LOG_WARNING
-        << "LibusbOverChromeUsb::LibusbReleaseInterface request failed: "
+        << "LibusbJsProxy::LibusbReleaseInterface request failed: "
         << result.error_message();
     return LIBUSB_ERROR_OTHER;
   }
   return LIBUSB_SUCCESS;
 }
 
-int LibusbOverChromeUsb::LibusbResetDevice(libusb_device_handle* dev) {
+int LibusbJsProxy::LibusbResetDevice(libusb_device_handle* dev) {
   GOOGLE_SMART_CARD_CHECK(dev);
 
   const RequestResult<chrome_usb::ResetDeviceResult> result =
       chrome_usb_api_bridge_->ResetDevice(dev->chrome_usb_connection_handle());
   if (!result.is_successful()) {
     GOOGLE_SMART_CARD_LOG_WARNING
-        << "LibusbOverChromeUsb::LibusbResetDevice request failed: "
+        << "LibusbJsProxy::LibusbResetDevice request failed: "
         << result.error_message();
     return LIBUSB_ERROR_OTHER;
   }
   return LIBUSB_SUCCESS;
 }
 
-libusb_transfer* LibusbOverChromeUsb::LibusbAllocTransfer(int iso_packets) {
+libusb_transfer* LibusbJsProxy::LibusbAllocTransfer(int iso_packets) {
   // Isochronous transfers are not supported.
   GOOGLE_SMART_CARD_CHECK(!iso_packets);
 
@@ -794,7 +793,7 @@ void CreateChromeUsbGenericTransferInfo(
 chrome_usb::AsyncTransferCallback MakeChromeUsbTransferCallback(
     std::weak_ptr<libusb_context> context,
     const UsbTransferDestination& transfer_destination,
-    LibusbOverChromeUsb::TransferAsyncRequestStatePtr async_request_state) {
+    LibusbJsProxy::TransferAsyncRequestStatePtr async_request_state) {
   return [context, transfer_destination, async_request_state](
              RequestResult<chrome_usb::TransferResult> request_result) {
     const std::shared_ptr<libusb_context> locked_context = context.lock();
@@ -816,7 +815,7 @@ chrome_usb::AsyncTransferCallback MakeChromeUsbTransferCallback(
 
 }  // namespace
 
-int LibusbOverChromeUsb::LibusbSubmitTransfer(libusb_transfer* transfer) {
+int LibusbJsProxy::LibusbSubmitTransfer(libusb_transfer* transfer) {
   GOOGLE_SMART_CARD_CHECK(transfer);
   GOOGLE_SMART_CARD_CHECK(transfer->dev_handle);
 
@@ -896,7 +895,7 @@ int LibusbOverChromeUsb::LibusbSubmitTransfer(libusb_transfer* transfer) {
   return LIBUSB_SUCCESS;
 }
 
-int LibusbOverChromeUsb::LibusbCancelTransfer(libusb_transfer* transfer) {
+int LibusbJsProxy::LibusbCancelTransfer(libusb_transfer* transfer) {
   GOOGLE_SMART_CARD_CHECK(transfer);
 
   libusb_context* const context = GetLibusbTransferContextChecked(transfer);
@@ -904,7 +903,7 @@ int LibusbOverChromeUsb::LibusbCancelTransfer(libusb_transfer* transfer) {
                                            : LIBUSB_ERROR_NOT_FOUND;
 }
 
-void LibusbOverChromeUsb::LibusbFreeTransfer(libusb_transfer* transfer) {
+void LibusbJsProxy::LibusbFreeTransfer(libusb_transfer* transfer) {
   GOOGLE_SMART_CARD_CHECK(transfer);
 
   if (transfer->flags & LIBUSB_TRANSFER_FREE_BUFFER)
@@ -967,14 +966,14 @@ int LibusbTransferStatusToLibusbErrorCode(
 
 }  // namespace
 
-int LibusbOverChromeUsb::LibusbControlTransfer(libusb_device_handle* dev,
-                                               uint8_t bmRequestType,
-                                               uint8_t bRequest,
-                                               uint16_t wValue,
-                                               uint16_t index,
-                                               unsigned char* data,
-                                               uint16_t wLength,
-                                               unsigned timeout) {
+int LibusbJsProxy::LibusbControlTransfer(libusb_device_handle* dev,
+                                         uint8_t bmRequestType,
+                                         uint8_t bRequest,
+                                         uint16_t wValue,
+                                         uint16_t index,
+                                         unsigned char* data,
+                                         uint16_t wLength,
+                                         unsigned timeout) {
   GOOGLE_SMART_CARD_CHECK(dev);
 
   chrome_usb::ControlTransferInfo transfer_info;
@@ -997,7 +996,7 @@ int LibusbOverChromeUsb::LibusbControlTransfer(libusb_device_handle* dev,
 
   if (!result.is_successful()) {
     GOOGLE_SMART_CARD_LOG_WARNING
-        << "LibusbOverChromeUsb::LibusbControlTransfer request failed: "
+        << "LibusbJsProxy::LibusbControlTransfer request failed: "
         << result.error_message();
     return LIBUSB_ERROR_OTHER;
   }
@@ -1010,12 +1009,12 @@ int LibusbOverChromeUsb::LibusbControlTransfer(libusb_device_handle* dev,
   return error_code;
 }
 
-int LibusbOverChromeUsb::LibusbBulkTransfer(libusb_device_handle* dev,
-                                            unsigned char endpoint_address,
-                                            unsigned char* data,
-                                            int length,
-                                            int* actual_length,
-                                            unsigned timeout) {
+int LibusbJsProxy::LibusbBulkTransfer(libusb_device_handle* dev,
+                                      unsigned char endpoint_address,
+                                      unsigned char* data,
+                                      int length,
+                                      int* actual_length,
+                                      unsigned timeout) {
   GOOGLE_SMART_CARD_CHECK(dev);
 
   chrome_usb::GenericTransferInfo transfer_info;
@@ -1035,7 +1034,7 @@ int LibusbOverChromeUsb::LibusbBulkTransfer(libusb_device_handle* dev,
 
   if (!result.is_successful()) {
     GOOGLE_SMART_CARD_LOG_WARNING
-        << "LibusbOverChromeUsb::LibusbBulkTransfer request failed: "
+        << "LibusbJsProxy::LibusbBulkTransfer request failed: "
         << result.error_message();
     return LIBUSB_ERROR_OTHER;
   }
@@ -1043,12 +1042,12 @@ int LibusbOverChromeUsb::LibusbBulkTransfer(libusb_device_handle* dev,
       result.payload().result_info, false, length, data, actual_length));
 }
 
-int LibusbOverChromeUsb::LibusbInterruptTransfer(libusb_device_handle* dev,
-                                                 unsigned char endpoint_address,
-                                                 unsigned char* data,
-                                                 int length,
-                                                 int* actual_length,
-                                                 unsigned timeout) {
+int LibusbJsProxy::LibusbInterruptTransfer(libusb_device_handle* dev,
+                                           unsigned char endpoint_address,
+                                           unsigned char* data,
+                                           int length,
+                                           int* actual_length,
+                                           unsigned timeout) {
   GOOGLE_SMART_CARD_CHECK(dev);
 
   chrome_usb::GenericTransferInfo transfer_info;
@@ -1068,7 +1067,7 @@ int LibusbOverChromeUsb::LibusbInterruptTransfer(libusb_device_handle* dev,
 
   if (!result.is_successful()) {
     GOOGLE_SMART_CARD_LOG_WARNING
-        << "LibusbOverChromeUsb::LibusbInterruptTransfer request failed: "
+        << "LibusbJsProxy::LibusbInterruptTransfer request failed: "
         << result.error_message();
     return LIBUSB_ERROR_OTHER;
   }
@@ -1076,12 +1075,12 @@ int LibusbOverChromeUsb::LibusbInterruptTransfer(libusb_device_handle* dev,
       result.payload().result_info, false, length, data, actual_length));
 }
 
-int LibusbOverChromeUsb::LibusbHandleEvents(libusb_context* ctx) {
+int LibusbJsProxy::LibusbHandleEvents(libusb_context* ctx) {
   return LibusbHandleEventsWithTimeout(ctx, kHandleEventsTimeoutSeconds);
 }
 
-int LibusbOverChromeUsb::LibusbHandleEventsCompleted(libusb_context* ctx,
-                                                     int* completed) {
+int LibusbJsProxy::LibusbHandleEventsCompleted(libusb_context* ctx,
+                                               int* completed) {
   ctx = SubstituteDefaultContextIfNull(ctx);
 
   ctx->WaitAndProcessAsyncTransferReceivedResults(
@@ -1090,12 +1089,12 @@ int LibusbOverChromeUsb::LibusbHandleEventsCompleted(libusb_context* ctx,
   return LIBUSB_SUCCESS;
 }
 
-LibusbOverChromeUsb::SyncTransferHelper::SyncTransferHelper(
+LibusbJsProxy::SyncTransferHelper::SyncTransferHelper(
     std::shared_ptr<libusb_context> context,
     const UsbTransferDestination& transfer_destination)
     : context_(context), transfer_destination_(transfer_destination) {
   const auto async_request_state_callback =
-      [this](LibusbOverChromeUsb::TransferRequestResult request_result) {
+      [this](LibusbJsProxy::TransferRequestResult request_result) {
         result_ = std::move(request_result);
       };
 
@@ -1105,16 +1104,16 @@ LibusbOverChromeUsb::SyncTransferHelper::SyncTransferHelper(
   context->AddSyncTransferInFlight(async_request_state_, transfer_destination_);
 }
 
-LibusbOverChromeUsb::SyncTransferHelper::~SyncTransferHelper() = default;
+LibusbJsProxy::SyncTransferHelper::~SyncTransferHelper() = default;
 
 chrome_usb::AsyncTransferCallback
-LibusbOverChromeUsb::SyncTransferHelper::chrome_usb_transfer_callback() const {
+LibusbJsProxy::SyncTransferHelper::chrome_usb_transfer_callback() const {
   return MakeChromeUsbTransferCallback(context_, transfer_destination_,
                                        async_request_state_);
 }
 
 RequestResult<chrome_usb::TransferResult>
-LibusbOverChromeUsb::SyncTransferHelper::WaitForCompletion() {
+LibusbJsProxy::SyncTransferHelper::WaitForCompletion() {
   if (transfer_destination_.IsInputDirection()) {
     context_->WaitAndProcessInputSyncTransferReceivedResult(
         async_request_state_, transfer_destination_);
@@ -1125,15 +1124,15 @@ LibusbOverChromeUsb::SyncTransferHelper::WaitForCompletion() {
   return std::move(result_);
 }
 
-libusb_context* LibusbOverChromeUsb::SubstituteDefaultContextIfNull(
+libusb_context* LibusbJsProxy::SubstituteDefaultContextIfNull(
     libusb_context* context_or_nullptr) const {
   if (context_or_nullptr)
     return context_or_nullptr;
   return default_context_.get();
 }
 
-LibusbOverChromeUsb::TransferAsyncRequestCallback
-LibusbOverChromeUsb::WrapLibusbTransferCallback(libusb_transfer* transfer) {
+LibusbJsProxy::TransferAsyncRequestCallback
+LibusbJsProxy::WrapLibusbTransferCallback(libusb_transfer* transfer) {
   GOOGLE_SMART_CARD_CHECK(transfer);
 
   return [this,
@@ -1178,8 +1177,8 @@ LibusbOverChromeUsb::WrapLibusbTransferCallback(libusb_transfer* transfer) {
   };
 }
 
-int LibusbOverChromeUsb::LibusbHandleEventsWithTimeout(libusb_context* context,
-                                                       int timeout_seconds) {
+int LibusbJsProxy::LibusbHandleEventsWithTimeout(libusb_context* context,
+                                                 int timeout_seconds) {
   context = SubstituteDefaultContextIfNull(context);
 
   context->WaitAndProcessAsyncTransferReceivedResults(

--- a/third_party/libusb/webport/src/libusb_js_proxy.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy.h
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#ifndef GOOGLE_SMART_CARD_THIRD_PARTY_LIBUSB_LIBUSB_OVER_CHROME_USB_H_
-#define GOOGLE_SMART_CARD_THIRD_PARTY_LIBUSB_LIBUSB_OVER_CHROME_USB_H_
+#ifndef GOOGLE_SMART_CARD_THIRD_PARTY_LIBUSB_LIBUSB_JS_PROXY_H_
+#define GOOGLE_SMART_CARD_THIRD_PARTY_LIBUSB_LIBUSB_JS_PROXY_H_
 
 #include <stdint.h>
 
@@ -40,7 +40,7 @@ namespace google_smart_card {
 //
 // For the details of the integration with the chrome.usb JavaScript API, see
 // the chrome_usb/api_bridge.h file.
-class LibusbOverChromeUsb final : public LibusbInterface {
+class LibusbJsProxy final : public LibusbInterface {
  public:
   using TransferRequestResult = RequestResult<chrome_usb::TransferResult>;
   using TransferAsyncRequestState =
@@ -50,11 +50,10 @@ class LibusbOverChromeUsb final : public LibusbInterface {
   using TransferAsyncRequestCallback =
       AsyncRequestCallback<chrome_usb::TransferResult>;
 
-  explicit LibusbOverChromeUsb(
-      chrome_usb::ApiBridgeInterface* chrome_usb_api_bridge);
-  LibusbOverChromeUsb(const LibusbOverChromeUsb&) = delete;
-  LibusbOverChromeUsb& operator=(const LibusbOverChromeUsb&) = delete;
-  ~LibusbOverChromeUsb() override;
+  explicit LibusbJsProxy(chrome_usb::ApiBridgeInterface* chrome_usb_api_bridge);
+  LibusbJsProxy(const LibusbJsProxy&) = delete;
+  LibusbJsProxy& operator=(const LibusbJsProxy&) = delete;
+  ~LibusbJsProxy() override;
 
   // LibusbInterface:
   int LibusbInit(libusb_context** ctx) override;
@@ -148,4 +147,4 @@ class LibusbOverChromeUsb final : public LibusbInterface {
 
 }  // namespace google_smart_card
 
-#endif  // GOOGLE_SMART_CARD_THIRD_PARTY_LIBUSB_LIBUSB_OVER_CHROME_USB_H_
+#endif  // GOOGLE_SMART_CARD_THIRD_PARTY_LIBUSB_LIBUSB_JS_PROXY_H_

--- a/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
@@ -14,7 +14,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include "libusb_over_chrome_usb.h"
+#include "libusb_js_proxy.h"
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -130,50 +130,50 @@ class MockChromeUsbApiBridge final : public chrome_usb::ApiBridgeInterface {
                    const chrome_usb::ConnectionHandle& connection_handle));
 };
 
-class LibusbOverChromeUsbTest : public ::testing::Test {
+class LibusbJsProxyTest : public ::testing::Test {
  protected:
   void SetUp() override {
     ::testing::Test::SetUp();
 
     chrome_usb_api_bridge.reset(new MockChromeUsbApiBridge);
-    libusb_over_chrome_usb.reset(
-        new LibusbOverChromeUsb(chrome_usb_api_bridge.get()));
+    libusb_js_proxy.reset(
+        new LibusbJsProxy(chrome_usb_api_bridge.get()));
   }
 
   void TearDown() override {
-    libusb_over_chrome_usb.reset();
+    libusb_js_proxy.reset();
     chrome_usb_api_bridge.reset();
 
     ::testing::Test::TearDown();
   }
 
   std::unique_ptr<MockChromeUsbApiBridge> chrome_usb_api_bridge;
-  std::unique_ptr<LibusbOverChromeUsb> libusb_over_chrome_usb;
+  std::unique_ptr<LibusbJsProxy> libusb_js_proxy;
 };
 
 }  // namespace
 
-TEST_F(LibusbOverChromeUsbTest, ContextsCreation) {
-  ASSERT_EQ(LIBUSB_SUCCESS, libusb_over_chrome_usb->LibusbInit(nullptr));
+TEST_F(LibusbJsProxyTest, ContextsCreation) {
+  ASSERT_EQ(LIBUSB_SUCCESS, libusb_js_proxy->LibusbInit(nullptr));
 
   // Initializing a default context for the second time doesn't do anything
-  ASSERT_EQ(LIBUSB_SUCCESS, libusb_over_chrome_usb->LibusbInit(nullptr));
+  ASSERT_EQ(LIBUSB_SUCCESS, libusb_js_proxy->LibusbInit(nullptr));
 
   libusb_context* context_1;
-  ASSERT_EQ(LIBUSB_SUCCESS, libusb_over_chrome_usb->LibusbInit(&context_1));
+  ASSERT_EQ(LIBUSB_SUCCESS, libusb_js_proxy->LibusbInit(&context_1));
   EXPECT_TRUE(context_1);
 
   libusb_context* context_2;
-  ASSERT_EQ(LIBUSB_SUCCESS, libusb_over_chrome_usb->LibusbInit(&context_2));
+  ASSERT_EQ(LIBUSB_SUCCESS, libusb_js_proxy->LibusbInit(&context_2));
   EXPECT_TRUE(context_2);
   EXPECT_NE(context_1, context_2);
 
-  libusb_over_chrome_usb->LibusbExit(context_1);
-  libusb_over_chrome_usb->LibusbExit(context_2);
-  libusb_over_chrome_usb->LibusbExit(nullptr);
+  libusb_js_proxy->LibusbExit(context_1);
+  libusb_js_proxy->LibusbExit(context_2);
+  libusb_js_proxy->LibusbExit(nullptr);
 }
 
-TEST_F(LibusbOverChromeUsbTest, DevicesListingWithFailure) {
+TEST_F(LibusbJsProxyTest, DevicesListingWithFailure) {
   EXPECT_CALL(*chrome_usb_api_bridge, GetDevices(_))
       .WillOnce(InvokeWithoutArgs([]() {
         return RequestResult<chrome_usb::GetDevicesResult>::CreateFailed(
@@ -182,10 +182,10 @@ TEST_F(LibusbOverChromeUsbTest, DevicesListingWithFailure) {
 
   libusb_device** device_list;
   ASSERT_EQ(LIBUSB_ERROR_OTHER,
-            libusb_over_chrome_usb->LibusbGetDeviceList(nullptr, &device_list));
+            libusb_js_proxy->LibusbGetDeviceList(nullptr, &device_list));
 }
 
-TEST_F(LibusbOverChromeUsbTest, DevicesListingWithNoItems) {
+TEST_F(LibusbJsProxyTest, DevicesListingWithNoItems) {
   EXPECT_CALL(*chrome_usb_api_bridge, GetDevices(_))
       .WillOnce(InvokeWithoutArgs([]() {
         return RequestResult<chrome_usb::GetDevicesResult>::CreateSuccessful(
@@ -194,14 +194,14 @@ TEST_F(LibusbOverChromeUsbTest, DevicesListingWithNoItems) {
 
   libusb_device** device_list = nullptr;
   ASSERT_EQ(0,
-            libusb_over_chrome_usb->LibusbGetDeviceList(nullptr, &device_list));
+            libusb_js_proxy->LibusbGetDeviceList(nullptr, &device_list));
   ASSERT_TRUE(device_list);
   ASSERT_FALSE(device_list[0]);
 
-  libusb_over_chrome_usb->LibusbFreeDeviceList(device_list, true);
+  libusb_js_proxy->LibusbFreeDeviceList(device_list, true);
 }
 
-TEST_F(LibusbOverChromeUsbTest, DevicesListingWithTwoItems) {
+TEST_F(LibusbJsProxyTest, DevicesListingWithTwoItems) {
   chrome_usb::GetDevicesResult chrome_usb_get_devices_result;
   chrome_usb::Device chrome_usb_device_1;
   chrome_usb_device_1.device = 0;
@@ -221,13 +221,13 @@ TEST_F(LibusbOverChromeUsbTest, DevicesListingWithTwoItems) {
 
   libusb_device** device_list = nullptr;
   ASSERT_EQ(2,
-            libusb_over_chrome_usb->LibusbGetDeviceList(nullptr, &device_list));
+            libusb_js_proxy->LibusbGetDeviceList(nullptr, &device_list));
   ASSERT_TRUE(device_list);
   ASSERT_TRUE(device_list[0]);
   ASSERT_TRUE(device_list[1]);
   ASSERT_NE(device_list[0], device_list[1]);
   ASSERT_FALSE(device_list[2]);
-  libusb_over_chrome_usb->LibusbFreeDeviceList(device_list, true);
+  libusb_js_proxy->LibusbFreeDeviceList(device_list, true);
 }
 
 // TODO(emaxx): Add a test on referencing/unreferencing devices
@@ -238,7 +238,7 @@ TEST_F(LibusbOverChromeUsbTest, DevicesListingWithTwoItems) {
 
 namespace {
 
-class LibusbOverChromeUsbWithFakeDeviceTest : public LibusbOverChromeUsbTest {
+class LibusbOverChromeUsbWithFakeDeviceTest : public LibusbJsProxyTest {
  public:
   LibusbOverChromeUsbWithFakeDeviceTest()
       : device(nullptr), device_handle(nullptr) {
@@ -257,22 +257,22 @@ class LibusbOverChromeUsbWithFakeDeviceTest : public LibusbOverChromeUsbTest {
 
  protected:
   void SetUp() override {
-    LibusbOverChromeUsbTest::SetUp();
+    LibusbJsProxyTest::SetUp();
 
-    ASSERT_EQ(LIBUSB_SUCCESS, libusb_over_chrome_usb->LibusbInit(nullptr));
+    ASSERT_EQ(LIBUSB_SUCCESS, libusb_js_proxy->LibusbInit(nullptr));
     SetUpMocksForFakeDevice();
     ObtainLibusbDevice();
     ObtainLibusbDeviceHandle();
   }
 
   void TearDown() override {
-    libusb_over_chrome_usb->LibusbClose(device_handle);
+    libusb_js_proxy->LibusbClose(device_handle);
     device_handle = nullptr;
-    libusb_over_chrome_usb->LibusbUnrefDevice(device);
+    libusb_js_proxy->LibusbUnrefDevice(device);
     device = nullptr;
-    libusb_over_chrome_usb->LibusbExit(nullptr);
+    libusb_js_proxy->LibusbExit(nullptr);
 
-    LibusbOverChromeUsbTest::TearDown();
+    LibusbJsProxyTest::TearDown();
   }
 
   chrome_usb::Device chrome_usb_device;
@@ -313,16 +313,16 @@ class LibusbOverChromeUsbWithFakeDeviceTest : public LibusbOverChromeUsbTest {
   void ObtainLibusbDevice() {
     libusb_device** device_list = nullptr;
     EXPECT_EQ(
-        1, libusb_over_chrome_usb->LibusbGetDeviceList(nullptr, &device_list));
+        1, libusb_js_proxy->LibusbGetDeviceList(nullptr, &device_list));
     EXPECT_TRUE(device_list);
     EXPECT_TRUE(device_list[0]);
     device = device_list[0];
-    libusb_over_chrome_usb->LibusbFreeDeviceList(device_list, false);
+    libusb_js_proxy->LibusbFreeDeviceList(device_list, false);
   }
 
   void ObtainLibusbDeviceHandle() {
     EXPECT_EQ(LIBUSB_SUCCESS,
-              libusb_over_chrome_usb->LibusbOpen(device, &device_handle));
+              libusb_js_proxy->LibusbOpen(device, &device_handle));
     EXPECT_TRUE(device_handle);
   }
 };
@@ -372,7 +372,7 @@ class LibusbOverChromeUsbTransfersTest
     else
       data.resize(GenerateTransferData(transfer_index, false).size());
 
-    const int return_code = libusb_over_chrome_usb->LibusbControlTransfer(
+    const int return_code = libusb_js_proxy->LibusbControlTransfer(
         device_handle,
         LIBUSB_RECIPIENT_ENDPOINT | LIBUSB_REQUEST_TYPE_STANDARD |
             (is_output ? LIBUSB_ENDPOINT_OUT : LIBUSB_ENDPOINT_IN),
@@ -409,7 +409,7 @@ class LibusbOverChromeUsbTransfersTest
         actual_data.size());
 
     libusb_transfer* const transfer =
-        libusb_over_chrome_usb->LibusbAllocTransfer(0);
+        libusb_js_proxy->LibusbAllocTransfer(0);
     libusb_fill_control_transfer(
         transfer, device_handle, buffer,
         &AsyncTransferCallbackWrapper::Callback,
@@ -420,7 +420,7 @@ class LibusbOverChromeUsbTransfersTest
         LIBUSB_TRANSFER_FREE_TRANSFER | LIBUSB_TRANSFER_FREE_BUFFER;
 
     EXPECT_EQ(LIBUSB_SUCCESS,
-              libusb_over_chrome_usb->LibusbSubmitTransfer(transfer));
+              libusb_js_proxy->LibusbSubmitTransfer(transfer));
 
     return transfer;
   }
@@ -651,7 +651,7 @@ TEST_P(LibusbOverChromeUsbSingleTransferTest, AsyncControlTransfer) {
   ASSERT_TRUE(Mock::VerifyAndClearExpectations(&transfer_callback));
   SetUpTransferCallbackMockExpectations(GetParam().transfer_index, false,
                                         &transfer_callback);
-  libusb_over_chrome_usb->LibusbHandleEvents(nullptr);
+  libusb_js_proxy->LibusbHandleEvents(nullptr);
 }
 
 // Test cancellation of an asynchronous control transfers.
@@ -672,15 +672,15 @@ TEST_P(LibusbOverChromeUsbSingleTransferTest, AsyncTransferCancellation) {
 
   if (is_cancellation_successful) {
     EXPECT_EQ(LIBUSB_SUCCESS,
-              libusb_over_chrome_usb->LibusbCancelTransfer(transfer));
+              libusb_js_proxy->LibusbCancelTransfer(transfer));
   } else {
     EXPECT_NE(LIBUSB_SUCCESS,
-              libusb_over_chrome_usb->LibusbCancelTransfer(transfer));
+              libusb_js_proxy->LibusbCancelTransfer(transfer));
   }
 
   // Second attempt to cancel a transfer is never successful
   EXPECT_NE(LIBUSB_SUCCESS,
-            libusb_over_chrome_usb->LibusbCancelTransfer(transfer));
+            libusb_js_proxy->LibusbCancelTransfer(transfer));
 
   if (!is_cancellation_successful) {
     // Resolve the chrome.usb transfer if the transfer was an output transfer,
@@ -692,7 +692,7 @@ TEST_P(LibusbOverChromeUsbSingleTransferTest, AsyncTransferCancellation) {
   SetUpTransferCallbackMockExpectations(GetParam().transfer_index,
                                         is_cancellation_successful,
                                         &transfer_callback);
-  libusb_over_chrome_usb->LibusbHandleEvents(nullptr);
+  libusb_js_proxy->LibusbHandleEvents(nullptr);
 }
 
 // Test that received result of a canceled asynchronous transfer is delivered to
@@ -723,7 +723,7 @@ TEST_P(LibusbOverChromeUsbSingleTransferTest,
                             &second_transfer_callback);
 
   EXPECT_EQ(LIBUSB_SUCCESS,
-            libusb_over_chrome_usb->LibusbCancelTransfer(first_transfer));
+            libusb_js_proxy->LibusbCancelTransfer(first_transfer));
 
   first_chrome_usb_transfer_resolver();
 
@@ -733,8 +733,8 @@ TEST_P(LibusbOverChromeUsbSingleTransferTest,
                                         &first_transfer_callback);
   SetUpTransferCallbackMockExpectations(GetParam().transfer_index, false,
                                         &second_transfer_callback);
-  libusb_over_chrome_usb->LibusbHandleEvents(nullptr);
-  libusb_over_chrome_usb->LibusbHandleEvents(nullptr);
+  libusb_js_proxy->LibusbHandleEvents(nullptr);
+  libusb_js_proxy->LibusbHandleEvents(nullptr);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -908,7 +908,7 @@ TEST_F(LibusbOverChromeUsbAsyncTransfersMultiThreadingTest,
 
         for (bool is_transfer_output : kBoolValues) {
           while (!transfer_completed[is_transfer_output]) {
-            libusb_over_chrome_usb->LibusbHandleEventsCompleted(
+            libusb_js_proxy->LibusbHandleEventsCompleted(
                 nullptr, &transfer_completed[is_transfer_output]);
           }
         }

--- a/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
@@ -136,8 +136,7 @@ class LibusbJsProxyTest : public ::testing::Test {
     ::testing::Test::SetUp();
 
     chrome_usb_api_bridge.reset(new MockChromeUsbApiBridge);
-    libusb_js_proxy.reset(
-        new LibusbJsProxy(chrome_usb_api_bridge.get()));
+    libusb_js_proxy.reset(new LibusbJsProxy(chrome_usb_api_bridge.get()));
   }
 
   void TearDown() override {
@@ -193,8 +192,7 @@ TEST_F(LibusbJsProxyTest, DevicesListingWithNoItems) {
       }));
 
   libusb_device** device_list = nullptr;
-  ASSERT_EQ(0,
-            libusb_js_proxy->LibusbGetDeviceList(nullptr, &device_list));
+  ASSERT_EQ(0, libusb_js_proxy->LibusbGetDeviceList(nullptr, &device_list));
   ASSERT_TRUE(device_list);
   ASSERT_FALSE(device_list[0]);
 
@@ -220,8 +218,7 @@ TEST_F(LibusbJsProxyTest, DevicesListingWithTwoItems) {
       }));
 
   libusb_device** device_list = nullptr;
-  ASSERT_EQ(2,
-            libusb_js_proxy->LibusbGetDeviceList(nullptr, &device_list));
+  ASSERT_EQ(2, libusb_js_proxy->LibusbGetDeviceList(nullptr, &device_list));
   ASSERT_TRUE(device_list);
   ASSERT_TRUE(device_list[0]);
   ASSERT_TRUE(device_list[1]);
@@ -238,10 +235,9 @@ TEST_F(LibusbJsProxyTest, DevicesListingWithTwoItems) {
 
 namespace {
 
-class LibusbOverChromeUsbWithFakeDeviceTest : public LibusbJsProxyTest {
+class LibusbJsProxyWithFakeDeviceTest : public LibusbJsProxyTest {
  public:
-  LibusbOverChromeUsbWithFakeDeviceTest()
-      : device(nullptr), device_handle(nullptr) {
+  LibusbJsProxyWithFakeDeviceTest() : device(nullptr), device_handle(nullptr) {
     chrome_usb_device.device = 1;
     chrome_usb_device.vendor_id = 2;
     chrome_usb_device.product_id = 3;
@@ -312,8 +308,7 @@ class LibusbOverChromeUsbWithFakeDeviceTest : public LibusbJsProxyTest {
 
   void ObtainLibusbDevice() {
     libusb_device** device_list = nullptr;
-    EXPECT_EQ(
-        1, libusb_js_proxy->LibusbGetDeviceList(nullptr, &device_list));
+    EXPECT_EQ(1, libusb_js_proxy->LibusbGetDeviceList(nullptr, &device_list));
     EXPECT_TRUE(device_list);
     EXPECT_TRUE(device_list[0]);
     device = device_list[0];
@@ -327,8 +322,7 @@ class LibusbOverChromeUsbWithFakeDeviceTest : public LibusbJsProxyTest {
   }
 };
 
-class LibusbOverChromeUsbTransfersTest
-    : public LibusbOverChromeUsbWithFakeDeviceTest {
+class LibusbJsProxyTransfersTest : public LibusbJsProxyWithFakeDeviceTest {
  protected:
   void SetUpMockForSyncControlTransfer(size_t transfer_index, bool is_output) {
     EXPECT_CALL(*chrome_usb_api_bridge,
@@ -408,8 +402,7 @@ class LibusbOverChromeUsbTransfersTest
         kTransferRequestField, kTransferValueField, transfer_index,
         actual_data.size());
 
-    libusb_transfer* const transfer =
-        libusb_js_proxy->LibusbAllocTransfer(0);
+    libusb_transfer* const transfer = libusb_js_proxy->LibusbAllocTransfer(0);
     libusb_fill_control_transfer(
         transfer, device_handle, buffer,
         &AsyncTransferCallbackWrapper::Callback,
@@ -419,8 +412,7 @@ class LibusbOverChromeUsbTransfersTest
     transfer->flags =
         LIBUSB_TRANSFER_FREE_TRANSFER | LIBUSB_TRANSFER_FREE_BUFFER;
 
-    EXPECT_EQ(LIBUSB_SUCCESS,
-              libusb_js_proxy->LibusbSubmitTransfer(transfer));
+    EXPECT_EQ(LIBUSB_SUCCESS, libusb_js_proxy->LibusbSubmitTransfer(transfer));
 
     return transfer;
   }
@@ -459,7 +451,7 @@ class LibusbOverChromeUsbTransfersTest
   class AsyncTransferCallbackWrapper {
    public:
     AsyncTransferCallbackWrapper(
-        LibusbOverChromeUsbTransfersTest* test_instance,
+        LibusbJsProxyTransfersTest* test_instance,
         size_t transfer_index,
         bool is_output,
         MockFunction<void(libusb_transfer_status)>* transfer_callback)
@@ -473,7 +465,7 @@ class LibusbOverChromeUsbTransfersTest
       AsyncTransferCallbackWrapper* const instance =
           static_cast<AsyncTransferCallbackWrapper*>(transfer->user_data);
 
-      LibusbOverChromeUsbTransfersTest* const test_instance =
+      LibusbJsProxyTransfersTest* const test_instance =
           instance->test_instance_;
       const size_t transfer_index = instance->transfer_index_;
       const bool is_output = instance->is_output_;
@@ -487,7 +479,7 @@ class LibusbOverChromeUsbTransfersTest
     }
 
    private:
-    LibusbOverChromeUsbTransfersTest* test_instance_;
+    LibusbJsProxyTransfersTest* test_instance_;
     size_t transfer_index_;
     bool is_output_;
     MockFunction<void(libusb_transfer_status)>* transfer_callback_;
@@ -583,9 +575,9 @@ class LibusbOverChromeUsbTransfersTest
   }
 };
 
-struct LibusbOverChromeUsbSingleTransferTestParam {
-  LibusbOverChromeUsbSingleTransferTestParam(size_t transfer_index,
-                                             bool is_transfer_output)
+struct LibusbJsProxySingleTransferTestParam {
+  LibusbJsProxySingleTransferTestParam(size_t transfer_index,
+                                       bool is_transfer_output)
       : transfer_index(transfer_index),
         is_transfer_output(is_transfer_output) {}
 
@@ -593,10 +585,10 @@ struct LibusbOverChromeUsbSingleTransferTestParam {
   bool is_transfer_output;
 };
 
-class LibusbOverChromeUsbSingleTransferTest
-    : public LibusbOverChromeUsbTransfersTest,
+class LibusbJsProxySingleTransferTest
+    : public LibusbJsProxyTransfersTest,
       public ::testing::WithParamInterface<
-          LibusbOverChromeUsbSingleTransferTestParam> {
+          LibusbJsProxySingleTransferTestParam> {
  public:
   static size_t GetTransferIndexToSucceed() {
     const size_t kTransferIndex = 1234;
@@ -626,7 +618,7 @@ class LibusbOverChromeUsbSingleTransferTest
 //
 // The transfer request is resolved immediately on the same thread that
 // initiated the transfer.
-TEST_P(LibusbOverChromeUsbSingleTransferTest, SyncControlTransfer) {
+TEST_P(LibusbJsProxySingleTransferTest, SyncControlTransfer) {
   SetUpMockForSyncControlTransfer(GetParam().transfer_index,
                                   GetParam().is_transfer_output);
   TestSyncControlTransfer(GetParam().transfer_index,
@@ -637,7 +629,7 @@ TEST_P(LibusbOverChromeUsbSingleTransferTest, SyncControlTransfer) {
 //
 // The transfer request is resolved on the same thread that initiated the
 // transfer, before the libusb events handling starts.
-TEST_P(LibusbOverChromeUsbSingleTransferTest, AsyncControlTransfer) {
+TEST_P(LibusbJsProxySingleTransferTest, AsyncControlTransfer) {
   const std::function<void()> chrome_usb_transfer_resolver =
       SetUpMockForAsyncControlTransfer(GetParam().transfer_index,
                                        GetParam().is_transfer_output);
@@ -657,7 +649,7 @@ TEST_P(LibusbOverChromeUsbSingleTransferTest, AsyncControlTransfer) {
 // Test cancellation of an asynchronous control transfers.
 //
 // Note that output control transfers cancellation never succeeds.
-TEST_P(LibusbOverChromeUsbSingleTransferTest, AsyncTransferCancellation) {
+TEST_P(LibusbJsProxySingleTransferTest, AsyncTransferCancellation) {
   const std::function<void()> chrome_usb_transfer_resolver =
       SetUpMockForAsyncControlTransfer(GetParam().transfer_index,
                                        GetParam().is_transfer_output);
@@ -671,16 +663,13 @@ TEST_P(LibusbOverChromeUsbSingleTransferTest, AsyncTransferCancellation) {
   const bool is_cancellation_successful = !GetParam().is_transfer_output;
 
   if (is_cancellation_successful) {
-    EXPECT_EQ(LIBUSB_SUCCESS,
-              libusb_js_proxy->LibusbCancelTransfer(transfer));
+    EXPECT_EQ(LIBUSB_SUCCESS, libusb_js_proxy->LibusbCancelTransfer(transfer));
   } else {
-    EXPECT_NE(LIBUSB_SUCCESS,
-              libusb_js_proxy->LibusbCancelTransfer(transfer));
+    EXPECT_NE(LIBUSB_SUCCESS, libusb_js_proxy->LibusbCancelTransfer(transfer));
   }
 
   // Second attempt to cancel a transfer is never successful
-  EXPECT_NE(LIBUSB_SUCCESS,
-            libusb_js_proxy->LibusbCancelTransfer(transfer));
+  EXPECT_NE(LIBUSB_SUCCESS, libusb_js_proxy->LibusbCancelTransfer(transfer));
 
   if (!is_cancellation_successful) {
     // Resolve the chrome.usb transfer if the transfer was an output transfer,
@@ -697,7 +686,7 @@ TEST_P(LibusbOverChromeUsbSingleTransferTest, AsyncTransferCancellation) {
 
 // Test that received result of a canceled asynchronous transfer is delivered to
 // the next transfer with the same parameters.
-TEST_P(LibusbOverChromeUsbSingleTransferTest,
+TEST_P(LibusbJsProxySingleTransferTest,
        AsyncTransferCompletionAfterCancellation) {
   if (GetParam().is_transfer_output) {
     // Cancellation of an output transfer is not supported, so the whole test
@@ -739,31 +728,31 @@ TEST_P(LibusbOverChromeUsbSingleTransferTest,
 
 INSTANTIATE_TEST_SUITE_P(
     InputTransferTest,
-    LibusbOverChromeUsbSingleTransferTest,
+    LibusbJsProxySingleTransferTest,
     ::testing::Values(
-        LibusbOverChromeUsbSingleTransferTestParam(
-            LibusbOverChromeUsbSingleTransferTest::GetTransferIndexToSucceed(),
+        LibusbJsProxySingleTransferTestParam(
+            LibusbJsProxySingleTransferTest::GetTransferIndexToSucceed(),
             false),
-        LibusbOverChromeUsbSingleTransferTestParam(
-            LibusbOverChromeUsbSingleTransferTest::GetTransferIndexToFail(),
+        LibusbJsProxySingleTransferTestParam(
+            LibusbJsProxySingleTransferTest::GetTransferIndexToFail(),
             false),
-        LibusbOverChromeUsbSingleTransferTestParam(
-            LibusbOverChromeUsbSingleTransferTest::
+        LibusbJsProxySingleTransferTestParam(
+            LibusbJsProxySingleTransferTest::
                 GetTransferIndexToFinishUnsuccessful(),
             false)));
 
 INSTANTIATE_TEST_SUITE_P(
     OutputTransferTest,
-    LibusbOverChromeUsbSingleTransferTest,
+    LibusbJsProxySingleTransferTest,
     ::testing::Values(
-        LibusbOverChromeUsbSingleTransferTestParam(
-            LibusbOverChromeUsbSingleTransferTest::GetTransferIndexToSucceed(),
+        LibusbJsProxySingleTransferTestParam(
+            LibusbJsProxySingleTransferTest::GetTransferIndexToSucceed(),
             true),
-        LibusbOverChromeUsbSingleTransferTestParam(
-            LibusbOverChromeUsbSingleTransferTest::GetTransferIndexToFail(),
+        LibusbJsProxySingleTransferTestParam(
+            LibusbJsProxySingleTransferTest::GetTransferIndexToFail(),
             true),
-        LibusbOverChromeUsbSingleTransferTestParam(
-            LibusbOverChromeUsbSingleTransferTest::
+        LibusbJsProxySingleTransferTestParam(
+            LibusbJsProxySingleTransferTest::
                 GetTransferIndexToFinishUnsuccessful(),
             true)));
 
@@ -780,7 +769,7 @@ INSTANTIATE_TEST_SUITE_P(
 //
 // Each transfer request is resolved immediately on the same thread that
 // initiated the transfer.
-TEST_F(LibusbOverChromeUsbTransfersTest,
+TEST_F(LibusbJsProxyTransfersTest,
        MAYBE_SyncControlTransfersWithMultiThreading) {
   const size_t kMaxTransferIndex = 1000;
   const size_t kThreadCount = 10;
@@ -807,11 +796,11 @@ TEST_F(LibusbOverChromeUsbTransfersTest,
 
 namespace {
 
-class LibusbOverChromeUsbAsyncTransfersMultiThreadingTest
-    : public LibusbOverChromeUsbTransfersTest {
+class LibusbJsProxyAsyncTransfersMultiThreadingTest
+    : public LibusbJsProxyTransfersTest {
  public:
   void SetUp() override {
-    LibusbOverChromeUsbTransfersTest::SetUp();
+    LibusbJsProxyTransfersTest::SetUp();
 
     for (size_t index = 0; index <= kMaxTransferIndex; ++index) {
       for (bool is_transfer_output : kBoolValues) {
@@ -825,7 +814,7 @@ class LibusbOverChromeUsbAsyncTransfersMultiThreadingTest
     chrome_usb_transfer_resolvers_.clear();
     transfers_in_flight_.clear();
 
-    LibusbOverChromeUsbTransfersTest::TearDown();
+    LibusbJsProxyTransfersTest::TearDown();
   }
 
  protected:
@@ -884,8 +873,7 @@ class LibusbOverChromeUsbAsyncTransfersMultiThreadingTest
 // asynchronous transfer requests and running libusb event loops.
 //
 // The requests are resolved asynchronously from the main thread.
-TEST_F(LibusbOverChromeUsbAsyncTransfersMultiThreadingTest,
-       MAYBE_ControlTransfers) {
+TEST_F(LibusbJsProxyAsyncTransfersMultiThreadingTest, MAYBE_ControlTransfers) {
   const size_t kThreadCount = 10;
 
   std::vector<std::thread> threads;

--- a/third_party/libusb/webport/src/public/libusb_web_port_service.cc
+++ b/third_party/libusb/webport/src/public/libusb_web_port_service.cc
@@ -52,8 +52,7 @@ class LibusbWebPortService::Impl final {
                                     typed_message_router)),
         libusb_js_proxy_(&chrome_usb_api_bridge_) {
 #ifndef NDEBUG
-    libusb_tracing_wrapper_.reset(
-        new LibusbTracingWrapper(&libusb_js_proxy_));
+    libusb_tracing_wrapper_.reset(new LibusbTracingWrapper(&libusb_js_proxy_));
 #endif  // NDEBUG
   }
 

--- a/third_party/libusb/webport/src/public/libusb_web_port_service.cc
+++ b/third_party/libusb/webport/src/public/libusb_web_port_service.cc
@@ -25,7 +25,7 @@
 
 #include "chrome_usb/api_bridge.h"
 #include "libusb_interface.h"
-#include "libusb_over_chrome_usb.h"
+#include "libusb_js_proxy.h"
 #include "libusb_tracing_wrapper.h"
 
 namespace {
@@ -50,10 +50,10 @@ class LibusbWebPortService::Impl final {
             MakeUnique<JsRequester>(chrome_usb::kApiBridgeRequesterName,
                                     global_context,
                                     typed_message_router)),
-        libusb_over_chrome_usb_(&chrome_usb_api_bridge_) {
+        libusb_js_proxy_(&chrome_usb_api_bridge_) {
 #ifndef NDEBUG
     libusb_tracing_wrapper_.reset(
-        new LibusbTracingWrapper(&libusb_over_chrome_usb_));
+        new LibusbTracingWrapper(&libusb_js_proxy_));
 #endif  // NDEBUG
   }
 
@@ -66,12 +66,12 @@ class LibusbWebPortService::Impl final {
   LibusbInterface* libusb() {
     if (libusb_tracing_wrapper_)
       return libusb_tracing_wrapper_.get();
-    return &libusb_over_chrome_usb_;
+    return &libusb_js_proxy_;
   }
 
  private:
   chrome_usb::ApiBridge chrome_usb_api_bridge_;
-  LibusbOverChromeUsb libusb_over_chrome_usb_;
+  LibusbJsProxy libusb_js_proxy_;
   std::unique_ptr<LibusbTracingWrapper> libusb_tracing_wrapper_;
 };
 

--- a/third_party/libusb/webport/src/public/libusb_web_port_service.h
+++ b/third_party/libusb/webport/src/public/libusb_web_port_service.h
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#ifndef GOOGLE_SMART_CARD_LIBUSB_GLOBAL_H_
-#define GOOGLE_SMART_CARD_LIBUSB_GLOBAL_H_
+#ifndef GOOGLE_SMART_CARD_LIBUSB_WEB_PORT_SERVICE_H_
+#define GOOGLE_SMART_CARD_LIBUSB_WEB_PORT_SERVICE_H_
 
 #include <memory>
 
@@ -24,7 +24,7 @@
 
 namespace google_smart_card {
 
-// This class owns a LibusbOverChromeUsb instance and enables it to be used by
+// This class owns a LibusbJsProxy instance and enables it to be used by
 // the implementation of the global libusb_* functions.
 //
 // All global libusb_* functions are allowed to be called only while the
@@ -77,4 +77,4 @@ class LibusbWebPortService final {
 
 }  // namespace google_smart_card
 
-#endif  // GOOGLE_SMART_CARD_LIBUSB_GLOBAL_H_
+#endif  // GOOGLE_SMART_CARD_LIBUSB_WEB_PORT_SERVICE_H_

--- a/third_party/libusb/webport/src/public/libusb_web_port_service.h
+++ b/third_party/libusb/webport/src/public/libusb_web_port_service.h
@@ -43,7 +43,7 @@ class LibusbWebPortService final {
   LibusbWebPortService(const LibusbWebPortService&) = delete;
   LibusbWebPortService& operator=(const LibusbWebPortService&) = delete;
 
-  // Destroys the self instance and the owned LibusbOverChromeUsb instance.
+  // Destroys the self instance and the owned LibusbJsProxy instance.
   //
   // After the destructor is called, any global libusb_* function calls are not
   // allowed (and the still running calls, if any, will introduce undefined

--- a/third_party/libusb/webport/src/usb_transfers_parameters_storage.h
+++ b/third_party/libusb/webport/src/usb_transfers_parameters_storage.h
@@ -36,7 +36,7 @@ namespace google_smart_card {
 //
 // One index has the TransferAsyncRequestStatePtr type, which corresponds to the
 // transfer result storage of each synchronous and asynchronous transfer that is
-// executed by the LibusbOverChromeUsb class methods.
+// executed by the LibusbJsProxy class methods.
 //
 // Another index has the UsbTransferDestination type, which uniquely represents
 // the target USB device and a set of transfer parameters.


### PR DESCRIPTION
Rename the LibusbOverChromeUsb class to LibusbJsProxy, to anticipate the
upcoming change to support both chrome.usb and WebUSB APIs.

This is a pure refactoring change. It's preparatory work for the WebUSB
support effort tracked by #429.