### PR TITLE
Clean coverage artifacts in clean-all.sh

### DIFF
--- a/clean-all.sh
+++ b/clean-all.sh
@@ -27,7 +27,7 @@ set -eu
 
 BUILT_APP_PACKAGES_DIR="built_app_packages"
 CONFIGS="Release Debug"
-TOOLCHAINS="emscripten pnacl"
+TOOLCHAINS="emscripten pnacl coverage"
 
 
 log_message() {


### PR DESCRIPTION
Extend the clean-all.sh script to also clean the coverage artifacts
(only relevant to developers who previously built with
TOOLCHAIN=coverage locally).