### PR TITLE
Rename Detach() to ShutDown()

### DIFF
--- a/common/cpp/src/google_smart_card_common/global_context.h
+++ b/common/cpp/src/google_smart_card_common/global_context.h
@@ -35,9 +35,9 @@ class GlobalContext {
   // intended to be used to avoid blocking/deadlocking the main thread.
   virtual bool IsMainEventLoopThread() const = 0;
 
-  // Disables communication with the JavaScript side. All calls to
-  // `PostMessageToJs()` after this point will return `false`.
-  virtual void DisableJsCommunication() = 0;
+  // Shuts down and disables communication with the JavaScript side. All calls
+  // to `PostMessageToJs()` after this point will return `false`.
+  virtual void ShutDown() = 0;
 };
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.cc
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.cc
@@ -74,7 +74,7 @@ bool GlobalContextImplEmscripten::IsMainEventLoopThread() const {
   return std::this_thread::get_id() == main_thread_id_;
 }
 
-void GlobalContextImplEmscripten::DisableJsCommunication() {
+void GlobalContextImplEmscripten::ShutDown() {
   GOOGLE_SMART_CARD_CHECK(IsMainEventLoopThread());
   post_message_callback_ = emscripten::val::undefined();
 }

--- a/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.h
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.h
@@ -51,7 +51,7 @@ class GlobalContextImplEmscripten final
   // GlobalContext:
   void PostMessageToJs(Value message) override;
   bool IsMainEventLoopThread() const override;
-  void DisableJsCommunication() override;
+  void ShutDown() override;
 
  private:
   static void PostMessageOnMainThreadTrampoline(int raw_this_weak_ptr,

--- a/common/cpp/src/google_smart_card_common/global_context_impl_nacl.cc
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_nacl.cc
@@ -45,7 +45,7 @@ bool GlobalContextImplNacl::IsMainEventLoopThread() const {
   return pp_core_->IsMainThread();
 }
 
-void GlobalContextImplNacl::DisableJsCommunication() {
+void GlobalContextImplNacl::ShutDown() {
   const std::unique_lock<std::mutex> lock(mutex_);
   pp_instance_ = nullptr;
 }

--- a/common/cpp/src/google_smart_card_common/global_context_impl_nacl.h
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_nacl.h
@@ -41,7 +41,7 @@ class GlobalContextImplNacl final : public GlobalContext {
   // GlobalContext:
   void PostMessageToJs(Value message) override;
   bool IsMainEventLoopThread() const override;
-  void DisableJsCommunication() override;
+  void ShutDown() override;
 
  private:
   pp::Core* const pp_core_;

--- a/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.cc
@@ -38,10 +38,10 @@ JsRequestReceiver::JsRequestReceiver(const std::string& name,
 }
 
 JsRequestReceiver::~JsRequestReceiver() {
-  Detach();
+  ShutDown();
 }
 
-void JsRequestReceiver::Detach() {
+void JsRequestReceiver::ShutDown() {
   TypedMessageRouter* const typed_message_router =
       typed_message_router_.exchange(nullptr);
   if (typed_message_router)

--- a/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.h
+++ b/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.h
@@ -57,12 +57,12 @@ class JsRequestReceiver final : public RequestReceiver,
 
   ~JsRequestReceiver() override;
 
-  // Detaches the request receiver, which prevents it from sending request
-  // responses and from receiving of new requests (as the corresponding route
-  // gets removed from the associated TypedMessageRouter object).
+  // Stop sending request responses and prevent receiving of new requests (as
+  // the corresponding route gets removed from the associated TypedMessageRouter
+  // object).
   //
   // This function is safe to be called from any thread.
-  void Detach();
+  void ShutDown();
 
  private:
   // RequestReceiver:

--- a/common/cpp/src/google_smart_card_common/requesting/js_requester.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/js_requester.cc
@@ -38,16 +38,16 @@ JsRequester::JsRequester(const std::string& name,
 }
 
 JsRequester::~JsRequester() {
-  Detach();
+  ShutDown();
 }
 
-void JsRequester::Detach() {
+void JsRequester::ShutDown() {
   TypedMessageRouter* const typed_message_router =
       typed_message_router_.exchange(nullptr);
   if (typed_message_router)
     typed_message_router->RemoveRoute(this);
 
-  Requester::Detach();
+  Requester::ShutDown();
 }
 
 void JsRequester::StartAsyncRequest(Value payload,

--- a/common/cpp/src/google_smart_card_common/requesting/js_requester.h
+++ b/common/cpp/src/google_smart_card_common/requesting/js_requester.h
@@ -47,8 +47,8 @@ class JsRequester final : public Requester, public TypedMessageListener {
   //
   // `global_context` - must outlive `this`.
   // Note that the passed TypedMessageRouter is allowed to be destroyed earlier
-  // than the JsRequester object - but the Detach() method must be called before
-  // destroying it.
+  // than the JsRequester object - but the `ShutDown()` method must be called
+  // before destroying it.
   JsRequester(const std::string& name,
               GlobalContext* global_context,
               TypedMessageRouter* typed_message_router);
@@ -59,7 +59,7 @@ class JsRequester final : public Requester, public TypedMessageListener {
   ~JsRequester() override;
 
   // Requester implementation
-  void Detach() override;
+  void ShutDown() override;
   void StartAsyncRequest(Value payload,
                          GenericAsyncRequestCallback callback,
                          GenericAsyncRequest* async_request) override;

--- a/common/cpp/src/google_smart_card_common/requesting/requester.h
+++ b/common/cpp/src/google_smart_card_common/requesting/requester.h
@@ -51,12 +51,13 @@ class Requester {
 
   std::string name() const { return name_; }
 
-  // Detaches the requester, which may prevent it from sending new requests (new
-  // requests may immediately finish with the RequestResultStatus::kFailed
-  // state) and/or from receiving results of already sent ones.
+  // Prevent the requester from sending new requests to the JavaScript side (new
+  // requests triggered through this class will immediately finish with the
+  // RequestResultStatus::kFailed state) and/or from receiving results of
+  // already sent ones.
   //
   // This function is safe to be called from any thread.
-  virtual void Detach() {}
+  virtual void ShutDown() {}
 
   // Starts an asynchronous request with the given payload and the given
   // callback, which will be executed once the request finishes (either

--- a/example_cpp_smart_card_client_app/src/application.cc
+++ b/example_cpp_smart_card_client_app/src/application.cc
@@ -309,12 +309,12 @@ Application::Application(gsc::GlobalContext* global_context,
 Application::~Application() {
   // Intentionally leak `pcsc_lite_over_requester_global_` without destroying
   // it, because there might still be background threads that access it.
-  pcsc_lite_over_requester_global_->Detach();
+  pcsc_lite_over_requester_global_->ShutDown();
   (void)pcsc_lite_over_requester_global_.release();
 
-  built_in_pin_dialog_server_->Detach();
-  chrome_certificate_provider_api_bridge_->Detach();
-  ui_bridge_->Detach();
+  built_in_pin_dialog_server_->ShutDown();
+  chrome_certificate_provider_api_bridge_->ShutDown();
+  ui_bridge_->ShutDown();
 }
 
 }  // namespace smart_card_client

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.cc
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.cc
@@ -47,8 +47,8 @@ BuiltInPinDialogServer::BuiltInPinDialogServer(
 
 BuiltInPinDialogServer::~BuiltInPinDialogServer() = default;
 
-void BuiltInPinDialogServer::Detach() {
-  js_requester_.Detach();
+void BuiltInPinDialogServer::ShutDown() {
+  js_requester_.ShutDown();
 }
 
 bool BuiltInPinDialogServer::RequestPin(std::string* pin) {

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.h
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.h
@@ -51,9 +51,8 @@ class BuiltInPinDialogServer final {
 
   ~BuiltInPinDialogServer();
 
-  // Detaches from the typed message router and the JavaScript side, which
-  // prevents making any further requests and prevents waiting for the responses
-  // of the already started requests.
+  // Stops sending any further requests to the JavaScript side and prevents
+  // receiving responses from it.
   //
   // This function is primarily intended to be used during the executable
   // shutdown process, for preventing the situations when some other threads
@@ -61,7 +60,7 @@ class BuiltInPinDialogServer final {
   // destroyed objects.
   //
   // This function is safe to be called from any thread.
-  void Detach();
+  void ShutDown();
 
   // Sends a PIN request and waits for the response being received.
   //

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
@@ -112,9 +112,9 @@ ApiBridge::ApiBridge(gsc::GlobalContext* global_context,
 
 ApiBridge::~ApiBridge() = default;
 
-void ApiBridge::Detach() {
-  requester_.Detach();
-  request_receiver_->Detach();
+void ApiBridge::ShutDown() {
+  requester_.ShutDown();
+  request_receiver_->ShutDown();
 }
 
 void ApiBridge::SetCertificatesRequestHandler(

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
@@ -99,7 +99,7 @@ class ApiBridge final : public google_smart_card::RequestHandler {
 
   ~ApiBridge() override;
 
-  void Detach();
+  void ShutDown();
 
   void SetCertificatesRequestHandler(
       std::weak_ptr<CertificatesRequestHandler> handler);

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
@@ -114,7 +114,7 @@ void ApiBridgeIntegrationTestHelper::SetUp(
 }
 
 void ApiBridgeIntegrationTestHelper::TearDown() {
-  api_bridge_->Detach();
+  api_bridge_->ShutDown();
   api_bridge_.reset();
 }
 

--- a/example_cpp_smart_card_client_app/src/entry_point_emscripten.cc
+++ b/example_cpp_smart_card_client_app/src/entry_point_emscripten.cc
@@ -59,7 +59,7 @@ class GoogleSmartCardModule final {
   ~GoogleSmartCardModule() {
     // Intentionally leak `global_context_` without destroying it, because there
     // might still be background threads that access it.
-    global_context_->DisableJsCommunication();
+    global_context_->ShutDown();
     new std::shared_ptr<gsc::GlobalContextImplEmscripten>(global_context_);
   }
 

--- a/example_cpp_smart_card_client_app/src/entry_point_nacl.cc
+++ b/example_cpp_smart_card_client_app/src/entry_point_nacl.cc
@@ -78,7 +78,7 @@ class PpInstance final : public pp::Instance {
   ~PpInstance() override {
     // Intentionally leak `global_context_` without destroying it, because there
     // might still be background threads that access it.
-    global_context_->DisableJsCommunication();
+    global_context_->ShutDown();
     (void)global_context_.release();
   }
 

--- a/example_cpp_smart_card_client_app/src/ui_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/ui_bridge.cc
@@ -70,10 +70,10 @@ UiBridge::UiBridge(gsc::GlobalContext* global_context,
 }
 
 UiBridge::~UiBridge() {
-  Detach();
+  ShutDown();
 }
 
-void UiBridge::Detach() {
+void UiBridge::ShutDown() {
   gsc::TypedMessageRouter* const typed_message_router =
       typed_message_router_.exchange(nullptr);
   if (typed_message_router)

--- a/example_cpp_smart_card_client_app/src/ui_bridge.h
+++ b/example_cpp_smart_card_client_app/src/ui_bridge.h
@@ -56,7 +56,7 @@ class UiBridge final : public google_smart_card::TypedMessageListener {
 
   ~UiBridge() override;
 
-  void Detach();
+  void ShutDown();
 
   void SetHandler(std::weak_ptr<MessageFromUiHandler> handler);
   void RemoveHandler();

--- a/smart_card_connector_app/src/application.cc
+++ b/smart_card_connector_app/src/application.cc
@@ -50,8 +50,8 @@ Application::Application(
 
 Application::~Application() {
   // Intentionally leak objects that might still be used by background threads.
-  // Only shut them down (which makes them stop referring to `this` and sending
-  // requests to the JavaScript side).
+  // Only shut them down (which makes them stop referring to `this` and stop
+  // sending requests to the JavaScript side).
   libusb_web_port_service_->ShutDown();
   (void)libusb_web_port_service_.release();
   (void)pcsc_lite_server_global_.release();

--- a/smart_card_connector_app/src/application.cc
+++ b/smart_card_connector_app/src/application.cc
@@ -50,8 +50,9 @@ Application::Application(
 
 Application::~Application() {
   // Intentionally leak objects that might still be used by background threads.
-  // Only detach them from `this` and the JavaScript side.
-  libusb_web_port_service_->Detach();
+  // Only shut them down (which makes them stop referring to `this` and sending
+  // requests to the JavaScript side).
+  libusb_web_port_service_->ShutDown();
   (void)libusb_web_port_service_.release();
   (void)pcsc_lite_server_global_.release();
 }

--- a/smart_card_connector_app/src/entry_point_emscripten.cc
+++ b/smart_card_connector_app/src/entry_point_emscripten.cc
@@ -56,7 +56,7 @@ class GoogleSmartCardModule final {
   ~GoogleSmartCardModule() {
     // Intentionally leak `global_context_` without destroying it, because there
     // might still be background threads that access it.
-    global_context_->DisableJsCommunication();
+    global_context_->ShutDown();
     new std::shared_ptr<GlobalContextImplEmscripten>(global_context_);
   }
 

--- a/smart_card_connector_app/src/entry_point_nacl.cc
+++ b/smart_card_connector_app/src/entry_point_nacl.cc
@@ -65,8 +65,9 @@ class PpInstance final : public pp::Instance {
     typed_message_router_.RemoveRoute(&external_logs_printer_);
 
     // Intentionally leak the global context as it might still be used by
-    // background threads. Only detach it from the JavaScript side.
-    global_context_->DisableJsCommunication();
+    // background threads. Only shut it down (which prevents it from referring
+    // to us and from talking to the JavaScript side).
+    global_context_->ShutDown();
     (void)global_context_.release();
   }
 

--- a/third_party/libusb/webport/src/chrome_usb/api_bridge.cc
+++ b/third_party/libusb/webport/src/chrome_usb/api_bridge.cc
@@ -31,8 +31,8 @@ ApiBridge::ApiBridge(std::unique_ptr<Requester> requester)
 
 ApiBridge::~ApiBridge() = default;
 
-void ApiBridge::Detach() {
-  requester_->Detach();
+void ApiBridge::ShutDown() {
+  requester_->ShutDown();
 }
 
 RequestResult<GetDevicesResult> ApiBridge::GetDevices(

--- a/third_party/libusb/webport/src/chrome_usb/api_bridge.h
+++ b/third_party/libusb/webport/src/chrome_usb/api_bridge.h
@@ -49,7 +49,7 @@ class ApiBridge final : public ApiBridgeInterface {
   ApiBridge& operator=(const ApiBridge&) = delete;
   ~ApiBridge() override;
 
-  void Detach();
+  void ShutDown();
 
   // ApiBridgeInterface:
   RequestResult<GetDevicesResult> GetDevices(

--- a/third_party/libusb/webport/src/public/libusb_web_port_service.cc
+++ b/third_party/libusb/webport/src/public/libusb_web_port_service.cc
@@ -60,7 +60,7 @@ class LibusbWebPortService::Impl final {
   Impl& operator=(const Impl&) = delete;
   ~Impl() = default;
 
-  void Detach() { chrome_usb_api_bridge_.Detach(); }
+  void ShutDown() { chrome_usb_api_bridge_.ShutDown(); }
 
   LibusbInterface* libusb() {
     if (libusb_tracing_wrapper_)
@@ -87,8 +87,8 @@ LibusbWebPortService::~LibusbWebPortService() {
   g_libusb = nullptr;
 }
 
-void LibusbWebPortService::Detach() {
-  impl_->Detach();
+void LibusbWebPortService::ShutDown() {
+  impl_->ShutDown();
 }
 
 }  // namespace google_smart_card

--- a/third_party/libusb/webport/src/public/libusb_web_port_service.h
+++ b/third_party/libusb/webport/src/public/libusb_web_port_service.h
@@ -64,7 +64,7 @@ class LibusbWebPortService final {
   // already destroyed objects.
   //
   // This function is safe to be called from any thread.
-  void Detach();
+  void ShutDown();
 
  private:
   // Use the "pimpl" pattern, so that other code can include our .h file without

--- a/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.cc
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.cc
@@ -77,7 +77,7 @@ class PcscLiteOverRequesterGlobal::Impl final {
   Impl& operator=(const Impl&) = delete;
   ~Impl() = default;
 
-  void Detach() { pcsc_lite_over_requester_.Detach(); }
+  void ShutDown() { pcsc_lite_over_requester_.ShutDown(); }
 
   PcscLite* pcsc_lite() {
     if (pcsc_lite_tracing_wrapper_)
@@ -103,8 +103,8 @@ PcscLiteOverRequesterGlobal::~PcscLiteOverRequesterGlobal() {
   g_pcsc_lite = nullptr;
 }
 
-void PcscLiteOverRequesterGlobal::Detach() {
-  impl_->Detach();
+void PcscLiteOverRequesterGlobal::ShutDown() {
+  impl_->ShutDown();
 }
 
 }  // namespace google_smart_card

--- a/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.h
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.h
@@ -74,7 +74,7 @@ class PcscLiteOverRequesterGlobal final {
   // accesses to already destroyed objects.
   //
   // This function is safe to be called from any thread.
-  void Detach();
+  void ShutDown();
 
  private:
   class Impl;

--- a/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.cc
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.cc
@@ -168,8 +168,8 @@ PcscLiteOverRequester::PcscLiteOverRequester(
 
 PcscLiteOverRequester::~PcscLiteOverRequester() = default;
 
-void PcscLiteOverRequester::Detach() {
-  requester_->Detach();
+void PcscLiteOverRequester::ShutDown() {
+  requester_->ShutDown();
 }
 
 LONG PcscLiteOverRequester::SCardEstablishContext(

--- a/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.h
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.h
@@ -81,7 +81,7 @@ class PcscLiteOverRequester final : public PcscLite {
   // object or some other associated objects.
   //
   // This function is safe to be called from any thread.
-  void Detach();
+  void ShutDown();
 
   // PcscLite:
   LONG SCardEstablishContext(DWORD scope,

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
@@ -99,10 +99,10 @@ PcscLiteServerClientsManager::PcscLiteServerClientsManager(
 }
 
 PcscLiteServerClientsManager::~PcscLiteServerClientsManager() {
-  Detach();
+  ShutDown();
 }
 
-void PcscLiteServerClientsManager::Detach() {
+void PcscLiteServerClientsManager::ShutDown() {
   if (!typed_message_router_)
     return;
   typed_message_router_->RemoveRoute(&create_handler_message_listener_);
@@ -174,7 +174,7 @@ PcscLiteServerClientsManager::Handler::~Handler() {
   request_processor_->ScheduleRunningRequestsCancellation();
   // Stop receiving the new PC/SC-Lite requests from the JavaScript side, and
   // also disable sending of the request responses back to the JavaScript side.
-  request_receiver_->Detach();
+  request_receiver_->ShutDown();
 }
 
 void PcscLiteServerClientsManager::Handler::HandleRequest(

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h
@@ -64,7 +64,7 @@ namespace google_smart_card {
 //    them to the PcscLiteClientRequestProcessor instance).
 // 2. The manager receives a special "remove client" message with the client id.
 //    As a result, the manager removes the corresponding instance of the
-//    PcscLiteServerClientsManager::Client class, which, in turn, detaches the
+//    PcscLiteServerClientsManager::Client class, which, in turn, shuts down the
 //    JsRequestReceiver owned by it - so this ensures that new requests for
 //    this client won't be received, and the responses for the currently
 //    processed requests from this client will be discarded.
@@ -92,7 +92,7 @@ class PcscLiteServerClientsManager final {
 
   ~PcscLiteServerClientsManager();
 
-  void Detach();
+  void ShutDown();
 
  private:
   // Message listener for the client handler creation messages received from the

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.cc
@@ -38,7 +38,7 @@ class PcscLiteServerClientsManagementBackend::Impl final {
 
   Impl(const Impl&) = delete;
 
-  ~Impl() { clients_manager_.Detach(); }
+  ~Impl() { clients_manager_.ShutDown(); }
 
  private:
   PcscLiteServerClientsManager clients_manager_;


### PR DESCRIPTION
Rename all Detach() methods in the C++ code to ShutDown(). The new name
is more self-explanatory.

This is a pure refactoring commit. It's done as part of the preparation
for the WebUSB implementation effort, since we'ge going to add a bunch
of new classes and want to use consistent naming.