### PR TITLE
Enable Clang source-based coverage

### DIFF
--- a/common/make/internal/executable_building_coverage.mk
+++ b/common/make/internal/executable_building_coverage.mk
@@ -62,7 +62,12 @@ COVERAGE_COMMON_FLAGS := \
 	-g \
 
 # Flags passed to the compiler, in addition to COVERAGE_COMMON_FLAGS.
-COVERAGE_COMPILER_FLAGS :=
+#
+# * "fcoverage-mapping", "fprofile-instr-generate": Enable Clang's source-based
+#   coverage.
+COVERAGE_COMPILER_FLAGS := \
+	-fcoverage-mapping \
+	-fprofile-instr-generate \
 
 # Flags passed to the linker, in addition to COVERAGE_COMMON_FLAGS.
 COVERAGE_LINKER_FLAGS :=


### PR DESCRIPTION
Pass Clang flags that enable source-based coverage when building in the
TOOLCHAIN=coverage mode.