### PR TITLE
[common] Fix boolean debug dumping in JS

### DIFF
--- a/common/js/src/logging/debug-dump-unittest.js
+++ b/common/js/src/logging/debug-dump-unittest.js
@@ -32,6 +32,9 @@ goog.exportSymbol('testDebugDump', function() {
 
   assertEquals('null', dump(null));
 
+  assertEquals('false', dump(false));
+  assertEquals('true', dump(true));
+
   assertEquals('0x00', dump(0));
   assertEquals('0xFE', dump(254));
   assertEquals('0x00000100', dump(256));

--- a/common/js/src/logging/debug-dump.js
+++ b/common/js/src/logging/debug-dump.js
@@ -44,6 +44,14 @@ function encodeJson(value) {
 }
 
 /**
+ * @param {boolean} value
+ * @return {string}
+ */
+function dumpBoolean(value) {
+  return value ? 'true' : 'false';
+}
+
+/**
  * @param {number} value
  * @return {number}
  */
@@ -262,18 +270,26 @@ function dump(value, recursionParentObjects) {
     return 'undefined';
   if (value === null)
     return 'null';
-  if (typeof value === 'number')
-    return dumpNumber(value);
-  if (typeof value === 'string')
-    return dumpString(value);
+  switch (typeof value) {
+    case 'boolean':
+      return dumpBoolean(value);
+    case 'number':
+      return dumpNumber(value);
+    case 'string':
+      return dumpString(value);
+  }
   if (goog.functions.isFunction(value))
     return dumpFunction(value);
   if (value instanceof ArrayBuffer)
     return dumpArrayBuffer(value);
 
   // Detect circular references and prevent infinite recursion by checking
-  // against the values in the upper stack frames. Only do this after handling
-  // all non-recursive cases, in order to reduce the performance penalty.
+  // against the values in the upper stack frames.
+  if (!goog.isObject(value)) {
+    // `WeakSet` only supports objects, and normally all non-objects should be
+    // handled above. As a safety measure, exit here too.
+    return encodeJson(value);
+  }
   if (recursionParentObjects.has(value))
     return '<circular>';
   recursionParentObjects.add(value);


### PR DESCRIPTION
Fix the regression introduced by #481: the dump() function was throwing
this error when called with a boolean:

  TypeError: Invalid value used in weak set

The reason is that WeakSet, used by us in order to detect circular
references, doesn't support non-objects. And also that we also never
handle the boolean value explicitly - it was dumped by the fallback JSON
serialization (which might've been a small performance issue itself).

This commit fixes both aspects: it dumps booleans explicitly, but also
adds a safety fallback for non-objects before triggering WeakSet
operations.