### PR TITLE
[js] Fix unit tests for optimized mode

### DIFF
--- a/common/js/src/container-helpers-unittest.js
+++ b/common/js/src/container-helpers-unittest.js
@@ -30,12 +30,12 @@ const substituteArrayBuffersRecursively =
 goog.exportSymbol('testBuildObjectFromMap', function() {
   assertObjectEquals(buildObjectFromMap(new Map), {});
   assertObjectEquals(
-      buildObjectFromMap(new Map([['key', 'value']])), {key: 'value'});
+      buildObjectFromMap(new Map([['key', 'value']])), {'key': 'value'});
   assertObjectEquals(
       buildObjectFromMap(new Map([['key1', 'value1'], ['key2', 'value2']])),
-      {key1: 'value1', key2: 'value2'});
+      {'key1': 'value1', 'key2': 'value2'});
   // Test cases where keys and/or values are not strings.
-  assertObjectEquals(buildObjectFromMap(new Map([['key', 123]])), {key: 123});
+  assertObjectEquals(buildObjectFromMap(new Map([['key', 123]])), {'key': 123});
   assertObjectEquals(
       buildObjectFromMap(new Map([[123, 'value']])), {123: 'value'});
   assertObjectEquals(

--- a/common/js/src/messaging/message-channel-pinging.js
+++ b/common/js/src/messaging/message-channel-pinging.js
@@ -51,17 +51,38 @@ const PINGER_LOGGER_TITLE = 'Pinger';
 const PING_RESPONDER_LOGGER_TITLE = 'PingResponder';
 const CHANNEL_ID_MESSAGE_KEY = 'channel_id';
 
+/**
+ * This constant represents the timeout in milliseconds after which the channel
+ * is considered dead.
+ */
+const PINGER_TIMEOUT_MILLISECONDS = goog.DEBUG ? 20 * 1000 : 600 * 1000;
+
+/**
+ * This constant represents the time in milliseconds between consecutive ping
+ * requests.
+ */
+const PINGER_INTERVAL_MILLISECONDS = goog.DEBUG ? 1 * 1000 : 10 * 1000;
+
 const GSC = GoogleSmartCard;
+
+// The implementation in this file relies on the interval to be stricly smaller
+// than the timeout.
+goog.asserts.assert(PINGER_INTERVAL_MILLISECONDS < PINGER_TIMEOUT_MILLISECONDS);
+
+// Used for overriding `PINGER_TIMEOUT_MILLISECONDS` and
+// `PINGER_INTERVAL_MILLISECONDS` constants in tests.
+let timeoutOverrideForTesting = null;
+let intervalOverrideForTesting = null;
 
 /**
  * This class implements pinging of the specified message channel.
  *
  * Upon construction and then later with some periodicity (see the
- * PINGER_INTERVAL_MILLISECONDS constant), a special "ping" message is sent
+ * `PINGER_INTERVAL_MILLISECONDS` constant), a special "ping" message is sent
  * through the message channel. Also the class subscribes itself for receiving
  * the special "pong" messages through the channel. If no responses are received
- * within some timeout (see the PINGER_TIMEOUT_MILLISECONDS constant) or if the
- * received response is incorrect, then the message channel is immediately
+ * within some timeout (see the `PINGER_TIMEOUT_MILLISECONDS` constant) or if
+ * the received response is incorrect, then the message channel is immediately
  * disposed.
  *
  * Note that the "pong" message should contain the special channel identifier,
@@ -114,25 +135,22 @@ const Pinger = GSC.MessageChannelPinging.Pinger;
 
 goog.inherits(Pinger, goog.Disposable);
 
-/**
- * This constant represents the timeout in milliseconds after which the channel
- * is considered dead.
- * @const
- */
-Pinger.TIMEOUT_MILLISECONDS = goog.DEBUG ? 20 * 1000 : 600 * 1000;
-
-/**
- * This constant represents the time in milliseconds between consecutive ping
- * requests.
- *
- * Note that Pinger.INTERVAL_MILLISECONDS < Pinger.TIMEOUT_MILLISECONDS needs to
- * hold because of how pinging is implemented here.
- * @const
- */
-Pinger.INTERVAL_MILLISECONDS = goog.DEBUG ? 1 * 1000 : 10 * 1000;
-
 /** @const */
 Pinger.SERVICE_NAME = 'ping';
+
+/**
+ * @param {number|null} timeoutMilliseconds
+ */
+Pinger.overrideTimeoutForTesting = function(timeoutMilliseconds) {
+  timeoutOverrideForTesting = timeoutMilliseconds;
+};
+
+/**
+ * @param {number|null} intervalMilliseconds
+ */
+Pinger.overrideIntervalForTesting = function(intervalMilliseconds) {
+  intervalOverrideForTesting = intervalMilliseconds;
+};
 
 /**
  * @return {!Object}
@@ -238,15 +256,20 @@ Pinger.prototype.postPingMessageAndScheduleNext_ = function() {
 Pinger.prototype.schedulePostingPingMessage_ = function() {
   if (this.isDisposed())
     return;
-  goog.Timer.callOnce(
-      this.postPingMessageAndScheduleNext_, Pinger.INTERVAL_MILLISECONDS, this);
+  const interval = intervalOverrideForTesting !== null ?
+      intervalOverrideForTesting :
+      PINGER_INTERVAL_MILLISECONDS;
+  goog.Timer.callOnce(this.postPingMessageAndScheduleNext_, interval, this);
 };
 
 /** @private */
 Pinger.prototype.scheduleTimeoutTimer_ = function() {
   GSC.Logging.checkWithLogger(this.logger, this.timeoutTimerId_ === null);
-  this.timeoutTimerId_ = goog.Timer.callOnce(
-      this.timeoutCallback_.bind(this), Pinger.TIMEOUT_MILLISECONDS, this);
+  const timeout = timeoutOverrideForTesting !== null ?
+      timeoutOverrideForTesting :
+      PINGER_TIMEOUT_MILLISECONDS;
+  this.timeoutTimerId_ =
+      goog.Timer.callOnce(this.timeoutCallback_.bind(this), timeout, this);
 };
 
 /** @private */

--- a/common/js/src/messaging/message-channel-pinging.js
+++ b/common/js/src/messaging/message-channel-pinging.js
@@ -65,7 +65,7 @@ const PINGER_INTERVAL_MILLISECONDS = goog.DEBUG ? 1 * 1000 : 10 * 1000;
 
 const GSC = GoogleSmartCard;
 
-// The implementation in this file relies on the interval to be stricly smaller
+// The implementation in this file relies on the interval to be strictly smaller
 // than the timeout.
 goog.asserts.assert(PINGER_INTERVAL_MILLISECONDS < PINGER_TIMEOUT_MILLISECONDS);
 

--- a/common/js/src/requesting/requester-unittest.js
+++ b/common/js/src/requesting/requester-unittest.js
@@ -19,6 +19,7 @@ goog.require('GoogleSmartCard.Requester');
 goog.require('GoogleSmartCard.RequesterMessage');
 goog.require('GoogleSmartCard.RequesterMessage.RequestMessageData');
 goog.require('GoogleSmartCard.RequesterMessage.ResponseMessageData');
+goog.require('goog.reflect');
 goog.require('goog.testing.MockControl');
 goog.require('goog.testing.jsunit');
 goog.require('goog.testing.messaging.MockMessageChannel');
@@ -129,7 +130,8 @@ goog.exportSymbol('testRequester', function() {
     // Hack: call the protected disposeInternal() method in order to trigger the
     // disposal notifications; the MockMessageChannel.dispose() doesn't call
     // them.
-    mockMessageChannel['disposeInternal']();
+    mockMessageChannel[goog.reflect.objectProperty(
+        'disposeInternal', mockMessageChannel)]();
     return request0Promise.then(null, function(rejectionError) {
       assert(request0PromiseTracker.isResolved);
       assert(request1PromiseTracker.isResolved);

--- a/smart_card_connector_app/src/window-apps-displaying.js
+++ b/smart_card_connector_app/src/window-apps-displaying.js
@@ -26,7 +26,7 @@ goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.MessagingOrigin');
 goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientInfo');
-goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientsRegistry');
+goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientsRegistryImpl');
 goog.require('goog.Promise');
 goog.require('goog.array');
 goog.require('goog.asserts');
@@ -46,7 +46,8 @@ const logger = GSC.Logging.getScopedLogger('ConnectorApp.MainWindow');
 const appListElement =
     /** @type {!Element} */ (goog.dom.getElement('app-list'));
 
-const trustedClientsRegistry = new GSC.PcscLiteServer.TrustedClientsRegistry();
+const trustedClientsRegistry =
+    new GSC.PcscLiteServer.TrustedClientsRegistryImpl();
 
 /**
  * @type {goog.Promise.<!Array.<!TrustedClientInfo>>?}
@@ -98,10 +99,12 @@ function onUpdateListener(clientOriginList) {
   trustedClientInfosPromise.then(
       function(trustedClientInfos) {
         updateAppView(
-            trustedClientInfosPromise, sortedClientOriginList, trustedClientInfos);
+            trustedClientInfosPromise, sortedClientOriginList,
+            trustedClientInfos);
       },
       function(error) {
-        if (!updateAppView(trustedClientInfosPromise, sortedClientOriginList, null))
+        if (!updateAppView(
+                trustedClientInfosPromise, sortedClientOriginList, null))
           return;
 
         goog.log.warning(logger, 'Couldn\'t resolve client origins: ' + error);

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittest.js
@@ -63,7 +63,7 @@ const MockedDialogBehavior = {
 };
 
 /**
- * A fake implementtion of `TrustedClientsRegistry`.
+ * A fake implementation of `TrustedClientsRegistry`.
  *
  * It's only aware of `FAKE_CLIENT_1_ORIGIN`.
  * @implements {TrustedClientsRegistry}


### PR DESCRIPTION
Fix a few tests to make them work in the advanced optimizations mode of
Closure Compiler. This paves the way for enabling this mode in unit
tests in Release builds - currently tests are built without
optimizations, which puts us under risk of shipping broken code.

The challenge with unit tests is that many mocking tricks are broken
when the compiler renames fields and methods, inlines function calls
and substitutes constants. Hence in this commit we go back to classic
methods like "overrideXForTesting" and class inheritance in a few
places - these approaches are guaranteed to work with any kind of
optimizations.

Other issues fixed in this commit are mostly related to quoting object
properties where needed, in case the test injects or expects data in
particular format.