### PR TITLE
[usb] Reset device via new JS proxy

### DIFF
--- a/third_party/libusb/webport/src/libusb-proxy-receiver.js
+++ b/third_party/libusb/webport/src/libusb-proxy-receiver.js
@@ -123,6 +123,10 @@ GSC.LibusbProxyReceiver = class {
         await this.libusbToJsApiAdaptor_.releaseInterface(
             ...remoteCallMessage.functionArguments);
         return [];
+      case 'resetDevice':
+        await this.libusbToJsApiAdaptor_.resetDevice(
+            ...remoteCallMessage.functionArguments);
+        return [];
     }
     // TODO(#429): Delete this fallback to ChromeUsbBackend once all functions
     // are implemented in LibusbToJsApiAdaptor.

--- a/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
@@ -115,9 +115,8 @@ GSC.LibusbToChromeUsbAdaptor = class extends GSC.LibusbToJsApiAdaptor {
 
   /** @override */
   async resetDevice(deviceId, deviceHandle) {
-    const chromeUsbDevice = this.getDeviceByIdOrThrow_(deviceId);
     const chromeUsbConnectionHandle =
-        getChromeUsbConnectionHandle(chromeUsbDevice, deviceHandle);
+        this.getConnectionHandleWithDeviceIdOrThrow_(deviceId, deviceHandle);
     await promisify(chrome.usb.resetDevice, chromeUsbConnectionHandle);
   }
 

--- a/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
@@ -113,6 +113,14 @@ GSC.LibusbToChromeUsbAdaptor = class extends GSC.LibusbToJsApiAdaptor {
         interfaceNumber);
   }
 
+  /** @override */
+  async resetDevice(deviceId, deviceHandle) {
+    const chromeUsbDevice = this.getDeviceByIdOrThrow_(deviceId);
+    const chromeUsbConnectionHandle =
+        getChromeUsbConnectionHandle(chromeUsbDevice, deviceHandle);
+    await promisify(chrome.usb.resetDevice, chromeUsbConnectionHandle);
+  }
+
   /**
    * @private
    * @param {!Array<!chrome.usb.Device>} chromeUsbDevices

--- a/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
@@ -66,5 +66,12 @@ GSC.LibusbToJsApiAdaptor = class {
    * @return {!Promise<void>}
    */
   async releaseInterface(deviceId, deviceHandle, interfaceNumber) {}
+
+  /**
+   * @param {number} deviceId
+   * @param {number} deviceHandle
+   * @return {!Promise<void>}
+   */
+  async resetDevice(deviceId, deviceHandle) {}
 };
 });  // goog.scope

--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -43,6 +43,7 @@ constexpr char kJsRequestOpenDeviceHandle[] = "openDeviceHandle";
 constexpr char kJsRequestCloseDeviceHandle[] = "closeDeviceHandle";
 constexpr char kJsRequestClaimInterface[] = "claimInterface";
 constexpr char kJsRequestReleaseInterface[] = "releaseInterface";
+constexpr char kJsRequestResetDevice[] = "resetDevice";
 
 //
 // We use stubs for the device bus number (as the chrome.usb API does not
@@ -591,12 +592,13 @@ int LibusbJsProxy::LibusbReleaseInterface(libusb_device_handle* dev,
 int LibusbJsProxy::LibusbResetDevice(libusb_device_handle* dev) {
   GOOGLE_SMART_CARD_CHECK(dev);
 
-  const RequestResult<chrome_usb::ResetDeviceResult> result =
-      chrome_usb_api_bridge_->ResetDevice(GetChromeUsbConnectionHandle(*dev));
-  if (!result.is_successful()) {
-    GOOGLE_SMART_CARD_LOG_WARNING
-        << "LibusbJsProxy::LibusbResetDevice request failed: "
-        << result.error_message();
+  GenericRequestResult request_result = js_call_adaptor_.SyncCall(
+      kJsRequestResetDevice, dev->device()->js_device().device_id,
+      dev->js_device_handle());
+  std::string error_message;
+  if (!request_result.is_successful()) {
+    GOOGLE_SMART_CARD_LOG_WARNING << "LibusbResetDevice request failed: "
+                                  << request_result.error_message();
     return LIBUSB_ERROR_OTHER;
   }
   return LIBUSB_SUCCESS;

--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -595,7 +595,6 @@ int LibusbJsProxy::LibusbResetDevice(libusb_device_handle* dev) {
   GenericRequestResult request_result = js_call_adaptor_.SyncCall(
       kJsRequestResetDevice, dev->device()->js_device().device_id,
       dev->js_device_handle());
-  std::string error_message;
   if (!request_result.is_successful()) {
     GOOGLE_SMART_CARD_LOG_WARNING << "LibusbResetDevice request failed: "
                                   << request_result.error_message();


### PR DESCRIPTION
Implement resetting a USB device via the new libusb-to-JS adaptor and
its chrome.usb implementation.

It's preparatory work for the WebUSB support effort tracked by #429.