### PR TITLE
[usb] Open/close devices via new JS proxy

### DIFF
--- a/third_party/libusb/webport/src/libusb-proxy-receiver.js
+++ b/third_party/libusb/webport/src/libusb-proxy-receiver.js
@@ -90,13 +90,12 @@ GSC.LibusbProxyReceiver = class {
       // constructor.
       throw new Error('USB API unavailable');
     }
-    const result = await this.dispatchLibusbJsFunction_(remoteCallMessage);
-    return [result];
+    return await this.dispatchLibusbJsFunction_(remoteCallMessage);
   }
 
   /**
    * @param {!GSC.RemoteCallMessage} remoteCallMessage
-   * @return {!Promise<*>}
+   * @return {!Promise<!Array>}
    * @private
    */
   async dispatchLibusbJsFunction_(remoteCallMessage) {
@@ -104,11 +103,18 @@ GSC.LibusbProxyReceiver = class {
     // libusb_js_proxy.cc.
     switch (remoteCallMessage.functionName) {
       case 'listDevices':
-        return await this.libusbToJsApiAdaptor_.listDevices(
-            ...remoteCallMessage.functionArguments);
+        return [await this.libusbToJsApiAdaptor_.listDevices(
+            ...remoteCallMessage.functionArguments)];
       case 'getConfigurations':
-        return await this.libusbToJsApiAdaptor_.getConfigurations(
+        return [await this.libusbToJsApiAdaptor_.getConfigurations(
+            ...remoteCallMessage.functionArguments)];
+      case 'openDeviceHandle':
+        return [await this.libusbToJsApiAdaptor_.openDeviceHandle(
+            ...remoteCallMessage.functionArguments)];
+      case 'closeDeviceHandle':
+        await this.libusbToJsApiAdaptor_.closeDeviceHandle(
             ...remoteCallMessage.functionArguments);
+        return [];
     }
     // TODO(#429): Delete this fallback to ChromeUsbBackend once all functions
     // are implemented in LibusbToJsApiAdaptor.

--- a/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
@@ -80,6 +80,23 @@ GSC.LibusbToChromeUsbAdaptor = class extends GSC.LibusbToJsApiAdaptor {
         convertChromeUsbDeviceDescriptorToLibusb);
   }
 
+  /** @override */
+  async openDeviceHandle(deviceId) {
+    const chromeUsbDevice = this.getDeviceByIdOrThrow_(deviceId);
+    const chromeUsbConnectionHandle =
+        /** @type {!chrome.usb.ConnectionHandle} */ (
+            await promisify(chrome.usb.openDevice, chromeUsbDevice));
+    return chromeUsbConnectionHandle.handle;
+  }
+
+  /** @override */
+  async closeDeviceHandle(deviceId, deviceHandle) {
+    const chromeUsbDevice = this.getDeviceByIdOrThrow_(deviceId);
+    const chromeUsbConnectionHandle =
+        getChromeUsbConnectionHandle(chromeUsbDevice, deviceHandle);
+    await promisify(chrome.usb.closeDevice, chromeUsbConnectionHandle);
+  }
+
   /**
    * @private
    * @param {!Array<!chrome.usb.Device>} chromeUsbDevices
@@ -236,5 +253,18 @@ function convertChromeUsbEndpointTypeToLibusb(chromeUsbEndpointType) {
   GSC.Logging.failWithLogger(
       logger, `Unexpected chrome.usb endpoint type: ${chromeUsbEndpointType}`);
   goog.asserts.fail();
+}
+
+/**
+ * @param {!chrome.usb.Device} chromeUsbDevice
+ * @param {number} deviceHandle
+ * @return {!chrome.usb.ConnectionHandle}
+ */
+function getChromeUsbConnectionHandle(chromeUsbDevice, deviceHandle) {
+  return /** @type {!chrome.usb.ConnectionHandle} */ ({
+    'handle': deviceHandle,
+    'productId': chromeUsbDevice.productId,
+    'vendorId': chromeUsbDevice.vendorId,
+  });
 }
 });  // goog.scope

--- a/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
@@ -37,5 +37,18 @@ GSC.LibusbToJsApiAdaptor = class {
    * @return {!Promise<!Array<!LibusbJsConfigurationDescriptor>>}
    */
   async getConfigurations(deviceId) {}
+
+  /**
+   * @param {number} deviceId
+   * @return {!Promise<number>} Device handle.
+   */
+  async openDeviceHandle(deviceId) {}
+
+  /**
+   * @param {number} deviceId
+   * @param {number} deviceHandle
+   * @return {!Promise<void>}
+   */
+  async closeDeviceHandle(deviceId, deviceHandle) {}
 };
 });  // goog.scope

--- a/third_party/libusb/webport/src/libusb_opaque_types.cc
+++ b/third_party/libusb/webport/src/libusb_opaque_types.cc
@@ -372,12 +372,9 @@ void libusb_device::RemoveReference() {
     delete this;
 }
 
-libusb_device_handle::libusb_device_handle(
-    libusb_device* device,
-    const google_smart_card::chrome_usb::ConnectionHandle&
-        chrome_usb_connection_handle)
-    : device_(device),
-      chrome_usb_connection_handle_(chrome_usb_connection_handle) {
+libusb_device_handle::libusb_device_handle(libusb_device* device,
+                                           int64_t js_device_handle)
+    : device_(device), js_device_handle_(js_device_handle) {
   GOOGLE_SMART_CARD_CHECK(device_);
   device_->AddReference();
 }
@@ -394,7 +391,6 @@ libusb_context* libusb_device_handle::context() const {
   return device_->context();
 }
 
-const google_smart_card::chrome_usb::ConnectionHandle&
-libusb_device_handle::chrome_usb_connection_handle() const {
-  return chrome_usb_connection_handle_;
+int64_t libusb_device_handle::js_device_handle() const {
+  return js_device_handle_;
 }

--- a/third_party/libusb/webport/src/libusb_opaque_types.h
+++ b/third_party/libusb/webport/src/libusb_opaque_types.h
@@ -212,8 +212,6 @@ struct libusb_context final
 };
 
 // Definition of the libusb_device type declared in the libusb headers.
-//
-// The structure corresponds to the Device structure in chrome.usb interface.
 struct libusb_device final {
   // Creates a new structure with the reference counter equal to 1.
   libusb_device(libusb_context* context,
@@ -237,15 +235,10 @@ struct libusb_device final {
 };
 
 // Definition of the libusb_device_handle type declared in the libusb headers.
-//
-// The structure corresponds to the ConnectionHandle structure in chrome.usb
-// interface.
 struct libusb_device_handle final {
   // Constructs the structure and increments the reference counter of the
   // specified libusb_device instance.
-  libusb_device_handle(libusb_device* device,
-                       const google_smart_card::chrome_usb::ConnectionHandle&
-                           chrome_usb_connection_handle);
+  libusb_device_handle(libusb_device* device, int64_t js_device_handle);
 
   // Destructs the structure and decrements the reference counter of the
   // specified libusb_device instance.
@@ -253,12 +246,11 @@ struct libusb_device_handle final {
 
   libusb_device* device() const;
   libusb_context* context() const;
-  const google_smart_card::chrome_usb::ConnectionHandle&
-  chrome_usb_connection_handle() const;
+  int64_t js_device_handle() const;
 
  private:
-  libusb_device* device_;
-  google_smart_card::chrome_usb::ConnectionHandle chrome_usb_connection_handle_;
+  libusb_device* const device_;
+  const int64_t js_device_handle_;
 };
 
 #endif  // GOOGLE_SMART_CARD_THIRD_PARTY_LIBUSB_LIBUSB_OPAQUE_TYPES_H_


### PR DESCRIPTION
Implement opening/closing a device via the new libusb-to-JS adaptor and
its chrome.usb implementation.

It's preparatory work for the WebUSB support effort tracked by #429.