### PR TITLE
Stop copying .crx files in make-all.sh

### DIFF
--- a/make-all.sh
+++ b/make-all.sh
@@ -74,7 +74,6 @@ copy_app_packages() {
 	local dir=${1}
 	local config=${2}
 
-	cp -p ${dir}/*.crx ${BUILT_APP_PACKAGES_DIR}/${config}/
 	cp -p ${dir}/*.zip ${BUILT_APP_PACKAGES_DIR}/${config}/
 }
 


### PR DESCRIPTION
Now that we don't build .crx files by default in makefiles, change the
make-all.sh script to also stop copying them into the
"built_app_packages" directory.

Presumably, these .crx files became mostly useless, because all
development flows are much easier when done via .zip files. Hence
there's very little value in putting the .crx files in the
"built_app_packages" directory.