### PR TITLE
[wasm] Use content security policy in extension

### DIFF
--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -25,6 +25,7 @@ ${if PACKAGING=extension}
     "default_title": "__MSG_appShortName__",
     "default_popup": "window.html"
   },
+  "content_security_policy": "script-src 'self' 'wasm-eval'; object-src 'self'",
 ${endif}
   "minimum_chrome_version": "48",
   "default_locale": "en",


### PR DESCRIPTION
This commit adds a content_security_policy key into manifest.json file
when the EXTENSION packaging mode is used. This allows the WebAssembly
module to be loaded in that mode, since by default the extension CSP
forbids this.

Note that this is not required in the APP packaging mode, since App's
default CSP is not so strict:
https://source.chromium.org/chromium/chromium/src/+/main:extensions/common/manifest_handlers/csp_info.cc;l=61;drc=1e0c2a218eb71bef788fd87b0e7a4e9e93ecfe1d