### PR TITLE
Upload built app .zips in CI

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -60,6 +60,11 @@ jobs:
           source env/python2_venv/bin/activate &&
           TOOLCHAIN=pnacl make
 
+    - name: Upload built app packages
+      uses: kittaakos/upload-artifact-as-is@v0
+      with:
+        path: built_app_packages
+
     # When building for coverage, explicitly tell Clang to use the right include
     # path, because Clang's heuristics often fail to deduce it automatically.
     - name: Build coverage report

--- a/common/make/packaging_common.mk
+++ b/common/make/packaging_common.mk
@@ -66,12 +66,12 @@ $(TARGET)__webstore.zip: all
 	@mkdir -p "$(ROOT_PATH)/built_app_packages/$(TOOLCHAIN)-$(CONFIG)"
 	cp \
 		"$(CURDIR)/$(TARGET)__webstore.zip" \
-		"$(ROOT_PATH)/built_app_packages/$(TOOLCHAIN)-$(CONFIG)/$(TARGET).zip"
+		"$(ROOT_PATH)/built_app_packages/$(TARGET)-$(TOOLCHAIN)-$(CONFIG)-$(PACKAGING).zip"
 
 package: $(TARGET)__webstore.zip
 
 $(eval $(call CLEAN_RULE,$(TARGET)__webstore.zip))
-$(eval $(call CLEAN_RULE,$(ROOT_PATH)/built_app_packages/$(TOOLCHAIN)-$(CONFIG)/$(TARGET).zip))
+$(eval $(call CLEAN_RULE,$(ROOT_PATH)/built_app_packages/$(TARGET)-$(TOOLCHAIN)-$(CONFIG)-$(PACKAGING).zip))
 
 
 # A "package_crx" target that creates a packaged App/Extension .CRX file.


### PR DESCRIPTION
Extend the Continuous Integration script to upload all built .zip
packages (for the applications built in various build modes) as build
artifacts. This makes it possible for developers to obtain the .zips
from a reliable and consistent environment (Github Actions VMs),
rather than to rely on themselves to compile the code correctly locally.

Additionally flatten the contents of the "built_app_packages" directory
(removing the "Debug"/"Release" subfolders), so that the upload step can
just take individual files from it and upload them as separate
artifacts. Also include the packaging mode ("app"/"extension") into the
.zip name, to avoid any potential confusion.