### PR TITLE
Revert "[wasm] Specify COOP/COEP when using WebAssembly"

### DIFF
--- a/smart_card_connector_app/build/Makefile
+++ b/smart_card_connector_app/build/Makefile
@@ -111,7 +111,6 @@ $(OUT_DIR_PATH)/manifest.json: $(SOURCES_PATH)/create_app_manifest.py $(SOURCES_
 		--ccid-supported-readers-config-path="$(CCID_SUPPORTED_READERS_CONFIG_PATH)" \
 		--target-file-path="$(OUT_DIR_PATH)/manifest.json" \
 		--enable-condition="CONFIG=$(CONFIG)" \
-		--enable-condition="TOOLCHAIN=$(TOOLCHAIN)" \
 		--enable-condition="PACKAGING=$(PACKAGING)"
 
 generate_out: $(OUT_DIR_PATH)/manifest.json

--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -27,14 +27,6 @@ ${if PACKAGING=extension}
   },
   "content_security_policy": "script-src 'self' 'wasm-eval'; object-src 'self'",
 ${endif}
-${if TOOLCHAIN=emscripten}
-  "cross_origin_embedder_policy": {
-    "value": "require-corp"
-  },
-  "cross_origin_opener_policy": {
-    "value": "same-origin"
-  },
-${endif}
   "minimum_chrome_version": "48",
   "default_locale": "en",
   "icons": {


### PR DESCRIPTION
Reverts GoogleChromeLabs/chromeos_smart_card_connector#477

As it was discovered, the COOP policy causes multiple issues,
both in App and Extension modes: http://crbug.com/1275140,
http://crbug.com/1275145.

Hence reverting this commit for now, until the discussion on the
linked issues suggests the best path forward.