### PR TITLE
Bring back support of extension IDs in policies

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/checker.js
@@ -116,7 +116,7 @@ Checker.prototype.checkByManagedRegistry_ = function(
       'Checking permissions for the client ' + clientOrigin +
           ' through the managed registry...');
 
-  this.managedRegistry_.getById(clientOrigin)
+  this.managedRegistry_.getByOrigin(clientOrigin)
       .then(
           function() {
             goog.log.log(


### PR DESCRIPTION
Fix the regression introduced in the effort to switch to generic
messaging origins (#377). The regression is that we accidentally
switched the policy syntax from the list of extension IDs to the list of
origins, like "chrome-extension://something". This is a breaking
change for existing customer deployments who use the policy,
because the policy effectively becomes ignored.

This commit brings the backwards compatibility back, so that we still
recognize the policies that mention lists of extension IDs. Using the
new, origin-based, syntax in the policies is allowed too, although
not enforced.

This fixes #540.