### PR TITLE
[usb] Implement transfer timeouts in proxy

### DIFF
--- a/third_party/libusb/webport/src/libusb_opaque_types.cc
+++ b/third_party/libusb/webport/src/libusb_opaque_types.cc
@@ -62,9 +62,9 @@ void libusb_context::WaitAndProcessAsyncTransferReceivedResults(
       const std::chrono::time_point<std::chrono::high_resolution_clock>
           min_transfer_timeout = GetMinTransferTimeout();
 
-      // Wait until an event happens, or some transfer times out, or we time out
-      // according to `timeout_time_point`, or the conditonal variable wakes up
-      // spuriously.
+      // Wait until a transfer result arrives, or some transfer times out, or we
+      // time out according to `timeout_time_point`, or the conditonal variable
+      // wakes up spuriously.
       const auto wait_until_time_point =
           std::min(timeout_time_point, min_transfer_timeout);
       condition_.wait_until(lock, wait_until_time_point);

--- a/third_party/libusb/webport/src/libusb_opaque_types.cc
+++ b/third_party/libusb/webport/src/libusb_opaque_types.cc
@@ -187,17 +187,14 @@ void libusb_context::RemoveTransferInFlight(
 
   transfers_in_flight_.RemoveByAsyncRequestState(async_request_state);
 
-  // Note that the check is correct because cancellation of output transfers
-  // never happens (this is guaranteed by the implementation of the
-  // CancelTransfer method).
-  GOOGLE_SMART_CARD_CHECK(
-      !received_output_transfer_result_map_.count(async_request_state_ptr));
+  // Note that the entry can be present in that map, for example, when the
+  // result arrived shortly before the transfer timed out.
+  received_output_transfer_result_map_.erase(async_request_state_ptr);
 
   if (transfer) {
     // Note that this assertion relies on the fact that transfer cancellation
-    // has precedence over receiving of results for the transfer (this is
-    // guaranteed by the implementation of the GetAsyncTransferStateUpdate
-    // method).
+    // has precedence over all other events (i.e., the results processing and
+    // the timeout processing - see `GetAsyncTransferStateUpdate()`).
     GOOGLE_SMART_CARD_CHECK(!transfers_to_cancel_.count(transfer));
   }
 }

--- a/third_party/libusb/webport/src/libusb_opaque_types.cc
+++ b/third_party/libusb/webport/src/libusb_opaque_types.cc
@@ -16,6 +16,7 @@
 
 #include "libusb_opaque_types.h"
 
+#include <chrono>
 #include <utility>
 
 #include <google_smart_card_common/logging/logging.h>
@@ -42,6 +43,7 @@ void libusb_context::WaitAndProcessAsyncTransferReceivedResults(
   {
     std::unique_lock<std::mutex> lock(mutex_);
 
+    // Start the event loop.
     for (;;) {
       if (completed && *completed) {
         // The transfer has already been completed (either previously or in some
@@ -50,18 +52,41 @@ void libusb_context::WaitAndProcessAsyncTransferReceivedResults(
       }
 
       if (ExtractAsyncTransferStateUpdate(&async_request_state, &result)) {
+        // Picked up a transfer that can be populated with a result. Stop
+        // tracking the transfer and exit the event loop (to populate the
+        // transfer with the result outside the mutex - see the comment below).
         RemoveTransferInFlight(async_request_state.get());
         break;
       }
 
-      if (condition_.wait_until(lock, timeout_time_point) ==
-          std::cv_status::timeout) {
+      const std::chrono::time_point<std::chrono::high_resolution_clock>
+          min_transfer_timeout = GetMinTransferTimeout();
+
+      // Wait until an event happens, or some transfer times out, or we time out
+      // according to `timeout_time_point`, or the conditonal variable wakes up
+      // spuriously.
+      const auto wait_until_time_point =
+          std::min(timeout_time_point, min_transfer_timeout);
+      condition_.wait_until(lock, wait_until_time_point);
+
+      // Immediately exit if we timed out according to `timeout_time_point`.
+      if (std::chrono::high_resolution_clock::now() >= timeout_time_point)
         return;
-      }
     }
   }
 
+  GOOGLE_SMART_CARD_CHECK(async_request_state);
+  // TODO(#429): Assert the result is non-empty.
   SetTransferResult(async_request_state.get(), std::move(result));
+
+  {
+    // In case some other thread is waiting for this particular transfer's
+    // result via the transfer's completed flag, let it awake. Note that it's
+    // crucial to do this under mutex again, since otherwise the other thread
+    // might miss the notification.
+    std::unique_lock<std::mutex> lock(mutex_);
+    condition_.notify_all();
+  }
 }
 
 bool libusb_context::CancelTransfer(libusb_transfer* transfer) {
@@ -112,11 +137,14 @@ void libusb_context::OnOutputTransferResultReceived(
     TransferRequestResult result) {
   const std::unique_lock<std::mutex> lock(mutex_);
 
-  // Note that the check is correct because cancellation of output transfers
-  // never happens (this is guaranteed by the implementation of the
-  // CancelTransfer method).
-  GOOGLE_SMART_CARD_CHECK(transfers_in_flight_.ContainsWithAsyncRequestState(
-      async_request_state.get()));
+  if (!transfers_in_flight_.ContainsWithAsyncRequestState(
+          async_request_state.get())) {
+    // The output transfer timed out in the meantime, so just discard the
+    // result.
+    // Note that the transfer couldn't have been cancelled, as
+    // `CancelTransfer()` only allows input transfers.
+    return;
+  }
 
   GOOGLE_SMART_CARD_CHECK(received_output_transfer_result_map_
                               .emplace(async_request_state, std::move(result))
@@ -131,7 +159,18 @@ void libusb_context::AddTransferInFlight(
     libusb_transfer* transfer) {
   GOOGLE_SMART_CARD_CHECK(async_request_state);
 
-  transfers_in_flight_.Add(async_request_state, transfer_destination, transfer);
+  std::chrono::time_point<std::chrono::high_resolution_clock> timeout;
+  if (transfer->timeout == 0) {
+    // A zero timeout field denotes an infinite timeout.
+    timeout =
+        std::chrono::time_point<std::chrono::high_resolution_clock>::max();
+  } else {
+    timeout = std::chrono::high_resolution_clock::now() +
+              std::chrono::milliseconds(transfer->timeout);
+  }
+
+  transfers_in_flight_.Add(async_request_state, transfer_destination, transfer,
+                           timeout);
 
   condition_.notify_all();
 }
@@ -163,15 +202,23 @@ void libusb_context::RemoveTransferInFlight(
   }
 }
 
+std::chrono::time_point<std::chrono::high_resolution_clock>
+libusb_context::GetMinTransferTimeout() const {
+  if (transfers_in_flight_.empty())
+    return std::chrono::time_point<std::chrono::high_resolution_clock>::max();
+  return transfers_in_flight_.GetWithMinTimeout().timeout;
+}
+
 bool libusb_context::ExtractAsyncTransferStateUpdate(
     TransferAsyncRequestStatePtr* async_request_state,
     TransferRequestResult* result) {
   // Note that it's crucial to do this check of canceled requests before all
-  // other options, because the cancellation of the transfer, if accepted,
-  // should have precedence over receiving of results for the transfer (and this
-  // is asserted in method RemoveTransferInFlight).
+  // other options, because the cancellation of the transfer, after it got
+  // accepted, should have precedence over receiving of results for the transfer
+  // (and this is asserted in `RemoveTransferInFlight()`).
   return ExtractAsyncTransferStateCancellationUpdate(async_request_state,
                                                      result) ||
+         ExtractTimedOutTransfer(async_request_state, result) ||
          ExtractOutputAsyncTransferStateUpdate(async_request_state, result) ||
          ExtractInputAsyncTransferStateUpdate(async_request_state, result);
 }
@@ -189,6 +236,22 @@ bool libusb_context::ExtractAsyncTransferStateCancellationUpdate(
   *async_request_state = transfers_in_flight_.GetAsyncByLibusbTransfer(transfer)
                              .async_request_state;
   *result = TransferRequestResult::CreateCanceled();
+  return true;
+}
+
+bool libusb_context::ExtractTimedOutTransfer(
+    TransferAsyncRequestStatePtr* async_request_state,
+    TransferRequestResult* result) {
+  if (transfers_in_flight_.empty())
+    return false;
+  UsbTransfersParametersStorage::Item nearest =
+      transfers_in_flight_.GetWithMinTimeout();
+  if (std::chrono::high_resolution_clock::now() < nearest.timeout)
+    return false;
+  *async_request_state = nearest.async_request_state;
+  // TODO(#47): Use a common constant here that can be checked in
+  // `LibusbJsProxy`, so that it can distinguish timeouts from other failures.
+  *result = TransferRequestResult::CreateFailed("Timed out");
   return true;
 }
 

--- a/third_party/libusb/webport/src/libusb_opaque_types.h
+++ b/third_party/libusb/webport/src/libusb_opaque_types.h
@@ -134,10 +134,16 @@ struct libusb_context final
   void RemoveTransferInFlight(
       const TransferAsyncRequestState* async_request_state);
 
+  std::chrono::time_point<std::chrono::high_resolution_clock>
+  GetMinTransferTimeout() const;
+
   bool ExtractAsyncTransferStateUpdate(
       TransferAsyncRequestStatePtr* async_request_state,
       TransferRequestResult* result);
   bool ExtractAsyncTransferStateCancellationUpdate(
+      TransferAsyncRequestStatePtr* async_request_state,
+      TransferRequestResult* result);
+  bool ExtractTimedOutTransfer(
       TransferAsyncRequestStatePtr* async_request_state,
       TransferRequestResult* result);
   bool ExtractOutputAsyncTransferStateUpdate(

--- a/third_party/libusb/webport/src/usb_transfers_parameters_storage.h
+++ b/third_party/libusb/webport/src/usb_transfers_parameters_storage.h
@@ -60,18 +60,25 @@ class UsbTransfersParametersStorage final {
 
     Item(TransferAsyncRequestStatePtr async_request_state,
          const UsbTransferDestination& transfer_destination,
-         libusb_transfer* transfer);
+         libusb_transfer* transfer,
+         const std::chrono::time_point<std::chrono::high_resolution_clock>&
+             timeout);
 
     TransferAsyncRequestStatePtr async_request_state;
     UsbTransferDestination transfer_destination;
     libusb_transfer* transfer;
+    std::chrono::time_point<std::chrono::high_resolution_clock> timeout;
   };
+
+  bool empty() const;
 
   void Add(const Item& item);
 
   void Add(TransferAsyncRequestStatePtr async_request_state,
            const UsbTransferDestination& transfer_destination,
-           libusb_transfer* transfer);
+           libusb_transfer* transfer,
+           const std::chrono::time_point<std::chrono::high_resolution_clock>&
+               timeout);
 
   bool ContainsWithAsyncRequestState(
       const TransferAsyncRequestState* async_request_state) const;
@@ -88,6 +95,8 @@ class UsbTransfersParametersStorage final {
       const UsbTransferDestination& transfer_destination) const;
 
   Item GetAsyncByLibusbTransfer(const libusb_transfer* transfer) const;
+
+  Item GetWithMinTimeout() const;
 
   void Remove(const Item& item);
 
@@ -111,6 +120,9 @@ class UsbTransfersParametersStorage final {
   std::map<UsbTransferDestination, std::set<const TransferAsyncRequestState*>>
       async_destination_mapping_;
   std::map<const libusb_transfer*, Item> async_libusb_transfer_mapping_;
+  std::map<std::chrono::time_point<std::chrono::high_resolution_clock>,
+           std::set<const TransferAsyncRequestState*>>
+      timeout_mapping_;
 };
 
 }  // namespace google_smart_card

--- a/third_party/libusb/webport/src/usb_transfers_parameters_storage.h
+++ b/third_party/libusb/webport/src/usb_transfers_parameters_storage.h
@@ -96,6 +96,7 @@ class UsbTransfersParametersStorage final {
 
   Item GetAsyncByLibusbTransfer(const libusb_transfer* transfer) const;
 
+  // Returns the transfer with the minimum `timeout` value.
   Item GetWithMinTimeout() const;
 
   void Remove(const Item& item);


### PR DESCRIPTION
Add implementation of USB transfer timeouts into the libusb-to-JS
proxy. Two main aspects of this are: (1) waiting for the transfer result
shouldn't exceed the timeout, and (2) data that's read after an input
transfer is timed out should be rerouted to later transfers.

The goal is to stop relying on the JavaScript counterpart to enforce the
timeouts, since, unlike chrome.usb, WebUSB doesn't support timeouts.

Luckily, "2" was already implemented by us in the past (for the
cancellation to work), so implementing timeouts in this commit isn't a
radical change.