### PR TITLE
[build] Tests are built after the main code

### DIFF
--- a/common/js/build/Makefile
+++ b/common/js/build/Makefile
@@ -16,7 +16,7 @@
 all:
 
 
-test::
+test:: all
 	+$(MAKE) --directory unittests run_test
 
 tests_clean::

--- a/example_cpp_smart_card_client_app/build/Makefile
+++ b/example_cpp_smart_card_client_app/build/Makefile
@@ -74,7 +74,7 @@ $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/built_in_pin_dialog/built-in-
 
 # Rules for building and running tests and for cleaning test build files.
 
-test::
+test:: all
 	+$(MAKE) --directory integration_tests run_test
 
 tests_clean::

--- a/third_party/libusb/webport/build/Makefile
+++ b/third_party/libusb/webport/build/Makefile
@@ -71,7 +71,7 @@ $(foreach src,$(CXX_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CPPFLAGS) $(CXX
 $(eval $(call LIB_RULE,$(TARGET),$(SOURCES)))
 
 
-test::
+test:: all
 	+$(MAKE) --directory tests run_test
 	+$(MAKE) --directory js_unittests run_test
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server_clients_management/build/Makefile
@@ -79,7 +79,7 @@ JS_COMPILER_FLAGS := \
 $(eval $(call BUILD_JS_SCRIPT,pcsc_lite_server_clients_management/user-prompt-dialog.js,$(JS_COMPILER_INPUT_PATHS),GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.UserPromptDialog.Main,$(JS_COMPILER_FLAGS)))
 
 
-test::
+test:: all
 	+$(MAKE) --directory js_unittests run_test
 
 tests_clean::


### PR DESCRIPTION
Add missing dependencies into the Makefiles, so that tests aren't
attempted to be built before the libraries they're testing. Without
this, there were flaky link errors.