### PR TITLE
[js] Fix Closure Library jsunit in optimized mode

### DIFF
--- a/third_party/closure-library/src/closure/goog/testing/testcase.js
+++ b/third_party/closure-library/src/closure/goog/testing/testcase.js
@@ -2013,8 +2013,8 @@ goog.testing.TestCase.Test = function(name, ref, scope, objChain) {
 
   if (objChain) {
     for (var i = 0; i < objChain.length; i++) {
-      if (typeof objChain[i].setUp === 'function') {
-        this.setUps.push(goog.bind(objChain[i].setUp, objChain[i]));
+      if (typeof objChain[i]['setUp'] === 'function') {
+        this.setUps.push(goog.bind(objChain[i]['setUp'], objChain[i]));
       }
       if (typeof objChain[i].tearDown === 'function') {
         this.tearDowns.push(goog.bind(objChain[i].tearDown, objChain[i]));

--- a/third_party/closure-library/src/closure/goog/testing/testcase.js
+++ b/third_party/closure-library/src/closure/goog/testing/testcase.js
@@ -2016,8 +2016,8 @@ goog.testing.TestCase.Test = function(name, ref, scope, objChain) {
       if (typeof objChain[i]['setUp'] === 'function') {
         this.setUps.push(goog.bind(objChain[i]['setUp'], objChain[i]));
       }
-      if (typeof objChain[i].tearDown === 'function') {
-        this.tearDowns.push(goog.bind(objChain[i].tearDown, objChain[i]));
+      if (typeof objChain[i]['tearDown'] === 'function') {
+        this.tearDowns.push(goog.bind(objChain[i]['tearDown'], objChain[i]));
       }
     }
     this.tearDowns.reverse();


### PR DESCRIPTION
Patch the Closure Library locally in order to fix an error in the unit
test framework when optimizations are on: the framework fails to call
the setUp() and tearDown() methods due to property renaming.

We'll try to upstream the fix separately from this local patch.