### PR TITLE
Store Debug/Release coverage profiles separately

### DIFF
--- a/common/cpp/build/tests/.gitignore
+++ b/common/cpp/build/tests/.gitignore
@@ -1,3 +1,4 @@
+/*.profraw
 /out/
 /out-artifacts-coverage/
 /out-artifacts-emscripten/

--- a/common/cpp_unit_test_runner/src/build_coverage.mk
+++ b/common/cpp_unit_test_runner/src/build_coverage.mk
@@ -43,6 +43,9 @@ GOOGLETEST_LIBS_PATTERN := \
 $(GOOGLETEST_LIBS_PATTERN):
 	$(MAKE) -C $(ROOT_PATH)/third_party/googletest/webport/build
 
-# Execute the test binary.
+# Execute the test binary. Write the collected coverage profile into
+# ./{Debug|Release}.profraw, so that we can later merge these profiles from all
+# runs and build a summarized report.
 run_test: all
-	$(OUT_DIR_PATH)/$(TARGET)
+	LLVM_PROFILE_FILE="./$(CONFIG).profraw" \
+		$(OUT_DIR_PATH)/$(TARGET)

--- a/third_party/libusb/webport/build/tests/.gitignore
+++ b/third_party/libusb/webport/build/tests/.gitignore
@@ -1,3 +1,4 @@
+/*.profraw
 /out/
 /out-artifacts-coverage/
 /out-artifacts-emscripten/


### PR DESCRIPTION
Set up an environment variable to tell Clang instrumentation store the
coverage raw profiles in files called "Debug.profraw"/"Release.profraw"
instead of just "default.profraw".

In the follow-up change we'll implement merging all these raw profiles
into a single profile and building a summarized coverage report from it.