### PR TITLE
Explicitly specify the "C" compilation language

### DIFF
--- a/third_party/ccid/webport/build/Makefile
+++ b/third_party/ccid/webport/build/Makefile
@@ -76,6 +76,7 @@ CCID_SOURCES := \
 #   under Linux (but are actually provided by the NaCl SDK too);
 # * The "macro-redefined" warning diagnostic is disabled because of some
 #   non-clean code;
+# * "xc": Use the "C" language.
 CCID_CPPFLAGS := \
 	$(COMMON_CPPFLAGS) \
 	-DBUNDLE='"ifd-ccid.bundle"' \
@@ -87,6 +88,7 @@ CCID_CPPFLAGS := \
 	-I$(ROOT_PATH)/common/cpp/src/google_smart_card_common/logging/syslog \
 	-I$(ROOT_PATH)/third_party/libusb/src/libusb \
 	-Wno-macro-redefined \
+	-xc \
 
 $(foreach src,$(CCID_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CCID_CPPFLAGS))))
 
@@ -95,10 +97,12 @@ CCID_OPENCT_SOURCES := \
 	$(CCID_SOURCES_PATH)/openct/checksum.c \
 	$(CCID_SOURCES_PATH)/openct/proto-t1.c \
 
+# * "xc": Use the "C" language.
 CCID_OPENCT_CPPFLAGS := \
 	$(COMMON_CPPFLAGS) \
 	-I$(CCID_NACL_SOURCES_PATH) \
 	-I$(PCSC_LITE_ORIGINAL_HEADERS_DIR_PATH) \
+	-xc \
 
 $(foreach src,$(CCID_OPENCT_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CCID_OPENCT_CPPFLAGS))))
 
@@ -111,12 +115,14 @@ CCID_SIMCLIST_SOURCES := \
 #   simclist library which are not compiling under the NaCl SDK environment;
 # * The "macro-redefined" warning diagnostic is disabled because of some
 #   non-clean code;
+# * "xc": Use the "C" language.
 CCID_SIMCLIST_CPPFLAGS := \
 	$(COMMON_CPPFLAGS) \
 	-Dlog_msg=ccid_log_msg \
 	-Dlog_xxd=ccid_log_xxd \
 	-DSIMCLIST_NO_DUMPRESTORE \
 	-Wno-macro-redefined \
+	-xc \
 
 $(foreach src,$(CCID_SIMCLIST_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CCID_SIMCLIST_CPPFLAGS))))
 
@@ -124,11 +130,13 @@ CCID_TOWITOKO_SOURCES := \
 	$(CCID_SOURCES_PATH)/towitoko/atr.c \
 	$(CCID_SOURCES_PATH)/towitoko/pps.c \
 
+# * "xc": Use the "C" language.
 CCID_TOWITOKO_CPPFLAGS := \
 	$(COMMON_CPPFLAGS) \
 	-I$(CCID_NACL_SOURCES_PATH) \
 	-I$(PCSC_LITE_ORIGINAL_HEADERS_DIR_PATH) \
 	-I$(ROOT_PATH)/third_party/libusb/src/libusb \
+	-xc \
 
 $(foreach src,$(CCID_TOWITOKO_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CCID_TOWITOKO_CPPFLAGS))))
 

--- a/third_party/libusb/webport/build/Makefile
+++ b/third_party/libusb/webport/build/Makefile
@@ -59,10 +59,14 @@ CPPFLAGS := \
 	-Wextra \
 	-Wno-sign-compare \
 
+# * "xc": Use the "C" language.
+CFLAGS := \
+	-xc \
+
 CXXFLAGS := \
 	-std=$(CXX_DIALECT) \
 
-$(foreach src,$(C_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CPPFLAGS))))
+$(foreach src,$(C_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CPPFLAGS) $(CFLAGS))))
 
 $(foreach src,$(CXX_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CPPFLAGS) $(CXXFLAGS))))
 

--- a/third_party/pcsc-lite/naclport/cpp_client/build/Makefile
+++ b/third_party/pcsc-lite/naclport/cpp_client/build/Makefile
@@ -58,8 +58,10 @@ $(foreach src,$(CXX_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
 C_SOURCES := \
 	$(SOURCES_PATH)/error.c \
 
+# * "xc": Use the "C" language.
 CFLAGS := \
 	$(COMMON_CPPFLAGS) \
+	-xc \
 
 $(foreach src,$(C_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CFLAGS))))
 

--- a/third_party/pcsc-lite/naclport/server/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server/build/Makefile
@@ -107,6 +107,7 @@ PCSC_LITE_SERVER_SOURCES := \
 #   required for compiling the original PC/SC-Lite daemon source files.
 # * SCard* functions are redefined in order to not collide with the symbols
 #   from the PC/SC-Lite server-side libraries
+# * "xc": Use the "C" language.
 PCSC_LITE_SERVER_CPPFLAGS := \
 	$(PCSC_LITE_COMMON_CPPFLAGS) \
 	-DPCSCD \
@@ -122,6 +123,7 @@ PCSC_LITE_SERVER_CPPFLAGS := \
 	-DSCardSetAttrib=SCardSetAttribServer \
 	-DSCardStatus=SCardStatusServer \
 	-DSCardTransmit=SCardTransmitServer \
+	-xc \
 
 $(foreach src,$(PCSC_LITE_SERVER_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_CPPFLAGS))))
 
@@ -138,10 +140,12 @@ PCSC_LITE_SERVER_SVC_SOURCES := \
 # * no-return-type suppresses spurious compiler errors in cases when it doesn't
 #   recognize calls to library functions that terminate the thread or the
 #   program and bypass returning from a non-void function.
+# * "xc": Use the "C" language.
 PCSC_LITE_SERVER_SVC_CPPFLAGS := \
 	$(PCSC_LITE_SERVER_CPPFLAGS) \
 	-Dclose=ServerCloseSession \
 	-Wno-return-type \
+	-xc \
 
 $(foreach src,$(PCSC_LITE_SERVER_SVC_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_SVC_CPPFLAGS))))
 
@@ -151,9 +155,11 @@ PCSC_LITE_SERVER_DEBUGLOG_SOURCES := \
 
 # * suppress spurious compiler errors due to usage of non-portable in printf
 #   formats.
+# * "xc": Use the "C" language.
 PCSC_LITE_SERVER_DEBUGLOG_CPPFLAGS := \
 	$(PCSC_LITE_SERVER_CPPFLAGS) \
 	-Wno-format \
+	-xc \
 
 $(foreach src,$(PCSC_LITE_SERVER_DEBUGLOG_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_DEBUGLOG_CPPFLAGS))))
 
@@ -161,12 +167,14 @@ $(foreach src,$(PCSC_LITE_SERVER_DEBUGLOG_SOURCES),$(eval $(call COMPILE_RULE,$(
 PCSC_LITE_SERVER_READERFACTORY_SOURCES := \
 	$(PCSC_LITE_SOURCES_PATH)/readerfactory.c \
 
-# Calls to RFAddReader and RFRemoveReader (readerfactory.c) are hooked to get
-# better information on reader status.
+# * Calls to RFAddReader and RFRemoveReader (readerfactory.c) are hooked to get
+#   better information on reader status.
+# * "xc": Use the "C" language.
 PCSC_LITE_SERVER_READERFACTORY_CPPFLAGS := \
 	$(PCSC_LITE_SERVER_CPPFLAGS) \
 	-DRFAddReader=RFAddReaderOriginal \
 	-DRFRemoveReader=RFRemoveReaderOriginal \
+	-xc \
 
 $(foreach src,$(PCSC_LITE_SERVER_READERFACTORY_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_READERFACTORY_CPPFLAGS))))
 
@@ -180,12 +188,14 @@ PCSC_LITE_SERVER_HOTPLUG_LIBUSB_SOURCES := \
 #   O_NONBLOCK flag specified); read() and close() need to be mocked out, since
 #   our fake pipe() implementation returns fake file descriptors (based on
 #   simple counters).
+# * "xc": Use the "C" language.
 PCSC_LITE_SERVER_HOTPLUG_LIBUSB_CPPFLAGS := \
 	$(PCSC_LITE_SERVER_CPPFLAGS) \
 	-Dclose=GoogleSmartCardIpcEmulationClose \
 	-Dpipe=GoogleSmartCardIpcEmulationPipe \
 	-Dread=GoogleSmartCardIpcEmulationRead \
 	-Dwrite=GoogleSmartCardIpcEmulationWrite \
+	-xc \
 
 $(foreach src,$(PCSC_LITE_SERVER_HOTPLUG_LIBUSB_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_HOTPLUG_LIBUSB_CPPFLAGS))))
 
@@ -193,8 +203,10 @@ $(foreach src,$(PCSC_LITE_SERVER_HOTPLUG_LIBUSB_SOURCES),$(eval $(call COMPILE_R
 PCSC_LITE_CLIENT_SOURCES := \
 	$(PCSC_LITE_SOURCES_PATH)/winscard_clnt.c \
 
+# * "xc": Use the "C" language.
 PCSC_LITE_SERVER_CLIENT_CPPFLAGS := \
 	$(PCSC_LITE_COMMON_CPPFLAGS) \
+	-xc \
 
 $(foreach src,$(PCSC_LITE_CLIENT_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_CLIENT_CPPFLAGS))))
 


### PR DESCRIPTION
Use the "-xc" compiler flag when compiling C (not C++) source files.

This is needed when compiling with recent compiler versions (e.g., Clang
13); previously the compiler was automatically selecting the language
based on the input file's extension.