### PR TITLE
[usb] Do sync bulk/interrupt transfers via async

### DIFF
--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -1115,14 +1115,12 @@ int LibusbJsProxy::DoGenericSyncTranfer(libusb_transfer_type transfer_type,
   if (transfer_type == LIBUSB_TRANSFER_TYPE_BULK) {
     libusb_fill_bulk_transfer(&transfer, device_handle, endpoint_address, data,
                               length,
-                              /*callback=*/
-                              &OnSyncTransferCompleted,
+                              /*callback=*/&OnSyncTransferCompleted,
                               /*user_data=*/&transfer_completed, timeout);
   } else if (transfer_type == LIBUSB_TRANSFER_TYPE_INTERRUPT) {
     libusb_fill_interrupt_transfer(&transfer, device_handle, endpoint_address,
                                    data, length,
-                                   /*callback=*/
-                                   &OnSyncTransferCompleted,
+                                   /*callback=*/&OnSyncTransferCompleted,
                                    /*user_data=*/&transfer_completed, timeout);
   } else {
     GOOGLE_SMART_CARD_NOTREACHED;

--- a/third_party/libusb/webport/src/libusb_js_proxy.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy.h
@@ -129,32 +129,19 @@ class LibusbJsProxy final : public LibusbInterface {
  private:
   const int kHandleEventsTimeoutSeconds = 60;
 
-  class SyncTransferHelper final {
-   public:
-    SyncTransferHelper(std::shared_ptr<libusb_context> context,
-                       const UsbTransferDestination& transfer_destination);
-    SyncTransferHelper(const SyncTransferHelper&) = delete;
-    SyncTransferHelper& operator=(const SyncTransferHelper&) = delete;
-    ~SyncTransferHelper();
-
-    chrome_usb::AsyncTransferCallback chrome_usb_transfer_callback() const;
-
-    TransferRequestResult WaitForCompletion();
-
-   private:
-    std::shared_ptr<libusb_context> context_;
-    UsbTransferDestination transfer_destination_;
-    TransferRequestResult result_;
-    TransferAsyncRequestStatePtr async_request_state_;
-    chrome_usb::AsyncTransferCallback chrome_usb_transfer_callback_;
-  };
-
   libusb_context* SubstituteDefaultContextIfNull(
       libusb_context* context_or_nullptr) const;
   TransferAsyncRequestCallback WrapLibusbTransferCallback(
       libusb_transfer* transfer);
   int LibusbHandleEventsWithTimeout(libusb_context* context,
                                     int timeout_seconds);
+  int DoGenericSyncTranfer(libusb_transfer_type transfer_type,
+                           libusb_device_handle* device_handle,
+                           unsigned char endpoint_address,
+                           unsigned char* data,
+                           int length,
+                           int* actual_length,
+                           unsigned timeout);
 
   // Helpers for making requests to the JavaScript side.
   JsRequester js_requester_;

--- a/third_party/libusb/webport/src/libusb_opaque_types.cc
+++ b/third_party/libusb/webport/src/libusb_opaque_types.cc
@@ -20,16 +20,6 @@
 
 #include <google_smart_card_common/logging/logging.h>
 
-void libusb_context::AddSyncTransferInFlight(
-    TransferAsyncRequestStatePtr async_request_state,
-    const UsbTransferDestination& transfer_destination) {
-  GOOGLE_SMART_CARD_CHECK(async_request_state);
-
-  const std::unique_lock<std::mutex> lock(mutex_);
-
-  AddTransferInFlight(async_request_state, transfer_destination, nullptr);
-}
-
 void libusb_context::AddAsyncTransferInFlight(
     TransferAsyncRequestStatePtr async_request_state,
     const UsbTransferDestination& transfer_destination,
@@ -40,58 +30,6 @@ void libusb_context::AddAsyncTransferInFlight(
   const std::unique_lock<std::mutex> lock(mutex_);
 
   AddTransferInFlight(async_request_state, transfer_destination, transfer);
-}
-
-void libusb_context::WaitAndProcessInputSyncTransferReceivedResult(
-    TransferAsyncRequestStatePtr async_request_state,
-    const UsbTransferDestination& transfer_destination) {
-  TransferRequestResult result;
-
-  {
-    std::unique_lock<std::mutex> lock(mutex_);
-
-    for (;;) {
-      GOOGLE_SMART_CARD_CHECK(
-          transfers_in_flight_.ContainsWithAsyncRequestState(
-              async_request_state.get()));
-
-      if (ExtractMatchingInputTransferResult(transfer_destination, &result)) {
-        RemoveTransferInFlight(async_request_state.get());
-        break;
-      }
-
-      condition_.wait(lock);
-    }
-  }
-
-  SetTransferResult(async_request_state.get(), std::move(result));
-}
-
-void libusb_context::WaitAndProcessOutputSyncTransferReceivedResult(
-    TransferAsyncRequestStatePtr async_request_state) {
-  TransferRequestResult result;
-
-  {
-    std::unique_lock<std::mutex> lock(mutex_);
-
-    for (;;) {
-      GOOGLE_SMART_CARD_CHECK(
-          transfers_in_flight_.ContainsWithAsyncRequestState(
-              async_request_state.get()));
-
-      if (received_output_transfer_result_map_.count(async_request_state)) {
-        result = std::move(
-            received_output_transfer_result_map_[async_request_state]);
-        received_output_transfer_result_map_.erase(async_request_state);
-        RemoveTransferInFlight(async_request_state.get());
-        break;
-      }
-
-      condition_.wait(lock);
-    }
-  }
-
-  SetTransferResult(async_request_state.get(), std::move(result));
 }
 
 void libusb_context::WaitAndProcessAsyncTransferReceivedResults(
@@ -303,25 +241,6 @@ bool libusb_context::ExtractInputAsyncTransferStateUpdate(
   }
 
   return false;
-}
-
-bool libusb_context::ExtractMatchingInputTransferResult(
-    const UsbTransferDestination& transfer_destination,
-    TransferRequestResult* result) {
-  const auto iter =
-      received_input_transfer_result_map_.find(transfer_destination);
-  if (iter == received_input_transfer_result_map_.end())
-    return false;
-  std::queue<TransferRequestResult>* results_queue = &iter->second;
-
-  GOOGLE_SMART_CARD_CHECK(!results_queue->empty());
-  *result = std::move(results_queue->front());
-  results_queue->pop();
-
-  if (results_queue->empty())
-    received_input_transfer_result_map_.erase(iter);
-
-  return true;
 }
 
 void libusb_context::SetTransferResult(

--- a/third_party/libusb/webport/src/libusb_opaque_types.h
+++ b/third_party/libusb/webport/src/libusb_opaque_types.h
@@ -78,17 +78,6 @@ struct libusb_context final
   using UsbTransfersParametersStorage =
       google_smart_card::UsbTransfersParametersStorage;
 
-  // Adds information about a new synchronous transfer into internal structures.
-  //
-  // The async_request_state argument points to the instance that should be
-  // used to store the transfer result. The transfer_destination argument
-  // contains the set of parameters that represent the transfer destination,
-  // which for input transfers allows to receive the suitable results from the
-  // previous canceled transfers.
-  void AddSyncTransferInFlight(
-      TransferAsyncRequestStatePtr async_request_state,
-      const UsbTransferDestination& transfer_destination);
-
   // Adds information about a new asynchronous transfer into internal
   // structures.
   //
@@ -101,26 +90,6 @@ struct libusb_context final
       TransferAsyncRequestStatePtr async_request_state,
       const UsbTransferDestination& transfer_destination,
       libusb_transfer* transfer);
-
-  // Blocks until the specified input synchronous transfer finishes.
-  //
-  // The transfer_destination argument contains the set of parameters that
-  // uniquely represent the transfer destination, which for input transfers
-  // allows to receive the suitable results from the previous canceled
-  // transfers.
-  //
-  // It is guaranteed that the instance pointed by the async_request_state
-  // argument will contain the transfer result once the method finishes.
-  void WaitAndProcessInputSyncTransferReceivedResult(
-      TransferAsyncRequestStatePtr async_request_state,
-      const UsbTransferDestination& transfer_destination);
-
-  // Blocks until the specified output synchronous transfer finishes.
-  //
-  // It is guaranteed that the instance pointed by the async_request_state
-  // argument will contain the transfer result once the method finishes.
-  void WaitAndProcessOutputSyncTransferReceivedResult(
-      TransferAsyncRequestStatePtr async_request_state);
 
   // Blocks until either a new asynchronous transfer result is received (in
   // which case the transfer callback is executed), or the specified completed
@@ -177,10 +146,6 @@ struct libusb_context final
       TransferRequestResult* result);
   bool ExtractInputAsyncTransferStateUpdate(
       TransferAsyncRequestStatePtr* async_request_state,
-      TransferRequestResult* result);
-
-  bool ExtractMatchingInputTransferResult(
-      const UsbTransferDestination& transfer_destination,
       TransferRequestResult* result);
 
   void SetTransferResult(TransferAsyncRequestState* async_request_state,


### PR DESCRIPTION
Change our libusb_bulk_transfer/libusb_interrupt_transfer implementation -
which perform synchronous transfers - to redirect to our asynchronous
transfer implementation.

Also delete various helpers for sync transfers which became unnecessary
now.

This helps streamlining various USB transfer flows. When migrating to
the new libusb-to-JS adaptor, we'll only need to take care of the
asynchronous code path. It's preparatory work for the WebUSB
support effort tracked by #429.