### PR TITLE
Enable ASan in coverage builds

### DIFF
--- a/common/make/internal/executable_building_coverage.mk
+++ b/common/make/internal/executable_building_coverage.mk
@@ -61,12 +61,15 @@ endef
 #
 # * "fcoverage-mapping", "fprofile-instr-generate": Enable Clang's source-based
 #   coverage.
+# * "fsanitize=address": Use Address Sanitizer (not strictly necessary for
+#   coverage builds, but having unit tests verified by it is useful).
 # * "g": Enable debug symbols.
 # * "m32": Build in 32-bit mode (this is also what Emscripten and NaCl
 #   toolchains use).
 COVERAGE_COMMON_FLAGS := \
 	-fcoverage-mapping \
 	-fprofile-instr-generate \
+	-fsanitize=address \
 	-g \
 	-m32 \
 


### PR DESCRIPTION
Enable Clang's Address Sanitizer in TOOLCHAIN=coverage builds.

ASan is not strictly related to coverage, however it's useful to have
unit tests run under it as another way to assess correctness of our
code. (Meanwhile Emscripten nominally supports ASan too, and that'd in
theory give us even better assessment of code in real-world scenarios,
in practice Emscripten's ASan breaks with many mysterious errors. Stock
Clang's ASan is much more stable and predictable in that regard,
even though we're limited to unit tests with it.)