### PR TITLE
[usb] Fetch WebUSB extraData via handles

### DIFF
--- a/third_party/libusb/webport/src/libusb-to-webusb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-webusb-adaptor.js
@@ -331,7 +331,7 @@ GSC.LibusbToWebusbAdaptor = class extends GSC.LibusbToJsApiAdaptor {
   }
 
   /**
-   * Fills the extraData fields of the passed configurations, by fetching and
+   * Fills the extraData fields of all passed configurations by fetching and
    * parsing USB descriptors from the device.
    * @param {number} deviceId
    * @param {!Object} webusbDevice The WebUSB USBDevice object.
@@ -806,7 +806,7 @@ async function openWebusbDevice(deviceState) {
 }
 
 /**
- * Fills the extraData fields of the passed configuration, by fetching and
+ * Fills the extraData fields of the passed configuration by fetching and
  * parsing USB descriptors from the device.
  * @param {!Object} webusbDevice The WebUSB USBDevice value.
  * @param {!LibusbJsConfigurationDescriptor} libusbJsConfiguration


### PR DESCRIPTION
Switch the polyfill that fetches extraData from direct calls to WebUSB
open()/close() methods to using device handles. This allows to make sure
that we don't try to open a device twice (if a concurrent request is
started later), and that we don't close a device that's still in use
(again by some concurrent operation).

Also while doing this, apply a small optimization: don't open-close the
device for each configuration descriptor, but do this once for all
descriptors of a single device.