### PR TITLE
[wasm] Fix&enable multi-threading in tests

### DIFF
--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_router_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_router_unittest.cc
@@ -131,8 +131,8 @@ TEST(MessagingTypedMessageRouterTest, Basic) {
 }
 
 TEST(MessagingTypedMessageRouterTest, MultiThreading) {
-  // The bigger number of iterations increases the chances of catching a bug,
-  // but the constant is lower in the Debug mode to avoid running too long.
+  // A high number of iterations increases the chances of catching a bug, but
+  // the constant is lower in the Debug mode to avoid running too long.
   const int kIterationCount =
 #ifdef NDEBUG
       100 * 1000

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_router_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_router_unittest.cc
@@ -130,14 +130,16 @@ TEST(MessagingTypedMessageRouterTest, Basic) {
       MakeTypedMessageValue(kSampleType1, MakeSampleData(7))));
 }
 
-#ifdef __EMSCRIPTEN__
-// TODO(#185): Crashes in Emscripten due to out-of-memory.
-#define MAYBE_MultiThreading DISABLED_MultiThreading
+TEST(MessagingTypedMessageRouterTest, MultiThreading) {
+  // The bigger number of iterations increases the chances of catching a bug,
+  // but the constant is lower in the Debug mode to avoid running too long.
+  const int kIterationCount =
+#ifdef NDEBUG
+      100 * 1000
 #else
-#define MAYBE_MultiThreading MultiThreading
+      10 * 1000
 #endif
-TEST(MessagingTypedMessageRouterTest, MAYBE_MultiThreading) {
-  const int kIterationCount = 100 * 1000;
+      ;
 
   TypedMessageRouter router;
 

--- a/common/cpp/src/google_smart_card_common/requesting/async_request_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/async_request_unittest.cc
@@ -71,14 +71,7 @@ TEST(RequestingAsyncRequestTest, AsyncRequestStateBasic) {
   EXPECT_EQ(callback.request_result().payload().GetInteger(), kValue);
 }
 
-#ifdef __EMSCRIPTEN__
-// TODO(#185): Crashes in Emscripten due to out-of-memory.
-#define MAYBE_AsyncRequestStateMultiThreading \
-  DISABLED_AsyncRequestStateMultiThreading
-#else
-#define MAYBE_AsyncRequestStateMultiThreading AsyncRequestStateMultiThreading
-#endif
-TEST(RequestingAsyncRequestTest, MAYBE_AsyncRequestStateMultiThreading) {
+TEST(RequestingAsyncRequestTest, AsyncRequestStateMultiThreading) {
   const int kIterationCount = 300;
   const int kStateCount = 100;
   const int kThreadCount = 10;

--- a/common/cpp/src/google_smart_card_common/requesting/async_requests_storage_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/async_requests_storage_unittest.cc
@@ -85,13 +85,7 @@ TEST(RequestingAsyncRequestsStorageTest, Basic) {
   EXPECT_FALSE(storage.Pop(request_4_id));
 }
 
-#ifdef __EMSCRIPTEN__
-// TODO(#185): Crashes in Emscripten due to out-of-memory.
-#define MAYBE_MultiThreading DISABLED_MultiThreading
-#else
-#define MAYBE_MultiThreading MultiThreading
-#endif
-TEST(RequestingAsyncRequestsStorageTest, MAYBE_MultiThreading) {
+TEST(RequestingAsyncRequestsStorageTest, MultiThreading) {
   const int kThreadCount = 10;
   const int kIterationCount = 10 * 1000;
 

--- a/common/cpp_unit_test_runner/src/build_emscripten.mk
+++ b/common/cpp_unit_test_runner/src/build_emscripten.mk
@@ -16,18 +16,37 @@
 # builds the C++ unit test runner using the Emscripten toolchain.
 
 # Documented in ../include.mk.
+#
+# Explanation:
+# GTEST_HAS_PTHREAD: Make GoogleTest/GoogleMock thread-safe via pthreads. Note
+#   that this must match the flag passed when building GoogleTest/GoogleMock -
+#   see //third_party/googletest/webport/build/Makefile.
 TEST_ADDITIONAL_CXXFLAGS := \
+	-DGTEST_HAS_PTHREAD=1 \
 	-I$(ROOT_PATH)/third_party/googletest/src/googlemock/include \
 	-I$(ROOT_PATH)/third_party/googletest/src/googletest/include \
 
 # Documented in ../include.mk.
 #
 # Explanation:
+# EXIT_RUNTIME: Quit the program when the main() exits - otherwise the execution
+#   will hang.
+# EXPORT_NAME: Restore the standard value "Module" for this flag, overriding the
+#   setting specified in
+#   //common/make/internal/executable_building_emscripten.mk. Otherwise loading
+#   the test under Node.js will fail.
 # MODULARIZE: Disable putting the Emscripten module JavaScript loading code into
-#   a factory function, so that the test runner module is loaded automatically
-#   on startup.
+#   a factory function, overriding the setting specified in
+#   //common/make/internal/executable_building_emscripten.mk. Otherwise the test
+#   runner won't be loaded automatically when running the file in Node.js.
+# PROXY_TO_PTHREAD: Run the main() function, and hence all test bodies, in a
+#   separate thread. Otherwise, multi-threaded tests will hang as background
+#   tests aren't created until the main thread yields.
 TEST_ADDITIONAL_LDFLAGS := \
+	-s EXIT_RUNTIME \
+	-s EXPORT_NAME=Module \
 	-s MODULARIZE=0 \
+	-s PROXY_TO_PTHREAD \
 
 # Documented in ../include.mk.
 TEST_RUNNER_SOURCES :=

--- a/third_party/googletest/webport/build/Makefile
+++ b/third_party/googletest/webport/build/Makefile
@@ -86,8 +86,9 @@ endif
 # LDFLAGS: Enables Emscripten Pthreads support.
 # B: Build directory.
 # CMAKE_BUILD_TYPE: Specify debug/release build.
-# gtest_disable_pthreads: Disables pthreads-based functionality in GoogleTest
-#   that doesn't behave well under Emscripten (it deadlocks on startup).
+# GTEST_HAS_PTHREAD: Make GoogleTest/GoogleMock thread-safe via pthreads. Note
+#   that the same definition must be passed when compiling test files - see
+#   //common/cpp_unit_test_runner/src/build_emscripten.mk.
 $(ARTIFACTS_LIBS) &:
 	rm -rf out-artifacts
 	mkdir out-artifacts
@@ -100,7 +101,7 @@ $(ARTIFACTS_LIBS) &:
 		../../src \
 		-B out-artifacts \
 		-DCMAKE_BUILD_TYPE=$(CONFIG) \
-		-Dgtest_disable_pthreads=on
+		-DGTEST_HAS_PTHREAD=1
 	+$(MAKE) -C out-artifacts
 
 # Rule for creating target library files, as copies of the temporary libraries.

--- a/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
@@ -762,8 +762,8 @@ INSTANTIATE_TEST_SUITE_P(
 // Each transfer request is resolved immediately on the same thread that
 // initiated the transfer.
 TEST_F(LibusbJsProxyTransfersTest, SyncControlTransfersWithMultiThreading) {
-  // The bigger number of transfers increases the chances of catching a bug, but
-  // the constant is lower in the Debug mode to avoid running too long.
+  // A high number of transfers increases the chances of catching a bug, but the
+  // constant is lower in the Debug mode to avoid running too long.
   const size_t kMaxTransferIndex =
 #ifdef NDEBUG
       1000
@@ -817,8 +817,8 @@ class LibusbJsProxyAsyncTransfersMultiThreadingTest
   }
 
  protected:
-  // The bigger number of transfers increases the chances of catching a bug, but
-  // the constant is lower in the Debug mode to avoid running too long.
+  // A high number of transfers increases the chances of catching a bug, but the
+  // constant is lower in the Debug mode to avoid running too long.
   const size_t kMaxTransferIndex =
 #ifdef NDEBUG
       1000

--- a/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
@@ -756,22 +756,21 @@ INSTANTIATE_TEST_SUITE_P(
                 GetTransferIndexToFinishUnsuccessful(),
             true)));
 
-#ifdef __EMSCRIPTEN__
-// TODO(#185): Crashes in Emscripten due to out-of-memory.
-#define MAYBE_SyncControlTransfersWithMultiThreading \
-  DISABLED_SyncControlTransfersWithMultiThreading
-#else
-#define MAYBE_SyncControlTransfersWithMultiThreading \
-  SyncControlTransfersWithMultiThreading
-#endif
 // Test the correctness of work of multiple threads issuing a sequence of
 // synchronous transfer requests.
 //
 // Each transfer request is resolved immediately on the same thread that
 // initiated the transfer.
-TEST_F(LibusbJsProxyTransfersTest,
-       MAYBE_SyncControlTransfersWithMultiThreading) {
-  const size_t kMaxTransferIndex = 1000;
+TEST_F(LibusbJsProxyTransfersTest, SyncControlTransfersWithMultiThreading) {
+  // The bigger number of transfers increases the chances of catching a bug, but
+  // the constant is lower in the Debug mode to avoid running too long.
+  const size_t kMaxTransferIndex =
+#ifdef NDEBUG
+      1000
+#else
+      100
+#endif
+      ;
   const size_t kThreadCount = 10;
 
   for (size_t index = 0; index <= kMaxTransferIndex; ++index) {
@@ -818,7 +817,15 @@ class LibusbJsProxyAsyncTransfersMultiThreadingTest
   }
 
  protected:
-  const size_t kMaxTransferIndex = 1000;
+  // The bigger number of transfers increases the chances of catching a bug, but
+  // the constant is lower in the Debug mode to avoid running too long.
+  const size_t kMaxTransferIndex =
+#ifdef NDEBUG
+      1000
+#else
+      100
+#endif
+      ;
 
   void AddTransferInFlight(size_t transfer_index, bool is_transfer_output) {
     const std::unique_lock<std::mutex> lock(mutex_);
@@ -863,17 +870,11 @@ class LibusbJsProxyAsyncTransfersMultiThreadingTest
 
 }  // namespace
 
-#ifdef __EMSCRIPTEN__
-// TODO(#185): Crashes in Emscripten due to out-of-memory.
-#define MAYBE_ControlTransfers DISABLED_ControlTransfers
-#else
-#define MAYBE_ControlTransfers ControlTransfers
-#endif
 // Test the correctness of work of multiple threads issuing a sequence of
 // asynchronous transfer requests and running libusb event loops.
 //
 // The requests are resolved asynchronously from the main thread.
-TEST_F(LibusbJsProxyAsyncTransfersMultiThreadingTest, MAYBE_ControlTransfers) {
+TEST_F(LibusbJsProxyAsyncTransfersMultiThreadingTest, ControlTransfers) {
   const size_t kThreadCount = 10;
 
   std::vector<std::thread> threads;


### PR DESCRIPTION
Fix the configuration issues that prevented the usage of
multi-threading in unit tests. This required a few "magic" flags to
Emscripten and tweaking the GoogleTest build parameters, but also we had
to wait until Emscripten fixes a few toolchain issues.

This commit also reenables all multi-threading tests to be run on
Emscripten as well, as they were previously NaCl-only. Given that the
Debug mode is 1-2 orders of magntiude slower in Emscripten than the
Release mode, the commit also tweaks the parameters in stress tests.