### PR TITLE
[usb] Compile-time checks for struct field sizes

### DIFF
--- a/common/cpp/src/google_smart_card_common/numeric_conversions.h
+++ b/common/cpp/src/google_smart_card_common/numeric_conversions.h
@@ -155,7 +155,7 @@ template <typename FirstType, typename SecondType>
 inline void AssignWithTypeSizeCheck(optional<FirstType>* lhs,
                                     const SecondType& rhs) {
   GOOGLE_SMART_CARD_CHECK(lhs);
-  // Assign a dummy value in order to be able to derefence the optional.
+  // Assign a dummy value in order to be able to dereference the optional.
   *lhs = FirstType();
   AssignWithTypeSizeCheck(&lhs->value(), rhs);
 }

--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include <google_smart_card_common/logging/logging.h>
+#include <google_smart_card_common/numeric_conversions.h>
 #include <google_smart_card_common/requesting/request_result.h>
 
 #include "libusb_js_proxy_data_model.h"
@@ -440,14 +441,14 @@ void FillLibusbDeviceDescriptor(const LibusbJsDevice& js_device,
 
   result->bDescriptorType = LIBUSB_DT_DEVICE;
 
-  result->idVendor = js_device.vendor_id;
+  AssignWithTypeSizeCheck(&result->idVendor, js_device.vendor_id);
 
-  result->idProduct = js_device.product_id;
+  AssignWithTypeSizeCheck(&result->idProduct, js_device.product_id);
 
+  // When using the chrome.usb API, the version field is filled only in
+  // Chrome >= 51 (see <http://crbug.com/598825>).
   if (js_device.version) {
-    // When using the chrome.usb API, the version field is filled only in
-    // Chrome >= 51 (see <http://crbug.com/598825>).
-    result->bcdDevice = *js_device.version;
+    AssignWithTypeSizeCheck(&result->bcdDevice, *js_device.version);
   }
 
   //
@@ -673,9 +674,9 @@ bool CreateLibusbJsControlTransferParameters(
       GOOGLE_SMART_CARD_NOTREACHED;
   }
 
-  result->request = control_setup->bRequest;
-  result->value = libusb_le16_to_cpu(control_setup->wValue);
-  result->index = libusb_le16_to_cpu(control_setup->wIndex);
+  AssignWithTypeSizeCheck(&result->request, control_setup->bRequest);
+  AssignWithTypeSizeCheck(&result->value, libusb_le16_to_cpu(control_setup->wValue));
+  AssignWithTypeSizeCheck(&result->index, libusb_le16_to_cpu(control_setup->wIndex));
 
   if ((control_setup->bmRequestType & LIBUSB_ENDPOINT_DIR_MASK) ==
       LIBUSB_ENDPOINT_OUT) {
@@ -683,7 +684,7 @@ bool CreateLibusbJsControlTransferParameters(
         libusb_control_transfer_get_data(transfer),
         libusb_control_transfer_get_data(transfer) + data_length);
   } else {
-    result->length_to_receive = data_length;
+    AssignWithTypeSizeCheck(&result->length_to_receive, data_length);
   }
 
   return true;
@@ -697,13 +698,13 @@ void CreateLibusbJsGenericTransferParameters(
                           transfer->type == LIBUSB_TRANSFER_TYPE_INTERRUPT);
   GOOGLE_SMART_CARD_CHECK(result);
 
-  result->endpoint_address = transfer->endpoint;
+  AssignWithTypeSizeCheck(&result->endpoint_address, transfer->endpoint);
   if ((transfer->endpoint & LIBUSB_ENDPOINT_DIR_MASK) == LIBUSB_ENDPOINT_OUT) {
     GOOGLE_SMART_CARD_CHECK(transfer->buffer);
     result->data_to_send = std::vector<uint8_t>(
         transfer->buffer, transfer->buffer + transfer->length);
   } else {
-    result->length_to_receive = transfer->length;
+    AssignWithTypeSizeCheck(&result->length_to_receive,transfer->length);
   }
 }
 

--- a/third_party/libusb/webport/src/libusb_js_proxy_data_model.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy_data_model.h
@@ -41,12 +41,12 @@ struct LibusbJsDevice {
   // plugged back).
   int64_t device_id;
   // The USB vendor ID.
-  uint32_t vendor_id;
+  uint16_t vendor_id;
   // The USB product ID.
-  uint32_t product_id;
+  uint16_t product_id;
   // The version number (according to the bcdDevice field of the USB specs), or
   // an empty optional if unavailable.
-  optional<int64_t> version;
+  optional<uint16_t> version;
   // The USB iProduct string, or an empty optional if unavailable.
   optional<std::string> product_name;
   // The USB iManufacturer string, or an empty optional if unavailable.


### PR DESCRIPTION
Add compile-time assertions into some of the C/C++ code that performs
data conversion to/from libusb structs and to/from libusb-to-JS adaptor
structs. This should prevent bugs with accidental data clamping, similar
to #469.

Also make some of the libusb-to-JS structs have a more precise sizing,
as a few fields were violating the checks added by this commit.

This commit is part of the WebUSB implementation effort, tracked
by #429.