### PR TITLE
[usb] Add types for control transfer

### DIFF
--- a/third_party/libusb/webport/src/libusb-proxy-data-model.js
+++ b/third_party/libusb/webport/src/libusb-proxy-data-model.js
@@ -111,4 +111,58 @@ GSC.LibusbProxyDataModel.LibusbJsConfigurationDescriptor;
 
 const LibusbJsConfigurationDescriptor =
     GSC.LibusbProxyDataModel.LibusbJsConfigurationDescriptor;
+
+/**
+ * The string values must match the ones in libusb_js_proxy_data_model.cc.
+ * @enum {string}
+ */
+GSC.LibusbProxyDataModel.LibusbJsTransferRequestType = {
+  STANDARD: 'standard',
+  CLASS: 'class',
+  VENDOR: 'vendor',
+};
+
+const LibusbJsTransferRequestType =
+    GSC.LibusbProxyDataModel.LibusbJsTransferRequestType;
+
+/**
+ * The string values must match the ones in libusb_js_proxy_data_model.cc.
+ * @enum {string}
+ */
+GSC.LibusbProxyDataModel.LibusbJsTransferRecipient = {
+  DEVICE: 'device',
+  INTERFACE: 'interface',
+  ENDPOINT: 'endpoint',
+  OTHER: 'other',
+};
+
+const LibusbJsTransferRecipient =
+    GSC.LibusbProxyDataModel.LibusbJsTransferRecipient;
+
+/**
+ * The key strings must match the ones in libusb_js_proxy_data_model.cc.
+ * @typedef {{
+ *            requestType:!LibusbJsTransferRequestType,
+ *            recipient:!LibusbJsTransferRecipient,
+ *            request:number,
+ *            value:number,
+ *            index:number,
+ *            dataToSend:(!ArrayBuffer|undefined),
+ *            lengthToReceive:(number|undefined)
+ *          }}
+ */
+GSC.LibusbProxyDataModel.LibusbJsControlTransferParameters;
+
+const LibusbJsControlTransferParameters =
+    GSC.LibusbProxyDataModel.LibusbJsControlTransferParameters;
+
+/**
+ * The key strings must match the ones in libusb_js_proxy_data_model.cc.
+ * @typedef {{
+ *            receivedData:(!ArrayBuffer|undefined),
+ *          }}
+ */
+GSC.LibusbProxyDataModel.LibusbJsTransferResult;
+
+const LibusbJsTransferResult = GSC.LibusbProxyDataModel.LibusbJsTransferResult;
 });  // goog.scope

--- a/third_party/libusb/webport/src/libusb-proxy-receiver.js
+++ b/third_party/libusb/webport/src/libusb-proxy-receiver.js
@@ -127,6 +127,9 @@ GSC.LibusbProxyReceiver = class {
         await this.libusbToJsApiAdaptor_.resetDevice(
             ...remoteCallMessage.functionArguments);
         return [];
+      case 'controlTransfer':
+        return [await this.libusbToJsApiAdaptor_.controlTransfer(
+            ...remoteCallMessage.functionArguments)];
     }
     // TODO(#429): Delete this fallback to ChromeUsbBackend once all functions
     // are implemented in LibusbToJsApiAdaptor.

--- a/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
@@ -141,7 +141,7 @@ GSC.LibusbToChromeUsbAdaptor = class extends GSC.LibusbToJsApiAdaptor {
       throw new Error(`USB API failed with resultCode=${
           chromeUsbTransferResultInfo.resultCode}`);
     }
-    /** @type {LibusbJsTransferResult} */
+    /** @type {!LibusbJsTransferResult} */
     const libusbJsTransferResult = {};
     if (chromeUsbTransferResultInfo.data)
       libusbJsTransferResult['receivedData'] = chromeUsbTransferResultInfo.data;

--- a/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
@@ -30,6 +30,8 @@ goog.scope(function() {
 const GSC = GoogleSmartCard;
 const LibusbJsConfigurationDescriptor =
     GSC.LibusbProxyDataModel.LibusbJsConfigurationDescriptor;
+const LibusbJsControlTransferParameters =
+    GSC.LibusbProxyDataModel.LibusbJsControlTransferParameters;
 const LibusbJsDevice = GSC.LibusbProxyDataModel.LibusbJsDevice;
 const LibusbJsDirection = GSC.LibusbProxyDataModel.LibusbJsDirection;
 const LibusbJsEndpointDescriptor =
@@ -37,6 +39,11 @@ const LibusbJsEndpointDescriptor =
 const LibusbJsEndpointType = GSC.LibusbProxyDataModel.LibusbJsEndpointType;
 const LibusbJsInterfaceDescriptor =
     GSC.LibusbProxyDataModel.LibusbJsInterfaceDescriptor;
+const LibusbJsTransferRecipient =
+    GSC.LibusbProxyDataModel.LibusbJsTransferRecipient;
+const LibusbJsTransferRequestType =
+    GSC.LibusbProxyDataModel.LibusbJsTransferRequestType;
+const LibusbJsTransferResult = GSC.LibusbProxyDataModel.LibusbJsTransferResult;
 
 const logger = GSC.Logging.getScopedLogger('LibusbToChromeUsbAdaptor');
 
@@ -118,6 +125,27 @@ GSC.LibusbToChromeUsbAdaptor = class extends GSC.LibusbToJsApiAdaptor {
     const chromeUsbConnectionHandle =
         this.getConnectionHandleWithDeviceIdOrThrow_(deviceId, deviceHandle);
     await promisify(chrome.usb.resetDevice, chromeUsbConnectionHandle);
+  }
+
+  /** @override */
+  async controlTransfer(deviceId, deviceHandle, parameters) {
+    const chromeUsbConnectionHandle =
+        this.getConnectionHandleWithDeviceIdOrThrow_(deviceId, deviceHandle);
+    const chromeUsbControlTransferInfo =
+        getChromeUsbControlTranferInfo(parameters);
+    const chromeUsbTransferResultInfo =
+        /** @type {!chrome.usb.TransferResultInfo} */ (await promisify(
+            chrome.usb.controlTransfer, chromeUsbConnectionHandle,
+            chromeUsbControlTransferInfo));
+    if (chromeUsbTransferResultInfo.resultCode) {
+      throw new Error(`USB API failed with resultCode=${
+          chromeUsbTransferResultInfo.resultCode}`);
+    }
+    /** @type {LibusbJsTransferResult} */
+    const libusbJsTransferResult = {};
+    if (chromeUsbTransferResultInfo.data)
+      libusbJsTransferResult['receivedData'] = chromeUsbTransferResultInfo.data;
+    return libusbJsTransferResult;
   }
 
   /**
@@ -300,5 +328,62 @@ function getChromeUsbConnectionHandle(chromeUsbDevice, deviceHandle) {
     'productId': chromeUsbDevice.productId,
     'vendorId': chromeUsbDevice.vendorId,
   });
+}
+
+/**
+ * @param {!LibusbJsControlTransferParameters} libusbJsParameters
+ * @return {!chrome.usb.ControlTransferInfo}
+ */
+function getChromeUsbControlTranferInfo(libusbJsParameters) {
+  const controlTransferInfo = /** @type {!chrome.usb.ControlTransferInfo} */ ({
+    'direction': libusbJsParameters['dataToSend'] ? 'out' : 'in',
+    'index': libusbJsParameters['index'],
+    'recipient': getChromeUsbRecipient(libusbJsParameters['recipient']),
+    'request': libusbJsParameters['request'],
+    'requestType': getChromeUsbRequestType(libusbJsParameters['requestType']),
+  });
+  if (libusbJsParameters['dataToSend'])
+    controlTransferInfo['data'] = libusbJsParameters['dataToSend'];
+  if (libusbJsParameters['lengthToReceive'] !== undefined)
+    controlTransferInfo['length'] = libusbJsParameters['lengthToReceive'];
+  return controlTransferInfo;
+}
+
+/**
+ * @param {!LibusbJsTransferRecipient} libusbJsTransferRecipient
+ * @return {string} The chrome.usb.Recipient value.
+ */
+function getChromeUsbRecipient(libusbJsTransferRecipient) {
+  switch (libusbJsTransferRecipient) {
+    case LibusbJsTransferRecipient.DEVICE:
+      return 'device';
+    case LibusbJsTransferRecipient.INTERFACE:
+      return 'interface';
+    case LibusbJsTransferRecipient.ENDPOINT:
+      return 'endpoint';
+    case LibusbJsTransferRecipient.OTHER:
+      return 'other';
+  }
+  GSC.Logging.failWithLogger(
+      logger, `Unexpected libusb recipient: ${libusbJsTransferRecipient}`);
+  goog.asserts.fail();
+}
+
+/**
+ * @param {!LibusbJsTransferRequestType} libusbJsTransferRequestType
+ * @return {string} The chrome.usb.RequestType value.
+ */
+function getChromeUsbRequestType(libusbJsTransferRequestType) {
+  switch (libusbJsTransferRequestType) {
+    case LibusbJsTransferRequestType.STANDARD:
+      return 'standard';
+    case LibusbJsTransferRequestType.CLASS:
+      return 'class';
+    case LibusbJsTransferRequestType.VENDOR:
+      return 'vendor';
+  }
+  GSC.Logging.failWithLogger(
+      logger, `Unexpected libusb request type: ${libusbJsTransferRequestType}`);
+  goog.asserts.fail();
 }
 });  // goog.scope

--- a/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
@@ -26,7 +26,10 @@ goog.scope(function() {
 const GSC = GoogleSmartCard;
 const LibusbJsConfigurationDescriptor =
     GSC.LibusbProxyDataModel.LibusbJsConfigurationDescriptor;
+const LibusbJsControlTransferParameters =
+    GSC.LibusbProxyDataModel.LibusbJsControlTransferParameters;
 const LibusbJsDevice = GSC.LibusbProxyDataModel.LibusbJsDevice;
+const LibusbJsTransferResult = GSC.LibusbProxyDataModel.LibusbJsTransferResult;
 
 GSC.LibusbToJsApiAdaptor = class {
   /** @return {!Promise<!Array<!LibusbJsDevice>>} */
@@ -73,5 +76,13 @@ GSC.LibusbToJsApiAdaptor = class {
    * @return {!Promise<void>}
    */
   async resetDevice(deviceId, deviceHandle) {}
+
+  /**
+   * @param {number} deviceId
+   * @param {number} deviceHandle
+   * @param {!LibusbJsControlTransferParameters} parameters
+   * @return {!Promise<!LibusbJsTransferResult>}
+   */
+  async controlTransfer(deviceId, deviceHandle, parameters) {}
 };
 });  // goog.scope

--- a/third_party/libusb/webport/src/libusb_js_proxy_data_model.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_data_model.cc
@@ -105,4 +105,53 @@ StructValueDescriptor<LibusbJsConfigurationDescriptor>::GetDescription() {
       .WithField(&LibusbJsConfigurationDescriptor::interfaces, "interfaces");
 }
 
+template <>
+EnumValueDescriptor<LibusbJsTransferRequestType>::Description
+EnumValueDescriptor<LibusbJsTransferRequestType>::GetDescription() {
+  // Note: Strings passed to WithItem() below must match the ones in
+  // libusb-proxy-data-model.js.
+  return Describe("LibusbJsTransferRequestType")
+      .WithItem(LibusbJsTransferRequestType::kStandard, "standard")
+      .WithItem(LibusbJsTransferRequestType::kClass, "class")
+      .WithItem(LibusbJsTransferRequestType::kVendor, "vendor");
+}
+
+template <>
+EnumValueDescriptor<LibusbJsTransferRecipient>::Description
+EnumValueDescriptor<LibusbJsTransferRecipient>::GetDescription() {
+  // Note: Strings passed to WithItem() below must match the ones in
+  // libusb-proxy-data-model.js.
+  return Describe("LibusbJsTransferRecipient")
+      .WithItem(LibusbJsTransferRecipient::kDevice, "device")
+      .WithItem(LibusbJsTransferRecipient::kInterface, "interface")
+      .WithItem(LibusbJsTransferRecipient::kEndpoint, "endpoint")
+      .WithItem(LibusbJsTransferRecipient::kOther, "other");
+}
+
+template <>
+StructValueDescriptor<LibusbJsControlTransferParameters>::Description
+StructValueDescriptor<LibusbJsControlTransferParameters>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the ones in
+  // libusb-proxy-data-model.js.
+  return Describe("LibusbJsControlTransferParameters")
+      .WithField(&LibusbJsControlTransferParameters::request_type,
+                 "requestType")
+      .WithField(&LibusbJsControlTransferParameters::recipient, "recipient")
+      .WithField(&LibusbJsControlTransferParameters::request, "request")
+      .WithField(&LibusbJsControlTransferParameters::value, "value")
+      .WithField(&LibusbJsControlTransferParameters::index, "index")
+      .WithField(&LibusbJsControlTransferParameters::data_to_send, "dataToSend")
+      .WithField(&LibusbJsControlTransferParameters::length_to_receive,
+                 "lengthToReceive");
+}
+
+template <>
+StructValueDescriptor<LibusbJsTransferResult>::Description
+StructValueDescriptor<LibusbJsTransferResult>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the ones in
+  // libusb-proxy-data-model.js.
+  return Describe("LibusbJsTransferResult")
+      .WithField(&LibusbJsTransferResult::received_data, "receivedData");
+}
+
 }  // namespace google_smart_card

--- a/third_party/libusb/webport/src/libusb_js_proxy_data_model.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy_data_model.h
@@ -99,6 +99,41 @@ struct LibusbJsConfigurationDescriptor {
   std::vector<LibusbJsInterfaceDescriptor> interfaces;
 };
 
+// Corresponds to the "type" bits of the USB bmRequestType field.
+enum class LibusbJsTransferRequestType {
+  kStandard,
+  kClass,
+  kVendor,
+};
+
+// Corresponds to the "recipient" bits of the USB bmRequestType field.
+enum class LibusbJsTransferRecipient {
+  kDevice,
+  kInterface,
+  kEndpoint,
+  kOther,
+};
+
+struct LibusbJsControlTransferParameters {
+  LibusbJsTransferRequestType request_type;
+  LibusbJsTransferRecipient recipient;
+  // The USB bRequest field.
+  uint8_t request;
+  // The USB wValue field.
+  uint16_t value;
+  // The USB wIndex field.
+  uint16_t index;
+  // Only set for output transfers.
+  optional<std::vector<uint8_t>> data_to_send;
+  // Only set for input transfers.
+  optional<uint16_t> length_to_receive;
+};
+
+struct LibusbJsTransferResult {
+  // This field is only populated for input transfers.
+  optional<std::vector<uint8_t>> received_data;
+};
+
 }  // namespace google_smart_card
 
 #endif  // GOOGLE_SMART_CARD_THIRD_PARTY_LIBUSB_LIBUSB_JS_PROXY_DATA_MODEL_H_


### PR DESCRIPTION
Add data model and implement the JS side of the USB control transfers in
the new libusb-to-JS adaptor.

The C++ side is not wired up with this new code yet.

It's preparatory work for the WebUSB support effort tracked by #429.