### PR TITLE
[usb] Fix chrome.usb empty output transfer results

### DIFF
--- a/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
@@ -143,8 +143,13 @@ GSC.LibusbToChromeUsbAdaptor = class extends GSC.LibusbToJsApiAdaptor {
     }
     /** @type {!LibusbJsTransferResult} */
     const libusbJsTransferResult = {};
-    if (chromeUsbTransferResultInfo.data)
+    // Note that both checks - that `data` is present and that it's non-empty -
+    // are necessary, since contrary to the docs even output transfers have the
+    // field provided (as an empty array buffer).
+    if (chromeUsbTransferResultInfo.data &&
+        chromeUsbTransferResultInfo.data.byteLength) {
       libusbJsTransferResult['receivedData'] = chromeUsbTransferResultInfo.data;
+    }
     return libusbJsTransferResult;
   }
 

--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -778,7 +778,8 @@ RequestResult<LibusbJsTransferResult> ConvertChromeUsbTransferResultToLibusb(
         return RequestResult<LibusbJsTransferResult>::CreateFailed(
             "USB API returned error");
       }
-      if (chrome_usb_request_result.payload().result_info.data) {
+      if (chrome_usb_request_result.payload().result_info.data &&
+          !chrome_usb_request_result.payload().result_info.data->empty()) {
         js_result.received_data =
             chrome_usb_request_result.payload().result_info.data;
       }


### PR DESCRIPTION
Contrary to the chrome.usb API docs, the transfer result's "data" field
is always provided, even for output transfers - for them it's set to an
empty array buffer. Fix our code to stop being confused by that, since
we were misinterpreting this as a zero-length write, effectively the
failure to do output transfers.

This commit is part of the WebUSB support effort tracked by #429.