### PR TITLE
[wasm] Keep background page forcibly

### DIFF
--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -146,6 +146,8 @@ if (GSC.ExecutableModule.TOOLCHAIN ===
   // background page always alive, and hence be responsive to incoming smart
   // card requests. The user who doesn't like extra resource usage can uninstall
   // our application if they don't actually use smart cards.
+  // This trick wasn't needed for NaCl, since Chrome was keeping the extension's
+  // page alive as long as the NaCl module is running.
   GSC.BackgroundPageUnloadPreventing.enable();
 }
 

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -17,6 +17,7 @@
 
 goog.provide('GoogleSmartCard.ConnectorApp.BackgroundMain');
 
+goog.require('GoogleSmartCard.BackgroundPageUnloadPreventing');
 goog.require('GoogleSmartCard.ConnectorApp.Background.MainWindowManaging');
 goog.require('GoogleSmartCard.EmscriptenModule');
 goog.require('GoogleSmartCard.ExecutableModule');
@@ -138,6 +139,15 @@ if (GSC.Packaging.MODE === GSC.Packaging.Mode.APP)
 chrome.runtime.onConnect.addListener(connectionListener);
 chrome.runtime.onConnectExternal.addListener(externalConnectionListener);
 chrome.runtime.onMessageExternal.addListener(externalMessageListener);
+
+if (GSC.ExecutableModule.TOOLCHAIN ===
+    GSC.ExecutableModule.Toolchain.EMSCRIPTEN) {
+  // Open a message channel to an invisible iframe, in order to keep our
+  // background page always alive, and hence be responsive to incoming smart
+  // card requests. The user who doesn't like extra resource usage can uninstall
+  // our application if they don't actually use smart cards.
+  GSC.BackgroundPageUnloadPreventing.enable();
+}
 
 /**
  * Called when the executable module is disposed of.


### PR DESCRIPTION
Make sure that the Smart Card Connector's background page is never
unloaded, even when the user and other applications don't communicate
with it. This allows to make sure that the Connector is responsive when
requests arrive to it.

This change is only needed for the Emscripten/WebAssembly mode, since
when using NaCl Chrome automatically keeps the page alive.