### PR TITLE
[usb] Fix memory leak on close failure

### DIFF
--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -608,7 +608,6 @@ void LibusbJsProxy::LibusbClose(libusb_device_handle* handle) {
     // It's essential to not crash in this case, because this may happen during
     // shutdown process.
     GOOGLE_SMART_CARD_LOG_ERROR << "Failed to close USB device";
-    return;
   }
 
   delete handle;


### PR DESCRIPTION
Don't leak the libusb_device_handle memory when the handle closing
failed. Such failures should never happen under normal circumstances,
but it's still better to avoid such leaks.