### PR TITLE
[usb] Add JsProxyReceiver

### DIFF
--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -22,6 +22,7 @@ goog.require('GoogleSmartCard.EmscriptenModule');
 goog.require('GoogleSmartCard.ExecutableModule');
 goog.require('GoogleSmartCard.Libusb.ChromeLoginStateHook');
 goog.require('GoogleSmartCard.Libusb.ChromeUsbBackend');
+goog.require('GoogleSmartCard.LibusbProxyReceiver');
 goog.require('GoogleSmartCard.LogBufferForwarder');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.MessageChannelPair');
@@ -123,6 +124,8 @@ chromeLoginStateHook.getHookReadyPromise()
     .then(function() {
       libusbChromeUsbBackend.startProcessingEvents();
     });
+const libusbProxyReceiver = new GSC.LibusbProxyReceiver(
+    executableModule.getMessageChannel(), libusbChromeUsbBackend);
 
 const pcscLiteReadinessTracker =
     new GSC.PcscLiteServerClientsManagement.ReadinessTracker(

--- a/third_party/libusb/webport/src/chrome_usb/api_bridge.h
+++ b/third_party/libusb/webport/src/chrome_usb/api_bridge.h
@@ -32,6 +32,7 @@ namespace google_smart_card {
 
 namespace chrome_usb {
 
+// This constant must match the string in libusb-proxy-receiver.js.
 constexpr char kApiBridgeRequesterName[] = "libusb";
 
 // This class implements the C++ bridge to the chrome.usb JavaScript API (see

--- a/third_party/libusb/webport/src/chrome_usb/api_bridge.h
+++ b/third_party/libusb/webport/src/chrome_usb/api_bridge.h
@@ -32,7 +32,7 @@ namespace google_smart_card {
 
 namespace chrome_usb {
 
-constexpr char kApiBridgeRequesterName[] = "libusb_chrome_usb";
+constexpr char kApiBridgeRequesterName[] = "libusb";
 
 // This class implements the C++ bridge to the chrome.usb JavaScript API (see
 // <https://developer.chrome.com/apps/usb>).

--- a/third_party/libusb/webport/src/chrome_usb/chrome-usb-backend.js
+++ b/third_party/libusb/webport/src/chrome_usb/chrome-usb-backend.js
@@ -64,7 +64,7 @@ GSC.Libusb.ChromeUsbBackend = function(naclModuleMessageChannel) {
   // Note: the request receiver instance is not stored anywhere, as it makes
   // itself being owned by the message channel.
   new GSC.RequestReceiver(
-      REQUESTER_NAME, naclModuleMessageChannel, this.handleRequest_.bind(this));
+      REQUESTER_NAME, naclModuleMessageChannel, this.handleRequest.bind(this));
   this.startObservingDevices_();
 
   /**
@@ -182,9 +182,8 @@ ChromeUsbBackend.prototype.logDevices_ = function(devices) {
 /**
  * @param {!Object} payload
  * @return {!goog.Promise}
- * @private
  */
-ChromeUsbBackend.prototype.handleRequest_ = function(payload) {
+ChromeUsbBackend.prototype.handleRequest = function(payload) {
   return this.deferredProcessor_.addJob(
       this.processRequest_.bind(this, payload));
 };

--- a/third_party/libusb/webport/src/libusb-proxy-receiver.js
+++ b/third_party/libusb/webport/src/libusb-proxy-receiver.js
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2021 Google Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+goog.provide('GoogleSmartCard.LibusbProxyReceiver');
+
+goog.require('GoogleSmartCard.DebugDump');
+goog.require('GoogleSmartCard.Libusb.ChromeUsbBackend');
+goog.require('GoogleSmartCard.Logging');
+goog.require('GoogleSmartCard.RemoteCallMessage');
+goog.require('goog.Promise');
+goog.require('goog.log');
+goog.require('goog.messaging.AbstractChannel');
+
+goog.scope(function() {
+
+const EXECUTABLE_MODULE_REQUESTER_NAME = 'libusb';
+
+const GSC = GoogleSmartCard;
+const debugDump = GSC.DebugDump.debugDump;
+
+const logger = GSC.Logging.getScopedLogger('LibusbProxyReceiver');
+
+GSC.LibusbProxyReceiver = class {
+  /**
+   * This class implements handling of libusb requests received from the
+   * executable module (the `LibusbJsProxy` class). The requests are handled by
+   * transforming them into the chrome.usb API requests.
+   *
+   * TODO(#429): Stop receiving the ChromeUsbBackend, and generalize to support
+   * WebUSB as well.
+   * @param {!goog.messaging.AbstractChannel} executableModuleMessageChannel
+   * @param {!GSC.Libusb.ChromeUsbBackend} libusbChromeUsbBackend
+   */
+  constructor(executableModuleMessageChannel, libusbChromeUsbBackend) {
+    // Note: the request receiver instance is not stored anywhere, as it makes
+    // itself being owned by the message channel.
+    new GSC.RequestReceiver(
+        EXECUTABLE_MODULE_REQUESTER_NAME, executableModuleMessageChannel,
+        this.onRequestReceivedFromExecutableModule_.bind(this));
+    /** @private @const */
+    this.libusbChromeUsbBackend_ = libusbChromeUsbBackend;
+  }
+
+  /**
+   * Handles a Libusb request sent from the
+   * @param {!Object} payload
+   * @return {!goog.Promise}
+   * @private
+   */
+  onRequestReceivedFromExecutableModule_(payload) {
+    const remoteCallMessage =
+        GSC.RemoteCallMessage.parseRequestPayload(payload);
+    if (!remoteCallMessage) {
+      GSC.Logging.failWithLogger(
+          logger,
+          'Failed to parse the remote call message: ' + debugDump(payload));
+    }
+    goog.log.fine(
+        logger,
+        `Received a remote call request: ${
+            remoteCallMessage.getDebugRepresentation()}`);
+
+    // TODO(#429): Handle the requests in our class instead of forwarding them
+    // to ChromeUsbBackend.
+    return this.libusbChromeUsbBackend_.handleRequest(payload);
+  }
+};
+});  // goog.scope

--- a/third_party/libusb/webport/src/libusb-proxy-receiver.js
+++ b/third_party/libusb/webport/src/libusb-proxy-receiver.js
@@ -36,14 +36,16 @@ const debugDump = GSC.DebugDump.debugDump;
 
 const logger = GSC.Logging.getScopedLogger('LibusbProxyReceiver');
 
+/**
+ * This class implements handling of libusb requests received from the
+ * executable module (the `LibusbJsProxy` class). The requests are handled by
+ * transforming them into the chrome.usb API requests.
+ *
+ * TODO(#429): Stop receiving the ChromeUsbBackend, and generalize to support
+ * WebUSB as well.
+ */
 GSC.LibusbProxyReceiver = class {
   /**
-   * This class implements handling of libusb requests received from the
-   * executable module (the `LibusbJsProxy` class). The requests are handled by
-   * transforming them into the chrome.usb API requests.
-   *
-   * TODO(#429): Stop receiving the ChromeUsbBackend, and generalize to support
-   * WebUSB as well.
    * @param {!goog.messaging.AbstractChannel} executableModuleMessageChannel
    * @param {!GSC.Libusb.ChromeUsbBackend} libusbChromeUsbBackend
    */
@@ -58,7 +60,8 @@ GSC.LibusbProxyReceiver = class {
   }
 
   /**
-   * Handles a Libusb request sent from the
+   * Handles a Libusb request sent from the C++ code in the executable module.
+   * The result is returned asynchronously via the returned promise.
    * @param {!Object} payload
    * @return {!goog.Promise}
    * @private

--- a/third_party/libusb/webport/src/libusb-proxy-receiver.js
+++ b/third_party/libusb/webport/src/libusb-proxy-receiver.js
@@ -29,6 +29,7 @@ goog.require('goog.messaging.AbstractChannel');
 
 goog.scope(function() {
 
+// This constant must match the string in api_bridge.h.
 const EXECUTABLE_MODULE_REQUESTER_NAME = 'libusb';
 
 const GSC = GoogleSmartCard;


### PR DESCRIPTION
Add a JavaScript class for handling the Libusb requests sent from the
C++ code. Redirect the C++ code to send requests to this class instead
of the ChromeUsbBackend JS class.

Currently the new JsProxyReceiver class only has a stub implementation
that forwards all requests to ChromeUsbBackend. Follow-up commits will
change it, by introducing an abstraction layer that abstracts away
differences between chrome.usb and WebUSB APIs.

It's preparatory work for the WebUSB support effort tracked by #429.