### PR TITLE
[ux] Improve heuristic for spurious USB failures

### DIFF
--- a/smart_card_connector_app/src/window-devices-displaying.js
+++ b/smart_card_connector_app/src/window-devices-displaying.js
@@ -72,8 +72,42 @@ const addDeviceElement =
  * @param {!Array.<!GSC.PcscLiteServer.ReaderInfo>} readers
  */
 function onReadersChanged(readers) {
-  displayReaderList(readers);
-  updateAddDeviceButtonText(readers.length);
+  const filteredReaders = removeSpuriousFailures(readers);
+  displayReaderList(filteredReaders);
+  updateAddDeviceButtonText(filteredReaders.length);
+}
+
+/**
+ * Filters out entries that correspond to spurious failures, based on heuristic.
+ *
+ * This is needed because for composite devices (e.g., a smart card reader and a
+ * keyboard) the CCID driver attempts to initialize all interfaces, and all
+ * non-smart-card-related interfaces fail. This function heuristically hides
+ * some of the errors, in order to minimize the user confusion.
+ * @param {!Array<!GSC.PcscLiteServer.ReaderInfo>} readers
+ * @return {!Array<!GSC.PcscLiteServer.ReaderInfo>}
+ */
+function removeSpuriousFailures(readers) {
+  // The heuristic is to hide such failure entries that evaluate to the same
+  // display name as a reader that got initialized successfully.
+  /** @type {!Array<!GSC.PcscLiteServer.ReaderInfo>} */
+  const nonFailedReaders = readers.filter(
+      reader => reader['status'] != GSC.PcscLiteServer.ReaderStatus.FAILURE);
+  /** @type {!Set<string>} */
+  const nonFailedDisplayNames = new Set(nonFailedReaders.map(
+      reader => makeReaderNameForDisplaying(reader['name'])));
+  /** @type {!Array<!GSC.PcscLiteServer.ReaderInfo>} */
+  const filteredReaders = readers.filter(reader => {
+    if (reader['status'] !== GSC.PcscLiteServer.ReaderStatus.FAILURE)
+      return true;
+    if (!nonFailedDisplayNames.has(
+            makeReaderNameForDisplaying(reader['name']))) {
+      return true;
+    }
+    goog.log.info(logger, `Hiding spuriously failed reader ${reader['name']}`);
+    return false;
+  });
+  return filteredReaders;
 }
 
 /**

--- a/smart_card_connector_app/src/window-devices-displaying.js
+++ b/smart_card_connector_app/src/window-devices-displaying.js
@@ -100,12 +100,13 @@ function removeSpuriousFailures(readers) {
   const filteredReaders = readers.filter(reader => {
     if (reader['status'] !== GSC.PcscLiteServer.ReaderStatus.FAILURE)
       return true;
-    if (!nonFailedDisplayNames.has(
+    if (nonFailedDisplayNames.has(
             makeReaderNameForDisplaying(reader['name']))) {
-      return true;
+      goog.log.info(
+          logger, `Hiding spuriously failed reader ${reader['name']}`);
+      return false;
     }
-    goog.log.info(logger, `Hiding spuriously failed reader ${reader['name']}`);
-    return false;
+    return true;
   });
   return filteredReaders;
 }


### PR DESCRIPTION
Improve the heuristic that we use for hiding failed devices from the UI.

The previous one - based on interface numbers - turned out to not work
for some popular devices like YubiKeys, so we ended up displaying two
items for them: a successfully initialized and a failed device, because
it's a composite device for which only the third interface is smart card
related.

The new heuristic is based on display names: if we're trying to show
multiple entries that have the same display name but some are failed and
others succeeded, then the failures are likely spurious.

For posterity, the last time we touched this heuristic was #362.