### PR TITLE
Mkdir the target dir in Googletest makefiles

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -212,8 +212,11 @@ endef
 # s: Write an object-index into the archive, in order to speed subsequent
 #    link operations.
 define LIB_RULE
+# Make sure LIB_DIR is created (using an order-only dependency).
+$(LIB_DIR)/lib$(1).a: | $(LIB_DIR)/dir.stamp
+
+# Library build rule
 $(LIB_DIR)/lib$(1).a: $(foreach src,$(2),$(call OBJ_FILE_NAME,$(src)))
-	@mkdir -p $(LIB_DIR)
 	@rm -f $(LIB_DIR)/lib$(1).a
 	emar \
 		crs \

--- a/third_party/googletest/webport/build/Makefile
+++ b/third_party/googletest/webport/build/Makefile
@@ -151,5 +151,9 @@ $(TARGET_LIBS_PATTERN): $(ARTIFACTS_LIBS)
 	cp out-artifacts/lib/libgtest_main.a $(LIB_DIR)/libgtest_main.a
 endif
 
+# Make sure LIB_DIR is created before we copy .a files into it (using an
+# order-only dependency).
+$(TARGET_LIBS): | $(LIB_DIR)/dir.stamp
+
 # Add the temporary build directory for deletion when running "make clean".
 $(eval $(call CLEAN_RULE,out-artifacts))


### PR DESCRIPTION
Fix a possible flakiness in the Googletest makefile, caused by the fact
it attempts to write into LIB_DIR (env/emsdk/lib/{Debug|Release})
without making sure it's already created. So if Googletest builds happen
before other libraries create LIB_DIR, the compilation will fail.

The fix is to add a dependency on the sentinel "dir.stamp" file that
acts as a declaration to create the parent directories. For consistency,
use this approach not only in the Googletest's makefile, but also in
executable_building_emscripten.mk.