### PR TITLE
[wasm] Fix crash on zero-size read/write

### DIFF
--- a/common/cpp/src/google_smart_card_common/ipc_emulation.cc
+++ b/common/cpp/src/google_smart_card_common/ipc_emulation.cc
@@ -80,7 +80,9 @@ class IpcEmulation::InMemoryFile final {
     GOOGLE_SMART_CARD_CHECK(size >= 0);
     if (!size)
       return true;
+    // Check it here, since `data==nullptr && size==0` is OK.
     GOOGLE_SMART_CARD_CHECK(data);
+
     const std::shared_ptr<InMemoryFile> locked_other_end = other_end_.lock();
     if (!locked_other_end)
       return false;
@@ -98,8 +100,13 @@ class IpcEmulation::InMemoryFile final {
 
   IpcEmulation::ReadResult Read(uint8_t* buffer, int64_t* in_out_size)
       GOOGLE_SMART_CARD_WARN_UNUSED_RESULT {
-    GOOGLE_SMART_CARD_CHECK(buffer);
+    GOOGLE_SMART_CARD_CHECK(in_out_size);
     GOOGLE_SMART_CARD_CHECK(*in_out_size >= 0);
+    if (!*in_out_size)
+      return IpcEmulation::ReadResult::kSuccess;
+    // Check it here, since `buffer==nullptr && *in_out_size==0` is OK.
+    GOOGLE_SMART_CARD_CHECK(buffer);
+
     std::unique_lock<std::mutex> lock(mutex_);
     if (is_closed_)
       return IpcEmulation::ReadResult::kNoSuchFile;
@@ -232,8 +239,12 @@ bool IpcEmulation::CloseInMemoryFile(int file_descriptor) {
 bool IpcEmulation::WriteToInMemoryFile(int file_descriptor,
                                        const uint8_t* data,
                                        int64_t size) {
-  GOOGLE_SMART_CARD_CHECK(data);
   GOOGLE_SMART_CARD_CHECK(size >= 0);
+  if (!size)
+    return true;
+  // Check it here, since `data==nullptr && size==0` is OK.
+  GOOGLE_SMART_CARD_CHECK(data);
+
   const std::shared_ptr<InMemoryFile> file =
       FindFileByDescriptor(file_descriptor);
   if (!file)
@@ -255,9 +266,13 @@ IpcEmulation::ReadResult IpcEmulation::ReadFromInMemoryFile(
     int file_descriptor,
     uint8_t* buffer,
     int64_t* in_out_size) {
-  GOOGLE_SMART_CARD_CHECK(buffer);
   GOOGLE_SMART_CARD_CHECK(in_out_size);
   GOOGLE_SMART_CARD_CHECK(*in_out_size >= 0);
+  if (!*in_out_size)
+    return IpcEmulation::ReadResult::kSuccess;
+  // Check it here, since `buffer==nullptr && *in_out_size==0` is OK.
+  GOOGLE_SMART_CARD_CHECK(buffer);
+
   const std::shared_ptr<InMemoryFile> file =
       FindFileByDescriptor(file_descriptor);
   if (!file)

--- a/common/cpp/src/google_smart_card_common/ipc_emulation_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/ipc_emulation_unittest.cc
@@ -134,7 +134,7 @@ TEST_F(IpcEmulationTest, WriteAndBlockingRead) {
       IpcEmulation::ReadResult::kNoSuchFile);
 }
 
-TEST_F(IpcEmulationTest, WriteAndZeroBytes) {
+TEST_F(IpcEmulationTest, WriteAndReadZeroBytes) {
   int fd1 = -1, fd2 = -1;
   ipc_emulation()->CreateInMemoryFilePair(&fd1, &fd2,
                                           /*reads_should_block=*/false);

--- a/common/cpp/src/google_smart_card_common/ipc_emulation_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/ipc_emulation_unittest.cc
@@ -134,4 +134,18 @@ TEST_F(IpcEmulationTest, WriteAndBlockingRead) {
       IpcEmulation::ReadResult::kNoSuchFile);
 }
 
+TEST_F(IpcEmulationTest, WriteAndZeroBytes) {
+  int fd1 = -1, fd2 = -1;
+  ipc_emulation()->CreateInMemoryFilePair(&fd1, &fd2,
+                                          /*reads_should_block=*/false);
+
+  EXPECT_TRUE(ipc_emulation()->WriteToInMemoryFile(fd1, nullptr, 0));
+  int64_t read_count = 0;
+  EXPECT_EQ(ipc_emulation()->ReadFromInMemoryFile(fd2, nullptr, &read_count),
+            IpcEmulation::ReadResult::kSuccess);
+
+  EXPECT_TRUE(ipc_emulation()->CloseInMemoryFile(fd1));
+  EXPECT_TRUE(ipc_emulation()->CloseInMemoryFile(fd2));
+}
+
 }  // namespace google_smart_card


### PR DESCRIPTION
Fix the ipc_emulation library to allow reads/writes to in-memory files
when both the buffer is null and the size is zero. Before this commit,
the library was crashing on these.

The example case in which this could happen is when the Smart Card
Connector is receiving a command, like SCardControl, which has a buffer
parameter equal to an empty array. In that case our C++ handler creates
a zero-sized std::vector, calls data() on it and passes the result to
the C PC/SC-Lite code, which in turn writes this data to an in-memory
file. The C++ Standard allows data() to return nullptr when the size is
zero, hence we were hitting the crash in ipc_emulation.

The fix is to simply quickly exit when the read/write size is zero. We
don't even check the file correctness before doing this -
POSIX-specified contract on read()/write() implementations doesn't
require to do so.