### PR TITLE
[usb] Implement getConfigurations via WebUSB

### DIFF
--- a/third_party/libusb/webport/src/libusb-to-webusb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-webusb-adaptor.js
@@ -228,6 +228,7 @@ function getLibusbJsConfigurationDescriptor(
                       .filter(item => item !== null),
   };
 }
+
 /**
  * @param {!Object} webusbInterface The WebUSB USBInterface value.
  * @return {!LibusbJsInterfaceDescriptor|null}
@@ -250,6 +251,7 @@ function getLibusbJsInterfaceDescriptor(webusbInterface) {
                      .filter(item => item !== null),
   };
 }
+
 /**
  * @param {!Object} webusbEndpoint The WebUSB USBEndpoint value.
  * @return {!LibusbJsEndpointDescriptor|null}
@@ -271,6 +273,7 @@ function getLibusbJsEndpointDescriptor(webusbEndpoint) {
     'maxPacketSize': webusbEndpoint['packetSize'],
   };
 }
+
 /**
  * @param {string} webusbEndpointType The WebUSB USBEndpointType value.
  * @return {!LibusbJsEndpointType|null}

--- a/third_party/libusb/webport/src/libusb-to-webusb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-webusb-adaptor.js
@@ -73,6 +73,11 @@ GSC.LibusbToWebusbAdaptor = class extends GSC.LibusbToJsApiAdaptor {
   /** @override */
   async getConfigurations(deviceId) {
     const webusbDevice = this.getDeviceByIdOrThrow_(deviceId);
+    // Note: It's incorrect to check whether the configuration is active by
+    // comparing it via "===" against `webusbDevice['configuration']`, because
+    // Chrome produces different objects for USBDevice::configuration and for
+    // USBDevice::configurations: see crbug.com/1274922. Hence the need to
+    // compare by the configurationValue fields.
     const activeConfigurationValue = webusbDevice['configuration'] ?
         webusbDevice['configuration']['configurationValue'] :
         null;

--- a/third_party/libusb/webport/src/libusb-to-webusb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-webusb-adaptor.js
@@ -233,7 +233,7 @@ function getLibusbJsConfigurationDescriptor(
  * @return {!LibusbJsInterfaceDescriptor|null}
  */
 function getLibusbJsInterfaceDescriptor(webusbInterface) {
-  if (!webusbInterface['alternates'])
+  if (webusbInterface['alternates'].length === 0)
     return null;
   // Note: We're not using the "alternate" field here, since, contrary to the
   // WebUSB specification, Chrome's implementation typically sets this field to


### PR DESCRIPTION
Add implementation of the "getConfigurations" command into the
LibusbToWebusbAdaptor JavaScript class.

Thanks to the previous refactoring work, no other changes are needed in
order to let the CCID driver obtain the device configurations via this
WebUSB integration. However, there's one major deficiency: the
"extra_data" field is not set, because WebUSB doesn't expose this
information; backfilling it will be done in a follow-up change.