### PR TITLE
[wasm] Abort if Emscripten is too old

### DIFF
--- a/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.cc
+++ b/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.cc
@@ -50,7 +50,7 @@ extern "C" {
 
 #include "server_sockets_manager.h"
 
-// Old version of Emscripten have buggy multi-threading - so bail out if the
+// Old versions of Emscripten have buggy multi-threading - so bail out if the
 // developer still hasn't updated their local Emscripten version.
 #ifdef __EMSCRIPTEN__
 #if __EMSCRIPTEN_major__ < 2 ||                                \

--- a/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.cc
+++ b/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.cc
@@ -50,6 +50,16 @@ extern "C" {
 
 #include "server_sockets_manager.h"
 
+// Old version of Emscripten have buggy multi-threading - so bail out if the
+// developer still hasn't updated their local Emscripten version.
+#ifdef __EMSCRIPTEN__
+#if __EMSCRIPTEN_major__ < 2 ||                                \
+    (__EMSCRIPTEN_major__ == 2 && __EMSCRIPTEN_minor__ == 0 && \
+     __EMSCRIPTEN_tiny__ < 31)
+#error "Emscripten >=2.0.31 must be used"
+#endif
+#endif  // __EMSCRIPTEN__
+
 namespace google_smart_card {
 
 namespace {


### PR DESCRIPTION
Explicitly abort the compilation if the used version of Emscripten is
too old. Our env/initialize.sh already installs a reasonably good
version, so this commit adds protection for the case the developer ran
this script a long time ago or is trying to use their own old Emscripten
checkout.