### PR TITLE
[common] Skip the "chrome" global from dumping

### DIFF
--- a/common/js/src/logging/debug-dump-unittest.js
+++ b/common/js/src/logging/debug-dump-unittest.js
@@ -137,4 +137,17 @@ goog.exportSymbol('testDebugDumpWithDuplicateRefs', function() {
   const diamond = {'x': {'a': array}, 'y': {'b': array}};
   assertEquals('{"x": {"a": []}, "y": {"b": []}}', dump(diamond));
 });
+
+// Test that calling `dump()` with the `chrome` object (the object that holds
+// all Apps/Extensions APIs) returns a short string instead of recursively
+// dumping all its properties.
+// Skip this test when not running inside Chrome (otherwise we'd need to mock
+// global objects, which isn't reliable due to Closure Compiler optimizations).
+if (goog.global['chrome']) {
+  goog.exportSymbol('testDebugDumpChrome', function() {
+    const chrome = goog.global['chrome'];
+    assertEquals('<chrome>', dump(chrome));
+    assertEquals('[0x01, <chrome>]', dump([1, chrome]));
+  });
+}
 });  // goog.scope

--- a/common/js/src/logging/debug-dump.js
+++ b/common/js/src/logging/debug-dump.js
@@ -300,6 +300,8 @@ function dump(value, recursionParentObjects) {
   }
   if (value instanceof goog.Disposable)
     return '<Class>';
+  if (goog.global['chrome'] && value === goog.global['chrome'])
+    return '<chrome>';
 
   // Handle leaf types - the ones for which we don't make recursive calls.
   if (value === undefined)


### PR DESCRIPTION
Bail out from JavaScript debugDump when the "chrome" global object is
passed.

If some JS code accidentally passes the "chrome" object to the debugDump
function, the function was attempting to recursively dump its properties.
The resulting dump isn't of any use (it'll contain a list of Extensions
API functions), so it'd be a waste of resources, and additionally it'll
trigger console warnings due to accessing deprecated functions. Hence
handle the case of the "chrome" global object explicitly, even if no
code should normally pass it.