### PR TITLE
Rename global to pcsc_lite_server_web_port_service

### DIFF
--- a/smart_card_connector_app/src/application.cc
+++ b/smart_card_connector_app/src/application.cc
@@ -25,11 +25,11 @@
 #include <google_smart_card_common/unique_ptr_utils.h>
 #include <google_smart_card_common/value.h>
 #include <google_smart_card_common/value_conversion.h>
-#include <google_smart_card_pcsc_lite_server/global.h>
 #include <google_smart_card_pcsc_lite_server_clients_management/backend.h>
 #include <google_smart_card_pcsc_lite_server_clients_management/ready_message.h>
 
 #include "third_party/libusb/webport/src/public/libusb_web_port_service.h"
+#include "third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.h"
 
 namespace google_smart_card {
 
@@ -43,8 +43,8 @@ Application::Application(
       libusb_web_port_service_(
           MakeUnique<LibusbWebPortService>(global_context_,
                                            typed_message_router_)),
-      pcsc_lite_server_global_(
-          MakeUnique<PcscLiteServerGlobal>(global_context_)) {
+      pcsc_lite_server_web_port_service_(
+          MakeUnique<PcscLiteServerWebPortService>(global_context_)) {
   ScheduleServicesInitialization();
 }
 
@@ -54,7 +54,7 @@ Application::~Application() {
   // sending requests to the JavaScript side).
   libusb_web_port_service_->ShutDown();
   (void)libusb_web_port_service_.release();
-  (void)pcsc_lite_server_global_.release();
+  (void)pcsc_lite_server_web_port_service_.release();
 }
 
 void Application::ScheduleServicesInitialization() {
@@ -68,7 +68,7 @@ void Application::InitializeServicesOnBackgroundThread() {
 
   if (background_initialization_callback_)
     background_initialization_callback_();
-  pcsc_lite_server_global_->InitializeAndRunDaemonThread();
+  pcsc_lite_server_web_port_service_->InitializeAndRunDaemonThread();
 
   pcsc_lite_server_clients_management_backend_ =
       MakeUnique<PcscLiteServerClientsManagementBackend>(global_context_,

--- a/smart_card_connector_app/src/application.h
+++ b/smart_card_connector_app/src/application.h
@@ -20,10 +20,10 @@
 
 #include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_pcsc_lite_server/global.h>
 #include <google_smart_card_pcsc_lite_server_clients_management/backend.h>
 
 #include "third_party/libusb/webport/src/public/libusb_web_port_service.h"
+#include "third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.h"
 
 namespace google_smart_card {
 
@@ -63,7 +63,8 @@ class Application final {
   std::unique_ptr<LibusbWebPortService> libusb_web_port_service_;
   std::unique_ptr<PcscLiteServerClientsManagementBackend>
       pcsc_lite_server_clients_management_backend_;
-  std::unique_ptr<PcscLiteServerGlobal> pcsc_lite_server_global_;
+  std::unique_ptr<PcscLiteServerWebPortService>
+      pcsc_lite_server_web_port_service_;
 };
 
 }  // namespace google_smart_card

--- a/third_party/pcsc-lite/naclport/server/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server/build/Makefile
@@ -61,6 +61,7 @@ COMMON_CPPFLAGS := \
 	-I$(SOURCES_PATH) \
 	-I$(PCSC_LITE_ORIGINAL_HEADERS_DIR_PATH) \
 	-I$(PCSC_LITE_SOURCES_PATH) \
+	-I$(ROOT_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
 
 # * DEBUG_HOTPLUG definition enables debug logging for the reader drivers
@@ -207,8 +208,8 @@ PCSC_LITE_SERVER_NACL_SOURCES := \
 	$(SOURCES_PATH)/auth_nacl.cc \
 	$(SOURCES_PATH)/cmath.cc \
 	$(SOURCES_PATH)/dyn_nacl.cc \
-	$(SOURCES_PATH)/google_smart_card_pcsc_lite_server/global.cc \
 	$(SOURCES_PATH)/pcscdaemon_nacl.cc \
+	$(SOURCES_PATH)/public/pcsc_lite_server_web_port_service.cc \
 	$(SOURCES_PATH)/readerfactory_nacl.cc \
 	$(SOURCES_PATH)/server_sockets_manager.cc \
 	$(SOURCES_PATH)/sys_nacl.cc \

--- a/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.h
+++ b/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.h
@@ -23,8 +23,8 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#ifndef GOOGLE_SMART_CARD_PCSC_LITE_SERVER_GLOBAL_H_
-#define GOOGLE_SMART_CARD_PCSC_LITE_SERVER_GLOBAL_H_
+#ifndef GOOGLE_SMART_CARD_PCSC_LITE_SERVER_WEB_PORT_SERVICE_H_
+#define GOOGLE_SMART_CARD_PCSC_LITE_SERVER_WEB_PORT_SERVICE_H_
 
 #include <thread>
 
@@ -42,14 +42,15 @@ namespace google_smart_card {
 //
 // Note: All methods except GetInstance are thread safe. Calls to GetInstance
 //       concurrent to class construction or destruction are not thread safe.
-class PcscLiteServerGlobal final {
+class PcscLiteServerWebPortService final {
  public:
-  explicit PcscLiteServerGlobal(GlobalContext* global_context);
-  PcscLiteServerGlobal(const PcscLiteServerGlobal&) = delete;
-  PcscLiteServerGlobal& operator=(const PcscLiteServerGlobal&) = delete;
-  ~PcscLiteServerGlobal();
+  explicit PcscLiteServerWebPortService(GlobalContext* global_context);
+  PcscLiteServerWebPortService(const PcscLiteServerWebPortService&) = delete;
+  PcscLiteServerWebPortService& operator=(const PcscLiteServerWebPortService&) =
+      delete;
+  ~PcscLiteServerWebPortService();
 
-  static const PcscLiteServerGlobal* GetInstance();
+  static const PcscLiteServerWebPortService* GetInstance();
 
   // Performs all necessary PC/SC-Lite daemon initialization steps and starts
   // the daemon.
@@ -86,4 +87,4 @@ class PcscLiteServerGlobal final {
 
 }  // namespace google_smart_card
 
-#endif  // GOOGLE_SMART_CARD_PCSC_LITE_SERVER_GLOBAL_H_
+#endif  // GOOGLE_SMART_CARD_PCSC_LITE_SERVER_WEB_PORT_SERVICE_H_

--- a/third_party/pcsc-lite/naclport/server/src/readerfactory_nacl.cc
+++ b/third_party/pcsc-lite/naclport/server/src/readerfactory_nacl.cc
@@ -26,7 +26,7 @@
 // This file contains replacement functions for the original readerfactory.c
 // PC/SC-Lite internal implementation.
 
-#include <google_smart_card_pcsc_lite_server/global.h>
+#include "third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.h"
 
 #include <wintypes.h>
 
@@ -46,12 +46,12 @@ LONG RFAddReader(const char* reader_name,
                  int port,
                  const char* library,
                  const char* device) {
-  google_smart_card::PcscLiteServerGlobal::GetInstance()
+  google_smart_card::PcscLiteServerWebPortService::GetInstance()
       ->PostReaderInitAddMessage(reader_name, port, device);
 
   LONG return_code = RFAddReaderOriginal(reader_name, port, library, device);
 
-  google_smart_card::PcscLiteServerGlobal::GetInstance()
+  google_smart_card::PcscLiteServerWebPortService::GetInstance()
       ->PostReaderFinishAddMessage(reader_name, port, device, return_code);
 
   return return_code;
@@ -63,7 +63,7 @@ LONG RFAddReader(const char* reader_name,
 // it is defined, but not from inside (readerfactory). Sometimes it may get
 // called from the inside, and that call won't be intercepted, but that is fine.
 LONG RFRemoveReader(const char* reader_name, int port) {
-  google_smart_card::PcscLiteServerGlobal::GetInstance()
+  google_smart_card::PcscLiteServerWebPortService::GetInstance()
       ->PostReaderRemoveMessage(reader_name, port);
 
   return RFRemoveReaderOriginal(reader_name, port);


### PR DESCRIPTION
This is a pure refactoring commit. The "global.{h,cc}" was a poor naming
scheme for the file and the corresponding class, so rename them to
"pcsc_lite_server_web_port_service.{h,cc}". Also rename their folder
from "google_smart_card_pcsc_lite_server" to just "public", which
reflects that these .h files can be included by code from other
subtrees.

Also while editing #include's pointing to it switch to using full
include paths like "third_party/pcsc-lite/etc.". This is a better and a
more maintainable naming scheme.

The new naming/inclusion scheme is inspired by Chromium's code
base.