### PR TITLE
[allowlist] Autoapprove permission for kiosk apps

### DIFF
--- a/third_party/closure-library/src/closure/goog/testing/testcase.js
+++ b/third_party/closure-library/src/closure/goog/testing/testcase.js
@@ -2013,11 +2013,11 @@ goog.testing.TestCase.Test = function(name, ref, scope, objChain) {
 
   if (objChain) {
     for (var i = 0; i < objChain.length; i++) {
-      if (typeof objChain[i].setUp === 'function') {
-        this.setUps.push(goog.bind(objChain[i].setUp, objChain[i]));
+      if (typeof objChain[i]['setUp'] === 'function') {
+        this.setUps.push(goog.bind(objChain[i]['setUp'], objChain[i]));
       }
-      if (typeof objChain[i].tearDown === 'function') {
-        this.tearDowns.push(goog.bind(objChain[i].tearDown, objChain[i]));
+      if (typeof objChain[i]['tearDown'] === 'function') {
+        this.tearDowns.push(goog.bind(objChain[i]['tearDown'], objChain[i]));
       }
     }
     this.tearDowns.reverse();

--- a/third_party/closure-library/src/closure/goog/testing/testcase.js
+++ b/third_party/closure-library/src/closure/goog/testing/testcase.js
@@ -2013,11 +2013,11 @@ goog.testing.TestCase.Test = function(name, ref, scope, objChain) {
 
   if (objChain) {
     for (var i = 0; i < objChain.length; i++) {
-      if (typeof objChain[i]['setUp'] === 'function') {
-        this.setUps.push(goog.bind(objChain[i]['setUp'], objChain[i]));
+      if (typeof objChain[i].setUp === 'function') {
+        this.setUps.push(goog.bind(objChain[i].setUp, objChain[i]));
       }
-      if (typeof objChain[i]['tearDown'] === 'function') {
-        this.tearDowns.push(goog.bind(objChain[i]['tearDown'], objChain[i]));
+      if (typeof objChain[i].tearDown === 'function') {
+        this.tearDowns.push(goog.bind(objChain[i].tearDown, objChain[i]));
       }
     }
     this.tearDowns.reverse();

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/known_client_apps.json
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/known_client_apps.json
@@ -67,5 +67,21 @@
   },
   "chrome-extension://ppkfnjlimknmjoaemnpidmdlfchhehel": {
     "name": "VMware Horizon Client"
+  },
+  "chrome-extension://cigmkcbeahhminphhnfaokgaofanldgj": {
+    "name": "Google TDS PC/SC test",
+    "autoapprove": true
+  },
+  "chrome-extension://gbecpjnejcnafnkgfciepngjcndodann": {
+    "name": "Guest@Google Kiosk App",
+    "autoapprove": true
+  },
+  "chrome-extension://kdffphekpginklcnoefcelkjclbjnbmi": {
+    "name": "Guest@Google Kiosk App DEV",
+    "autoapprove": true
+  },
+  "chrome-extension://hhbmmipodfklmbmiaegcbmbfmmfbngnf": {
+    "name": "Guest@Google Kiosk App UAT",
+    "autoapprove": true
   }
 }

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
@@ -48,6 +48,7 @@ const JSON_CONFIG_URL =
     'pcsc_lite_server_clients_management/known_client_apps.json';
 
 const CLIENT_NAME_FIELD = 'name';
+const AUTOAPPROVE_FIELD = 'autoapprove';
 
 const GSC = GoogleSmartCard;
 
@@ -55,13 +56,16 @@ const GSC = GoogleSmartCard;
  * This structure holds the information about a trusted client.
  * @param {string} origin
  * @param {string} name
+ * @param {boolean} autoapprove
  * @constructor
  */
-GSC.PcscLiteServer.TrustedClientInfo = function(origin, name) {
+GSC.PcscLiteServer.TrustedClientInfo = function(origin, name, autoapprove) {
   /** @const */
   this.origin = origin;
   /** @const */
   this.name = name;
+  /** @const */
+  this.autoapprove = autoapprove;
 };
 
 const TrustedClientInfo = GSC.PcscLiteServer.TrustedClientInfo;
@@ -272,6 +276,12 @@ TrustedClientsRegistryImpl.prototype.tryParseTrustedClientInfo_ = function(
   if (typeof nameField !== 'string')
     return null;
 
-  return new TrustedClientInfo(key, nameField);
+  let autoapproveField = value[AUTOAPPROVE_FIELD];
+  if (typeof autoapproveField === 'undefined')
+    autoapproveField = false;
+  else if (typeof autoapproveField !== 'boolean')
+    return null;
+
+  return new TrustedClientInfo(key, nameField, autoapproveField);
 };
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittest.js
@@ -41,15 +41,24 @@ const UserPromptingChecker = GSC.PcscLiteServerClientsManagement
                                  .PermissionsChecking.UserPromptingChecker;
 const ignoreArgument = goog.testing.mockmatchers.ignoreArgument;
 
+// Fake client #1: trusted.
 const FAKE_CLIENT_1_ORIGIN =
     'chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const FAKE_CLIENT_1_LEGACY_STORAGE_ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const FAKE_CLIENT_1_NAME = 'Application 1';
-const FAKE_TRUSTED_CLIENT_INFO_1 =
-    new TrustedClientInfo(FAKE_CLIENT_1_ORIGIN, FAKE_CLIENT_1_NAME);
+const FAKE_TRUSTED_CLIENT_INFO_1 = new TrustedClientInfo(
+    FAKE_CLIENT_1_ORIGIN, FAKE_CLIENT_1_NAME, /* autoapprove= */ false);
+// Fake client #2: untrusted.
 const FAKE_CLIENT_2_ORIGIN =
     'chrome-extension://bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 const FAKE_CLIENT_2_LEGACY_STORAGE_ID = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+// Fake client #3: trusted and autoapproved.
+const FAKE_CLIENT_3_ORIGIN =
+    'chrome-extension://autoapprovediiiiiiiiiiiiiiiiiiii';
+const FAKE_CLIENT_3_NAME = 'Application 3';
+const FAKE_TRUSTED_CLIENT_INFO_3 = new TrustedClientInfo(
+    FAKE_CLIENT_3_ORIGIN, FAKE_CLIENT_3_NAME, /* autoapprove= */ true);
+
 const STORAGE_KEY = 'pcsc_lite_clients_user_selections';
 
 /**
@@ -73,8 +82,11 @@ function FakeTrustedClientsRegistry() {}
 
 /** @override */
 FakeTrustedClientsRegistry.prototype.getByOrigin = function(origin) {
+  // Only fake clients ##1 and 3 are trusted.
   if (origin === FAKE_CLIENT_1_ORIGIN)
     return goog.Promise.resolve(FAKE_TRUSTED_CLIENT_INFO_1);
+  if (origin === FAKE_CLIENT_3_ORIGIN)
+    return goog.Promise.resolve(FAKE_TRUSTED_CLIENT_INFO_3);
   return goog.Promise.reject();
 };
 
@@ -264,6 +276,18 @@ goog.exportSymbol(
         function(userPromptingChecker) {
           return negatePromise(
               userPromptingChecker.check(FAKE_CLIENT_1_ORIGIN));
+        }));
+
+// Test that for an autoapproved client the check completes without any prompts
+// or previously stored decisions.
+goog.exportSymbol(
+    'test_UserPromptingChecker_EmptyStorage_AutoApproved',
+    makeTest(
+        {} /* fakeInitialStorageData */,
+        null /* expectedStorageDataToBeWritten */,
+        MockedDialogBehavior.NOT_RUN /* mockedDialogBehavior */,
+        function(userPromptingChecker) {
+          return userPromptingChecker.check(FAKE_CLIENT_3_ORIGIN);
         }));
 
 goog.exportSymbol(


### PR DESCRIPTION
Add a few kiosk apps that use smart card communication. Autoapprove
their permissions (without asking the user), in order to mitigate the
issue with invisible prompts in the kiosk mode when the Smart Card
Connector runs as a secondary app (normally the solution to this
problem is policy-for-extensions, however it doesn't exist for
secondary kiosk apps).