### PR TITLE
Automatically rebuild supported readers TXT file

### DIFF
--- a/smart_card_connector_app/build/Makefile
+++ b/smart_card_connector_app/build/Makefile
@@ -120,7 +120,7 @@ generate_out: $(OUT_DIR_PATH)/manifest.json
 # Rules for creating the human readable list of supported readers.
 #
 
-package: human_readable_supported_readers.txt
+all: human_readable_supported_readers.txt
 
 human_readable_supported_readers.txt: $(SOURCES_PATH)/create_human_readable_supported_readers.py $(CCID_SUPPORTED_READERS_CONFIG_PATH)
 	$(SOURCES_PATH)/create_human_readable_supported_readers.py \


### PR DESCRIPTION
Build the human_readable_supported_readers.txt file by default, instead
of requiring the developer to run "make package".

This makes it a bit more convenient for developers, and also it doesn't
slow anything down as the file is cheap to build.