### PR TITLE
Support cpp_unit_test_runner for coverage

### DIFF
--- a/common/cpp_unit_test_runner/include.mk
+++ b/common/cpp_unit_test_runner/include.mk
@@ -52,6 +52,8 @@ ifeq ($(TOOLCHAIN),emscripten)
 include $(ROOT_PATH)/common/cpp_unit_test_runner/src/build_emscripten.mk
 else ifeq ($(TOOLCHAIN),pnacl)
 include $(ROOT_PATH)/common/cpp_unit_test_runner/src/build_nacl.mk
+else ifeq ($(TOOLCHAIN),coverage)
+include $(ROOT_PATH)/common/cpp_unit_test_runner/src/build_coverage.mk
 else
 $(error Unknown TOOLCHAIN "$(TOOLCHAIN)".)
 endif

--- a/common/cpp_unit_test_runner/src/build_coverage.mk
+++ b/common/cpp_unit_test_runner/src/build_coverage.mk
@@ -1,0 +1,48 @@
+# Copyright 2022 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains the implementation of the ../include.mk interface that
+# builds the C++ unit test runner using the "coverage" toolchain.
+#
+# Note that the implementation is mostly similar to the one at
+# build-emscripten.mk.
+
+TEST_ADDITIONAL_CXXFLAGS := \
+	-DGTEST_HAS_PTHREAD=1 \
+	-I$(ROOT_PATH)/third_party/googletest/src/googlemock/include \
+	-I$(ROOT_PATH)/third_party/googletest/src/googletest/include \
+
+TEST_ADDITIONAL_LDFLAGS :=
+
+TEST_RUNNER_SOURCES :=
+
+TEST_RUNNER_LIBS := \
+	gtest_main \
+	gmock \
+	gtest \
+
+TEST_RUNNER_DEPS := \
+
+GOOGLETEST_LIBS_PATTERN := \
+	$(LIB_DIR)/libgmock% \
+	$(LIB_DIR)/libgmock_main% \
+	$(LIB_DIR)/libgtest% \
+	$(LIB_DIR)/libgtest_main% \
+
+$(GOOGLETEST_LIBS_PATTERN):
+	$(MAKE) -C $(ROOT_PATH)/third_party/googletest/webport/build
+
+# Execute the test binary.
+run_test: all
+	$(OUT_DIR_PATH)/$(TARGET)


### PR DESCRIPTION
Update the common/cpp_unit_test_runner/ build scripts to support the
TOOLCHAIN=coverage mode.