### PR TITLE
Fix UI buttons not reacting

### DIFF
--- a/common/js/src/popup-window/in-popup-main-script.js
+++ b/common/js/src/popup-window/in-popup-main-script.js
@@ -30,6 +30,7 @@ goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.Packaging');
 goog.require('goog.events');
+goog.require('goog.events.BrowserEvent');
 goog.require('goog.events.EventType');
 goog.require('goog.events.KeyCodes');
 goog.require('goog.log');
@@ -196,6 +197,7 @@ function closeWindow() {
   window.close();
 }
 
+/** @param {!goog.events.BrowserEvent} event */
 function documentClosingOnEscapeKeyDownListener(event) {
   if (event.keyCode == goog.events.KeyCodes.ESC) {
     goog.log.fine(logger, 'ESC key press received, the window will be closed');

--- a/smart_card_connector_app/src/window-about-showing.js
+++ b/smart_card_connector_app/src/window-about-showing.js
@@ -25,6 +25,7 @@ goog.provide('GoogleSmartCard.ConnectorApp.Window.AboutShowing');
 goog.require('GoogleSmartCard.Packaging');
 goog.require('goog.dom');
 goog.require('goog.events');
+goog.require('goog.events.BrowserEvent');
 goog.require('goog.events.EventType');
 
 goog.scope(function() {
@@ -53,7 +54,7 @@ const openAboutElement =
     /** @type {!Element} */ (goog.dom.getElement('open-about'));
 
 /**
- * @param {!Event} e
+ * @param {!goog.events.BrowserEvent} e
  */
 function openAboutClickListener(e) {
   e.preventDefault();

--- a/smart_card_connector_app/src/window-devices-displaying.js
+++ b/smart_card_connector_app/src/window-devices-displaying.js
@@ -32,6 +32,7 @@ goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.dom.dataset');
 goog.require('goog.events');
+goog.require('goog.events.BrowserEvent');
 goog.require('goog.events.EventType');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
@@ -207,7 +208,7 @@ function shouldUseWebusb() {
 }
 
 /**
- * @param {!Event} e
+ * @param {!goog.events.BrowserEvent} e
  */
 function addDeviceClickListener(e) {
   e.preventDefault();

--- a/smart_card_connector_app/src/window-help-showing.js
+++ b/smart_card_connector_app/src/window-help-showing.js
@@ -25,6 +25,7 @@ goog.provide('GoogleSmartCard.ConnectorApp.Window.HelpShowing');
 goog.require('GoogleSmartCard.Packaging');
 goog.require('goog.dom');
 goog.require('goog.events');
+goog.require('goog.events.BrowserEvent');
 goog.require('goog.events.EventType');
 
 goog.scope(function() {
@@ -37,7 +38,7 @@ const openHelpElement =
     /** @type {!Element} */ (goog.dom.getElement('open-help'));
 
 /**
- * @param {!Event} event
+ * @param {!goog.events.BrowserEvent} event
  */
 function openHelpClickListener(event) {
   event.preventDefault();

--- a/smart_card_connector_app/src/window-logs-exporting.js
+++ b/smart_card_connector_app/src/window-logs-exporting.js
@@ -27,6 +27,7 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('goog.Timer');
 goog.require('goog.dom');
 goog.require('goog.events');
+goog.require('goog.events.BrowserEvent');
 goog.require('goog.events.EventType');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
@@ -51,7 +52,7 @@ const exportLogsElement =
 let isExportLogsAvailable = true;
 
 /**
- * @param {!Event} e
+ * @param {!goog.events.BrowserEvent} e
  */
 function exportLogsClickListener(e) {
   e.preventDefault();

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompt-dialog-main.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompt-dialog-main.js
@@ -48,6 +48,7 @@ goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.dom.classlist');
 goog.require('goog.events');
+goog.require('goog.events.BrowserEvent');
 goog.require('goog.log.Logger');
 goog.require('goog.string');
 
@@ -95,11 +96,13 @@ function prepareMessage() {
   }
 }
 
+/** @param {!goog.events.BrowserEvent} event */
 function allowClickListener(event) {
   event.preventDefault();
   GSC.InPopupMainScript.resolveModalDialog(true);
 }
 
+/** @param {!goog.events.BrowserEvent} event */
 function denyClickListener(event) {
   event.preventDefault();
   GSC.InPopupMainScript.resolveModalDialog(false);


### PR DESCRIPTION
Fix the UI button listeners (like "About", "Help") to correctly work and
not throw exceptions.

The problem was that the "e.preventDefault()" calls were throwing
errors: apparently Closure Library passes not Event but
goog.events.BrowserEvent objects, and in the Release build the minifier
renames properties and methods of the goog.events.BrowserEvent class.
Hence the incorrect type signature we gave in the code confused the
compiler and didn't let it rename the "preventDefault()" calls into the
minified names.