### PR TITLE
Don't discard coverage failures in CI

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -71,8 +71,8 @@ jobs:
       id: build-coverage
       env:
         CPLUS_INCLUDE_PATH: /usr/i686-linux-gnu/include/c++/${{ env.COVERAGE_LIBSTDCPP_VERSION }}/i686-linux-gnu/
-      run: |
-        ./coverage-report.sh | tee coverage-output.txt
+      run: >
+        (./coverage-report.sh | tee coverage-output.txt) &&
         echo "::set-output name=LINE_COVERAGE_PERCENT::$(
           scripts/parse-coverage-output.py < coverage-output.txt
         )"


### PR DESCRIPTION
Fix the Continuous Integration script to not swallow errors from the
"coverage-report.sh" script.

If this script failed, we were ignoring this and proceeding to
subsequent steps of the CI script, eventually posting a misleading "All
tests passed" comment on the Pull Request. The reason was that the
coverage step was encoded as a multi-line text, which GitHub interprets
as separate Bash commands, so that only the last command determines the
overall step's exit code. The fix is to use the folded-style YAML text
(">") and add "&&" between commands, so that any failure is bubbled up.