### PR TITLE
Update Emscripten to 3.1.2

### DIFF
--- a/env/constants.sh
+++ b/env/constants.sh
@@ -18,7 +18,7 @@
 DEPOT_TOOLS_REPOSITORY_URL="https://chromium.googlesource.com/chromium/tools/depot_tools.git"
 
 EMSCRIPTEN_SDK_REPOSITORY_URL="https://github.com/emscripten-core/emsdk.git"
-EMSCRIPTEN_VERSION="2.0.31"
+EMSCRIPTEN_VERSION="3.1.2"
 
 NACL_SDK_VERSION="47"
 


### PR DESCRIPTION
Uprev the pinned third-party dependency - Emscripten - to 3.1.2.

This update is not strictly required, but Emscripten seems to have fixed a few
bugs and also got updated to use LLVM 13.