### PR TITLE
Parallelize WebAssembly builds in CI

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -31,4 +31,4 @@ jobs:
       run: >
         source env/activate &&
           source env/python2_venv/bin/activate &&
-          TOOLCHAIN=pnacl make -j30
+          TOOLCHAIN=pnacl make

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -24,6 +24,11 @@ jobs:
       run: env/initialize.sh
 
     - name: Compile in WebAssembly mode
-      run: source env/activate && TOOLCHAIN=emscripten make
+      run: >
+        source env/activate &&
+          TOOLCHAIN=emscripten make -j30
     - name: Compile in NaCl mode
-      run: source env/activate && source env/python2_venv/bin/activate && TOOLCHAIN=pnacl make
+      run: >
+        source env/activate &&
+          source env/python2_venv/bin/activate &&
+          TOOLCHAIN=pnacl make -j30


### PR DESCRIPTION
Pass "-j30" to Make in the Continuous Integration script when building
in the WebAssembly mode, so that the builds finish faster.

This is possible now that we fixed the issue with Make version
incompatibility (where parallel builds could corrupt files due to us
using the "&:" directive on Make <4.3).