### PR TITLE
Build JS unit tests for the Connector application

### DIFF
--- a/smart_card_connector_app/build/Makefile
+++ b/smart_card_connector_app/build/Makefile
@@ -140,3 +140,12 @@ $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/window.css))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/card-present.png))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/about-window.html))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/about-window.css))
+
+
+# Rules for running unit tests.
+
+test:: all
+	+$(MAKE) --directory js_unittests run_test
+
+tests_clean::
+	+$(MAKE) --directory js_unittests clean

--- a/smart_card_connector_app/build/js_unittests/.gitignore
+++ b/smart_card_connector_app/build/js_unittests/.gitignore
@@ -1,0 +1,2 @@
+/js_build/
+/out/

--- a/smart_card_connector_app/build/js_unittests/Makefile
+++ b/smart_card_connector_app/build/js_unittests/Makefile
@@ -1,0 +1,33 @@
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#
+# This makefile builds and runs JavaScript unit tests for the Smart Card
+# Connector.
+#
+
+
+TARGET := js_smart_card_connector_unittests
+
+include ../../../common/make/common.mk
+include $(COMMON_DIR_PATH)/make/js_building_common.mk
+include $(COMMON_DIR_PATH)/js/include.mk
+
+JS_COMPILER_INPUT_PATHS := \
+  $(JS_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \
+  ../../../third_party/libusb/webport/src \
+  ../../src \
+
+$(eval $(call BUILD_JS_UNITTESTS,$(JS_COMPILER_INPUT_PATHS)))

--- a/test-all.sh
+++ b/test-all.sh
@@ -30,6 +30,7 @@ TEST_DIRS="
   common/cpp/build
   common/js/build
   example_cpp_smart_card_client_app/build
+  smart_card_connector/build
   third_party/libusb/webport/build
   third_party/pcsc-lite/naclport/server_clients_management/build"
 


### PR DESCRIPTION
Add build script boilerplate for compiling and running JavaScript
unit tests from the //smart_card_connector/src/ directory.

Currently there are no JS unit tests there, but they will be added in
follow-up commits.