### PR TITLE
[common] Improve debug logging of JS typed arrays

### DIFF
--- a/common/js/src/logging/debug-dump-unittest.js
+++ b/common/js/src/logging/debug-dump-unittest.js
@@ -67,6 +67,32 @@ goog.exportSymbol('testDebugDump', function() {
   assertEquals('<HTMLCollection>', dump(document.body.children));
 });
 
+goog.exportSymbol('testDebugDumpTypedArray', function() {
+  assertEquals('Uint8Array[]', dump(new Uint8Array(0)));
+  assertEquals('Uint8Array[0x01FF]', dump(new Uint8Array([1, 255])));
+  assertEquals('Uint16Array[]', dump(new Uint16Array(0)));
+  assertEquals(
+      'Uint16Array[0x01, 0x0000FFFF]', dump(new Uint16Array([1, 65535])));
+  assertEquals('Float32Array[]', dump(new Float32Array([])));
+  assertEquals('Float32Array[0.5, 2.5]', dump(new Float32Array([0.5, 2.5])));
+});
+
+goog.exportSymbol('testDebugDumpDataView', function() {
+  const emptyBuffer = new ArrayBuffer(0);
+  assertEquals('DataView[]', dump(new DataView(emptyBuffer)));
+
+  const buffer = (new Uint8Array([1, 16, 255])).buffer;
+  assertEquals('DataView[0x0110FF]', dump(new DataView(buffer)));
+  assertEquals(
+      'DataView[0x10FF]', dump(new DataView(buffer, /*byteOffset=*/ 1)));
+  assertEquals(
+      'DataView[0x10]',
+      dump(new DataView(buffer, /*byteOffset=*/ 1, /*byteLength=*/ 1)));
+  assertEquals(
+      'DataView[]',
+      dump(new DataView(buffer, /*byteOffset=*/ 1, /*byteLength=*/ 0)));
+});
+
 // Test the `dump()` method against container types with circular references: it
 // should detect the loops and avoid infinite recursion.
 goog.exportSymbol('testDebugDumpWithCircularRefs', function() {

--- a/common/js/src/logging/debug-dump.js
+++ b/common/js/src/logging/debug-dump.js
@@ -133,7 +133,7 @@ function dumpByte(value) {
  * @param {!Uint8Array} value
  * @return {string}
  */
-function dumpBytes(value) {
+function dumpByteArray(value) {
   if (!value.length)
     return '';
   // The format is different than the one `dump()` produces for arrays, and also
@@ -173,7 +173,7 @@ function dumpFunction(value) {
  * @return {string}
  */
 function dumpArrayBuffer(value) {
-  const dumpedBytes = dumpBytes(new Uint8Array(value));
+  const dumpedBytes = dumpByteArray(new Uint8Array(value));
   return `ArrayBuffer[${dumpedBytes}]`;
 }
 
@@ -182,7 +182,7 @@ function dumpArrayBuffer(value) {
  * @return {string}
  */
 function dumpDataView(value) {
-  const dumpedBytes = dumpBytes(
+  const dumpedBytes = dumpByteArray(
       new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
   return `DataView[${dumpedBytes}]`;
 }
@@ -197,7 +197,7 @@ function dumpTypedArray(value) {
   if (value instanceof Uint8Array) {
     // This is a fast branch, also the format for dumping bytes is more compact
     // than for generic sequences.
-    dumpedItems = dumpBytes(value);
+    dumpedItems = dumpByteArray(value);
   } else {
     const itemsAsString = goog.iter.map(value, item => dumpNumber(item));
     dumpedItems = goog.iter.join(itemsAsString, ', ');

--- a/common/js/src/logging/debug-dump.js
+++ b/common/js/src/logging/debug-dump.js
@@ -121,12 +121,27 @@ function dumpNumber(value) {
  * @param {number} value
  * @return {string}
  */
-function dumpArrayBufferByte(value) {
+function dumpByte(value) {
   const HEX_LENGTH_OF_BYTE = 2;
   const hexValue = value.toString(16).toUpperCase();
   const zeroPadding =
       goog.string.repeat('0', HEX_LENGTH_OF_BYTE - hexValue.length);
   return zeroPadding + hexValue;
+}
+
+/**
+ * @param {!Uint8Array} value
+ * @return {string}
+ */
+function dumpBytes(value) {
+  if (!value.length)
+    return '';
+  // The format is different than the one `dump()` produces for arrays, and also
+  // directly calling `dumpByte()` is much faster than calling generic dump
+  // functions.
+  const dumpedBytes = goog.iter.map(value, byte => dumpByte(byte));
+  const concatenated = goog.iter.join(dumpedBytes, '');
+  return `0x${concatenated}`;
 }
 
 /**
@@ -158,15 +173,36 @@ function dumpFunction(value) {
  * @return {string}
  */
 function dumpArrayBuffer(value) {
-  if (!value.byteLength)
-    return 'ArrayBuffer[]';
-  const bytes = new Uint8Array(value);
-  // The format is different than the one `dump()` produces for arrays, and also
-  // directly calling `dumpArrayBufferByte()` is much faster than calling
-  // generic dump functions.
-  const dumpedBytes = goog.iter.map(bytes, byte => dumpArrayBufferByte(byte));
-  const concatenated = goog.iter.join(dumpedBytes, '');
-  return `ArrayBuffer[0x${concatenated}]`;
+  const dumpedBytes = dumpBytes(new Uint8Array(value));
+  return `ArrayBuffer[${dumpedBytes}]`;
+}
+
+/**
+ * @param {!DataView} value
+ * @return {string}
+ */
+function dumpDataView(value) {
+  const dumpedBytes = dumpBytes(
+      new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
+  return `DataView[${dumpedBytes}]`;
+}
+
+/**
+ * @param {?} value
+ * @return {string}
+ */
+function dumpTypedArray(value) {
+  const typeName = value['constructor']['name'];
+  let dumpedItems;
+  if (value instanceof Uint8Array) {
+    // This is a fast branch, also the format for dumping bytes is more compact
+    // than for generic sequences.
+    dumpedItems = dumpBytes(value);
+  } else {
+    const itemsAsString = goog.iter.map(value, item => dumpNumber(item));
+    dumpedItems = goog.iter.join(itemsAsString, ', ');
+  }
+  return `${typeName}[${dumpedItems}]`;
 }
 
 /**
@@ -270,6 +306,11 @@ function dump(value, recursionParentObjects) {
     return dumpFunction(value);
   if (value instanceof ArrayBuffer)
     return dumpArrayBuffer(value);
+  if (ArrayBuffer.isView(value)) {
+    if (value instanceof DataView)
+      return dumpDataView(value);
+    return dumpTypedArray(value);
+  }
 
   // Detect circular references and prevent infinite recursion by checking
   // against the values in the upper stack frames. Only do this after handling


### PR DESCRIPTION
Improve the debugDump JavaScript helper to produce better formatting for
typed arrays (like Uint8Array) and to produce a non-empty dump for
DataViews.

Dumping a sample DataView: before:
  {}
after this commit:
  DataView[0x01FF]

Dumping a sample Uint8Array: before:
  {"0": 0x01, "1": 0xFF}
after this commit:
  Uint8Array[0x01FF]