### PR TITLE
[usb] JS base for bulk/interrupt transfers

### DIFF
--- a/third_party/libusb/webport/src/libusb-proxy-data-model.js
+++ b/third_party/libusb/webport/src/libusb-proxy-data-model.js
@@ -159,6 +159,19 @@ const LibusbJsControlTransferParameters =
 /**
  * The key strings must match the ones in libusb_js_proxy_data_model.cc.
  * @typedef {{
+ *            endpointAddress:number,
+ *            dataToSend:(!ArrayBuffer|undefined),
+ *            lengthToReceive:(number|undefined)
+ *          }}
+ */
+GSC.LibusbProxyDataModel.LibusbJsGenericTransferParameters;
+
+const LibusbJsGenericTransferParameters =
+    GSC.LibusbProxyDataModel.LibusbJsGenericTransferParameters;
+
+/**
+ * The key strings must match the ones in libusb_js_proxy_data_model.cc.
+ * @typedef {{
  *            receivedData:(!ArrayBuffer|undefined),
  *          }}
  */

--- a/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
@@ -37,6 +37,8 @@ const LibusbJsDirection = GSC.LibusbProxyDataModel.LibusbJsDirection;
 const LibusbJsEndpointDescriptor =
     GSC.LibusbProxyDataModel.LibusbJsEndpointDescriptor;
 const LibusbJsEndpointType = GSC.LibusbProxyDataModel.LibusbJsEndpointType;
+const LibusbJsGenericTransferParameters =
+    GSC.LibusbProxyDataModel.LibusbJsGenericTransferParameters;
 const LibusbJsInterfaceDescriptor =
     GSC.LibusbProxyDataModel.LibusbJsInterfaceDescriptor;
 const LibusbJsTransferRecipient =
@@ -132,20 +134,24 @@ GSC.LibusbToChromeUsbAdaptor = class extends GSC.LibusbToJsApiAdaptor {
     const chromeUsbConnectionHandle =
         this.getConnectionHandleWithDeviceIdOrThrow_(deviceId, deviceHandle);
     const chromeUsbControlTransferInfo =
-        getChromeUsbControlTranferInfo(parameters);
+        getChromeUsbControlTransferInfo(parameters);
     const chromeUsbTransferResultInfo =
         /** @type {!chrome.usb.TransferResultInfo} */ (await promisify(
             chrome.usb.controlTransfer, chromeUsbConnectionHandle,
             chromeUsbControlTransferInfo));
-    if (chromeUsbTransferResultInfo.resultCode) {
-      throw new Error(`USB API failed with resultCode=${
-          chromeUsbTransferResultInfo.resultCode}`);
-    }
-    /** @type {!LibusbJsTransferResult} */
-    const libusbJsTransferResult = {};
-    if (chromeUsbTransferResultInfo.data)
-      libusbJsTransferResult['receivedData'] = chromeUsbTransferResultInfo.data;
-    return libusbJsTransferResult;
+    return getLibusbJsTransferResultOrThrow(chromeUsbTransferResultInfo);
+  }
+
+  /** @override */
+  async bulkTransfer(deviceId, deviceHandle, parameters) {
+    return this.genericTransfer_(
+        chrome.usb.bulkTransfer, deviceId, deviceHandle, parameters);
+  }
+
+  /** @override */
+  async interruptTransfer(deviceId, deviceHandle, parameters) {
+    return this.genericTransfer_(
+        chrome.usb.interruptTransfer, deviceId, deviceHandle, parameters);
   }
 
   /**
@@ -179,6 +185,29 @@ GSC.LibusbToChromeUsbAdaptor = class extends GSC.LibusbToJsApiAdaptor {
   getConnectionHandleWithDeviceIdOrThrow_(deviceId, deviceHandle) {
     const chromeUsbDevice = this.getDeviceByIdOrThrow_(deviceId);
     return getChromeUsbConnectionHandle(chromeUsbDevice, deviceHandle);
+  }
+
+  /**
+   * Performs a bulk or an interrupt transfer (depending on the passed API
+   * method).
+   * @private
+   * @param {!Function} chromeUsbApiMethod
+   * @param {number} deviceId
+   * @param {number} deviceHandle
+   * @param {!LibusbJsGenericTransferParameters} parameters
+   * @return {!Promise<!LibusbJsTransferResult>}
+   */
+  async genericTransfer_(
+      chromeUsbApiMethod, deviceId, deviceHandle, parameters) {
+    const chromeUsbConnectionHandle =
+        this.getConnectionHandleWithDeviceIdOrThrow_(deviceId, deviceHandle);
+    const chromeUsbGenericTransferInfo =
+        getChromeUsbGenericTransferInfo(parameters);
+    const chromeUsbTransferResultInfo =
+        /** @type {!chrome.usb.TransferResultInfo} */ (await promisify(
+            chromeUsbApiMethod, chromeUsbConnectionHandle,
+            chromeUsbGenericTransferInfo));
+    return getLibusbJsTransferResultOrThrow(chromeUsbTransferResultInfo);
   }
 };
 
@@ -334,7 +363,7 @@ function getChromeUsbConnectionHandle(chromeUsbDevice, deviceHandle) {
  * @param {!LibusbJsControlTransferParameters} libusbJsParameters
  * @return {!chrome.usb.ControlTransferInfo}
  */
-function getChromeUsbControlTranferInfo(libusbJsParameters) {
+function getChromeUsbControlTransferInfo(libusbJsParameters) {
   const controlTransferInfo = /** @type {!chrome.usb.ControlTransferInfo} */ ({
     'direction': libusbJsParameters['dataToSend'] ? 'out' : 'in',
     'index': libusbJsParameters['index'],
@@ -385,5 +414,37 @@ function getChromeUsbRequestType(libusbJsTransferRequestType) {
   GSC.Logging.failWithLogger(
       logger, `Unexpected libusb request type: ${libusbJsTransferRequestType}`);
   goog.asserts.fail();
+}
+
+/**
+ * @param {!LibusbJsGenericTransferParameters} libusbJsParameters
+ * @return {!chrome.usb.GenericTransferInfo}
+ */
+function getChromeUsbGenericTransferInfo(libusbJsParameters) {
+  const genericTransferInfo = /** @type {!chrome.usb.GenericTransferInfo} */ ({
+    'direction': libusbJsParameters['dataToSend'] ? 'out' : 'in',
+    'endpoint': libusbJsParameters['endpoint'],
+  });
+  if (libusbJsParameters['dataToSend'])
+    genericTransferInfo['data'] = libusbJsParameters['dataToSend'];
+  if (libusbJsParameters['lengthToReceive'] !== undefined)
+    genericTransferInfo['length'] = libusbJsParameters['lengthToReceive'];
+  return genericTransferInfo;
+}
+
+/**
+ * @param {!chrome.usb.TransferResultInfo} chromeUsbTransferResultInfo
+ * @return {!LibusbJsTransferResult}
+ */
+function getLibusbJsTransferResultOrThrow(chromeUsbTransferResultInfo) {
+  if (chromeUsbTransferResultInfo.resultCode) {
+    throw new Error(`USB API failed with resultCode=${
+        chromeUsbTransferResultInfo.resultCode}`);
+  }
+  /** @type {!LibusbJsTransferResult} */
+  const libusbJsTransferResult = {};
+  if (chromeUsbTransferResultInfo.data)
+    libusbJsTransferResult['receivedData'] = chromeUsbTransferResultInfo.data;
+  return libusbJsTransferResult;
 }
 });  // goog.scope

--- a/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
@@ -443,8 +443,13 @@ function getLibusbJsTransferResultOrThrow(chromeUsbTransferResultInfo) {
   }
   /** @type {!LibusbJsTransferResult} */
   const libusbJsTransferResult = {};
-  if (chromeUsbTransferResultInfo.data)
+  // Note that both checks - that `data` is present and that it's non-empty -
+  // are necessary, since contrary to the docs even output transfers have the
+  // field provided (as an empty array buffer).
+  if (chromeUsbTransferResultInfo.data &&
+      chromeUsbTransferResultInfo.data.byteLength) {
     libusbJsTransferResult['receivedData'] = chromeUsbTransferResultInfo.data;
+  }
   return libusbJsTransferResult;
 }
 });  // goog.scope

--- a/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
@@ -423,7 +423,7 @@ function getChromeUsbRequestType(libusbJsTransferRequestType) {
 function getChromeUsbGenericTransferInfo(libusbJsParameters) {
   const genericTransferInfo = /** @type {!chrome.usb.GenericTransferInfo} */ ({
     'direction': libusbJsParameters['dataToSend'] ? 'out' : 'in',
-    'endpoint': libusbJsParameters['endpoint'],
+    'endpoint': libusbJsParameters['endpointAddress'],
   });
   if (libusbJsParameters['dataToSend'])
     genericTransferInfo['data'] = libusbJsParameters['dataToSend'];

--- a/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
@@ -29,6 +29,8 @@ const LibusbJsConfigurationDescriptor =
 const LibusbJsControlTransferParameters =
     GSC.LibusbProxyDataModel.LibusbJsControlTransferParameters;
 const LibusbJsDevice = GSC.LibusbProxyDataModel.LibusbJsDevice;
+const LibusbJsGenericTransferParameters =
+    GSC.LibusbProxyDataModel.LibusbJsGenericTransferParameters;
 const LibusbJsTransferResult = GSC.LibusbProxyDataModel.LibusbJsTransferResult;
 
 GSC.LibusbToJsApiAdaptor = class {
@@ -84,5 +86,21 @@ GSC.LibusbToJsApiAdaptor = class {
    * @return {!Promise<!LibusbJsTransferResult>}
    */
   async controlTransfer(deviceId, deviceHandle, parameters) {}
+
+  /**
+   * @param {number} deviceId
+   * @param {number} deviceHandle
+   * @param {!LibusbJsGenericTransferParameters} parameters
+   * @return {!Promise<!LibusbJsTransferResult>}
+   */
+  async bulkTransfer(deviceId, deviceHandle, parameters) {}
+
+  /**
+   * @param {number} deviceId
+   * @param {number} deviceHandle
+   * @param {!LibusbJsGenericTransferParameters} parameters
+   * @return {!Promise<!LibusbJsTransferResult>}
+   */
+  async interruptTransfer(deviceId, deviceHandle, parameters) {}
 };
 });  // goog.scope

--- a/third_party/libusb/webport/src/libusb_js_proxy_data_model.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_data_model.cc
@@ -146,6 +146,19 @@ StructValueDescriptor<LibusbJsControlTransferParameters>::GetDescription() {
 }
 
 template <>
+StructValueDescriptor<LibusbJsGenericTransferParameters>::Description
+StructValueDescriptor<LibusbJsGenericTransferParameters>::GetDescription() {
+  // Note: Strings passed to WithField() below must match the ones in
+  // libusb-proxy-data-model.js.
+  return Describe("LibusbJsGenericTransferParameters")
+      .WithField(&LibusbJsGenericTransferParameters::endpoint_address,
+                 "endpointAddress")
+      .WithField(&LibusbJsGenericTransferParameters::data_to_send, "dataToSend")
+      .WithField(&LibusbJsGenericTransferParameters::length_to_receive,
+                 "lengthToReceive");
+}
+
+template <>
 StructValueDescriptor<LibusbJsTransferResult>::Description
 StructValueDescriptor<LibusbJsTransferResult>::GetDescription() {
   // Note: Strings passed to WithField() below must match the ones in

--- a/third_party/libusb/webport/src/libusb_js_proxy_data_model.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy_data_model.h
@@ -129,6 +129,15 @@ struct LibusbJsControlTransferParameters {
   optional<uint16_t> length_to_receive;
 };
 
+struct LibusbJsGenericTransferParameters {
+  // The USB bEndpointAddress field.
+  uint8_t endpoint_address;
+  // Only set for output transfers.
+  optional<std::vector<uint8_t>> data_to_send;
+  // Only set for input transfers.
+  optional<uint16_t> length_to_receive;
+};
+
 struct LibusbJsTransferResult {
   // This field is only populated for input transfers.
   optional<std::vector<uint8_t>> received_data;


### PR DESCRIPTION
Add types for the wire format of bulk and interrupt USB transfers in the
libusb-to-JS adaptor, and implement these transfers in the chrome.usb
adaptor.

The C++ side is not wired up with this new code yet.

It's preparatory work for the WebUSB support effort tracked by #429.