### PR TITLE
Use Python 3 in build scripts

### DIFF
--- a/common/make/common.mk
+++ b/common/make/common.mk
@@ -47,8 +47,12 @@ PACKAGING ?= app
 #    $1: Path to be normalized.
 #
 
-NORMALIZE_PATH = \
-	$(shell python -c 'import os.path, sys; print os.path.normpath(sys.argv[1])' "$(1)")
+NORMALIZE_PATH_COMMAND = \
+	python3 \
+		-c 'import os.path, sys; print(os.path.normpath(sys.argv[1]))' \
+		"$(1)"
+
+NORMALIZE_PATH = $(shell $(call NORMALIZE_PATH_COMMAND,$(1)))
 
 
 #
@@ -60,8 +64,8 @@ NORMALIZE_PATH = \
 #
 
 RELATIVE_PATH_COMMAND = \
-	python \
-		-c 'import os.path, sys; print os.path.relpath(sys.argv[1],sys.argv[2])' \
+	python3 \
+		-c 'import os.path, sys; print(os.path.relpath(sys.argv[1],sys.argv[2]))' \
 		"$(1)" \
 		"$(2)"
 

--- a/env/initialize.sh
+++ b/env/initialize.sh
@@ -73,7 +73,7 @@ initialize_nacl_sdk() {
   log_message "Installing Native Client SDK (version ${NACL_SDK_VERSION})..."
   rm -rf nacl_sdk
   cp -r ../third_party/nacl_sdk/nacl_sdk .
-  python nacl_sdk/sdk_tools/sdk_update_main.py install pepper_${NACL_SDK_VERSION}
+  python2 nacl_sdk/sdk_tools/sdk_update_main.py install pepper_${NACL_SDK_VERSION}
   log_message "Native Client SDK was installed successfully."
 }
 

--- a/prepare-binaries-for-github-release.py
+++ b/prepare-binaries-for-github-release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2017 Google Inc. All Rights Reserved.
 #

--- a/smart_card_connector_app/src/create_app_manifest.py
+++ b/smart_card_connector_app/src/create_app_manifest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2016 Google Inc. All Rights Reserved.
 #
@@ -96,10 +96,9 @@ def load_usb_devices(ccid_supported_readers_file):
   if not usb_devices:
     raise RuntimeError('No supported USB devices were extracted from the CCID '
                        'supported readers config')
-  print >>sys.stderr, ('Extracted {0} supported USB devices from the CCID '
-                       'supported readers config, and ignored {1} '
-                       'items.'.format(
-                           len(usb_devices), ignored_usb_device_count))
+  sys.stderr.write('Extracted {0} supported USB devices from the CCID '
+                   'supported readers config, and ignored {1} items.'.format(
+                       len(usb_devices), ignored_usb_device_count))
 
   return usb_devices
 

--- a/smart_card_connector_app/src/create_human_readable_supported_readers.py
+++ b/smart_card_connector_app/src/create_human_readable_supported_readers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2020 Google Inc. All Rights Reserved.
 #


### PR DESCRIPTION
Switch most of the build scripts to using Python3 instead of simply
calling "python" (and assuming it's Python ±2.7).

What this commit doesn't address is the NaCl builds, since they use the
unmaintained third-party build scripts that still rely on Python 2.
Fixing those will be a separate effort.