### PR TITLE
[js] Compile using use_types_for_optimization

### DIFF
--- a/common/make/js_building_common.mk
+++ b/common/make/js_building_common.mk
@@ -114,6 +114,8 @@ endif
 #   inheritance and promote this to jscomp_error.
 # jscomp_off unknownDefines: Suppressed in order to avoid compiler complaints
 #   when an unused constant is passed via --define.
+# use_types_for_optimization: Allow compiler to do code optimizations based on
+#   type annotations.
 JS_BUILD_COMPILATION_FLAGS += \
 	--define='GoogleSmartCard.ExecutableModule.TOOLCHAIN=$(TOOLCHAIN)' \
 	--define='GoogleSmartCard.Logging.USE_SCOPED_LOGGERS=false' \
@@ -126,7 +128,7 @@ JS_BUILD_COMPILATION_FLAGS += \
 	--jscomp_off reportUnknownTypes \
 	--jscomp_off strictMissingProperties \
 	--jscomp_off unknownDefines \
-	--use_types_for_optimization=false \
+	--use_types_for_optimization=true \
 	--warning_level=VERBOSE \
 
 ifeq ($(PACKAGING),app)


### PR DESCRIPTION
Specify the use_types_for_optimization flag as true to Closure Compiler.

This allows to optimize the resulting file significantly better - at
least the size is decreased by 13%. For the background, originally in
this project we only used "safe" options of Closure Compiler and
disabled all optimizations, but the paradigm shifted and we started to
pay more attention to minimizing and speeding up the resulting program.