### PR TITLE
[usb] Fix output transfer length overflow

### DIFF
--- a/third_party/libusb/webport/src/libusb_js_proxy_data_model.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy_data_model.h
@@ -135,7 +135,7 @@ struct LibusbJsGenericTransferParameters {
   // Only set for output transfers.
   optional<std::vector<uint8_t>> data_to_send;
   // Only set for input transfers.
-  optional<uint16_t> length_to_receive;
+  optional<int64_t> length_to_receive;
 };
 
 struct LibusbJsTransferResult {


### PR DESCRIPTION
Use 64-bit integers for storing bulk/interrupt transfer length. The
length we used before - 16 bits - is only sufficient for control
transfers, and we incorrectly used it for all types of transfers,
causing the length to be clamped due to integer overflow.