### PR TITLE
Unsubscribe app when extension popup is closed

### DIFF
--- a/common/js/src/messaging/message-channel-pool.js
+++ b/common/js/src/messaging/message-channel-pool.js
@@ -24,6 +24,7 @@
 goog.provide('GoogleSmartCard.MessageChannelPool');
 
 goog.require('GoogleSmartCard.Logging');
+goog.require('goog.array');
 goog.require('goog.labs.structs.Multimap');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
@@ -97,16 +98,34 @@ MessageChannelPool.prototype.addChannel = function(
 };
 
 /**
+ * Adds a listener that will be called with the list of app information
+ * objects each time it gets updated.
  * @param {function(!Array.<string>)} listener
  * @param {!Object=} opt_scope
  */
 MessageChannelPool.prototype.addOnUpdateListener = function(
     listener, opt_scope) {
-  goog.log.fine(this.logger, 'Added an OnUpdateListener');
   this.onUpdateListeners_.push(
       opt_scope !== undefined ? goog.bind(listener, opt_scope) : listener);
+  goog.log.fine(this.logger, 'Added an OnUpdateListener');
+
   // Fire it once immediately to update.
   this.fireOnUpdateListeners_();
+};
+
+/**
+ * Removes a previously added listener function.
+ * @param {function(!Array.<string>)} listener
+ */
+MessageChannelPool.prototype.removeOnUpdateListener = function(listener) {
+  if (goog.array.remove(this.onUpdateListeners_, listener)) {
+    goog.log.fine(this.logger, 'Removed an update listener');
+  } else {
+    goog.log.warning(
+        this.logger,
+        'Failed to remove an update listener: the passed ' +
+            'function was not found');
+  }
 };
 
 /**

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -113,8 +113,8 @@ if (logBufferForwarderToNaclModule) {
   }, () => {});
 }
 
-const libusbProxyReceiver = new GSC.LibusbProxyReceiver(
-    executableModule.getMessageChannel());
+const libusbProxyReceiver =
+    new GSC.LibusbProxyReceiver(executableModule.getMessageChannel());
 libusbProxyReceiver.addHook(new GSC.LibusbLoginStateHook());
 
 const pcscLiteReadinessTracker =
@@ -316,6 +316,8 @@ function createClientHandler(clientMessageChannel, clientOrigin) {
 function exposeGlobalsForMainWindow() {
   goog.global['googleSmartCard_clientAppListUpdateSubscriber'] =
       messageChannelPool.addOnUpdateListener.bind(messageChannelPool);
+  goog.global['googleSmartCard_clientAppListUpdateUnsubscriber'] =
+      messageChannelPool.removeOnUpdateListener.bind(messageChannelPool);
   goog.global['googleSmartCard_readerTrackerSubscriber'] =
       readerTracker.addOnUpdateListener.bind(readerTracker);
   goog.global['googleSmartCard_readerTrackerUnsubscriber'] =

--- a/smart_card_connector_app/src/window-apps-displaying.js
+++ b/smart_card_connector_app/src/window-apps-displaying.js
@@ -25,6 +25,8 @@ goog.provide('GoogleSmartCard.ConnectorApp.Window.AppsDisplaying');
 goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.MessagingOrigin');
+goog.require('GoogleSmartCard.ObjectHelpers');
+goog.require('GoogleSmartCard.Packaging');
 goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientInfo');
 goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientsRegistryImpl');
 goog.require('goog.Promise');
@@ -121,8 +123,8 @@ function initializeWithBackgroundPage(backgroundPage) {
   goog.log.fine(logger, 'Registering listener on connected clients update');
 
   /**
-   * Points to the "addOnUpdateListener" method of the AppList instance
-   * that is owned by the background page.
+   * Points to the "addOnUpdateListener" method of the MessageChannelPool
+   * instance that is owned by the background page.
    */
   const appListSubscriber =
       /** @type {function(function(!Array.<string>))} */
@@ -132,8 +134,8 @@ function initializeWithBackgroundPage(backgroundPage) {
   appListSubscriber(onUpdateListener);
 
   /**
-   * Points to the "removeOnUpdateListener" method of the AppList instance
-   * that is owned by the background page.
+   * Points to the "removeOnUpdateListener" method of the MessageChannelPool
+   * instance that is owned by the background page.
    */
   const appListUnsubscriber =
       /** @type {function(function(!Array.<string>))} */


### PR DESCRIPTION
This PR fixes apps not being unsubscribed when SCC window is closed in the extension mode.

This is to prevent onUpdateListener() to be called when the UI is closed, since it'll try to update a not-existing-anymore UI controls, causing an exception.