### PR TITLE
[usb] Mark LibusbToJsApiAdaptor as abstract

### DIFF
--- a/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
@@ -33,23 +33,30 @@ const LibusbJsGenericTransferParameters =
     GSC.LibusbProxyDataModel.LibusbJsGenericTransferParameters;
 const LibusbJsTransferResult = GSC.LibusbProxyDataModel.LibusbJsTransferResult;
 
+/** @abstract */
 GSC.LibusbToJsApiAdaptor = class {
-  /** @return {!Promise<!Array<!LibusbJsDevice>>} */
+  /**
+   * @abstract
+   * @return {!Promise<!Array<!LibusbJsDevice>>}
+   */
   async listDevices() {}
 
   /**
+   * @abstract
    * @param {number} deviceId
    * @return {!Promise<!Array<!LibusbJsConfigurationDescriptor>>}
    */
   async getConfigurations(deviceId) {}
 
   /**
+   * @abstract
    * @param {number} deviceId
    * @return {!Promise<number>} Device handle.
    */
   async openDeviceHandle(deviceId) {}
 
   /**
+   * @abstract
    * @param {number} deviceId
    * @param {number} deviceHandle
    * @return {!Promise<void>}
@@ -57,6 +64,7 @@ GSC.LibusbToJsApiAdaptor = class {
   async closeDeviceHandle(deviceId, deviceHandle) {}
 
   /**
+   * @abstract
    * @param {number} deviceId
    * @param {number} deviceHandle
    * @param {number} interfaceNumber
@@ -65,6 +73,7 @@ GSC.LibusbToJsApiAdaptor = class {
   async claimInterface(deviceId, deviceHandle, interfaceNumber) {}
 
   /**
+   * @abstract
    * @param {number} deviceId
    * @param {number} deviceHandle
    * @param {number} interfaceNumber
@@ -73,6 +82,7 @@ GSC.LibusbToJsApiAdaptor = class {
   async releaseInterface(deviceId, deviceHandle, interfaceNumber) {}
 
   /**
+   * @abstract
    * @param {number} deviceId
    * @param {number} deviceHandle
    * @return {!Promise<void>}
@@ -80,6 +90,7 @@ GSC.LibusbToJsApiAdaptor = class {
   async resetDevice(deviceId, deviceHandle) {}
 
   /**
+   * @abstract
    * @param {number} deviceId
    * @param {number} deviceHandle
    * @param {!LibusbJsControlTransferParameters} parameters
@@ -88,6 +99,7 @@ GSC.LibusbToJsApiAdaptor = class {
   async controlTransfer(deviceId, deviceHandle, parameters) {}
 
   /**
+   * @abstract
    * @param {number} deviceId
    * @param {number} deviceHandle
    * @param {!LibusbJsGenericTransferParameters} parameters
@@ -96,6 +108,7 @@ GSC.LibusbToJsApiAdaptor = class {
   async bulkTransfer(deviceId, deviceHandle, parameters) {}
 
   /**
+   * @abstract
    * @param {number} deviceId
    * @param {number} deviceHandle
    * @param {!LibusbJsGenericTransferParameters} parameters

--- a/third_party/libusb/webport/src/libusb-to-webusb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-webusb-adaptor.js
@@ -59,6 +59,60 @@ GSC.LibusbToWebusbAdaptor = class extends GSC.LibusbToJsApiAdaptor {
         webusbDevice => this.convertWebusbDeviceToLibusb_(webusbDevice));
   }
 
+  /** @override */
+  async getConfigurations(deviceId) {
+    // TODO(#429): Implement this method.
+    throw new Error('Not implemented');
+  }
+
+  /** @override */
+  async openDeviceHandle(deviceId) {
+    // TODO(#429): Implement this method.
+    throw new Error('Not implemented');
+  }
+
+  /** @override */
+  async closeDeviceHandle(deviceId, deviceHandle) {
+    // TODO(#429): Implement this method.
+    throw new Error('Not implemented');
+  }
+
+  /** @override */
+  async claimInterface(deviceId, deviceHandle, interfaceNumber) {
+    // TODO(#429): Implement this method.
+    throw new Error('Not implemented');
+  }
+
+  /** @override */
+  async releaseInterface(deviceId, deviceHandle, interfaceNumber) {
+    // TODO(#429): Implement this method.
+    throw new Error('Not implemented');
+  }
+
+  /** @override */
+  async resetDevice(deviceId, deviceHandle) {
+    // TODO(#429): Implement this method.
+    throw new Error('Not implemented');
+  }
+
+  /** @override */
+  async controlTransfer(deviceId, deviceHandle, parameters) {
+    // TODO(#429): Implement this method.
+    throw new Error('Not implemented');
+  }
+
+  /** @override */
+  async bulkTransfer(deviceId, deviceHandle, parameters) {
+    // TODO(#429): Implement this method.
+    throw new Error('Not implemented');
+  }
+
+  /** @override */
+  async interruptTransfer(deviceId, deviceHandle, parameters) {
+    // TODO(#429): Implement this method.
+    throw new Error('Not implemented');
+  }
+
   /**
    * @private
    * @param {!Object} webusbDevice The USBDevice object.


### PR DESCRIPTION
All subclasses of the LibusbToJsApiAdaptor JS class should implement all
methods, hence mark it as "@abstract" in order to emit compilation
warnings when this is violated.

Temporarily add empty method implementations into the
LibusbToWebusbAdaptor JS class, in order to silence the warnings until
we finish implementing the class.

This is a pure refactoring change. It's part of the WebUSB support
effort tracked by #429.