### PR TITLE
Undo unwanted change to permission popup width

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
@@ -52,7 +52,7 @@ const USER_PROMPT_DIALOG_URL =
     'pcsc_lite_server_clients_management/user-prompt-dialog.html';
 
 const USER_PROMPT_DIALOG_WINDOW_OPTIONS_OVERRIDES = {
-  'width': 500
+  'width': 300
 };
 
 const GSC = GoogleSmartCard;


### PR DESCRIPTION
This PR undoes an unwanted width change to the permission prompt popup window.