### PR TITLE
Run coverage report script in CI

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -32,3 +32,11 @@ jobs:
         source env/activate &&
           source env/python2_venv/bin/activate &&
           TOOLCHAIN=pnacl make
+
+    # When building for coverage, explicitly tell Clang to use the right include
+    # path, because Clang's heuristics often fail to deduce it automatically.
+    - name: Build coverage report
+      env:
+        CPLUS_INCLUDE_PATH: /usr/i686-linux-gnu/include/c++/${COVERAGE_LIBSTDCPP_VERSION}/i686-linux-gnu/
+      run:
+        ./coverage-report.sh


### PR DESCRIPTION
Extend the Continuous Integration script to perform the
TOOLCHAIN=coverage builds, run unit tests and create the resulting
coverage report.