### PR TITLE
[common] Optimize ArrayBuffer debug dumping

### DIFF
--- a/common/js/src/logging/debug-dump-unittest.js
+++ b/common/js/src/logging/debug-dump-unittest.js
@@ -47,8 +47,7 @@ goog.exportSymbol('testDebugDump', function() {
   assertEquals('[0x01, "foo", [0x02, 0x03], []]', dump([1, 'foo', [2, 3], []]));
 
   assertEquals('ArrayBuffer[]', dump(new ArrayBuffer(0)));
-  assertEquals(
-      'ArrayBuffer[0x01FF]', dump(new Uint8Array([1, 255]).buffer));
+  assertEquals('ArrayBuffer[0x01FF]', dump(new Uint8Array([1, 255]).buffer));
 
   assertEquals(
       'Map{0x01: 0x02, 0x03: "foo", "bar": {}, {}: 0x04}',

--- a/common/js/src/logging/debug-dump-unittest.js
+++ b/common/js/src/logging/debug-dump-unittest.js
@@ -46,8 +46,9 @@ goog.exportSymbol('testDebugDump', function() {
 
   assertEquals('[0x01, "foo", [0x02, 0x03], []]', dump([1, 'foo', [2, 3], []]));
 
+  assertEquals('ArrayBuffer[]', dump(new ArrayBuffer(0)));
   assertEquals(
-      'ArrayBuffer[0x01, 0xFF]', dump(new Uint8Array([1, 255]).buffer));
+      'ArrayBuffer[0x01FF]', dump(new Uint8Array([1, 255]).buffer));
 
   assertEquals(
       'Map{0x01: 0x02, 0x03: "foo", "bar": {}, {}: 0x04}',

--- a/common/js/src/logging/debug-dump.js
+++ b/common/js/src/logging/debug-dump.js
@@ -112,6 +112,19 @@ function dumpNumber(value) {
 }
 
 /**
+ * An optimized version of `dumpNumber()` for the case of an unsigned
+ * single-byte integer.
+ * @param {number} value
+ * @return {string}
+ */
+function dumpByte(value) {
+  const HEX_LENGTH_OF_BYTE = 2;
+  const hexValue = value.toString(16).toUpperCase();
+  const zeroPadding = goog.string.repeat('0', HEX_LENGTH_OF_BYTE - hexValue.length);
+  return `0x${zeroPadding}${hexValue}`;
+}
+
+/**
  * @param {string} value
  * @return {string}
  */
@@ -140,7 +153,11 @@ function dumpFunction(value) {
  * @return {string}
  */
 function dumpArrayBuffer(value) {
-  return 'ArrayBuffer[' + dumpSequenceItems(new Uint8Array(value)) + ']';
+  const bytes = new Uint8Array(value);
+  // Not using `dumpSequenceItems()` or `dumpNumber()` here, since we can avoid
+  // a lot of their overhead due to knowing the item type and boundaries.
+  const dumpedBytes = goog.iter.map(bytes, byte => dumpByte(byte));
+  return 'ArrayBuffer[' + goog.iter.join(dumpedBytes, ', ') + ']';
 }
 
 /**

--- a/common/js/src/logging/debug-dump.js
+++ b/common/js/src/logging/debug-dump.js
@@ -118,16 +118,14 @@ function dumpNumber(value) {
 }
 
 /**
- * An optimized version of `dumpNumber()` for the case of an unsigned
- * single-byte integer.
  * @param {number} value
  * @return {string}
  */
-function dumpByte(value) {
+function dumpArrayBufferByte(value) {
   const HEX_LENGTH_OF_BYTE = 2;
   const hexValue = value.toString(16).toUpperCase();
   const zeroPadding = goog.string.repeat('0', HEX_LENGTH_OF_BYTE - hexValue.length);
-  return `0x${zeroPadding}${hexValue}`;
+  return zeroPadding + hexValue;
 }
 
 /**
@@ -159,11 +157,15 @@ function dumpFunction(value) {
  * @return {string}
  */
 function dumpArrayBuffer(value) {
+  if (!value.byteLength)
+    return 'ArrayBuffer[]';
   const bytes = new Uint8Array(value);
-  // Not using `dumpSequenceItems()` or `dumpNumber()` here, since we can avoid
-  // a lot of their overhead due to knowing the item type and boundaries.
-  const dumpedBytes = goog.iter.map(bytes, byte => dumpByte(byte));
-  return 'ArrayBuffer[' + goog.iter.join(dumpedBytes, ', ') + ']';
+  // The format is different than the one `dump()` produces for arrays, and also
+  // directly calling `dumpArrayBufferByte()` is much faster than calling
+  // generic dump functions.
+  const dumpedBytes = goog.iter.map(bytes, byte => dumpArrayBufferByte(byte));
+  const concatenated = goog.iter.join(dumpedBytes, '');
+  return `ArrayBuffer[0x${concatenated}]`;
 }
 
 /**

--- a/common/js/src/logging/debug-dump.js
+++ b/common/js/src/logging/debug-dump.js
@@ -124,7 +124,8 @@ function dumpNumber(value) {
 function dumpArrayBufferByte(value) {
   const HEX_LENGTH_OF_BYTE = 2;
   const hexValue = value.toString(16).toUpperCase();
-  const zeroPadding = goog.string.repeat('0', HEX_LENGTH_OF_BYTE - hexValue.length);
+  const zeroPadding =
+      goog.string.repeat('0', HEX_LENGTH_OF_BYTE - hexValue.length);
   return zeroPadding + hexValue;
 }
 


### PR DESCRIPTION
Optimize the JavaScript DebugDump helper that deals with ArrayBuffers
and make the output format more compact (use a single "0x" instead of
prepending "0x" before every byte and using the ", " separator).

The previous implementation was doing lots of overhead by passing every
byte through a bunch of type and boundary checks. All of that is
unnecessary, as we know that after the type casting we're dealing with
an array of unsigned single-byte integers.

We don't have any measurements, but the inefficiency of the old version
could actually be user-visible, since we have a lot of log statements
that are calculated even in the Release mode (unlike when using C/C++,
it's not possible to automatically completely skip log message
calculation in JavaScript, even when we know that we're below the
current log level threshold).