### PR TITLE
Use 32-bit mode in Coverage builds

### DIFF
--- a/common/make/internal/executable_building_coverage.mk
+++ b/common/make/internal/executable_building_coverage.mk
@@ -58,8 +58,13 @@ $(BUILD_DIR)/$(basename $(subst ..,__,$(1))).d
 endef
 
 # Flags passed to both compiler and linker.
+#
+# * "g": Enable debug symbols.
+# * "m32": Build in 32-bit mode (this is also what Emscripten and NaCl
+#   toolchains use).
 COVERAGE_COMMON_FLAGS := \
 	-g \
+	-m32 \
 
 # Flags passed to the compiler, in addition to COVERAGE_COMMON_FLAGS.
 COVERAGE_COMPILER_FLAGS :=

--- a/third_party/googletest/webport/build/Makefile
+++ b/third_party/googletest/webport/build/Makefile
@@ -120,8 +120,13 @@ CMAKE_ARGS := \
 
 ifeq ($(TOOLCHAIN),coverage)
 
+# Arguments specific to Coverage builds:
+# * "clang++": Use clang (and not try to use gcc).
+# * "m32": build in 32-bit mode (which is also what Emscripten toolchain uses by
+#   default).
 CMAKE_ARGS += \
 	-DCMAKE_CXX_COMPILER="clang++" \
+	-DCMAKE_CXX_FLAGS="-m32" \
 
 endif
 


### PR DESCRIPTION
Tell Clang to build and link the code in the 32-bit mode in
TOOLCHAIN=coverage builds.

This fixes compilation errors caused by the fact that the "long" type is
the same as "int64_t" in 64-bit builds, which causes some of our
function overloads to become duplicates of each other. Also 32-bit mode
is what NaCl and WebAssembly builds use, hence it's better to use the
same in the coverage builds too.