### PR TITLE
[usb] Wire up transfers with libusb-to-JS

### DIFF
--- a/third_party/libusb/webport/src/libusb-proxy-receiver.js
+++ b/third_party/libusb/webport/src/libusb-proxy-receiver.js
@@ -130,6 +130,12 @@ GSC.LibusbProxyReceiver = class {
       case 'controlTransfer':
         return [await this.libusbToJsApiAdaptor_.controlTransfer(
             ...remoteCallMessage.functionArguments)];
+      case 'bulkTransfer':
+        return [await this.libusbToJsApiAdaptor_.bulkTransfer(
+            ...remoteCallMessage.functionArguments)];
+      case 'interruptTransfer':
+        return [await this.libusbToJsApiAdaptor_.interruptTransfer(
+            ...remoteCallMessage.functionArguments)];
     }
     // TODO(#429): Delete this fallback to ChromeUsbBackend once all functions
     // are implemented in LibusbToJsApiAdaptor.

--- a/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
@@ -370,6 +370,7 @@ function getChromeUsbControlTransferInfo(libusbJsParameters) {
     'recipient': getChromeUsbRecipient(libusbJsParameters['recipient']),
     'request': libusbJsParameters['request'],
     'requestType': getChromeUsbRequestType(libusbJsParameters['requestType']),
+    'value': libusbJsParameters['value'],
   });
   if (libusbJsParameters['dataToSend'])
     controlTransferInfo['data'] = libusbJsParameters['dataToSend'];

--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -610,6 +610,7 @@ bool CreateLibusbJsControlTransferParameters(
     libusb_transfer* transfer,
     LibusbJsControlTransferParameters* result) {
   GOOGLE_SMART_CARD_CHECK(transfer);
+  GOOGLE_SMART_CARD_CHECK(transfer->type == LIBUSB_TRANSFER_TYPE_CONTROL);
   GOOGLE_SMART_CARD_CHECK(result);
 
   //
@@ -692,9 +693,9 @@ void CreateLibusbJsGenericTransferParameters(
     libusb_transfer* transfer,
     LibusbJsGenericTransferParameters* result) {
   GOOGLE_SMART_CARD_CHECK(transfer);
-  GOOGLE_SMART_CARD_CHECK(result);
   GOOGLE_SMART_CARD_CHECK(transfer->type == LIBUSB_TRANSFER_TYPE_BULK ||
                           transfer->type == LIBUSB_TRANSFER_TYPE_INTERRUPT);
+  GOOGLE_SMART_CARD_CHECK(result);
 
   result->endpoint_address = transfer->endpoint;
   if ((transfer->endpoint & LIBUSB_ENDPOINT_DIR_MASK) == LIBUSB_ENDPOINT_OUT) {
@@ -714,8 +715,8 @@ std::function<void(GenericRequestResult)> MakeLibusbJsTransferCallback(
           async_request_state](GenericRequestResult js_result) {
     const std::shared_ptr<libusb_context> locked_context = context.lock();
     if (!locked_context) {
-      // The context that was used for the original transfer submission has
-      // been destroyed already.
+      // The context that was used for the original transfer submission has been
+      // destroyed already.
       return;
     }
     LibusbJsTransferResult js_transfer_result;


### PR DESCRIPTION
Finish the migration of the LibusbJsProxy code from the old
ChromeUsbApiBridge by letting the transfer requests be sent through the
new libusb-to-JS proxy.

It's preparatory work for the WebUSB support effort tracked by #429.