### PR TITLE
[nacl] Fix illegal offsetTop modification

### DIFF
--- a/common/js/src/nacl-module/nacl-module.js
+++ b/common/js/src/nacl-module/nacl-module.js
@@ -254,6 +254,8 @@ NaclModule.prototype.forceElementLoading_ = function() {
   // Request the offsetTop property to force a relayout. As of June 29, 2014,
   // this is needed if the module is being loaded in a background page (see
   // crbug.com/350445).
-  this.element_.offsetTop = this.element_.offsetTop;
+  // Assign the result to a random property, so that Closure Compiler doesn't
+  // optimize the "useless" expression away.
+  this.element_.style.top = this.element_.offsetTop;
 };
 });  // goog.scope


### PR DESCRIPTION
Stop trying to modify the Native Client embed's "offsetTop" property,
since it triggers an exception when the code uses "use strict":

  TypeError: Cannot set property offsetTop of #<HTMLElement> which has
  only a getter

This illegal assignment was silently ignored till #443 that added some
Closure Compiler parameters that specify the input/output language
version. Apparently, these new parameters also lead to the resulting
code containing "use strict", which in turn resulted in this exception
and the breakage when compiled in NaCl mode.

The fix is to write to value to a random other property, because we
don't actually care about the result: we only want an access to the
"offsetTop" property to be not optimized away by Closure Compiler, and
this access is itself a workaround for an old v8/NaCl bug with the
module not loading until this is done.