### PR TITLE
[common] Fix error handling in MessageChannelPair

### DIFF
--- a/common/js/src/messaging/message-channel-pair-unittest.js
+++ b/common/js/src/messaging/message-channel-pair-unittest.js
@@ -128,7 +128,7 @@ goog.exportSymbol(
 
       // Act: Send a message and dispose the channel pair immediately after
       // that. The message delivery should be canceled, because the channel
-      // pair's API guarantees it to happen asynchronously.
+      // pair's API guarantees the delivery to be asynchronous.
       messageChannelPair.getFirst().send(
           /*serviceName=*/ 'some-service', /*payload=*/ 'data');
       messageChannelPair.dispose();

--- a/common/js/src/messaging/message-channel-pair-unittest.js
+++ b/common/js/src/messaging/message-channel-pair-unittest.js
@@ -52,8 +52,9 @@ function failWhenReceivedUnexpectedMessage(messageChannel) {
 
 /**
  * @param {number} delayMilliseconds
+ * @return {!Promise<void>}
  */
-async function sleep(delayMilliseconds) {
+function sleep(delayMilliseconds) {
   return new Promise((resolve, reject) => {
     setTimeout(resolve, delayMilliseconds);
   });

--- a/common/js/src/messaging/message-channel-pair-unittest.js
+++ b/common/js/src/messaging/message-channel-pair-unittest.js
@@ -67,27 +67,25 @@ goog.exportSymbol('test_MessageChannelPair_sendViaSecond', function() {
 
 // That that the disposal of the channel pair causes disposing of both items of
 // the pair.
-goog.exportSymbol(
-    'test_MessageChannelPair_dispose', function() {
-      const messageChannelPair = new GSC.MessageChannelPair();
-      const first = messageChannelPair.getFirst();
-      const second = messageChannelPair.getSecond();
-      messageChannelPair.dispose();
-      assertTrue(first.isDisposed());
-      assertTrue(second.isDisposed());
-    });
+goog.exportSymbol('test_MessageChannelPair_dispose', function() {
+  const messageChannelPair = new GSC.MessageChannelPair();
+  const first = messageChannelPair.getFirst();
+  const second = messageChannelPair.getSecond();
+  messageChannelPair.dispose();
+  assertTrue(first.isDisposed());
+  assertTrue(second.isDisposed());
+});
 
 // That that the disposal of one item of the channel pair causes disposing of
 // the channel pair itself and the other item too.
-goog.exportSymbol(
-    'test_MessageChannelPair_disposeItem', function() {
-      const messageChannelPair = new GSC.MessageChannelPair();
-      const first = messageChannelPair.getFirst();
-      const second = messageChannelPair.getSecond();
-      first.dispose();
-      assertTrue(messageChannelPair.isDisposed());
-      assertTrue(second.isDisposed());
-    });
+goog.exportSymbol('test_MessageChannelPair_disposeItem', function() {
+  const messageChannelPair = new GSC.MessageChannelPair();
+  const first = messageChannelPair.getFirst();
+  const second = messageChannelPair.getSecond();
+  first.dispose();
+  assertTrue(messageChannelPair.isDisposed());
+  assertTrue(second.isDisposed());
+});
 
 // Test that the message to be sent is discarded if the channel pair is disposed
 // of before the sending task starts.

--- a/common/js/src/messaging/message-channel-pair-unittest.js
+++ b/common/js/src/messaging/message-channel-pair-unittest.js
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2021 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.require('GoogleSmartCard.MessageChannelPair');
+
+goog.setTestOnly();
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+// Send a message via the first item of the pair and check that it's received at
+// the second item of the pair.
+goog.exportSymbol('test_MessageChannelPair_sendViaFirst', function() {
+  return new Promise((resolve, reject) => {
+    const messageChannelPair = new GSC.MessageChannelPair();
+
+    // Set up the expectation - once the right message is received on the
+    // second item, make the test complete by resolving the promise.
+    messageChannelPair.getSecond().registerService(
+        /*serviceName=*/ 'some-service', (payload) => {
+          assertEquals(payload, 'data');
+          resolve();
+        });
+    // Any unexpected messages on the second item should abort the test.
+    messageChannelPair.getSecond().registerDefaultService((payload) => {
+      reject();
+    })
+
+    messageChannelPair.getFirst().send(
+        /*serviceName=*/ 'some-service', /*payload=*/ 'data');
+  });
+});
+
+// Inversion of the test above.
+goog.exportSymbol('test_MessageChannelPair_sendViaSecond', function() {
+  return new Promise((resolve, reject) => {
+    const messageChannelPair = new GSC.MessageChannelPair();
+
+    messageChannelPair.getFirst().registerService(
+        /*serviceName=*/ 'some-service', (payload) => {
+          assertEquals(payload, 'data');
+          resolve();
+        });
+    messageChannelPair.getFirst().registerDefaultService((payload) => {
+      reject();
+    })
+
+    messageChannelPair.getSecond().send(
+        /*serviceName=*/ 'some-service', /*payload=*/ 'data');
+  });
+});
+
+// That that the disposal of the channel pair causes disposing of both items of
+// the pair.
+goog.exportSymbol(
+    'test_MessageChannelPair_dispose', function() {
+      const messageChannelPair = new GSC.MessageChannelPair();
+      const first = messageChannelPair.getFirst();
+      const second = messageChannelPair.getSecond();
+      messageChannelPair.dispose();
+      assertTrue(first.isDisposed());
+      assertTrue(second.isDisposed());
+    });
+
+// That that the disposal of one item of the channel pair causes disposing of
+// the channel pair itself and the other item too.
+goog.exportSymbol(
+    'test_MessageChannelPair_disposeItem', function() {
+      const messageChannelPair = new GSC.MessageChannelPair();
+      const first = messageChannelPair.getFirst();
+      const second = messageChannelPair.getSecond();
+      first.dispose();
+      assertTrue(messageChannelPair.isDisposed());
+      assertTrue(second.isDisposed());
+    });
+
+// Test that the message to be sent is discarded if the channel pair is disposed
+// of before the sending task starts.
+goog.exportSymbol(
+    'test_MessageChannelPair_disposePairQuicklyAfterSend', function() {
+      return new Promise((resolve, reject) => {
+        const messageChannelPair = new GSC.MessageChannelPair();
+
+        // Abort the test if the message got delivered despite the disposal.
+        messageChannelPair.getSecond().registerDefaultService((payload) => {
+          reject();
+        })
+
+        messageChannelPair.getFirst().send(
+            /*serviceName=*/ 'some-service', /*payload=*/ 'data');
+        messageChannelPair.dispose();
+
+        // Wait for some time before resolving the test, to let the bug, if it's
+        // present, manifest itself. There's no reliable way to wait for this,
+        // since normally the message sent after disposal should be silently
+        // discarded.
+        setTimeout(resolve, 1000);
+      });
+    });
+});  // goog.scope

--- a/common/js/src/messaging/message-channel-pair-unittest.js
+++ b/common/js/src/messaging/message-channel-pair-unittest.js
@@ -135,8 +135,8 @@ goog.exportSymbol(
 
       // Assert: Wait for some time before resolving the test, to let the bug,
       // if it's present, manifest itself. There's no reliable way to wait for
-      // this, since normally the message sent after disposal should be
-      // silently discarded.
+      // this, since normally the message sent after disposal should be silently
+      // discarded.
       await sleep(/*delayMilliseconds=*/ 1000);
     });
 });  // goog.scope

--- a/common/js/src/messaging/message-channel-pair-unittest.js
+++ b/common/js/src/messaging/message-channel-pair-unittest.js
@@ -95,7 +95,7 @@ goog.exportSymbol('test_MessageChannelPair_sendViaSecond', async function() {
   assertEquals(await promiseForReceivedMessage, 'data');
 });
 
-// That that the disposal of the channel pair causes disposing of both items of
+// Test that the disposal of the channel pair causes disposing of both items of
 // the pair.
 goog.exportSymbol('test_MessageChannelPair_dispose', function() {
   const messageChannelPair = new GSC.MessageChannelPair();
@@ -106,7 +106,7 @@ goog.exportSymbol('test_MessageChannelPair_dispose', function() {
   assertTrue(second.isDisposed());
 });
 
-// That that the disposal of one item of the channel pair causes disposing of
+// Test that the disposal of one item of the channel pair causes disposing of
 // the channel pair itself and the other item too.
 goog.exportSymbol('test_MessageChannelPair_disposeItem', function() {
   const messageChannelPair = new GSC.MessageChannelPair();

--- a/common/js/src/messaging/message-channel-pair-unittest.js
+++ b/common/js/src/messaging/message-channel-pair-unittest.js
@@ -99,6 +99,9 @@ goog.exportSymbol(
           reject();
         })
 
+        // Send a message and dispose the channel pair immediately after that.
+        // The message delivery should be canceled, because the channel pair's
+        // API guarantees it to happen asynchronously.
         messageChannelPair.getFirst().send(
             /*serviceName=*/ 'some-service', /*payload=*/ 'data');
         messageChannelPair.dispose();

--- a/common/js/src/messaging/message-channel-pair.js
+++ b/common/js/src/messaging/message-channel-pair.js
@@ -103,11 +103,16 @@ MessageChannelPair.prototype.disposeInternal = function() {
  */
 MessageChannelPair.prototype.sendFrom_ = function(
     fromItemIndex, serviceName, payload) {
-  const targetItem = this.items_[1 - fromItemIndex];
   // Deliver the message to the target message channel asynchronously, because
   // that's how the real message channels usually work.
-  goog.async.nextTick(
-      targetItem.deliver_.bind(targetItem, serviceName, payload));
+  goog.async.nextTick(() => {
+    if (this.isDisposed()) {
+      // Bail out if we got disposed of in the meantime.
+      return;
+    }
+    const targetItem = this.items_[1 - fromItemIndex];
+    targetItem.deliver_(serviceName, payload);
+  });
 };
 
 /**
@@ -136,6 +141,9 @@ MessageChannelPairItem.prototype.send = function(serviceName, payload) {
 
 /** @override */
 MessageChannelPairItem.prototype.disposeInternal = function() {
+  // Our disposal triggers the disposal of the whole pair and, hence, disposal
+  // of the second item of the pair.
+  this.messageChannelPair_.dispose();
   this.messageChannelPair_ = undefined;
   MessageChannelPairItem.base(this, 'disposeInternal');
 };
@@ -146,6 +154,7 @@ MessageChannelPairItem.prototype.disposeInternal = function() {
  * @private
  */
 MessageChannelPairItem.prototype.deliver_ = function(serviceName, payload) {
+  GSC.Logging.checkWithLogger(logger, !this.isDisposed());
   this.deliver(serviceName, payload);
 };
 });  // goog.scope

--- a/common/js/src/messaging/message-channel-pair.js
+++ b/common/js/src/messaging/message-channel-pair.js
@@ -44,6 +44,9 @@ const logger = GSC.Logging.getScopedLogger('MessageChannelPair');
  *
  * When a message is sent through one message channel from the pair, it gets
  * received by the other message channel from the pair, and vice versa.
+ *
+ * Note that messages that are sent through the channel pair are always
+ * delivered asynchronously.
  * @constructor
  * @extends goog.Disposable
  */


### PR DESCRIPTION
Fix a corner case in the MessageChannelPair which could lead to the
"cannot read property of undefined" exception in some error handling
scenarios.

The problem was that if one channel of the pair gets destroyed quickly
after the message is sent to it, by the time it's delivered (which
happens asynchronously) we were trying to find the message handler using
already cleared data members. An example when this can happen is when
the Emscripten module fails to load (repro example: set a breakpoint in
DevTools shortly after we start loading the module, wait a minute after the
breakpoint is hit and then continue), and the exception would be triggered
while trying to deliver a PC/SC command message to the module.

The fix has two parts: first, check the disposal state right before
delivering the message, and, second, propagate the disposal of any of
the pair's items to the other item too.