### PR TITLE
[wasm] Minify the Emscripten JS files

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -123,6 +123,13 @@ EMSCRIPTEN_COMMON_FLAGS += \
 EMSCRIPTEN_COMPILER_FLAGS += \
   -DNDEBUG \
 
+# Add linker flags specific to release builds.
+#
+# Explanation:
+# closure=1: Minify the auxilliary .js file produced by Emscripten.
+EMSCRIPTEN_LINKER_FLAGS += \
+  --closure=1 \
+
 else ifeq ($(CONFIG),Debug)
 
 # Add compiler and linker flags specific to debug builds.


### PR DESCRIPTION
Use the Closure Compiler to minify the JavaScript files produced by
Emscripten. This reduces the executable_module.js file size by 55% (from
177KB to 80KB), which should make the .crx file be installed faster
and the JS code to be loaded faster.