### PR TITLE
Stub out main() in Coverage builds

### DIFF
--- a/common/cpp/src/empty_main.cc
+++ b/common/cpp/src/empty_main.cc
@@ -1,0 +1,17 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// An empty main() function. Useful to suppress linker errors when building for
+// coverage.
+int main() {}

--- a/example_cpp_smart_card_client_app/build/executable_module/Makefile
+++ b/example_cpp_smart_card_client_app/build/executable_module/Makefile
@@ -34,6 +34,7 @@ include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/cpp_demo/dependency.mk
 
 SOURCES_DIR := ../../src
 
+# List of sources to compile:
 SOURCES := \
 	$(SOURCES_DIR)/application.cc \
 	$(SOURCES_DIR)/built_in_pin_dialog/built_in_pin_dialog_server.cc \
@@ -43,13 +44,24 @@ SOURCES := \
 
 ifeq ($(TOOLCHAIN),emscripten)
 
+# Sources specific to Emscripten builds:
 SOURCES += \
 	$(SOURCES_DIR)/entry_point_emscripten.cc \
 
 else ifeq ($(TOOLCHAIN),pnacl)
 
+# Sources specific to NaCl builds:
 SOURCES += \
 	$(SOURCES_DIR)/entry_point_nacl.cc \
+
+else ifeq ($(TOOLCHAIN),coverage)
+
+# Sources specific to Coverage builds:
+#
+# * "empty_main": Provides an empty main() function, to avoid linking errors as
+#   NaCl/Emscripten builds don't need main().
+SOURCES += \
+	$(ROOT_PATH)/common/cpp/src/empty_main.cc \
 
 endif
 

--- a/smart_card_connector_app/build/executable_module/Makefile
+++ b/smart_card_connector_app/build/executable_module/Makefile
@@ -90,6 +90,15 @@ DEPS += \
 
 $(eval $(call DEPEND_RULE,nacl_io))
 
+else ifeq ($(TOOLCHAIN),coverage)
+
+# Coverage-specific build definitions:
+
+# * "empty_main": Provides an empty main() function, to avoid linking errors as
+#   NaCl/Emscripten builds don't need main().
+SOURCES += \
+	$(ROOT_PATH)/common/cpp/src/empty_main.cc \
+
 endif
 
 


### PR DESCRIPTION
Normal builds (WebAssembly/Emscripten) don't need a main() function,
because the framework takes care of the startup itself. In the coverage
builds, however, we're building using stock Clang, and it fails the
linking stage if there's no main() provided.

Note that the empty main() is just fine for coverage builds, since all
we care about is building an executable that the LLVM instrumentation
can see. All we want from it in these binaries is to account for all
functions that were present in corresponding object files (in order
to get a realistic coverage of the whole codebase, not only of the
files with unit tests).