### PR TITLE
[usb] Decouple USB destination from chrome.usb

### DIFF
--- a/third_party/libusb/webport/src/usb_transfer_destination.cc
+++ b/third_party/libusb/webport/src/usb_transfer_destination.cc
@@ -26,11 +26,83 @@
 
 #include <tuple>
 
+#include <libusb.h>
+
 namespace google_smart_card {
+
+namespace {
+
+// TODO(#429): Delete this converter once the C++ code gets fully abstracted
+// away from chrome.usb.
+uint8_t GetLibusbRequestType(
+    const chrome_usb::ControlTransferInfo& chrome_usb_control_transfer_info) {
+  uint8_t request_type = 0;
+  switch (chrome_usb_control_transfer_info.request_type) {
+    case chrome_usb::ControlTransferInfoRequestType::kStandard:
+      request_type |= LIBUSB_REQUEST_TYPE_STANDARD;
+      break;
+    case chrome_usb::ControlTransferInfoRequestType::kClass:
+      request_type |= LIBUSB_REQUEST_TYPE_CLASS;
+      break;
+    case chrome_usb::ControlTransferInfoRequestType::kVendor:
+      request_type |= LIBUSB_REQUEST_TYPE_VENDOR;
+      break;
+    case chrome_usb::ControlTransferInfoRequestType::kReserved:
+      request_type |= LIBUSB_REQUEST_TYPE_RESERVED;
+      break;
+  }
+  switch (chrome_usb_control_transfer_info.direction) {
+    case chrome_usb::Direction::kIn:
+      request_type |= LIBUSB_ENDPOINT_IN;
+      break;
+    case chrome_usb::Direction::kOut:
+      request_type |= LIBUSB_ENDPOINT_OUT;
+      break;
+  }
+  switch (chrome_usb_control_transfer_info.recipient) {
+    case chrome_usb::ControlTransferInfoRecipient::kDevice:
+      request_type |= LIBUSB_RECIPIENT_DEVICE;
+      break;
+    case chrome_usb::ControlTransferInfoRecipient::kInterface:
+      request_type |= LIBUSB_RECIPIENT_INTERFACE;
+      break;
+    case chrome_usb::ControlTransferInfoRecipient::kEndpoint:
+      request_type |= LIBUSB_RECIPIENT_ENDPOINT;
+      break;
+    case chrome_usb::ControlTransferInfoRecipient::kOther:
+      request_type |= LIBUSB_RECIPIENT_OTHER;
+      break;
+  }
+  return request_type;
+}
+
+}  // namespace
 
 UsbTransferDestination::UsbTransferDestination() = default;
 
 UsbTransferDestination::~UsbTransferDestination() = default;
+
+// static
+UsbTransferDestination UsbTransferDestination::CreateForControlTransfer(
+    int64_t js_device_handle,
+    uint8_t request_type,
+    uint8_t request,
+    uint16_t value,
+    uint16_t index) {
+  return UsbTransferDestination(js_device_handle,
+                                /*endpoint_address=*/{}, request_type, request,
+                                value, index);
+}
+
+// static
+UsbTransferDestination UsbTransferDestination::CreateForGenericTransfer(
+    int64_t js_device_handle,
+    uint8_t endpoint_address) {
+  return UsbTransferDestination(
+      js_device_handle, endpoint_address,
+      /*control_transfer_request_type=*/{}, /*control_transfer_request=*/{},
+      /*control_transfer_value=*/{}, /*control_transfer_index=*/{});
+}
 
 // static
 UsbTransferDestination
@@ -38,9 +110,9 @@ UsbTransferDestination::CreateFromChromeUsbControlTransfer(
     const chrome_usb::ConnectionHandle& connection_handle,
     const chrome_usb::ControlTransferInfo& transfer_info) {
   return UsbTransferDestination(
-      connection_handle, transfer_info.direction, {}, transfer_info.recipient,
-      transfer_info.request_type, transfer_info.request, transfer_info.value,
-      transfer_info.index);
+      connection_handle.handle,
+      /*endpoint_address=*/{}, GetLibusbRequestType(transfer_info),
+      transfer_info.request, transfer_info.value, transfer_info.index);
 }
 
 // static
@@ -48,12 +120,29 @@ UsbTransferDestination
 UsbTransferDestination::CreateFromChromeUsbGenericTransfer(
     const chrome_usb::ConnectionHandle& connection_handle,
     const chrome_usb::GenericTransferInfo& transfer_info) {
-  return UsbTransferDestination(connection_handle, transfer_info.direction,
-                                transfer_info.endpoint, {}, {}, {}, {}, {});
+  return UsbTransferDestination(
+      connection_handle.handle, transfer_info.endpoint,
+      /*control_transfer_request_type=*/{}, /*control_transfer_request=*/{},
+      /*control_transfer_value=*/{}, /*control_transfer_index=*/{});
 }
 
 bool UsbTransferDestination::IsInputDirection() const {
-  return direction_ == chrome_usb::Direction::kIn;
+  // It's only correct to check the flag presence by doing bitwise and against a
+  // non-zero constant.
+  static_assert(LIBUSB_ENDPOINT_IN != 0,
+                "Bad mask: LIBUSB_ENDPOINT_IN is zero");
+
+  if (control_transfer_request_type_) {
+    // For control transfers, the direction is encoded in the request type.
+    return (*control_transfer_request_type_ & LIBUSB_ENDPOINT_IN) != 0;
+  }
+  if (endpoint_address_) {
+    // For all other transfer types, the direction is encoded in the endpoint
+    // address.
+    return (*endpoint_address_ & LIBUSB_ENDPOINT_IN) != 0;
+  }
+  // It's invalid to call this function on a default-initialized instance.
+  GOOGLE_SMART_CARD_NOTREACHED;
 }
 
 bool UsbTransferDestination::operator<(
@@ -72,20 +161,14 @@ bool UsbTransferDestination::operator==(
 }
 
 UsbTransferDestination::UsbTransferDestination(
-    const chrome_usb::ConnectionHandle& connection_handle,
-    const chrome_usb::Direction& direction,
-    optional<int64_t> endpoint,
-    optional<chrome_usb::ControlTransferInfoRecipient>
-        control_transfer_recipient,
-    optional<chrome_usb::ControlTransferInfoRequestType>
-        control_transfer_request_type,
-    optional<int64_t> control_transfer_request,
-    optional<int64_t> control_transfer_value,
-    optional<int64_t> control_transfer_index)
-    : connection_handle_(connection_handle),
-      direction_(direction),
-      endpoint_(endpoint),
-      control_transfer_recipient_(control_transfer_recipient),
+    int64_t js_device_handle,
+    optional<uint8_t> endpoint_address,
+    optional<uint8_t> control_transfer_request_type,
+    optional<uint8_t> control_transfer_request,
+    optional<uint16_t> control_transfer_value,
+    optional<uint16_t> control_transfer_index)
+    : js_device_handle_(js_device_handle),
+      endpoint_address_(endpoint_address),
       control_transfer_request_type_(control_transfer_request_type),
       control_transfer_request_(control_transfer_request),
       control_transfer_value_(control_transfer_value),
@@ -106,17 +189,13 @@ int CompareValues(const T& lhs, const T& rhs) {
 
 int UsbTransferDestination::Compare(const UsbTransferDestination& other) const {
   return CompareValues(
-      std::tie(connection_handle_.handle, connection_handle_.vendor_id,
-               connection_handle_.product_id, direction_, endpoint_,
-               control_transfer_recipient_, control_transfer_request_type_,
-               control_transfer_request_, control_transfer_value_,
-               control_transfer_index_),
-      std::tie(
-          other.connection_handle_.handle, other.connection_handle_.vendor_id,
-          other.connection_handle_.product_id, other.direction_,
-          other.endpoint_, other.control_transfer_recipient_,
-          other.control_transfer_request_type_, other.control_transfer_request_,
-          other.control_transfer_value_, other.control_transfer_index_));
+      std::tie(js_device_handle_, endpoint_address_,
+               control_transfer_request_type_, control_transfer_request_,
+               control_transfer_value_, control_transfer_index_),
+      std::tie(other.js_device_handle_, other.endpoint_address_,
+               other.control_transfer_request_type_,
+               other.control_transfer_request_, other.control_transfer_value_,
+               other.control_transfer_index_));
 }
 
 }  // namespace google_smart_card

--- a/third_party/libusb/webport/src/usb_transfer_destination.cc
+++ b/third_party/libusb/webport/src/usb_transfer_destination.cc
@@ -127,19 +127,16 @@ UsbTransferDestination::CreateFromChromeUsbGenericTransfer(
 }
 
 bool UsbTransferDestination::IsInputDirection() const {
-  // It's only correct to check the flag presence by doing bitwise and against a
-  // non-zero constant.
-  static_assert(LIBUSB_ENDPOINT_IN != 0,
-                "Bad mask: LIBUSB_ENDPOINT_IN is zero");
-
   if (control_transfer_request_type_) {
     // For control transfers, the direction is encoded in the request type.
-    return (*control_transfer_request_type_ & LIBUSB_ENDPOINT_IN) != 0;
+    return (*control_transfer_request_type_ & LIBUSB_ENDPOINT_DIR_MASK) ==
+           LIBUSB_ENDPOINT_IN;
   }
   if (endpoint_address_) {
     // For all other transfer types, the direction is encoded in the endpoint
     // address.
-    return (*endpoint_address_ & LIBUSB_ENDPOINT_IN) != 0;
+    return (*endpoint_address_ & LIBUSB_ENDPOINT_DIR_MASK) ==
+           LIBUSB_ENDPOINT_IN;
   }
   // It's invalid to call this function on a default-initialized instance.
   GOOGLE_SMART_CARD_NOTREACHED;

--- a/third_party/libusb/webport/src/usb_transfer_destination.h
+++ b/third_party/libusb/webport/src/usb_transfer_destination.h
@@ -19,6 +19,8 @@
 
 #include <stdint.h>
 
+#include <libusb.h>
+
 #include <google_smart_card_common/optional.h>
 
 #include "chrome_usb/types.h"
@@ -28,7 +30,7 @@ namespace google_smart_card {
 // This structure uniquely represents a libusb/chrome.usb transfer destination.
 //
 // This structure is used for finding matches between transfers and transfer
-// results (see the comments in the libusb_over_chrome_usb.h header).
+// results (see the comments in the libusb_js_proxy.h header).
 class UsbTransferDestination final {
  public:
   UsbTransferDestination();
@@ -36,10 +38,19 @@ class UsbTransferDestination final {
   UsbTransferDestination& operator=(const UsbTransferDestination&) = default;
   ~UsbTransferDestination();
 
+  static UsbTransferDestination CreateForControlTransfer(
+      int64_t js_device_handle,
+      uint8_t request_type,
+      uint8_t request,
+      uint16_t value,
+      uint16_t index);
+  static UsbTransferDestination CreateForGenericTransfer(
+      int64_t js_device_handle,
+      uint8_t endpoint_address);
+
   static UsbTransferDestination CreateFromChromeUsbControlTransfer(
       const chrome_usb::ConnectionHandle& connection_handle,
       const chrome_usb::ControlTransferInfo& transfer_info);
-
   static UsbTransferDestination CreateFromChromeUsbGenericTransfer(
       const chrome_usb::ConnectionHandle& connection_handle,
       const chrome_usb::GenericTransferInfo& transfer_info);
@@ -51,29 +62,21 @@ class UsbTransferDestination final {
   bool operator==(const UsbTransferDestination& other) const;
 
  private:
-  UsbTransferDestination(const chrome_usb::ConnectionHandle& connection_handle,
-                         const chrome_usb::Direction& direction,
-                         optional<int64_t> endpoint,
-                         optional<chrome_usb::ControlTransferInfoRecipient>
-                             control_transfer_recipient,
-                         optional<chrome_usb::ControlTransferInfoRequestType>
-                             control_transfer_request_type,
-                         optional<int64_t> control_transfer_request,
-                         optional<int64_t> control_transfer_value,
-                         optional<int64_t> control_transfer_index);
+  UsbTransferDestination(int64_t js_device_handle,
+                         optional<uint8_t> endpoint_address,
+                         optional<uint8_t> control_transfer_request_type,
+                         optional<uint8_t> control_transfer_request,
+                         optional<uint16_t> control_transfer_value,
+                         optional<uint16_t> control_transfer_index);
 
   int Compare(const UsbTransferDestination& other) const;
 
-  chrome_usb::ConnectionHandle connection_handle_;
-  chrome_usb::Direction direction_;
-  optional<int64_t> endpoint_;
-  optional<chrome_usb::ControlTransferInfoRecipient>
-      control_transfer_recipient_;
-  optional<chrome_usb::ControlTransferInfoRequestType>
-      control_transfer_request_type_;
-  optional<int64_t> control_transfer_request_;
-  optional<int64_t> control_transfer_value_;
-  optional<int64_t> control_transfer_index_;
+  int64_t js_device_handle_;
+  optional<uint8_t> endpoint_address_;
+  optional<uint8_t> control_transfer_request_type_;
+  optional<uint8_t> control_transfer_request_;
+  optional<uint16_t> control_transfer_value_;
+  optional<uint16_t> control_transfer_index_;
 };
 
 }  // namespace google_smart_card


### PR DESCRIPTION
Refactor the UsbTransferDestination struct to stop using the chrome.usb
entities internally, and also to expose factory methods that don't use
chrome.usb entities.

This is a preparation for switching the callsites away from using
chrome.usb. It's preparatory work for the WebUSB support effort tracked
by #429.