### PR TITLE
Pin more Pip2 modules for NaCl webports

### DIFF
--- a/third_party/webports/src/src/requirements.txt
+++ b/third_party/webports/src/src/requirements.txt
@@ -8,3 +8,5 @@ rednose==0.4.1
 termcolor==1.1.0
 yapf==0.1.8
 astroid<2.0
+logilab-common<1.5.0
+lazy-object-proxy<1.7.0


### PR DESCRIPTION
Workaround Python 2 errors occurring when initializing NaCl webports, by
requiring two modules ("logilab-common" and "lazy-object-proxy") not go
beyond their last Python2-supporting versions.

This commit is similar to #360. New errors will probably continue to
appear over time, as more and more pip modules drop Python 2
compatibility. The only solution is stopping the usage of NaCl, which
will happen in some mid-term future.