### PR TITLE
Run tests in CI

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -25,5 +25,12 @@ jobs:
 
     - name: Compile in WebAssembly mode
       run: source env/activate && TOOLCHAIN=emscripten make
+
+    - name: Tests in WebAssembly mode
+      run: source env/activate && TOOLCHAIN=emscripten make test
+
     - name: Compile in NaCl mode
       run: source env/activate && source env/python2_venv/bin/activate && TOOLCHAIN=pnacl make
+
+    - name: Tests in NaCl mode
+      run: source env/activate && source env/python2_venv/bin/activate && TOOLCHAIN=pnacl make test

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -23,8 +23,14 @@ jobs:
     - name: Initialize env
       run: env/initialize.sh
 
+    - name: Dbg
+      run: ls -lh env/python3_venv/bin/activate
+
     - name: Compile in WebAssembly mode
       run: source env/activate && TOOLCHAIN=emscripten make
+
+    - name: Dbg
+      run: ls -lh env/python3_venv/bin/activate
 
     - name: Tests in WebAssembly mode
       run: source env/activate && TOOLCHAIN=emscripten make test

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -23,20 +23,11 @@ jobs:
     - name: Initialize env
       run: env/initialize.sh
 
-    - name: Dbg
-      run: ls -lh env/python3_venv/bin/activate
-
     - name: Compile in WebAssembly mode
       run: source env/activate && TOOLCHAIN=emscripten make
 
-    - name: Dbg
-      run: ls -lh env/python3_venv/bin/activate
-
-    - name: Tests in WebAssembly mode
+    - name: Test in WebAssembly mode
       run: source env/activate && TOOLCHAIN=emscripten make test
 
     - name: Compile in NaCl mode
       run: source env/activate && source env/python2_venv/bin/activate && TOOLCHAIN=pnacl make
-
-    - name: Tests in NaCl mode
-      run: source env/activate && source env/python2_venv/bin/activate && TOOLCHAIN=pnacl make test

--- a/common/make/js_building_common.mk
+++ b/common/make/js_building_common.mk
@@ -288,7 +288,7 @@ generate_out: $(OUT_DIR_PATH)/index.html
 .PHONY: run_test run_test_manually
 
 run_test: all
-	source $(ROOT_PATH)/env/python3_venv/bin/activate && \
+	. $(ROOT_PATH)/env/python3_venv/bin/activate && \
 		$(ROOT_PATH)/common/js_test_runner/run-js-tests.py \
 			$(OUT_DIR_PATH)/index.html \
 			--chromedriver-path=$(ROOT_PATH)/env/chromedriver


### PR DESCRIPTION
Append the execution of tests (both C++ and JavaScript) into the
Continuous Integration script.

This is possible now that the test execution is fully automated.

Note that we don't run tests in the NaCl mode yet: these still
require manual intervention at the moment, and automating these
will be done as a separate effort.