### PR TITLE
More tests for PC/SC client list policy registry

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry-unittest.js
@@ -275,16 +275,16 @@ goog.exportSymbol('testPcscClientManagedRegistry', {
     mockControl.$replayAll();
     // Create the registry (has to happen after the function mocks are set up).
     managedRegistry = new ManagedRegistry();
-    // Verify success for the first ID initially.
-    assertTrue(await booleanizedGetById(FIRST_EXTENSION_ID));
-    assertFalse(await booleanizedGetById(SECOND_EXTENSION_ID));
+    // Verify success for the first origin initially.
+    assertTrue(await booleanizedGetByOrigin(FIRST_ORIGIN));
+    assertFalse(await booleanizedGetByOrigin(SECOND_ORIGIN));
 
     // Act: Notify some unrelated policy is changed.
     notifyOnChanged({'foo': {'oldValue': ['bar'], 'newValue': []}}, 'managed');
 
-    // Assert: still success for the first ID.
-    assertTrue(await booleanizedGetById(FIRST_EXTENSION_ID));
-    assertFalse(await booleanizedGetById(SECOND_EXTENSION_ID));
+    // Assert: still success for the first origin.
+    assertTrue(await booleanizedGetByOrigin(FIRST_ORIGIN));
+    assertFalse(await booleanizedGetByOrigin(SECOND_ORIGIN));
   },
 
   // Test that changes of (unrelated) keys in the local storage doesn't affect
@@ -296,16 +296,16 @@ goog.exportSymbol('testPcscClientManagedRegistry', {
     mockControl.$replayAll();
     // Create the registry (has to happen after the function mocks are set up).
     managedRegistry = new ManagedRegistry();
-    // Verify success for the second ID initially.
-    assertFalse(await booleanizedGetById(FIRST_EXTENSION_ID));
-    assertTrue(await booleanizedGetById(SECOND_EXTENSION_ID));
+    // Verify success for the second origin initially.
+    assertFalse(await booleanizedGetByOrigin(FIRST_ORIGIN));
+    assertTrue(await booleanizedGetByOrigin(SECOND_ORIGIN));
 
     // Act: Notify some key in the local storage is changed.
     notifyOnChanged({'foo': {'oldValue': ['bar'], 'newValue': []}}, 'local');
 
-    // Assert: still success for the second ID.
-    assertFalse(await booleanizedGetById(FIRST_EXTENSION_ID));
-    assertTrue(await booleanizedGetById(SECOND_EXTENSION_ID));
+    // Assert: still success for the second origin.
+    assertFalse(await booleanizedGetByOrigin(FIRST_ORIGIN));
+    assertTrue(await booleanizedGetByOrigin(SECOND_ORIGIN));
   },
 });
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry-unittest.js
@@ -265,5 +265,61 @@ goog.exportSymbol('testPcscClientManagedRegistry', {
     assertFalse(await booleanizedGetByOrigin(FIRST_ORIGIN));
     assertTrue(await booleanizedGetByOrigin(SECOND_ORIGIN));
   },
+
+  // Test that changes of unrelated keys in the managed storage doesn't affect
+  // the result.
+  'testUnrelatedPolicyChange': async function() {
+    // Arrange: set up the mock expectation that chrome.storage.managed.get() is
+    // called and returns the first extension ID.
+    willReturnPolicies([FIRST_EXTENSION_ID]);
+    mockControl.$replayAll();
+    // Create the registry (has to happen after the function mocks are set up).
+    managedRegistry = new ManagedRegistry();
+    // Verify success for the first ID initially.
+    assertTrue(await booleanizedGetById(FIRST_EXTENSION_ID));
+    assertFalse(await booleanizedGetById(SECOND_EXTENSION_ID));
+
+    // Act: Notify some unrelated policy is changed.
+    notifyOnChanged(
+        {
+          'foo': {
+            'oldValue': ['bar'],
+            'newValue': []
+          }
+        },
+        'managed');
+
+    // Assert: still success for the first ID.
+    assertTrue(await booleanizedGetById(FIRST_EXTENSION_ID));
+    assertFalse(await booleanizedGetById(SECOND_EXTENSION_ID));
+  },
+
+  // Test that changes of (unrelated) keys in the local storage doesn't affect
+  // the result.
+  'testUnrelatedNamespaceChange': async function() {
+    // Arrange: set up the mock expectation that chrome.storage.managed.get() is
+    // called and returns the second extension ID.
+    willReturnPolicies([SECOND_EXTENSION_ID]);
+    mockControl.$replayAll();
+    // Create the registry (has to happen after the function mocks are set up).
+    managedRegistry = new ManagedRegistry();
+    // Verify success for the second ID initially.
+    assertFalse(await booleanizedGetById(FIRST_EXTENSION_ID));
+    assertTrue(await booleanizedGetById(SECOND_EXTENSION_ID));
+
+    // Act: Notify some key in the local storage is changed.
+    notifyOnChanged(
+        {
+          'foo': {
+            'oldValue': ['bar'],
+            'newValue': []
+          }
+        },
+        'managed');
+
+    // Assert: still success for the second ID.
+    assertFalse(await booleanizedGetById(FIRST_EXTENSION_ID));
+    assertTrue(await booleanizedGetById(SECOND_EXTENSION_ID));
+  },
 });
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry-unittest.js
@@ -280,14 +280,7 @@ goog.exportSymbol('testPcscClientManagedRegistry', {
     assertFalse(await booleanizedGetById(SECOND_EXTENSION_ID));
 
     // Act: Notify some unrelated policy is changed.
-    notifyOnChanged(
-        {
-          'foo': {
-            'oldValue': ['bar'],
-            'newValue': []
-          }
-        },
-        'managed');
+    notifyOnChanged({'foo': {'oldValue': ['bar'], 'newValue': []}}, 'managed');
 
     // Assert: still success for the first ID.
     assertTrue(await booleanizedGetById(FIRST_EXTENSION_ID));
@@ -308,14 +301,7 @@ goog.exportSymbol('testPcscClientManagedRegistry', {
     assertTrue(await booleanizedGetById(SECOND_EXTENSION_ID));
 
     // Act: Notify some key in the local storage is changed.
-    notifyOnChanged(
-        {
-          'foo': {
-            'oldValue': ['bar'],
-            'newValue': []
-          }
-        },
-        'managed');
+    notifyOnChanged({'foo': {'oldValue': ['bar'], 'newValue': []}}, 'local');
 
     // Assert: still success for the second ID.
     assertFalse(await booleanizedGetById(FIRST_EXTENSION_ID));


### PR DESCRIPTION
Add tests for the scenarios when unrelated keys are changed in the
chrome.storage.