### PR TITLE
[wasm] Specify COOP/COEP when using WebAssembly

### DIFF
--- a/smart_card_connector_app/build/Makefile
+++ b/smart_card_connector_app/build/Makefile
@@ -111,6 +111,7 @@ $(OUT_DIR_PATH)/manifest.json: $(SOURCES_PATH)/create_app_manifest.py $(SOURCES_
 		--ccid-supported-readers-config-path="$(CCID_SUPPORTED_READERS_CONFIG_PATH)" \
 		--target-file-path="$(OUT_DIR_PATH)/manifest.json" \
 		--enable-condition="CONFIG=$(CONFIG)" \
+		--enable-condition="TOOLCHAIN=$(TOOLCHAIN)" \
 		--enable-condition="PACKAGING=$(PACKAGING)"
 
 generate_out: $(OUT_DIR_PATH)/manifest.json

--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -26,6 +26,14 @@ ${if PACKAGING=extension}
     "default_popup": "window.html"
   },
 ${endif}
+${if TOOLCHAIN=emscripten}
+  "cross_origin_embedder_policy": {
+    "value": "require-corp"
+  },
+  "cross_origin_opener_policy": {
+    "value": "same-origin"
+  },
+${endif}
   "minimum_chrome_version": "48",
   "default_locale": "en",
   "icons": {


### PR DESCRIPTION
Add cross_origin_embedder_policy and cross_origin_opener_policy
properties into manifest.json, which allow to configure the extension's
Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy
correspondingly.

These settings will be required by new versions of Chrome for extensions
that use WebAssembly with multi-threading. See, for example:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/Planned_changes

Normally these settings are configured via HTTP headers, but inside the
extension this isn't possible. But the Chrome Extensions team added
special manifest entries that allow to achieve the same COOP/COEP
configuration as if it was done via headers:
https://groups.google.com/u/0/a/chromium.org/g/chromium-extensions/c/Auo0HwzsyG0/m/TIpqFyIaDAAJ