### PR TITLE
Re-apply "Patch the Closure Library to fix the test runner in Debug m…

### DIFF
--- a/third_party/closure-library/src/closure/goog/testing/testrunner.js
+++ b/third_party/closure-library/src/closure/goog/testing/testrunner.js
@@ -470,7 +470,7 @@ goog.testing.TestRunner.prototype.writeLog = function(log) {
       a.textContent = '(run individually)';
       a.style.fontSize = '0.8em';
       a.style.color = '#888';
-      goog.dom.safe.setAnchorHref(a, href);
+      a.href = href;
       div.appendChild(document.createTextNode(' '));
       div.appendChild(a);
     }


### PR DESCRIPTION
…ode"

This commit was lost when upreving Closure Library last time. Original
description:

> This fixes the recent regression in the Closure Library, where the test
> runner started to break when running in Debug mode from "file:///" URLs.
>
> Some details:
>
> https://github.com/google/closure-library/issues/872