### PR TITLE
[pcsc] Make exceptions in listener not break logic

### DIFF
--- a/common/js/src/messaging/message-channel-pool.js
+++ b/common/js/src/messaging/message-channel-pool.js
@@ -115,7 +115,15 @@ MessageChannelPool.prototype.addOnUpdateListener = function(
 MessageChannelPool.prototype.fireOnUpdateListeners_ = function() {
   goog.log.fine(this.logger, 'Firing channel update listeners');
   for (let listener of this.onUpdateListeners_) {
-    listener(this.getMessagingOrigins());
+    try {
+      listener(this.getMessagingOrigins());
+    } catch (exc) {
+      // Rethrow the listener's exception asynchronously, in order to not break
+      // our caller and also to still notify the remaining listeners.
+      setTimeout(() => {
+        throw exc;
+      })
+    }
   }
 };
 

--- a/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
+++ b/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
@@ -186,7 +186,15 @@ ReaderTracker.prototype.fireOnUpdateListeners_ = function() {
       'Firing readers updated listeners with data ' +
           GSC.DebugDump.dump(readers));
   for (let listener of this.updateListeners_) {
-    listener(readers);
+    try {
+      listener(readers);
+    } catch (exc) {
+      // Rethrow the listener's exception asynchronously, in order to not break
+      // our caller and also to still notify the remaining listeners.
+      setTimeout(() => {
+        throw exc;
+      })
+    }
   }
 };
 


### PR DESCRIPTION
Wrap calls of some of listeners into try-catch, so that even when some
of them throw error it doesn't prevent others from being notified and,
more importantly, it doesn't bubble the exception throw the whole stack.

A real example where this helps is when the PC/SC server notifies that
the list of readers changes. This notification triggers the UI update,
which can throw an exception when the UI is already closed (while this
can be addressed separately, it's still an example of something we want
to defend against). If we don't catch the exception, it bubbles back
into the PC/SC-Lite server code, causing the reader initialization to be
aborted.