### PR TITLE
[usb] Get device configs via new JS proxy

### DIFF
--- a/common/cpp/src/google_smart_card_common/value_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion.cc
@@ -290,6 +290,20 @@ bool ConvertFromValue(Value value,
 }
 
 bool ConvertFromValue(Value value,
+                      int16_t* number,
+                      std::string* error_message) {
+  return ConvertIntegerFromValue(std::move(value), "int16_t", number,
+                                 error_message);
+}
+
+bool ConvertFromValue(Value value,
+                      uint16_t* number,
+                      std::string* error_message) {
+  return ConvertIntegerFromValue(std::move(value), "uint16_t", number,
+                                 error_message);
+}
+
+bool ConvertFromValue(Value value,
                       int64_t* number,
                       std::string* error_message) {
   return ConvertIntegerFromValue(std::move(value), "int64_t", number,

--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -615,6 +615,12 @@ bool ConvertFromValue(Value value,
                       uint8_t* number,
                       std::string* error_message = nullptr);
 bool ConvertFromValue(Value value,
+                      int16_t* number,
+                      std::string* error_message = nullptr);
+bool ConvertFromValue(Value value,
+                      uint16_t* number,
+                      std::string* error_message = nullptr);
+bool ConvertFromValue(Value value,
                       int64_t* number,
                       std::string* error_message = nullptr);
 bool ConvertFromValue(Value value,

--- a/third_party/libusb/webport/src/libusb-proxy-data-model.js
+++ b/third_party/libusb/webport/src/libusb-proxy-data-model.js
@@ -19,6 +19,10 @@
 
 goog.provide('GoogleSmartCard.LibusbProxyDataModel');
 
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
 // The following definitions must match the ones in
 // libusb_js_proxy_data_model.h.
 
@@ -33,4 +37,72 @@ goog.provide('GoogleSmartCard.LibusbProxyDataModel');
  *            serialNumber:(string|undefined),
  *          }}
  */
-GoogleSmartCard.LibusbProxyDataModel.LibusbJsDevice;
+GSC.LibusbProxyDataModel.LibusbJsDevice;
+
+const LibusbJsDevice = GSC.LibusbProxyDataModel.LibusbJsDevice;
+
+/**
+ * @enum {string}
+ */
+GSC.LibusbProxyDataModel.LibusbJsDirection = {
+  IN: 'in',
+  OUT: 'out',
+};
+
+const LibusbJsDirection = GSC.LibusbProxyDataModel.LibusbJsDirection;
+
+/**
+ * @enum {string}
+ */
+GSC.LibusbProxyDataModel.LibusbJsEndpointType = {
+  BULK: 'bulk',
+  CONTROL: 'control',
+  INTERRUPT: 'interrupt',
+  ISOCHRONOUS: 'isochronous',
+};
+
+const LibusbJsEndpointType = GSC.LibusbProxyDataModel.LibusbJsEndpointType;
+
+/**
+ * @typedef {{
+ *            endpointAddress:number,
+ *            direction:!LibusbJsDirection,
+ *            type:!LibusbJsEndpointType,
+ *            extraData:(!ArrayBuffer|undefined),
+ *            maxPacketSize:number
+ *          }}
+ */
+GSC.LibusbProxyDataModel.LibusbJsEndpointDescriptor;
+
+const LibusbJsEndpointDescriptor =
+    GSC.LibusbProxyDataModel.LibusbJsEndpointDescriptor;
+
+/**
+ * @typedef {{
+ *            interfaceNumber:number,
+ *            interfaceClass:number,
+ *            interfaceSubclass:number,
+ *            interfaceProtocol:number,
+ *            extraData:(!ArrayBuffer|undefined),
+ *            endpoints:!Array<!LibusbJsEndpointDescriptor>
+ *          }}
+ */
+GSC.LibusbProxyDataModel.LibusbJsInterfaceDescriptor;
+
+const LibusbJsInterfaceDescriptor =
+    GSC.LibusbProxyDataModel.LibusbJsInterfaceDescriptor;
+
+/**
+ * TODO(#429): Investigate remote_wakeup, self_powered, max_power flags.
+ * @typedef {{
+ *            active:boolean,
+ *            configurationValue:number,
+ *            extraData:(!ArrayBuffer|undefined),
+ *            interfaces:!Array<!LibusbJsInterfaceDescriptor>
+ *          }}
+ */
+GSC.LibusbProxyDataModel.LibusbJsConfigurationDescriptor;
+
+const LibusbJsConfigurationDescriptor =
+    GSC.LibusbProxyDataModel.LibusbJsConfigurationDescriptor;
+});  // goog.scope

--- a/third_party/libusb/webport/src/libusb-proxy-data-model.js
+++ b/third_party/libusb/webport/src/libusb-proxy-data-model.js
@@ -27,6 +27,7 @@ const GSC = GoogleSmartCard;
 // libusb_js_proxy_data_model.h.
 
 /**
+ * The key strings must match the ones in libusb_js_proxy_data_model.cc.
  * @typedef {{
  *            deviceId:number,
  *            vendorId:number,
@@ -42,6 +43,7 @@ GSC.LibusbProxyDataModel.LibusbJsDevice;
 const LibusbJsDevice = GSC.LibusbProxyDataModel.LibusbJsDevice;
 
 /**
+ * The string values must match the ones in libusb_js_proxy_data_model.cc.
  * @enum {string}
  */
 GSC.LibusbProxyDataModel.LibusbJsDirection = {
@@ -52,6 +54,7 @@ GSC.LibusbProxyDataModel.LibusbJsDirection = {
 const LibusbJsDirection = GSC.LibusbProxyDataModel.LibusbJsDirection;
 
 /**
+ * The string values must match the ones in libusb_js_proxy_data_model.cc.
  * @enum {string}
  */
 GSC.LibusbProxyDataModel.LibusbJsEndpointType = {
@@ -64,6 +67,7 @@ GSC.LibusbProxyDataModel.LibusbJsEndpointType = {
 const LibusbJsEndpointType = GSC.LibusbProxyDataModel.LibusbJsEndpointType;
 
 /**
+ * The key strings must match the ones in libusb_js_proxy_data_model.cc.
  * @typedef {{
  *            endpointAddress:number,
  *            direction:!LibusbJsDirection,
@@ -78,6 +82,7 @@ const LibusbJsEndpointDescriptor =
     GSC.LibusbProxyDataModel.LibusbJsEndpointDescriptor;
 
 /**
+ * The key strings must match the ones in libusb_js_proxy_data_model.cc.
  * @typedef {{
  *            interfaceNumber:number,
  *            interfaceClass:number,
@@ -93,6 +98,7 @@ const LibusbJsInterfaceDescriptor =
     GSC.LibusbProxyDataModel.LibusbJsInterfaceDescriptor;
 
 /**
+ * The key strings must match the ones in libusb_js_proxy_data_model.cc.
  * TODO(#429): Investigate remote_wakeup, self_powered, max_power flags.
  * @typedef {{
  *            active:boolean,

--- a/third_party/libusb/webport/src/libusb-proxy-receiver.js
+++ b/third_party/libusb/webport/src/libusb-proxy-receiver.js
@@ -103,8 +103,11 @@ GSC.LibusbProxyReceiver = class {
     // Note: The function name strings must match the ones in
     // libusb_js_proxy.cc.
     switch (remoteCallMessage.functionName) {
-      case 'list_devices':
+      case 'listDevices':
         return await this.libusbToJsApiAdaptor_.listDevices(
+            ...remoteCallMessage.functionArguments);
+      case 'getConfigurations':
+        return await this.libusbToJsApiAdaptor_.getConfigurations(
             ...remoteCallMessage.functionArguments);
     }
     // TODO(#429): Delete this fallback to ChromeUsbBackend once all functions

--- a/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
@@ -24,10 +24,18 @@ goog.require('GoogleSmartCard.LibusbProxyDataModel');
 goog.scope(function() {
 
 const GSC = GoogleSmartCard;
+const LibusbJsConfigurationDescriptor =
+    GSC.LibusbProxyDataModel.LibusbJsConfigurationDescriptor;
 const LibusbJsDevice = GSC.LibusbProxyDataModel.LibusbJsDevice;
 
 GSC.LibusbToJsApiAdaptor = class {
   /** @return {!Promise<!Array<!LibusbJsDevice>>} */
   async listDevices() {}
+
+  /**
+   * @param {number} deviceId
+   * @return {!Promise<!Array<!LibusbJsConfigurationDescriptor>>}
+   */
+  async getConfigurations(deviceId) {}
 };
 });  // goog.scope

--- a/third_party/libusb/webport/src/libusb_js_proxy_data_model.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_data_model.cc
@@ -41,7 +41,7 @@ StructValueDescriptor<LibusbJsDevice>::GetDescription() {
 template <>
 EnumValueDescriptor<LibusbJsDirection>::Description
 EnumValueDescriptor<LibusbJsDirection>::GetDescription() {
-  // Note: Strings passed to WithField() below must match the ones in
+  // Note: Strings passed to WithItem() below must match the ones in
   // libusb-proxy-data-model.js.
   return Describe("LibusbJsDirection")
       .WithItem(LibusbJsDirection::kIn, "in")
@@ -51,7 +51,7 @@ EnumValueDescriptor<LibusbJsDirection>::GetDescription() {
 template <>
 EnumValueDescriptor<LibusbJsEndpointType>::Description
 EnumValueDescriptor<LibusbJsEndpointType>::GetDescription() {
-  // Note: Strings passed to WithField() below must match the ones in
+  // Note: Strings passed to WithItem() below must match the ones in
   // libusb-proxy-data-model.js.
   return Describe("LibusbJsEndpointType")
       .WithItem(LibusbJsEndpointType::kBulk, "bulk")

--- a/third_party/libusb/webport/src/libusb_js_proxy_data_model.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_data_model.cc
@@ -38,4 +38,71 @@ StructValueDescriptor<LibusbJsDevice>::GetDescription() {
       .WithField(&LibusbJsDevice::serial_number, "serialNumber");
 }
 
+template <>
+EnumValueDescriptor<LibusbJsDirection>::Description
+EnumValueDescriptor<LibusbJsDirection>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the ones in
+  // libusb-proxy-data-model.js.
+  return Describe("LibusbJsDirection")
+      .WithItem(LibusbJsDirection::kIn, "in")
+      .WithItem(LibusbJsDirection::kOut, "out");
+}
+
+template <>
+EnumValueDescriptor<LibusbJsEndpointType>::Description
+EnumValueDescriptor<LibusbJsEndpointType>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the ones in
+  // libusb-proxy-data-model.js.
+  return Describe("LibusbJsEndpointType")
+      .WithItem(LibusbJsEndpointType::kBulk, "bulk")
+      .WithItem(LibusbJsEndpointType::kControl, "control")
+      .WithItem(LibusbJsEndpointType::kInterrupt, "interrupt")
+      .WithItem(LibusbJsEndpointType::kIsochronous, "isochronous");
+}
+
+template <>
+StructValueDescriptor<LibusbJsEndpointDescriptor>::Description
+StructValueDescriptor<LibusbJsEndpointDescriptor>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the ones in
+  // libusb-proxy-data-model.js.
+  return Describe("LibusbJsEndpointDescriptor")
+      .WithField(&LibusbJsEndpointDescriptor::endpoint_address,
+                 "endpointAddress")
+      .WithField(&LibusbJsEndpointDescriptor::direction, "direction")
+      .WithField(&LibusbJsEndpointDescriptor::type, "type")
+      .WithField(&LibusbJsEndpointDescriptor::extra_data, "extraData")
+      .WithField(&LibusbJsEndpointDescriptor::max_packet_size, "maxPacketSize");
+}
+
+template <>
+StructValueDescriptor<LibusbJsInterfaceDescriptor>::Description
+StructValueDescriptor<LibusbJsInterfaceDescriptor>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the ones in
+  // libusb-proxy-data-model.js.
+  return Describe("LibusbJsInterfaceDescriptor")
+      .WithField(&LibusbJsInterfaceDescriptor::interface_number,
+                 "interfaceNumber")
+      .WithField(&LibusbJsInterfaceDescriptor::interface_class,
+                 "interfaceClass")
+      .WithField(&LibusbJsInterfaceDescriptor::interface_subclass,
+                 "interfaceSubclass")
+      .WithField(&LibusbJsInterfaceDescriptor::interface_protocol,
+                 "interfaceProtocol")
+      .WithField(&LibusbJsInterfaceDescriptor::extra_data, "extraData")
+      .WithField(&LibusbJsInterfaceDescriptor::endpoints, "endpoints");
+}
+
+template <>
+StructValueDescriptor<LibusbJsConfigurationDescriptor>::Description
+StructValueDescriptor<LibusbJsConfigurationDescriptor>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the ones in
+  // libusb-proxy-data-model.js.
+  return Describe("LibusbJsConfigurationDescriptor")
+      .WithField(&LibusbJsConfigurationDescriptor::active, "active")
+      .WithField(&LibusbJsConfigurationDescriptor::configuration_value,
+                 "configurationValue")
+      .WithField(&LibusbJsConfigurationDescriptor::extra_data, "extraData")
+      .WithField(&LibusbJsConfigurationDescriptor::interfaces, "interfaces");
+}
+
 }  // namespace google_smart_card

--- a/third_party/libusb/webport/src/libusb_js_proxy_data_model.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy_data_model.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 
 #include <string>
+#include <vector>
 
 #include <google_smart_card_common/optional.h>
 
@@ -52,6 +53,50 @@ struct LibusbJsDevice {
   optional<std::string> manufacturer_name;
   // The USB iSerialNumber string, or an empty optional if unavailable.
   optional<std::string> serial_number;
+};
+
+enum LibusbJsDirection {
+  kIn,
+  kOut,
+};
+
+enum LibusbJsEndpointType {
+  kBulk,
+  kControl,
+  kInterrupt,
+  kIsochronous,
+};
+
+struct LibusbJsEndpointDescriptor {
+  // The USB bEndpointAddress field.
+  uint8_t endpoint_address;
+  LibusbJsDirection direction;
+  LibusbJsEndpointType type;
+  optional<std::vector<uint8_t>> extra_data;
+  // The USB wMaxPacketSize field.
+  uint16_t max_packet_size;
+};
+
+struct LibusbJsInterfaceDescriptor {
+  // The USB bInterfaceNumber field.
+  uint8_t interface_number;
+  // The USB interfaceClass field.
+  uint8_t interface_class;
+  // The USB interfaceSubclass field.
+  uint8_t interface_subclass;
+  // The USB interfaceProtocol field.
+  uint8_t interface_protocol;
+  optional<std::vector<uint8_t>> extra_data;
+  std::vector<LibusbJsEndpointDescriptor> endpoints;
+};
+
+struct LibusbJsConfigurationDescriptor {
+  // Whether the configuration is active.
+  bool active;
+  // The USB bConfigurationValue field.
+  uint8_t configuration_value;
+  optional<std::vector<uint8_t>> extra_data;
+  std::vector<LibusbJsInterfaceDescriptor> interfaces;
 };
 
 }  // namespace google_smart_card


### PR DESCRIPTION
Add structures and boilerplate for the device config passing into the
libusb-to-JS adaptor, and provide its implementation for the chrome.usb
API.

It's preparatory work for the WebUSB support effort tracked by #429.