### PR TITLE
[wasm] Fix Emscripten load failure handling

### DIFF
--- a/common/js/src/executable-module/emscripten-module.js
+++ b/common/js/src/executable-module/emscripten-module.js
@@ -108,12 +108,14 @@ EmscriptenModule.prototype.getMessageChannel = function() {
 /** @override */
 EmscriptenModule.prototype.disposeInternal = function() {
   goog.log.fine(this.logger_, 'Disposed');
-  // Call `delete()` on the C++ object before dropping the reference on it, in
-  // order to make the C++ destructor called.
-  // Note: The method is accessed using the square bracket notation, to make
-  // sure that Closure Compiler doesn't rename this method call.
-  this.googleSmartCardModule_['delete']();
-  delete this.googleSmartCardModule_;
+  if (this.googleSmartCardModule_) {
+    // Call `delete()` on the C++ object before dropping the reference on it, in
+    // order to make the C++ destructor called.
+    // Note: The method is accessed using the square bracket notation, to make
+    // sure that Closure Compiler doesn't rename this method call.
+    this.googleSmartCardModule_['delete']();
+    delete this.googleSmartCardModule_;
+  }
   this.messageChannel_.dispose();
   EmscriptenModule.base(this, 'disposeInternal');
 };


### PR DESCRIPTION
Fix a corner case that could happen when the Emscripten code fails to
load. We were raising an unnecessary error in that case, which would
slightly pollute logs:

  TypeError: Cannot read properties of null (reading 'delete')
      at GoogleSmartCard.EmscriptenModule.disposeInternal

The fix is to only call the 'delete' method when the
googleSmartCardModule_ member is already non-null. This will protect
against cases when the load failure occurs before this member is
assigned.