### PR TITLE
[usb] Claim interface via new JS proxy

### DIFF
--- a/third_party/libusb/webport/src/libusb-proxy-receiver.js
+++ b/third_party/libusb/webport/src/libusb-proxy-receiver.js
@@ -115,6 +115,10 @@ GSC.LibusbProxyReceiver = class {
         await this.libusbToJsApiAdaptor_.closeDeviceHandle(
             ...remoteCallMessage.functionArguments);
         return [];
+      case 'claimInterface':
+        await this.libusbToJsApiAdaptor_.claimInterface(
+            ...remoteCallMessage.functionArguments);
+        return [];
     }
     // TODO(#429): Delete this fallback to ChromeUsbBackend once all functions
     // are implemented in LibusbToJsApiAdaptor.

--- a/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
@@ -97,6 +97,15 @@ GSC.LibusbToChromeUsbAdaptor = class extends GSC.LibusbToJsApiAdaptor {
     await promisify(chrome.usb.closeDevice, chromeUsbConnectionHandle);
   }
 
+  /** @override */
+  async claimInterface(deviceId, deviceHandle, interfaceNumber) {
+    const chromeUsbDevice = this.getDeviceByIdOrThrow_(deviceId);
+    const chromeUsbConnectionHandle =
+        getChromeUsbConnectionHandle(chromeUsbDevice, deviceHandle);
+    await promisify(
+        chrome.usb.claimInterface, chromeUsbConnectionHandle, interfaceNumber);
+  }
+
   /**
    * @private
    * @param {!Array<!chrome.usb.Device>} chromeUsbDevices

--- a/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
@@ -50,5 +50,13 @@ GSC.LibusbToJsApiAdaptor = class {
    * @return {!Promise<void>}
    */
   async closeDeviceHandle(deviceId, deviceHandle) {}
+
+  /**
+   * @param {number} deviceId
+   * @param {number} deviceHandle
+   * @param {number} interfaceNumber
+   * @return {!Promise<void>}
+   */
+  async claimInterface(deviceId, deviceHandle, interfaceNumber) {}
 };
 });  // goog.scope

--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -564,7 +564,6 @@ int LibusbJsProxy::LibusbClaimInterface(libusb_device_handle* dev,
   GenericRequestResult request_result = js_call_adaptor_.SyncCall(
       kJsRequestClaimInterface, dev->device()->js_device().device_id,
       dev->js_device_handle(), interface_number);
-  std::string error_message;
   if (!request_result.is_successful()) {
     GOOGLE_SMART_CARD_LOG_WARNING << "LibusbClaimInterface request failed: "
                                   << request_result.error_message();

--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -41,6 +41,7 @@ constexpr char kJsRequestListDevices[] = "listDevices";
 constexpr char kJsRequestGetConfigurations[] = "getConfigurations";
 constexpr char kJsRequestOpenDeviceHandle[] = "openDeviceHandle";
 constexpr char kJsRequestCloseDeviceHandle[] = "closeDeviceHandle";
+constexpr char kJsRequestClaimInterface[] = "claimInterface";
 
 //
 // We use stubs for the device bus number (as the chrome.usb API does not
@@ -560,13 +561,13 @@ int LibusbJsProxy::LibusbClaimInterface(libusb_device_handle* dev,
                                         int interface_number) {
   GOOGLE_SMART_CARD_CHECK(dev);
 
-  const RequestResult<chrome_usb::ClaimInterfaceResult> result =
-      chrome_usb_api_bridge_->ClaimInterface(GetChromeUsbConnectionHandle(*dev),
-                                             interface_number);
-  if (!result.is_successful()) {
-    GOOGLE_SMART_CARD_LOG_WARNING
-        << "LibusbJsProxy::LibusbClaimInterface request failed: "
-        << result.error_message();
+  GenericRequestResult request_result = js_call_adaptor_.SyncCall(
+      kJsRequestClaimInterface, dev->device()->js_device().device_id,
+      dev->js_device_handle(), interface_number);
+  std::string error_message;
+  if (!request_result.is_successful()) {
+    GOOGLE_SMART_CARD_LOG_WARNING << "LibusbClaimInterface request failed: "
+                                  << request_result.error_message();
     return LIBUSB_ERROR_OTHER;
   }
   return LIBUSB_SUCCESS;


### PR DESCRIPTION
Implement claiming a USB interface via the new libusb-to-JS adaptor and
its chrome.usb implementation.

It's preparatory work for the WebUSB support effort tracked by #429.