### PR TITLE
Implement graceful teardown of PC/SC's classes

### DIFF
--- a/common/cpp/src/google_smart_card_common/ipc_emulation.cc
+++ b/common/cpp/src/google_smart_card_common/ipc_emulation.cc
@@ -194,7 +194,7 @@ void IpcEmulation::CreateGlobalInstance() {
 }
 
 // static
-void IpcEmulation::DestroyGlobalInstanceForTesting() {
+void IpcEmulation::DestroyGlobalInstance() {
   delete g_ipc_emulation;
   g_ipc_emulation = nullptr;
 }

--- a/common/cpp/src/google_smart_card_common/ipc_emulation.h
+++ b/common/cpp/src/google_smart_card_common/ipc_emulation.h
@@ -63,7 +63,7 @@ class IpcEmulation final {
   static void CreateGlobalInstance();
   // Destroys the singleton instance created by `CreateGlobalInstance()`.
   // Non-thread-safe.
-  static void DestroyGlobalInstanceForTesting();
+  static void DestroyGlobalInstance();
   // Returns a previously created singleton instance of this class.
   //
   // Note: This function is not thread-safe!

--- a/common/cpp/src/google_smart_card_common/ipc_emulation_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/ipc_emulation_unittest.cc
@@ -23,9 +23,7 @@ namespace google_smart_card {
 class IpcEmulationTest : public testing::Test {
  protected:
   IpcEmulationTest() { IpcEmulation::CreateGlobalInstance(); }
-  ~IpcEmulationTest() override {
-    IpcEmulation::DestroyGlobalInstanceForTesting();
-  }
+  ~IpcEmulationTest() override { IpcEmulation::DestroyGlobalInstance(); }
 
   IpcEmulation* ipc_emulation() { return IpcEmulation::GetInstance(); }
 };

--- a/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.cc
+++ b/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.cc
@@ -36,6 +36,7 @@
 #include <google_smart_card_common/ipc_emulation.h>
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/messaging/typed_message.h>
+#include <google_smart_card_common/optional.h>
 #include <google_smart_card_common/value.h>
 #include <google_smart_card_common/value_conversion.h>
 
@@ -47,6 +48,7 @@
 extern "C" {
 #include "winscard.h"
 #include "debuglog.h"
+#include "eventhandler.h"
 #include "hotplug.h"
 #include "readerfactory.h"
 #include "sys_generic.h"
@@ -102,12 +104,17 @@ struct ReaderRemoveMessageData {
 };
 
 void PcscLiteServerDaemonThreadMain() {
-  // TODO(emaxx): Stop the event loop during pp::Instance destruction.
   while (true) {
     GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "[daemon thread] "
                                 << "Waiting for the new connected clients...";
-    uint32_t server_socket_file_descriptor = static_cast<uint32_t>(
-        PcscLiteServerSocketsManager::GetInstance()->WaitAndPop());
+    optional<int> server_socket_file_descriptor =
+        PcscLiteServerSocketsManager::GetInstance()->WaitAndPop();
+    if (!server_socket_file_descriptor) {
+      // A shutdown signal received.
+      GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix
+                                  << "[daemon thread] Shutting down...";
+      break;
+    }
 
     GOOGLE_SMART_CARD_LOG_DEBUG
         << kLoggingPrefix << "[daemon thread] A new "
@@ -115,14 +122,23 @@ void PcscLiteServerDaemonThreadMain() {
     // Note: even though the CreateContextThread function accepts its
     // server_socket_file_descriptor argument by pointer, it doesn't store the
     // pointer itself anywhere - so it's safe to use a local variable here.
+    uint32_t server_socket_file_descriptor_unsigned =
+        static_cast<uint32_t>(server_socket_file_descriptor.value());
     // FIXME(emaxx): Deal with cases when CreateContextThread returns errors.
     // Looks like it may happen legitimately when the abusive client(s) request
     // to establish too many requests. Probably, some limitation should be
     // applied to all clients.
     GOOGLE_SMART_CARD_CHECK(
-        ::CreateContextThread(&server_socket_file_descriptor) ==
+        ::CreateContextThread(&server_socket_file_descriptor_unsigned) ==
         SCARD_S_SUCCESS);
   }
+
+  // Cleanup:
+  HPStopHotPluggables();
+  SYS_Sleep(1);
+  RFCleanupReaders();
+  EHDeinitializeEventStructures();
+  ContextsDeinitialize();
 }
 
 }  // namespace
@@ -250,13 +266,26 @@ void PcscLiteServerGlobal::InitializeAndRunDaemonThread() {
 
   GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Starting PC/SC-Lite "
                               << "daemon thread...";
-  std::thread daemon_thread(PcscLiteServerDaemonThreadMain);
-  daemon_thread.detach();
+  daemon_thread_ = std::thread(PcscLiteServerDaemonThreadMain);
   GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "PC/SC-Lite daemon "
                               << "thread has started.";
 
   GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix << "Initialization "
                               << "successfully finished.";
+}
+
+void PcscLiteServerGlobal::StopDaemonThreadAndWait() {
+  GOOGLE_SMART_CARD_LOG_DEBUG
+      << kLoggingPrefix << "Shutting down the PC/SC-Lite daemon thread...";
+  // This notifies the daemon thread to shut down.
+  PcscLiteServerSocketsManager::GetInstance()->ShutDown();
+  daemon_thread_.join();
+  GOOGLE_SMART_CARD_LOG_DEBUG << kLoggingPrefix
+                              << "The PC/SC-Lite daemon thread shut down.";
+
+  // Shut down the global state created in `InitializeAndRunDaemonThread()`.
+  PcscLiteServerSocketsManager::DestroyGlobalInstance();
+  IpcEmulation::DestroyGlobalInstance();
 }
 
 void PcscLiteServerGlobal::PostReaderInitAddMessage(const char* reader_name,

--- a/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.h
+++ b/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.h
@@ -65,7 +65,7 @@ class PcscLiteServerGlobal final {
   // Shuts down the daemon thread; waits for the shutdown completion in a
   // blocking way.
   //
-  // Must be called after InitializeAndRunDaemonThread().
+  // Must be called after `InitializeAndRunDaemonThread()`.
   void ShutDownAndWait();
 
   void PostReaderInitAddMessage(const char* reader_name,

--- a/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.h
+++ b/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.h
@@ -26,6 +26,8 @@
 #ifndef GOOGLE_SMART_CARD_PCSC_LITE_SERVER_GLOBAL_H_
 #define GOOGLE_SMART_CARD_PCSC_LITE_SERVER_GLOBAL_H_
 
+#include <thread>
+
 #include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/value.h>
 
@@ -60,6 +62,12 @@ class PcscLiteServerGlobal final {
   // initialized.
   void InitializeAndRunDaemonThread();
 
+  // Shuts down the daemon thread; waits for the shutdown completion in a
+  // blocking way.
+  //
+  // Must be called after InitializeAndRunDaemonThread().
+  void StopDaemonThreadAndWait();
+
   void PostReaderInitAddMessage(const char* reader_name,
                                 int port,
                                 const char* device) const;
@@ -73,6 +81,7 @@ class PcscLiteServerGlobal final {
   void PostMessage(const char* type, Value message_data) const;
 
   GlobalContext* const global_context_;
+  std::thread daemon_thread_;
 };
 
 }  // namespace google_smart_card

--- a/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.h
+++ b/third_party/pcsc-lite/naclport/server/src/google_smart_card_pcsc_lite_server/global.h
@@ -66,7 +66,7 @@ class PcscLiteServerGlobal final {
   // blocking way.
   //
   // Must be called after InitializeAndRunDaemonThread().
-  void StopDaemonThreadAndWait();
+  void ShutDownAndWait();
 
   void PostReaderInitAddMessage(const char* reader_name,
                                 int port,

--- a/third_party/pcsc-lite/naclport/server/src/server_sockets_manager.h
+++ b/third_party/pcsc-lite/naclport/server/src/server_sockets_manager.h
@@ -30,6 +30,8 @@
 #include <mutex>
 #include <queue>
 
+#include <google_smart_card_common/optional.h>
+
 namespace google_smart_card {
 
 // Holder of a queue of server-side sockets for the socket pairs created at the
@@ -42,11 +44,21 @@ class PcscLiteServerSocketsManager final {
   // Note: This function is not thread-safe!
   static void CreateGlobalInstance();
   // Note: This function is not thread-safe!
+  static void DestroyGlobalInstance();
+  // Note: This function is not thread-safe!
   static PcscLiteServerSocketsManager* GetInstance();
 
+  // Inserts the descriptor into the wait queue.
   void Push(int server_socket_file_descriptor);
 
-  int WaitAndPop();
+  // Returns the next descriptor from the wait queue. When the queue is empty,
+  // waits in a blocking way until an item appears in it. If the class is shut
+  // down, exits with a null optional instead.
+  optional<int> WaitAndPop();
+
+  // Switches into the "shutting down" state. This makes all ongoing and future
+  // `WaitAndPop()` calls return a null optional.
+  void ShutDown();
 
  private:
   PcscLiteServerSocketsManager();
@@ -57,6 +69,7 @@ class PcscLiteServerSocketsManager final {
 
   std::mutex mutex_;
   std::condition_variable condition_;
+  bool shutting_down_ = false;
   std::queue<int> server_socket_file_descriptors_queue_;
 };
 


### PR DESCRIPTION
For unit testing purposes, the model "create singletons+threads and
never shut them down" that we're using for the production code isn't
suitable. This commit implements the proper teardown for a few classes
in //common/ and //third_party/pcsc-lite/.