### PR TITLE
Don't lose coverage profiles if test does chdir

### DIFF
--- a/common/cpp_unit_test_runner/src/build_coverage.mk
+++ b/common/cpp_unit_test_runner/src/build_coverage.mk
@@ -45,7 +45,8 @@ $(GOOGLETEST_LIBS_PATTERN):
 
 # Execute the test binary. Write the collected coverage profile into
 # ./{Debug|Release}.profraw, so that we can later merge these profiles from all
-# runs and build a summarized report.
+# runs and build a summarized report. Use "CURDIR" instead of ".", so that the
+# location isn't affected if the test does chdir.
 run_test: all
-	LLVM_PROFILE_FILE="./$(CONFIG).profraw" \
+	LLVM_PROFILE_FILE="$(CURDIR)/$(CONFIG).profraw" \
 		$(OUT_DIR_PATH)/$(TARGET)


### PR DESCRIPTION
Make sure the coverage profile path is set to an absolute path, so that
even if the unit test decides to change the working directory the
.profraw file is still created in the old place.