### PR TITLE
[usb] Port loginState hook to new adaptor

### DIFF
--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -20,8 +20,8 @@ goog.provide('GoogleSmartCard.ConnectorApp.BackgroundMain');
 goog.require('GoogleSmartCard.ConnectorApp.Background.MainWindowManaging');
 goog.require('GoogleSmartCard.EmscriptenModule');
 goog.require('GoogleSmartCard.ExecutableModule');
-goog.require('GoogleSmartCard.Libusb.ChromeLoginStateHook');
 goog.require('GoogleSmartCard.Libusb.ChromeUsbBackend');
+goog.require('GoogleSmartCard.LibusbLoginStateHook');
 goog.require('GoogleSmartCard.LibusbProxyReceiver');
 goog.require('GoogleSmartCard.LogBufferForwarder');
 goog.require('GoogleSmartCard.Logging');
@@ -115,17 +115,10 @@ if (logBufferForwarderToNaclModule) {
 
 const libusbChromeUsbBackend =
     new GSC.Libusb.ChromeUsbBackend(executableModule.getMessageChannel());
-const chromeLoginStateHook = new GSC.Libusb.ChromeLoginStateHook();
-libusbChromeUsbBackend.addRequestSuccessHook(
-    chromeLoginStateHook.getRequestSuccessHook());
-// Start the backend regardless of whether the hook initialization succeeded.
-chromeLoginStateHook.getHookReadyPromise()
-    .then(() => {}, () => {})
-    .then(function() {
-      libusbChromeUsbBackend.startProcessingEvents();
-    });
+libusbChromeUsbBackend.startProcessingEvents();
 const libusbProxyReceiver = new GSC.LibusbProxyReceiver(
     executableModule.getMessageChannel(), libusbChromeUsbBackend);
+libusbProxyReceiver.addHook(new GSC.LibusbLoginStateHook());
 
 const pcscLiteReadinessTracker =
     new GSC.PcscLiteServerClientsManagement.ReadinessTracker(

--- a/third_party/libusb/webport/src/chrome_usb/chrome-login-state-hook-unittest.js
+++ b/third_party/libusb/webport/src/chrome_usb/chrome-login-state-hook-unittest.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-goog.require('GoogleSmartCard.Libusb.ChromeLoginStateHook');
+goog.require('GoogleSmartCard.LibusbLoginStateHook');
 goog.require('GoogleSmartCard.Libusb.ChromeUsbBackend');
 goog.require('GoogleSmartCard.RemoteCallMessage');
 goog.require('GoogleSmartCard.Requester');
@@ -23,6 +23,7 @@ goog.require('GoogleSmartCard.RequestReceiver');
 goog.require('GoogleSmartCard.SingleMessageBasedChannel');
 goog.require('goog.Promise');
 goog.require('goog.array');
+goog.require('goog.asserts');
 goog.require('goog.messaging.AbstractChannel');
 goog.require('goog.testing');
 goog.require('goog.testing.MockControl');
@@ -40,6 +41,17 @@ const USER_PROFILE_TYPE = 'USER_PROFILE';
 const SIGNIN_PROFILE_TYPE = 'SIGNIN_PROFILE';
 const IN_SESSION_STATE = 'IN_SESSION';
 const IN_LOCK_SCREEN_STATE = 'IN_LOCK_SCREEN';
+const FAKE_DEVICE_ID = 123;
+const FAKE_DEVICE = {
+  'deviceId': FAKE_DEVICE_ID,
+  'vendorId': 1,
+  'productId': 2
+};
+const FAKE_DEVICE_CONFIG = {
+  'active': true,
+  'configurationValue': 4
+};
+const FAKE_DEVICE_HANDLE = 456;
 
 let sessionStateListeners = [];
 
@@ -108,6 +120,57 @@ function makeTest(fakeProfileType, fakeSessionState, testCallback) {
   };
 }
 
+class FakeLibusbProxyHookDelegate extends GSC.LibusbToJsApiAdaptor {
+  /** @override */
+  async listDevices() {
+    return [FAKE_DEVICE];
+  }
+  /** @override */
+  async getConfigurations(deviceId) {
+    assertEquals(deviceId, FAKE_DEVICE_ID);
+    return [FAKE_DEVICE_CONFIG];
+  }
+  /** @override */
+  async openDeviceHandle(deviceId) {
+    return FAKE_DEVICE_HANDLE;
+  }
+  /** @override */
+  async closeDeviceHandle(deviceId, deviceHandle) {
+    fail('Unexpected call');
+    goog.asserts.fail();
+  }
+  /** @override */
+  async claimInterface(deviceId, deviceHandle, interfaceNumber) {
+    fail('Unexpected call');
+    goog.asserts.fail();
+  }
+  /** @override */
+  async releaseInterface(deviceId, deviceHandle, interfaceNumber) {
+    fail('Unexpected call');
+    goog.asserts.fail();
+  }
+  /** @override */
+  async resetDevice(deviceId, deviceHandle) {
+    fail('Unexpected call');
+    goog.asserts.fail();
+  }
+  /** @override */
+  async controlTransfer(deviceId, deviceHandle, parameters) {
+    fail('Unexpected call');
+    goog.asserts.fail();
+  }
+  /** @override */
+  async bulkTransfer(deviceId, deviceHandle, parameters) {
+    fail('Unexpected call');
+    goog.asserts.fail();
+  }
+  /** @override */
+  async interruptTransfer(deviceId, deviceHandle, parameters) {
+    fail('Unexpected call');
+    goog.asserts.fail();
+  }
+};
+
 /**
  * Simulates Chrome changing the session state.
  * @param {string} fakeNewSessionState
@@ -123,85 +186,69 @@ function changeSessionState(fakeNewSessionState, propertyReplacer) {
   });
 }
 
-goog.exportSymbol('test_ChromeLoginStateHook_NoApi', function() {
-  const loginStateHook = new GSC.Libusb.ChromeLoginStateHook();
-  // Expect that getHookReadyPromise() gets rejected, because the
-  // chrome.loginState mock is not set up.
-  return loginStateHook.getHookReadyPromise().then(() => {
-    fail('Unexpected successful response');
-  }, () => {});
+goog.exportSymbol('test_ChromeLoginStateHook_NoApi', async function() {
+  const loginStateHook = new GSC.LibusbLoginStateHook();
+  loginStateHook.setDelegate(new FakeLibusbProxyHookDelegate());
+  const devices = await loginStateHook.listDevices();
+  assertObjectEquals(devices, [FAKE_DEVICE]);
+  const configs = await loginStateHook.getConfigurations(FAKE_DEVICE_ID);
+  assertObjectEquals(configs, [FAKE_DEVICE_CONFIG]);
 });
 
 goog.exportSymbol(
     'test_ChromeLoginStateHook_DoesNotFilterInSession',
-    makeTest(USER_PROFILE_TYPE, IN_SESSION_STATE, function() {
-      const loginStateHook = new GSC.Libusb.ChromeLoginStateHook();
-      return loginStateHook.getHookReadyPromise().then(() => {
-        const hook = loginStateHook.getRequestSuccessHook();
-        let apiCallResult = [['fakeResult']];
-        const hookResult = hook('getDevices', apiCallResult);
-        assertObjectEquals([['fakeResult']], hookResult);
-      });
+    makeTest(USER_PROFILE_TYPE, IN_SESSION_STATE, async function() {
+      const loginStateHook = new GSC.LibusbLoginStateHook();
+      loginStateHook.setDelegate(new FakeLibusbProxyHookDelegate());
+      const devices = await loginStateHook.listDevices();
+      assertObjectEquals(devices, [FAKE_DEVICE]);
+      const configs = await loginStateHook.getConfigurations(FAKE_DEVICE_ID);
+      assertObjectEquals(configs, [FAKE_DEVICE_CONFIG]);
     }));
 
 goog.exportSymbol(
     'test_ChromeLoginStateHook_FiltersInLockScreen',
-    makeTest(USER_PROFILE_TYPE, IN_LOCK_SCREEN_STATE, function() {
-      const loginStateHook = new GSC.Libusb.ChromeLoginStateHook();
-      return loginStateHook.getHookReadyPromise().then(() => {
-        const hook = loginStateHook.getRequestSuccessHook();
-
-        let apiCallResult = [['fakeResult']];
-        let hookResult = hook('getDevices', apiCallResult);
-        assertObjectEquals([[]], hookResult);
-
-        apiCallResult = [['fakeResult']];
-        hookResult = hook('getConfigurations', apiCallResult);
-        assertObjectEquals([[]], hookResult);
-
-        // only getDevices and getConfigurations should get filtered
-        apiCallResult = ['otherCallResult'];
-        hookResult = hook('listInterfaces', apiCallResult);
-        assertObjectEquals(['otherCallResult'], hookResult);
-      });
+    makeTest(USER_PROFILE_TYPE, IN_LOCK_SCREEN_STATE, async function() {
+      const loginStateHook = new GSC.LibusbLoginStateHook();
+      loginStateHook.setDelegate(new FakeLibusbProxyHookDelegate());
+      const devices = await loginStateHook.listDevices();
+      assertEquals(devices.length, 0);
+      const configs = await loginStateHook.getConfigurations(FAKE_DEVICE_ID);
+      assertEquals(configs.length, 0);
+      // only listDevices and getConfigurations should get filtered
+      const handle = await loginStateHook.openDeviceHandle(FAKE_DEVICE_ID);
+      assertEquals(handle, FAKE_DEVICE_HANDLE);
     }));
 
 goog.exportSymbol(
     'test_ChromeLoginStateHook_DoesNotFilterForSignInProfile',
-    makeTest(SIGNIN_PROFILE_TYPE, IN_SESSION_STATE, function() {
-      const loginStateHook = new GSC.Libusb.ChromeLoginStateHook();
-      return loginStateHook.getHookReadyPromise().then(() => {
-        const hook = loginStateHook.getRequestSuccessHook();
-        const apiCallResult = [['fakeResult']];
-        const hookResult = hook('getDevices', apiCallResult);
-        assertObjectEquals([['fakeResult']], hookResult);
-      });
+    makeTest(SIGNIN_PROFILE_TYPE, IN_SESSION_STATE, async function() {
+      const loginStateHook = new GSC.LibusbLoginStateHook();
+      loginStateHook.setDelegate(new FakeLibusbProxyHookDelegate());
+      const devices = await loginStateHook.listDevices();
+      assertObjectEquals(devices, [FAKE_DEVICE]);
     }));
 
 goog.exportSymbol(
     'test_ChromeLoginStateHook_ChangeToLockScreen',
-    makeTest(USER_PROFILE_TYPE, IN_SESSION_STATE, function(propertyReplacer) {
-      const loginStateHook = new GSC.Libusb.ChromeLoginStateHook();
-      return loginStateHook.getHookReadyPromise().then(() => {
-        changeSessionState(IN_LOCK_SCREEN_STATE, propertyReplacer);
-        const hook = loginStateHook.getRequestSuccessHook();
-        const apiCallResult = [['fakeResult']];
-        const hookResult = hook('getDevices', apiCallResult);
-        assertObjectEquals([[]], hookResult);
-      });
-    }));
+    makeTest(
+        USER_PROFILE_TYPE, IN_SESSION_STATE, async function(propertyReplacer) {
+          const loginStateHook = new GSC.LibusbLoginStateHook();
+          loginStateHook.setDelegate(new FakeLibusbProxyHookDelegate());
+          changeSessionState(IN_LOCK_SCREEN_STATE, propertyReplacer);
+          const devices = await loginStateHook.listDevices();
+          assertEquals(devices.length, 0);
+        }));
 
 goog.exportSymbol(
     'test_ChromeLoginStateHook_ChangeToSession',
     makeTest(
-        USER_PROFILE_TYPE, IN_LOCK_SCREEN_STATE, function(propertyReplacer) {
-          const loginStateHook = new GSC.Libusb.ChromeLoginStateHook();
-          return loginStateHook.getHookReadyPromise().then(() => {
-            changeSessionState(IN_SESSION_STATE, propertyReplacer);
-            const hook = loginStateHook.getRequestSuccessHook();
-            const apiCallResult = [['fakeResult']];
-            const hookResult = hook('getDevices', apiCallResult);
-            assertObjectEquals([['fakeResult']], hookResult);
-          });
+        USER_PROFILE_TYPE, IN_LOCK_SCREEN_STATE,
+        async function(propertyReplacer) {
+          const loginStateHook = new GSC.LibusbLoginStateHook();
+          loginStateHook.setDelegate(new FakeLibusbProxyHookDelegate());
+          changeSessionState(IN_SESSION_STATE, propertyReplacer);
+          const devices = await loginStateHook.listDevices();
+          assertObjectEquals(devices, [FAKE_DEVICE]);
         }));
 });  // goog.scope

--- a/third_party/libusb/webport/src/chrome_usb/chrome-login-state-hook.js
+++ b/third_party/libusb/webport/src/chrome_usb/chrome-login-state-hook.js
@@ -17,149 +17,100 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-goog.provide('GoogleSmartCard.Libusb.ChromeLoginStateHook');
+goog.provide('GoogleSmartCard.LibusbLoginStateHook');
 
-goog.require('GoogleSmartCard.Libusb.ChromeUsbBackend');
-goog.require('GoogleSmartCard.DebugDump');
+goog.require('GoogleSmartCard.LibusbProxyHook');
 goog.require('GoogleSmartCard.Logging');
-goog.require('GoogleSmartCard.RemoteCallMessage');
-goog.require('GoogleSmartCard.RequestReceiver');
-goog.require('goog.Promise');
 goog.require('goog.asserts');
-goog.require('goog.array');
-goog.require('goog.Disposable');
-goog.require('goog.iter');
 goog.require('goog.log');
-goog.require('goog.log.Logger');
-goog.require('goog.messaging.AbstractChannel');
-goog.require('goog.object');
-goog.require('goog.promise.Resolver');
 
 goog.scope(function() {
 
 const GSC = GoogleSmartCard;
 
-/**
- * This class implements a hook that hides USB devices when the app is running
- * for a user who has locked their screen. This causes PCSC Lite to release all
- * owned USB devices so that they can be accessed from the sign-in profile app.
- * @extends goog.Disposable
- * @constructor
- */
-GSC.Libusb.ChromeLoginStateHook = function() {
+const logger = GSC.Logging.getScopedLogger('LibusbLoginStateHook');
+
+// TODO(#429): Add event unsubscription.
+GSC.LibusbLoginStateHook = class extends GSC.LibusbProxyHook {
+  constructor() {
+    super();
+    /** @type {boolean} @private */
+    this.simulateDevicesAbsent_ = false;
+    /** @type {!Function} @private @const */
+    this.boundOnGotSessionState_ = this.onGotSessionState_.bind(this);
+    /** @type {!Function|null} @private */
+    this.resolveInitializationPromise_ = null;
+    /** @type {!Promise<void>} @private @const */
+    this.initializationPromise_ = new Promise((resolve, reject) => {
+      this.resolveInitializationPromise_ = resolve;
+    });
+    if (chrome && chrome.loginState) {
+      chrome.loginState.getProfileType(this.onGotProfileType_.bind(this));
+    } else {
+      goog.log.warning(
+          logger,
+          'chrome.loginState API is not available. This app might require a ' +
+              'newer version of Chrome.');
+      this.resolveInitializationPromise_();
+    }
+  }
+
+  /** @override */
+  async listDevices() {
+    await this.initializationPromise_;
+    if (this.simulateDevicesAbsent_)
+      return [];
+    return this.getDelegate().listDevices();
+  }
+
+  /** @override */
+  async getConfigurations(deviceId) {
+    await this.initializationPromise_;
+    if (this.simulateDevicesAbsent_)
+      return [];
+    return this.getDelegate().getConfigurations(deviceId);
+  }
+
   /**
-   * @type {boolean}
+   * @param {!chrome.loginState.ProfileType} profileType
    * @private
    */
-  this.simulateDevicesAbsent_ = false;
-  /** @type {!Function} @private @const */
-  this.boundOnGotSessionState_ = this.onGotSessionState_.bind(this);
-  /** @type {!goog.promise.Resolver} @private @const */
-  this.hookIsReadyResolver_ = goog.Promise.withResolver();
-  if (chrome.loginState) {
-    chrome.loginState.getProfileType(this.onGotProfileType_.bind(this));
-  } else {
-    goog.log.warning(
-        this.logger,
-        'chrome.loginState API is not available. This app might require a ' +
-            'newer version of Chrome.');
-    this.hookIsReadyResolver_.reject();
-  }
-};
-
-const ChromeLoginStateHook = GSC.Libusb.ChromeLoginStateHook;
-
-goog.inherits(ChromeLoginStateHook, goog.Disposable);
-
-/**
- * @type {!goog.log.Logger}
- * @const
- */
-ChromeLoginStateHook.prototype.logger =
-    GSC.Logging.getScopedLogger('Libusb.LoginStateHook');
-
-/** @override */
-ChromeLoginStateHook.prototype.disposeInternal = function() {
-  if (chrome.loginState) {
-    chrome.loginState.onSessionStateChanged.removeListener(
-        this.boundOnGotSessionState_);
+  onGotProfileType_(profileType) {
+    goog.asserts.assert(chrome.loginState);
+    if (profileType === chrome.loginState.ProfileType.USER_PROFILE) {
+      chrome.loginState.getSessionState(this.boundOnGotSessionState_);
+      chrome.loginState.onSessionStateChanged.addListener(
+          this.onSessionStateChanged_.bind(this));
+    } else {
+      this.resolveInitializationPromise_();
+    }
   }
 
-  goog.log.fine(this.logger, 'Disposed');
+  /**
+   * @param {!chrome.loginState.SessionState} sessionState
+   * @private
+   */
+  onGotSessionState_(sessionState) {
+    goog.asserts.assert(chrome.loginState);
+    if (sessionState === chrome.loginState.SessionState.IN_LOCK_SCREEN &&
+        !this.simulateDevicesAbsent_) {
+      goog.log.info(logger, 'No longer showing USB devices.');
+      this.simulateDevicesAbsent_ = true;
+    } else if (
+        sessionState !== chrome.loginState.SessionState.IN_LOCK_SCREEN &&
+        this.simulateDevicesAbsent_) {
+      goog.log.info(logger, 'Showing USB devices.');
+      this.simulateDevicesAbsent_ = false;
+    }
+    // All calls after the first one to resolve() will be ignored.
+    this.resolveInitializationPromise_();
+  }
 
-  ChromeLoginStateHook.base(this, 'disposeInternal');
-};
-
-/**
- * @return {function(string, !Array): !Array}
- * @public
- */
-ChromeLoginStateHook.prototype.getRequestSuccessHook = function() {
-  return this.requestSuccessHook_.bind(this);
-};
-
-/**
- * @return {!goog.Promise}
- * @public
- */
-ChromeLoginStateHook.prototype.getHookReadyPromise = function() {
-  return this.hookIsReadyResolver_.promise;
-};
-
-/**
- * @param {!chrome.loginState.ProfileType} profileType
- * @private
- */
-ChromeLoginStateHook.prototype.onGotProfileType_ = function(profileType) {
-  goog.asserts.assert(chrome.loginState);
-  if (profileType === chrome.loginState.ProfileType.USER_PROFILE) {
+  /**
+   * @private
+   */
+  onSessionStateChanged_() {
     chrome.loginState.getSessionState(this.boundOnGotSessionState_);
-    chrome.loginState.onSessionStateChanged.addListener(
-        this.onSessionStateChanged_.bind(this));
-  } else {
-    this.hookIsReadyResolver_.resolve();
   }
-};
-
-/**
- * @param {!chrome.loginState.SessionState} sessionState
- * @private
- */
-ChromeLoginStateHook.prototype.onGotSessionState_ = function(sessionState) {
-  goog.asserts.assert(chrome.loginState);
-  if (sessionState === chrome.loginState.SessionState.IN_LOCK_SCREEN &&
-      !this.simulateDevicesAbsent_) {
-    goog.log.info(this.logger, 'No longer showing USB devices.');
-    this.simulateDevicesAbsent_ = true;
-  } else if (
-      sessionState !== chrome.loginState.SessionState.IN_LOCK_SCREEN &&
-      this.simulateDevicesAbsent_) {
-    goog.log.info(this.logger, 'Showing USB devices.');
-    this.simulateDevicesAbsent_ = false;
-  }
-  // All calls after the first one to resolve() will be ignored.
-  this.hookIsReadyResolver_.resolve();
-};
-
-/**
- * @private
- */
-ChromeLoginStateHook.prototype.onSessionStateChanged_ = function() {
-  chrome.loginState.getSessionState(this.boundOnGotSessionState_);
-};
-
-/**
- * @param {string} functionName chrome.usb function that was called
- * @param {!Array} callResults
- * @return {!Array} new callResults
- * @private
- */
-ChromeLoginStateHook.prototype.requestSuccessHook_ = function(
-    functionName, callResults) {
-  if (this.simulateDevicesAbsent_ &&
-      (functionName === 'getDevices' || functionName === 'getConfigurations')) {
-    return [[]];
-  }
-  return callResults;
 };
 });  // goog.scope

--- a/third_party/libusb/webport/src/libusb-proxy-hook.js
+++ b/third_party/libusb/webport/src/libusb-proxy-hook.js
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2021 Google Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+goog.provide('GoogleSmartCard.LibusbProxyHook');
+
+goog.require('GoogleSmartCard.LibusbToChromeUsbAdaptor');
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+GSC.LibusbProxyHook = class extends GSC.LibusbToJsApiAdaptor {
+  constructor() {
+    super();
+    /** @type {!GSC.LibusbToJsApiAdaptor|null} */
+    this.delegate_ = null;
+  }
+
+  /**
+   * Sets the delegate, which can be used by the hook to invoke the original
+   * request handling implementation.
+   * @param {!GSC.LibusbToJsApiAdaptor} delegate
+   */
+  setDelegate(delegate) {
+    this.delegate_ = delegate;
+  }
+
+  /**
+   * @return {!GSC.LibusbToJsApiAdaptor|null}
+   */
+  getDelegate() {
+    return this.delegate_;
+  }
+
+  /**
+   * @return {!GSC.LibusbToJsApiAdaptor}
+   */
+  getDelegateOrThrow() {
+    if (!this.delegate_)
+      throw new Error('Delegate must be set for libusb proxy hook');
+    return this.delegate_;
+  }
+
+  /** @override */
+  async listDevices() {
+    return this.getDelegateOrThrow().listDevices();
+  }
+
+  /** @override */
+  async getConfigurations(deviceId) {
+    return this.getDelegateOrThrow().getConfigurations(deviceId);
+  }
+
+  /** @override */
+  async openDeviceHandle(deviceId) {
+    return this.getDelegateOrThrow().openDeviceHandle(deviceId);
+  }
+
+  /** @override */
+  async closeDeviceHandle(deviceId, deviceHandle) {
+    return this.getDelegateOrThrow().closeDeviceHandle(deviceId, deviceHandle);
+  }
+
+  /** @override */
+  async claimInterface(deviceId, deviceHandle, interfaceNumber) {
+    return this.getDelegateOrThrow().claimInterface(
+        deviceId, deviceHandle, interfaceNumber);
+  }
+
+  /** @override */
+  async releaseInterface(deviceId, deviceHandle, interfaceNumber) {
+    return this.getDelegateOrThrow().releaseInterface(
+        deviceId, deviceHandle, interfaceNumber);
+  }
+
+  /** @override */
+  async resetDevice(deviceId, deviceHandle) {
+    return this.getDelegateOrThrow().resetDevice(deviceId, deviceHandle);
+  }
+
+  /** @override */
+  async controlTransfer(deviceId, deviceHandle, parameters) {
+    return this.getDelegateOrThrow().controlTransfer(
+        deviceId, deviceHandle, parameters);
+  }
+
+  /** @override */
+  async bulkTransfer(deviceId, deviceHandle, parameters) {
+    return this.getDelegateOrThrow().bulkTransfer(
+        deviceId, deviceHandle, parameters);
+  }
+
+  /** @override */
+  async interruptTransfer(deviceId, deviceHandle, parameters) {
+    return this.getDelegateOrThrow().interruptTransfer(
+        deviceId, deviceHandle, parameters);
+  }
+};
+});  // goog.scope

--- a/third_party/libusb/webport/src/libusb-proxy-receiver.js
+++ b/third_party/libusb/webport/src/libusb-proxy-receiver.js
@@ -21,11 +21,13 @@ goog.provide('GoogleSmartCard.LibusbProxyReceiver');
 
 goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Libusb.ChromeUsbBackend');
+goog.require('GoogleSmartCard.LibusbProxyHook');
 goog.require('GoogleSmartCard.LibusbToChromeUsbAdaptor');
 goog.require('GoogleSmartCard.LibusbToJsApiAdaptor');
 goog.require('GoogleSmartCard.LibusbToWebusbAdaptor');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.RemoteCallMessage');
+goog.require('GoogleSmartCard.StubLibusbToJsApiAdaptor');
 goog.require('goog.Promise');
 goog.require('goog.log');
 goog.require('goog.messaging.AbstractChannel');
@@ -62,7 +64,30 @@ GSC.LibusbProxyReceiver = class {
     /** @private @const */
     this.libusbChromeUsbBackend_ = libusbChromeUsbBackend;
     /** @private @const */
-    this.libusbToJsApiAdaptor_ = chooseLibusbToJsApiAdaptor();
+    this.realLibusbToJsApiAdaptor_ = chooseLibusbToJsApiAdaptor();
+    /** @type {!Array<!GSC.LibusbProxyHook>} @private @const */
+    this.hooks_ = [];
+  }
+
+  /**
+   * Adds a new hook. Multiple hooks are chained in the FILO order.
+   * @param {!GSC.LibusbProxyHook} hook
+   */
+  addHook(hook) {
+    // If it's the first hook, then chain it with the real implementation,
+    // otherwise - with the previously added hook.
+    hook.setDelegate(this.getLibusbToJsApiAdaptor_());
+    this.hooks_.push(hook);
+  }
+
+  /**
+   * @return {!GSC.LibusbToJsApiAdaptor}
+   * @private
+   */
+  getLibusbToJsApiAdaptor_() {
+    if (this.hooks_.length)
+      return this.hooks_[this.hooks_.length - 1];
+    return this.realLibusbToJsApiAdaptor_;
   }
 
   /**
@@ -84,12 +109,6 @@ GSC.LibusbProxyReceiver = class {
         logger,
         `Received a remote call request: ${
             remoteCallMessage.getDebugRepresentation()}`);
-
-    if (!this.libusbToJsApiAdaptor_) {
-      // No need to log errors here, since this was already done in the
-      // constructor.
-      throw new Error('USB API unavailable');
-    }
     return await this.dispatchLibusbJsFunction_(remoteCallMessage);
   }
 
@@ -103,38 +122,38 @@ GSC.LibusbProxyReceiver = class {
     // libusb_js_proxy.cc.
     switch (remoteCallMessage.functionName) {
       case 'listDevices':
-        return [await this.libusbToJsApiAdaptor_.listDevices(
+        return [await this.getLibusbToJsApiAdaptor_().listDevices(
             ...remoteCallMessage.functionArguments)];
       case 'getConfigurations':
-        return [await this.libusbToJsApiAdaptor_.getConfigurations(
+        return [await this.getLibusbToJsApiAdaptor_().getConfigurations(
             ...remoteCallMessage.functionArguments)];
       case 'openDeviceHandle':
-        return [await this.libusbToJsApiAdaptor_.openDeviceHandle(
+        return [await this.getLibusbToJsApiAdaptor_().openDeviceHandle(
             ...remoteCallMessage.functionArguments)];
       case 'closeDeviceHandle':
-        await this.libusbToJsApiAdaptor_.closeDeviceHandle(
+        await this.getLibusbToJsApiAdaptor_().closeDeviceHandle(
             ...remoteCallMessage.functionArguments);
         return [];
       case 'claimInterface':
-        await this.libusbToJsApiAdaptor_.claimInterface(
+        await this.getLibusbToJsApiAdaptor_().claimInterface(
             ...remoteCallMessage.functionArguments);
         return [];
       case 'releaseInterface':
-        await this.libusbToJsApiAdaptor_.releaseInterface(
+        await this.getLibusbToJsApiAdaptor_().releaseInterface(
             ...remoteCallMessage.functionArguments);
         return [];
       case 'resetDevice':
-        await this.libusbToJsApiAdaptor_.resetDevice(
+        await this.getLibusbToJsApiAdaptor_().resetDevice(
             ...remoteCallMessage.functionArguments);
         return [];
       case 'controlTransfer':
-        return [await this.libusbToJsApiAdaptor_.controlTransfer(
+        return [await this.getLibusbToJsApiAdaptor_().controlTransfer(
             ...remoteCallMessage.functionArguments)];
       case 'bulkTransfer':
-        return [await this.libusbToJsApiAdaptor_.bulkTransfer(
+        return [await this.getLibusbToJsApiAdaptor_().bulkTransfer(
             ...remoteCallMessage.functionArguments)];
       case 'interruptTransfer':
-        return [await this.libusbToJsApiAdaptor_.interruptTransfer(
+        return [await this.getLibusbToJsApiAdaptor_().interruptTransfer(
             ...remoteCallMessage.functionArguments)];
     }
     // TODO(#429): Delete this fallback to ChromeUsbBackend once all functions
@@ -144,7 +163,7 @@ GSC.LibusbProxyReceiver = class {
   }
 };
 
-/** @return {!GSC.LibusbToJsApiAdaptor|null} */
+/** @return {!GSC.LibusbToJsApiAdaptor} */
 function chooseLibusbToJsApiAdaptor() {
   // chrome.usb takes precedence: WebUSB might be available but have
   // insufficient permissions.
@@ -159,6 +178,6 @@ function chooseLibusbToJsApiAdaptor() {
   goog.log.warning(
       logger,
       'The USB API is not available. All USB requests will silently fail.');
-  return null;
+  return new GSC.StubLibusbToJsApiAdaptor();
 }
 });  // goog.scope

--- a/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
@@ -18,6 +18,7 @@
  */
 
 goog.provide('GoogleSmartCard.LibusbToJsApiAdaptor');
+goog.provide('GoogleSmartCard.StubLibusbToJsApiAdaptor');
 
 goog.require('GoogleSmartCard.LibusbProxyDataModel');
 
@@ -102,5 +103,62 @@ GSC.LibusbToJsApiAdaptor = class {
    * @return {!Promise<!LibusbJsTransferResult>}
    */
   async interruptTransfer(deviceId, deviceHandle, parameters) {}
+};
+
+GSC.StubLibusbToJsApiAdaptor = class extends GSC.LibusbToJsApiAdaptor {
+  /** @override */
+  async listDevices() {
+    return this.callStub_();
+  }
+
+  /** @override */
+  async getConfigurations(deviceId) {
+    return this.callStub_();
+  }
+
+  /** @override */
+  async openDeviceHandle(deviceId) {
+    return this.callStub_();
+  }
+
+  /** @override */
+  async closeDeviceHandle(deviceId, deviceHandle) {
+    return this.callStub_();
+  }
+
+  /** @override */
+  async claimInterface(deviceId, deviceHandle, interfaceNumber) {
+    return this.callStub_();
+  }
+
+  /** @override */
+  async releaseInterface(deviceId, deviceHandle, interfaceNumber) {
+    return this.callStub_();
+  }
+
+  /** @override */
+  async resetDevice(deviceId, deviceHandle) {
+    return this.callStub_();
+  }
+
+  /** @override */
+  async controlTransfer(deviceId, deviceHandle, parameters) {
+    return this.callStub_();
+  }
+
+  /** @override */
+  async bulkTransfer(deviceId, deviceHandle, parameters) {
+    return this.callStub_();
+  }
+
+  /** @override */
+  async interruptTransfer(deviceId, deviceHandle, parameters) {
+    return this.callStub_();
+  }
+
+  /** @private */
+  callStub_() {
+    throw new Error('API unavailable');
+  }
 };
 });  // goog.scope

--- a/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-js-api-adaptor.js
@@ -21,6 +21,7 @@ goog.provide('GoogleSmartCard.LibusbToJsApiAdaptor');
 goog.provide('GoogleSmartCard.StubLibusbToJsApiAdaptor');
 
 goog.require('GoogleSmartCard.LibusbProxyDataModel');
+goog.require('goog.Disposable');
 
 goog.scope(function() {
 
@@ -34,7 +35,7 @@ const LibusbJsGenericTransferParameters =
     GSC.LibusbProxyDataModel.LibusbJsGenericTransferParameters;
 const LibusbJsTransferResult = GSC.LibusbProxyDataModel.LibusbJsTransferResult;
 
-GSC.LibusbToJsApiAdaptor = class {
+GSC.LibusbToJsApiAdaptor = class extends goog.Disposable {
   /** @return {!Promise<!Array<!LibusbJsDevice>>} */
   async listDevices() {}
 


### PR DESCRIPTION
Port ChromeLoginStateHook to the new libusb-to_JS adaptor, so that
Libusb doesn't see any devices when the devices is locked. For this, add
an abstract definition for the hook class and implement the new
loginState hook via it. Thanks to the better libusb-to-JS API and
extensive use of promises, the hook is now implemented in a more
type-check-friendly way.

This commit is part of the WebUSB support effort tracked by #429.