### PR TITLE
[usb] Use new libusbjs transfer type

### DIFF
--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -766,6 +766,8 @@ void CreateChromeUsbGenericTransferInfo(
                                      result);
 }
 
+// TODO(#429): Delete this converter once all C++ code is switched away from
+// chrome.usb.
 RequestResult<LibusbJsTransferResult> ConvertChromeUsbTransferResultToLibusb(
     RequestResult<chrome_usb::TransferResult> chrome_usb_request_result) {
   switch (chrome_usb_request_result.status()) {

--- a/third_party/libusb/webport/src/libusb_js_proxy.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy.h
@@ -46,13 +46,12 @@ namespace google_smart_card {
 // the chrome_usb/api_bridge.h file.
 class LibusbJsProxy final : public LibusbInterface {
  public:
-  using TransferRequestResult = RequestResult<chrome_usb::TransferResult>;
-  using TransferAsyncRequestState =
-      AsyncRequestState<chrome_usb::TransferResult>;
+  using TransferRequestResult = RequestResult<LibusbJsTransferResult>;
+  using TransferAsyncRequestState = AsyncRequestState<LibusbJsTransferResult>;
   using TransferAsyncRequestStatePtr =
       std::shared_ptr<TransferAsyncRequestState>;
   using TransferAsyncRequestCallback =
-      AsyncRequestCallback<chrome_usb::TransferResult>;
+      AsyncRequestCallback<LibusbJsTransferResult>;
 
   LibusbJsProxy(GlobalContext* global_context,
                 TypedMessageRouter* typed_message_router,

--- a/third_party/libusb/webport/src/libusb_opaque_types.h
+++ b/third_party/libusb/webport/src/libusb_opaque_types.h
@@ -41,7 +41,6 @@
 #include <google_smart_card_common/requesting/async_request.h>
 #include <google_smart_card_common/requesting/request_result.h>
 
-#include "chrome_usb/types.h"
 #include "libusb_js_proxy_data_model.h"
 #include "usb_transfer_destination.h"
 #include "usb_transfers_parameters_storage.h"
@@ -69,9 +68,9 @@
 struct libusb_context final
     : public std::enable_shared_from_this<libusb_context> {
   using TransferRequestResult = google_smart_card::RequestResult<
-      google_smart_card::chrome_usb::TransferResult>;
+      google_smart_card::LibusbJsTransferResult>;
   using TransferAsyncRequestState = google_smart_card::AsyncRequestState<
-      google_smart_card::chrome_usb::TransferResult>;
+      google_smart_card::LibusbJsTransferResult>;
   using TransferAsyncRequestStatePtr =
       std::shared_ptr<TransferAsyncRequestState>;
   using UsbTransferDestination = google_smart_card::UsbTransferDestination;

--- a/third_party/libusb/webport/src/usb_transfers_parameters_storage.h
+++ b/third_party/libusb/webport/src/usb_transfers_parameters_storage.h
@@ -26,7 +26,7 @@
 
 #include <google_smart_card_common/requesting/async_request.h>
 
-#include "chrome_usb/types.h"
+#include "libusb_js_proxy_data_model.h"
 #include "usb_transfer_destination.h"
 
 namespace google_smart_card {
@@ -45,8 +45,7 @@ namespace google_smart_card {
 // available only for asynchronous transfers.
 class UsbTransfersParametersStorage final {
  public:
-  using TransferAsyncRequestState =
-      AsyncRequestState<chrome_usb::TransferResult>;
+  using TransferAsyncRequestState = AsyncRequestState<LibusbJsTransferResult>;
   using TransferAsyncRequestStatePtr =
       std::shared_ptr<TransferAsyncRequestState>;
 


### PR DESCRIPTION
Migrate the LibusbJsProxy code to switch away from
chrome_usb::TransferResult to LibusbJsTransferResult.

This is expected to be a pure refactoring change. It's preparatory work
for the WebUSB support effort tracked by #429.