### PR TITLE
Unsubscribe reader when extension popup is closed

### DIFF
--- a/smart_card_connector_app/src/window-devices-displaying.js
+++ b/smart_card_connector_app/src/window-devices-displaying.js
@@ -312,7 +312,7 @@ function initializeWithBackgroundPage(backgroundPage) {
       readerTrackerUnsubscriber(onReadersChanged);
     });
   } else if (GSC.Packaging.MODE === GSC.Packaging.Mode.EXTENSION) {
-    chrome.windows.onRemoved.addListener(function() {
+    window.addEventListener('unload', function() {
       readerTrackerUnsubscriber(onReadersChanged);
     });
   }


### PR DESCRIPTION
This PR fixes readers not being unsubscribed when SCC window is closed in the extension mode.

This is to prevent onReadersChanged() to be called when the UI is closed, since it'll try to update a not-existing-anymore UI controls, causing an exception.