### PR TITLE
[js] Fix bad "this" in TrustedClientsRegistry

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
@@ -104,7 +104,7 @@ TrustedClientsRegistry.prototype.getByOrigin = function(origin) {
   const promiseResolver = goog.Promise.withResolver();
 
   this.tryGetByOrigins([origin]).then(
-      function(infos) {
+      infos => {
         GSC.Logging.checkWithLogger(this.logger, infos.length === 1);
         const info = infos[0];
         if (info) {


### PR DESCRIPTION
The code in TrustedClientsRegistry made an incorrect dereference of
"this" inside a local function. Fix this by changing the function to be
a lambda (a.k.a. "arrow function"), which inherits "this" from the outer
scope.

The bug was introduced in #412. Not sure why it wasn't visible earlier -
probably the recent changes of JS compilation levels made the compiler
produce slightly different code. Also it's unclear why the compiler
didn't emit a warning on this mistake.