### PR TITLE
Fix CI coverage env variable passing

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -64,6 +64,6 @@ jobs:
     # path, because Clang's heuristics often fail to deduce it automatically.
     - name: Build coverage report
       env:
-        CPLUS_INCLUDE_PATH: /usr/i686-linux-gnu/include/c++/${COVERAGE_LIBSTDCPP_VERSION}/i686-linux-gnu/
+        CPLUS_INCLUDE_PATH: /usr/i686-linux-gnu/include/c++/${{ env.COVERAGE_LIBSTDCPP_VERSION }}/i686-linux-gnu/
       run:
         ./coverage-report.sh


### PR DESCRIPTION
Use the correct syntax for passing a variable between Continuous
Integration script steps. For some reason, the regular "${}" Shell
syntax doesn't work for passing an env variable into another env
variable. Instead, the "$${{env.}}" syntax should be used in Github
Actions.