### PR TITLE
[common] Fix circular ref handling in JS debugDump

### DIFF
--- a/common/js/src/logging/debug-dump-unittest.js
+++ b/common/js/src/logging/debug-dump-unittest.js
@@ -66,4 +66,28 @@ goog.exportSymbol('testDebugDump', function() {
   assertEquals('<NodeList>', dump(document.body.childNodes));
   assertEquals('<HTMLCollection>', dump(document.body.children));
 });
+
+goog.exportSymbol('testDebugDumpWithCircularRefs', function() {
+  const circularInsideArray = [];
+  circularInsideArray.push(circularInsideArray);
+  assertEquals('[<duplicate>]', dump(circularInsideArray));
+
+  const circularInObject = {'a': 'b'};
+  circularInObject['c'] = circularInObject;
+  assertEquals('{"a": "b", "c": <duplicate>}', dump(circularInObject));
+
+  const circularInMap = new Map();
+  circularInMap.set('a', 'b');
+  circularInMap.set('c', circularInMap);
+  assertEquals('Map{"a": "b", "c": <duplicate>}', dump(circularInMap));
+
+  const circularInSet = new Set();
+  circularInSet.add('foo');
+  circularInSet.add(circularInSet);
+  assertEquals('Set{"foo", <duplicate>}', dump(circularInSet));
+
+  const nestedCircular = {};
+  nestedCircular['foo'] = {'bar': nestedCircular};
+  assertEquals('{"foo": {"bar": <duplicate>}}', dump(nestedCircular));
+});
 });  // goog.scope

--- a/common/js/src/logging/debug-dump-unittest.js
+++ b/common/js/src/logging/debug-dump-unittest.js
@@ -93,7 +93,7 @@ goog.exportSymbol('testDebugDumpWithCircularRefs', function() {
   assertEquals('{"foo": {"bar": <circular>}}', dump(nestedCircular));
 });
 
-// Test that the `dump()` method correct handles the case when an object is
+// Test that the `dump()` method correctly handles the case when an object is
 // linked from two different places: it shouldn't be confused with a circular
 // reference.
 goog.exportSymbol('testDebugDumpWithDuplicateRefs', function() {

--- a/common/js/src/logging/debug-dump.js
+++ b/common/js/src/logging/debug-dump.js
@@ -206,7 +206,7 @@ function dumpContainerRecursively(value, recursionParentObjects) {
   if (goog.isObject(value))
     return dumpObject(value, recursionParentObjects);
   // Fallback: this is an unknown type; let the built-in JSON stringification
-  // routine to produce something meaningful for it.
+  // routine produce something meaningful for it.
   return encodeJson(value);
 }
 


### PR DESCRIPTION
Make the JavaScript DebugDump helpers robust against circular
references in the input data. Achieve this by remembering the set
of already visited objects during the depth-first-search-like
traversal.

Previously, we only had an ad-hoc protection against such issues, by
checking for a few well-known types that typically contain circular
references, like the built-in Document type. Another ad-hoc protection
was catching and suppressing all exceptions thrown during the
traversal in the Release. The current commit doesn't delete these, since
the former makes logs more readable and the latter is a useful safety
belt.