### PR TITLE
[wasm] Fix background page keepalive

### DIFF
--- a/smart_card_connector_app/build/Makefile
+++ b/smart_card_connector_app/build/Makefile
@@ -142,6 +142,16 @@ $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/about-window.html))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/about-window.css))
 
 
+# Rules for the background page unload preventing feature. This feature is only
+# used in the Emscripten builds - see the src/background.js file for
+# explanation. Here we add rules that compile the .js file for the iframe and
+# copy it, together with an .html file, to the out directory.
+
+ifeq ($(TOOLCHAIN),emscripten)
+$(eval $(JS_COMMON_BACKGROUND_PAGE_UNLOAD_PREVENTING_IFRAME_RULE))
+endif
+
+
 # Rules for running unit tests.
 
 test:: all

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -177,6 +177,14 @@ function launchedListener() {
  */
 function connectionListener(port) {
   goog.log.fine(logger, 'Received onConnect event');
+  if (port.name === GSC.BackgroundPageUnloadPreventing.MESSAGING_PORT_NAME) {
+    // The opener is the iframe that's loaded by
+    // `GSC.BackgroundPageUnloadPreventing.enable()`. That component sets up its
+    // own onConnect event listener and manages the port itself, so just ignore
+    // it here.
+    return;
+  }
+  // The opener will send PC/SC commands - create a handler for processing them.
   const portMessageChannel = new GSC.PortMessageChannel(port);
   createClientHandler(portMessageChannel, undefined);
 }
@@ -194,6 +202,9 @@ function externalConnectionListener(port) {
         'Ignoring the external connection as there is no sender specified');
     return;
   }
+  // The opener will send PC/SC commands (or garbage if it's broken) - create a
+  // handler for processing these commands. Also add it to the pool of opened
+  // ports, so that subscribers (like UI) will learn about this new caller.
   messageChannelPool.addChannel(
       portMessageChannel.messagingOrigin, portMessageChannel);
   GSC.MessagingCommon.setNonFatalDefaultServiceCallback(portMessageChannel);


### PR DESCRIPTION
Fix the logic that forcibly keeps the Smart Card Connector'
background page alive. It was enabled in #499, however it turns out it
didn't work correctly for two reasons: first, we didn't copy the
needed .js+.html files into the Connector, and, second, the Connector's
background page gets confused by a messaging port opened by the iframe.

This commit addresses both of the problems, by invoking the necessary
build command in the makefile and by fixing the background page to
ignore the iframe's port. Additionally the commit improves some comments
and downgrades the failure to stay alive from a fatal exception to a
warning (we shouldn't do harakiri just because of the suspend event).