### PR TITLE
Revert "[wasm] Minify the Emscripten JS files"

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -123,13 +123,6 @@ EMSCRIPTEN_COMMON_FLAGS += \
 EMSCRIPTEN_COMPILER_FLAGS += \
   -DNDEBUG \
 
-# Add linker flags specific to release builds.
-#
-# Explanation:
-# closure=1: Minify the auxilliary .js file produced by Emscripten.
-EMSCRIPTEN_LINKER_FLAGS += \
-  --closure=1 \
-
 else ifeq ($(CONFIG),Debug)
 
 # Add compiler and linker flags specific to debug builds.


### PR DESCRIPTION
Reverts GoogleChromeLabs/chromeos_smart_card_connector#435.

Another bug was discovered in Emscripten related to this flag:
https://github.com/emscripten-core/emscripten/issues/15692
Until that issue is resolved, reverting our usage of the flag, so that
the Smart Card Connector works when built in Release mode.