### PR TITLE
[style] Call JS constructors with brackets

### DIFF
--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -130,9 +130,9 @@ const libusbProxyReceiver = new GSC.LibusbProxyReceiver(
 const pcscLiteReadinessTracker =
     new GSC.PcscLiteServerClientsManagement.ReadinessTracker(
         executableModule.getMessageChannel());
-const messageChannelPool = new GSC.MessageChannelPool;
+const messageChannelPool = new GSC.MessageChannelPool();
 
-const readerTrackerMessageChannelPair = new GSC.MessageChannelPair;
+const readerTrackerMessageChannelPair = new GSC.MessageChannelPair();
 createClientHandler(readerTrackerMessageChannelPair.getFirst(), undefined);
 const readerTracker = new GSC.PcscLiteServer.ReaderTracker(
     executableModule.getMessageChannel(),


### PR DESCRIPTION
The Google JavaScript Style Guide requires to always specify brackets
when invoking constructors. Fix a couple of places in our code that
violate that.

This is a pure refactoring commit.