### PR TITLE
[logging] Lower severity of loginState message

### DIFF
--- a/third_party/libusb/webport/src/chrome_usb/chrome-login-state-hook.js
+++ b/third_party/libusb/webport/src/chrome_usb/chrome-login-state-hook.js
@@ -51,10 +51,11 @@ GSC.LibusbLoginStateHook = class extends GSC.LibusbProxyHook {
     if (chrome && chrome.loginState) {
       chrome.loginState.getProfileType(this.onGotProfileType_.bind(this));
     } else {
-      goog.log.warning(
+      goog.log.info(
           logger,
-          'chrome.loginState API is not available. This app might require a ' +
-              'newer version of Chrome.');
+          'chrome.loginState API is not available (either the Chrome OS ' +
+              'version is too old or a different OS is used). Will skip ' +
+              'observing OS session state.');
       this.resolveInitializationPromise_();
     }
   }


### PR DESCRIPTION
Downgrade the logging about the lack of the chrome.loginState API from
warning to info - it's a non-fatal error, and it's expected when run on
desktop OSes.

This warning has confused a number of people because chrome://extensions
surfaces all warnings as if they were errors.