### PR TITLE
Revert "Explicitly specify the "C" compilation language"

### DIFF
--- a/third_party/ccid/webport/build/Makefile
+++ b/third_party/ccid/webport/build/Makefile
@@ -76,7 +76,6 @@ CCID_SOURCES := \
 #   under Linux (but are actually provided by the NaCl SDK too);
 # * The "macro-redefined" warning diagnostic is disabled because of some
 #   non-clean code;
-# * "xc": Use the "C" language.
 CCID_CPPFLAGS := \
 	$(COMMON_CPPFLAGS) \
 	-DBUNDLE='"ifd-ccid.bundle"' \
@@ -88,7 +87,6 @@ CCID_CPPFLAGS := \
 	-I$(ROOT_PATH)/common/cpp/src/google_smart_card_common/logging/syslog \
 	-I$(ROOT_PATH)/third_party/libusb/src/libusb \
 	-Wno-macro-redefined \
-	-xc \
 
 $(foreach src,$(CCID_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CCID_CPPFLAGS))))
 
@@ -97,12 +95,10 @@ CCID_OPENCT_SOURCES := \
 	$(CCID_SOURCES_PATH)/openct/checksum.c \
 	$(CCID_SOURCES_PATH)/openct/proto-t1.c \
 
-# * "xc": Use the "C" language.
 CCID_OPENCT_CPPFLAGS := \
 	$(COMMON_CPPFLAGS) \
 	-I$(CCID_NACL_SOURCES_PATH) \
 	-I$(PCSC_LITE_ORIGINAL_HEADERS_DIR_PATH) \
-	-xc \
 
 $(foreach src,$(CCID_OPENCT_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CCID_OPENCT_CPPFLAGS))))
 
@@ -115,14 +111,12 @@ CCID_SIMCLIST_SOURCES := \
 #   simclist library which are not compiling under the NaCl SDK environment;
 # * The "macro-redefined" warning diagnostic is disabled because of some
 #   non-clean code;
-# * "xc": Use the "C" language.
 CCID_SIMCLIST_CPPFLAGS := \
 	$(COMMON_CPPFLAGS) \
 	-Dlog_msg=ccid_log_msg \
 	-Dlog_xxd=ccid_log_xxd \
 	-DSIMCLIST_NO_DUMPRESTORE \
 	-Wno-macro-redefined \
-	-xc \
 
 $(foreach src,$(CCID_SIMCLIST_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CCID_SIMCLIST_CPPFLAGS))))
 
@@ -130,13 +124,11 @@ CCID_TOWITOKO_SOURCES := \
 	$(CCID_SOURCES_PATH)/towitoko/atr.c \
 	$(CCID_SOURCES_PATH)/towitoko/pps.c \
 
-# * "xc": Use the "C" language.
 CCID_TOWITOKO_CPPFLAGS := \
 	$(COMMON_CPPFLAGS) \
 	-I$(CCID_NACL_SOURCES_PATH) \
 	-I$(PCSC_LITE_ORIGINAL_HEADERS_DIR_PATH) \
 	-I$(ROOT_PATH)/third_party/libusb/src/libusb \
-	-xc \
 
 $(foreach src,$(CCID_TOWITOKO_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CCID_TOWITOKO_CPPFLAGS))))
 

--- a/third_party/libusb/webport/build/Makefile
+++ b/third_party/libusb/webport/build/Makefile
@@ -59,14 +59,10 @@ CPPFLAGS := \
 	-Wextra \
 	-Wno-sign-compare \
 
-# * "xc": Use the "C" language.
-CFLAGS := \
-	-xc \
-
 CXXFLAGS := \
 	-std=$(CXX_DIALECT) \
 
-$(foreach src,$(C_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CPPFLAGS) $(CFLAGS))))
+$(foreach src,$(C_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CPPFLAGS))))
 
 $(foreach src,$(CXX_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CPPFLAGS) $(CXXFLAGS))))
 

--- a/third_party/pcsc-lite/naclport/cpp_client/build/Makefile
+++ b/third_party/pcsc-lite/naclport/cpp_client/build/Makefile
@@ -58,10 +58,8 @@ $(foreach src,$(CXX_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
 C_SOURCES := \
 	$(SOURCES_PATH)/error.c \
 
-# * "xc": Use the "C" language.
 CFLAGS := \
 	$(COMMON_CPPFLAGS) \
-	-xc \
 
 $(foreach src,$(C_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CFLAGS))))
 

--- a/third_party/pcsc-lite/naclport/server/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server/build/Makefile
@@ -107,7 +107,6 @@ PCSC_LITE_SERVER_SOURCES := \
 #   required for compiling the original PC/SC-Lite daemon source files.
 # * SCard* functions are redefined in order to not collide with the symbols
 #   from the PC/SC-Lite server-side libraries
-# * "xc": Use the "C" language.
 PCSC_LITE_SERVER_CPPFLAGS := \
 	$(PCSC_LITE_COMMON_CPPFLAGS) \
 	-DPCSCD \
@@ -123,7 +122,6 @@ PCSC_LITE_SERVER_CPPFLAGS := \
 	-DSCardSetAttrib=SCardSetAttribServer \
 	-DSCardStatus=SCardStatusServer \
 	-DSCardTransmit=SCardTransmitServer \
-	-xc \
 
 $(foreach src,$(PCSC_LITE_SERVER_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_CPPFLAGS))))
 
@@ -140,12 +138,10 @@ PCSC_LITE_SERVER_SVC_SOURCES := \
 # * no-return-type suppresses spurious compiler errors in cases when it doesn't
 #   recognize calls to library functions that terminate the thread or the
 #   program and bypass returning from a non-void function.
-# * "xc": Use the "C" language.
 PCSC_LITE_SERVER_SVC_CPPFLAGS := \
 	$(PCSC_LITE_SERVER_CPPFLAGS) \
 	-Dclose=ServerCloseSession \
 	-Wno-return-type \
-	-xc \
 
 $(foreach src,$(PCSC_LITE_SERVER_SVC_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_SVC_CPPFLAGS))))
 
@@ -155,11 +151,9 @@ PCSC_LITE_SERVER_DEBUGLOG_SOURCES := \
 
 # * suppress spurious compiler errors due to usage of non-portable in printf
 #   formats.
-# * "xc": Use the "C" language.
 PCSC_LITE_SERVER_DEBUGLOG_CPPFLAGS := \
 	$(PCSC_LITE_SERVER_CPPFLAGS) \
 	-Wno-format \
-	-xc \
 
 $(foreach src,$(PCSC_LITE_SERVER_DEBUGLOG_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_DEBUGLOG_CPPFLAGS))))
 
@@ -167,14 +161,12 @@ $(foreach src,$(PCSC_LITE_SERVER_DEBUGLOG_SOURCES),$(eval $(call COMPILE_RULE,$(
 PCSC_LITE_SERVER_READERFACTORY_SOURCES := \
 	$(PCSC_LITE_SOURCES_PATH)/readerfactory.c \
 
-# * Calls to RFAddReader and RFRemoveReader (readerfactory.c) are hooked to get
-#   better information on reader status.
-# * "xc": Use the "C" language.
+# Calls to RFAddReader and RFRemoveReader (readerfactory.c) are hooked to get
+# better information on reader status.
 PCSC_LITE_SERVER_READERFACTORY_CPPFLAGS := \
 	$(PCSC_LITE_SERVER_CPPFLAGS) \
 	-DRFAddReader=RFAddReaderOriginal \
 	-DRFRemoveReader=RFRemoveReaderOriginal \
-	-xc \
 
 $(foreach src,$(PCSC_LITE_SERVER_READERFACTORY_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_READERFACTORY_CPPFLAGS))))
 
@@ -188,14 +180,12 @@ PCSC_LITE_SERVER_HOTPLUG_LIBUSB_SOURCES := \
 #   O_NONBLOCK flag specified); read() and close() need to be mocked out, since
 #   our fake pipe() implementation returns fake file descriptors (based on
 #   simple counters).
-# * "xc": Use the "C" language.
 PCSC_LITE_SERVER_HOTPLUG_LIBUSB_CPPFLAGS := \
 	$(PCSC_LITE_SERVER_CPPFLAGS) \
 	-Dclose=GoogleSmartCardIpcEmulationClose \
 	-Dpipe=GoogleSmartCardIpcEmulationPipe \
 	-Dread=GoogleSmartCardIpcEmulationRead \
 	-Dwrite=GoogleSmartCardIpcEmulationWrite \
-	-xc \
 
 $(foreach src,$(PCSC_LITE_SERVER_HOTPLUG_LIBUSB_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_HOTPLUG_LIBUSB_CPPFLAGS))))
 
@@ -203,10 +193,8 @@ $(foreach src,$(PCSC_LITE_SERVER_HOTPLUG_LIBUSB_SOURCES),$(eval $(call COMPILE_R
 PCSC_LITE_CLIENT_SOURCES := \
 	$(PCSC_LITE_SOURCES_PATH)/winscard_clnt.c \
 
-# * "xc": Use the "C" language.
 PCSC_LITE_SERVER_CLIENT_CPPFLAGS := \
 	$(PCSC_LITE_COMMON_CPPFLAGS) \
-	-xc \
 
 $(foreach src,$(PCSC_LITE_CLIENT_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_CLIENT_CPPFLAGS))))
 


### PR DESCRIPTION
Revert change #555. As it turned out, explicitly specifying the
language isn't needed when using the correct command-line
interface (e.g., "clang" instead of "clang++" for both C and C++
sources).