### PR TITLE
Install coverage deps in CI

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  # The version of libstdc++ to install for coverage builds.
+  COVERAGE_LIBSTDCPP_VERSION: 10
+
 jobs:
   build:
 
@@ -35,7 +39,7 @@ jobs:
         llvm
         clang
         libc6-dev-i386
-        libstdc++-10-dev-i386-cross
+        libstdc++-${COVERAGE_LIBSTDCPP_VERSION}-dev-i386-cross
 
     - name: Initialize env
       run: env/initialize.sh

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -14,11 +14,26 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Apt update
+      run: sudo apt-get update
+
     - name: Set up Python 3
       uses: actions/setup-python@v3.1.2
       with:
         python-version: 3.9
         cache: pip
+
+    # Building in the coverage mode requires LLVM and Clang, as well as 32-bit
+    # cross-compile versions of standard C and C++ libraries (needed as we're
+    # building code in 32-bit mode on the 64-bit host).
+    - name: Install coverage toolchain
+      run: >
+        sudo apt-get install -y
+          build-essential
+          llvm
+          clang
+          libc6-dev-i386
+          libstdc++-10-dev-i386-cross
 
     - name: Initialize env
       run: env/initialize.sh

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -29,11 +29,11 @@ jobs:
     - name: Install coverage toolchain
       run: >
         sudo apt-get install -y
-          build-essentials
-          llvm
-          clang
-          libc6-dev-i386
-          libstdc++-10-dev-i386-cross
+        build-essentials
+        llvm
+        clang
+        libc6-dev-i386
+        libstdc++-10-dev-i386-cross
 
     - name: Initialize env
       run: env/initialize.sh

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    # Update the Apt cache, since the default state in Github Actions VM might
+    # be stalled, causing 404 errors when trying to install packages later.
     - name: Apt update
       run: sudo apt-get update
 

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install coverage toolchain
       run: >
         sudo apt-get install -y
-          build-essential
+          build-essentials
           llvm
           clang
           libc6-dev-i386

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install coverage toolchain
       run: >
         sudo apt-get install -y
-        build-essentials
+        build-essential
         llvm
         clang
         libc6-dev-i386


### PR DESCRIPTION
Extend the Continuous Integration script to install the dependencies
needed for building in the TOOLCHAIN=coverage mode.

We also need to do "apt-get update" in the beginning, since by default
Github Actions VMs come with outdated Apt state (and installing some
packages will result in 404 errors).