### PR TITLE
[usb] Release interface via new JS proxy

### DIFF
--- a/third_party/libusb/webport/src/libusb-proxy-receiver.js
+++ b/third_party/libusb/webport/src/libusb-proxy-receiver.js
@@ -119,6 +119,10 @@ GSC.LibusbProxyReceiver = class {
         await this.libusbToJsApiAdaptor_.claimInterface(
             ...remoteCallMessage.functionArguments);
         return [];
+      case 'releaseInterface':
+        await this.libusbToJsApiAdaptor_.releaseInterface(
+            ...remoteCallMessage.functionArguments);
+        return [];
     }
     // TODO(#429): Delete this fallback to ChromeUsbBackend once all functions
     // are implemented in LibusbToJsApiAdaptor.

--- a/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
@@ -91,26 +91,23 @@ GSC.LibusbToChromeUsbAdaptor = class extends GSC.LibusbToJsApiAdaptor {
 
   /** @override */
   async closeDeviceHandle(deviceId, deviceHandle) {
-    const chromeUsbDevice = this.getDeviceByIdOrThrow_(deviceId);
     const chromeUsbConnectionHandle =
-        getChromeUsbConnectionHandle(chromeUsbDevice, deviceHandle);
+        this.getConnectionHandleWithDeviceIdOrThrow_(deviceId, deviceHandle);
     await promisify(chrome.usb.closeDevice, chromeUsbConnectionHandle);
   }
 
   /** @override */
   async claimInterface(deviceId, deviceHandle, interfaceNumber) {
-    const chromeUsbDevice = this.getDeviceByIdOrThrow_(deviceId);
     const chromeUsbConnectionHandle =
-        getChromeUsbConnectionHandle(chromeUsbDevice, deviceHandle);
+        this.getConnectionHandleWithDeviceIdOrThrow_(deviceId, deviceHandle);
     await promisify(
         chrome.usb.claimInterface, chromeUsbConnectionHandle, interfaceNumber);
   }
 
   /** @override */
   async releaseInterface(deviceId, deviceHandle, interfaceNumber) {
-    const chromeUsbDevice = this.getDeviceByIdOrThrow_(deviceId);
     const chromeUsbConnectionHandle =
-        getChromeUsbConnectionHandle(chromeUsbDevice, deviceHandle);
+        this.getConnectionHandleWithDeviceIdOrThrow_(deviceId, deviceHandle);
     await promisify(
         chrome.usb.releaseInterface, chromeUsbConnectionHandle,
         interfaceNumber);
@@ -136,6 +133,17 @@ GSC.LibusbToChromeUsbAdaptor = class extends GSC.LibusbToJsApiAdaptor {
     if (!chromeUsbDevice)
       throw new Error(`No device with ID ${deviceId}`);
     return chromeUsbDevice;
+  }
+
+  /**
+   * @private
+   * @param {number} deviceId
+   * @param {number} deviceHandle
+   * @return {!chrome.usb.ConnectionHandle}
+   */
+  getConnectionHandleWithDeviceIdOrThrow_(deviceId, deviceHandle) {
+    const chromeUsbDevice = this.getDeviceByIdOrThrow_(deviceId);
+    return getChromeUsbConnectionHandle(chromeUsbDevice, deviceHandle);
   }
 };
 

--- a/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
@@ -106,6 +106,16 @@ GSC.LibusbToChromeUsbAdaptor = class extends GSC.LibusbToJsApiAdaptor {
         chrome.usb.claimInterface, chromeUsbConnectionHandle, interfaceNumber);
   }
 
+  /** @override */
+  async releaseInterface(deviceId, deviceHandle, interfaceNumber) {
+    const chromeUsbDevice = this.getDeviceByIdOrThrow_(deviceId);
+    const chromeUsbConnectionHandle =
+        getChromeUsbConnectionHandle(chromeUsbDevice, deviceHandle);
+    await promisify(
+        chrome.usb.releaseInterface, chromeUsbConnectionHandle,
+        interfaceNumber);
+  }
+
   /**
    * @private
    * @param {!Array<!chrome.usb.Device>} chromeUsbDevices

--- a/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
@@ -58,5 +58,13 @@ GSC.LibusbToJsApiAdaptor = class {
    * @return {!Promise<void>}
    */
   async claimInterface(deviceId, deviceHandle, interfaceNumber) {}
+
+  /**
+   * @param {number} deviceId
+   * @param {number} deviceHandle
+   * @param {number} interfaceNumber
+   * @return {!Promise<void>}
+   */
+  async releaseInterface(deviceId, deviceHandle, interfaceNumber) {}
 };
 });  // goog.scope

--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -580,7 +580,6 @@ int LibusbJsProxy::LibusbReleaseInterface(libusb_device_handle* dev,
   GenericRequestResult request_result = js_call_adaptor_.SyncCall(
       kJsRequestReleaseInterface, dev->device()->js_device().device_id,
       dev->js_device_handle(), interface_number);
-  std::string error_message;
   if (!request_result.is_successful()) {
     GOOGLE_SMART_CARD_LOG_WARNING << "LibusbReleaseInterface request failed: "
                                   << request_result.error_message();

--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -42,6 +42,7 @@ constexpr char kJsRequestGetConfigurations[] = "getConfigurations";
 constexpr char kJsRequestOpenDeviceHandle[] = "openDeviceHandle";
 constexpr char kJsRequestCloseDeviceHandle[] = "closeDeviceHandle";
 constexpr char kJsRequestClaimInterface[] = "claimInterface";
+constexpr char kJsRequestReleaseInterface[] = "releaseInterface";
 
 //
 // We use stubs for the device bus number (as the chrome.usb API does not
@@ -576,13 +577,13 @@ int LibusbJsProxy::LibusbReleaseInterface(libusb_device_handle* dev,
                                           int interface_number) {
   GOOGLE_SMART_CARD_CHECK(dev);
 
-  const RequestResult<chrome_usb::ReleaseInterfaceResult> result =
-      chrome_usb_api_bridge_->ReleaseInterface(
-          GetChromeUsbConnectionHandle(*dev), interface_number);
-  if (!result.is_successful()) {
-    GOOGLE_SMART_CARD_LOG_WARNING
-        << "LibusbJsProxy::LibusbReleaseInterface request failed: "
-        << result.error_message();
+  GenericRequestResult request_result = js_call_adaptor_.SyncCall(
+      kJsRequestReleaseInterface, dev->device()->js_device().device_id,
+      dev->js_device_handle(), interface_number);
+  std::string error_message;
+  if (!request_result.is_successful()) {
+    GOOGLE_SMART_CARD_LOG_WARNING << "LibusbReleaseInterface request failed: "
+                                  << request_result.error_message();
     return LIBUSB_ERROR_OTHER;
   }
   return LIBUSB_SUCCESS;


### PR DESCRIPTION
Implement releasing a USB interface via the new libusb-to-JS adaptor
and its chrome.usb implementation.

It's preparatory work for the WebUSB support effort tracked by #429.