### PR TITLE
Add Value::StrictlyEquals()

### DIFF
--- a/common/cpp/src/google_smart_card_common/value.cc
+++ b/common/cpp/src/google_smart_card_common/value.cc
@@ -108,6 +108,46 @@ Value::~Value() {
   Destroy();
 }
 
+bool Value::StrictlyEquals(const Value& other) const {
+  if (type_ != other.type_)
+    return false;
+  switch (type_) {
+    case Type::kNull:
+      return true;
+    case Type::kBoolean:
+      return boolean_value_ == other.boolean_value_;
+    case Type::kInteger:
+      return integer_value_ == other.integer_value_;
+    case Type::kFloat:
+      return float_value_ == other.float_value_;
+    case Type::kString:
+      return string_value_ == other.string_value_;
+    case Type::kBinary:
+      return binary_value_ == other.binary_value_;
+    case Type::kDictionary: {
+      if (dictionary_value_.size() != other.dictionary_value_.size())
+        return false;
+      for (const auto& pair : dictionary_value_) {
+        const auto iter = other.dictionary_value_.find(pair.first);
+        if (iter == other.dictionary_value_.end() ||
+            !pair.second->StrictlyEquals(*iter->second)) {
+          return false;
+        }
+      }
+      return true;
+    }
+    case Type::kArray: {
+      if (array_value_.size() != other.array_value_.size())
+        return false;
+      for (size_t i = 0; i < array_value_.size(); ++i) {
+        if (!array_value_[i]->StrictlyEquals(*other.array_value_[i]))
+          return false;
+      }
+      return true;
+    }
+  }
+}
+
 bool Value::GetBoolean() const {
   GOOGLE_SMART_CARD_CHECK(is_boolean());
   return boolean_value_;

--- a/common/cpp/src/google_smart_card_common/value.h
+++ b/common/cpp/src/google_smart_card_common/value.h
@@ -83,6 +83,11 @@ class Value final {
 
   ~Value();
 
+  // Returns whether the value has the exact same type and value. Note that
+  // false is returned when comparing an integer and a float, even when their
+  // numerical value is the same.
+  bool StrictlyEquals(const Value& other) const;
+
   Type type() const { return type_; }
   bool is_null() const { return type_ == Type::kNull; }
   bool is_boolean() const { return type_ == Type::kBoolean; }

--- a/common/cpp/src/google_smart_card_common/value_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_unittest.cc
@@ -66,9 +66,8 @@ TEST(ValueTest, Integer) {
   EXPECT_EQ(value.GetInteger(), 123);
   EXPECT_DOUBLE_EQ(value.GetFloat(), 123);
 
-  // Test `StrictlyEquals()`() against the integer value.
+  // Test `StrictlyEquals()` against same/different integer values.
   EXPECT_TRUE(value.StrictlyEquals(Value(123)));
-  EXPECT_FALSE(value.StrictlyEquals(Value()));
   EXPECT_FALSE(value.StrictlyEquals(Value(1234)));
 }
 
@@ -86,9 +85,8 @@ TEST(ValueTest, Integer64BitMax) {
   EXPECT_EQ(value.GetInteger(), integer_value);
   EXPECT_DOUBLE_EQ(value.GetFloat(), static_cast<double>(integer_value));
 
-  // Test `StrictlyEquals()`() against the integer value.
+  // Test `StrictlyEquals()` against same/different integer values.
   EXPECT_TRUE(value.StrictlyEquals(Value(integer_value)));
-  EXPECT_FALSE(value.StrictlyEquals(Value()));
   EXPECT_FALSE(value.StrictlyEquals(Value(0)));
 }
 
@@ -106,9 +104,8 @@ TEST(ValueTest, Integer64BitMin) {
   EXPECT_EQ(value.GetInteger(), integer_value);
   EXPECT_DOUBLE_EQ(value.GetFloat(), integer_value);
 
-  // Test `StrictlyEquals()`() against the integer value.
+  // Test `StrictlyEquals()` against same/different integer values.
   EXPECT_TRUE(value.StrictlyEquals(Value(integer_value)));
-  EXPECT_FALSE(value.StrictlyEquals(Value()));
   EXPECT_FALSE(value.StrictlyEquals(Value(0)));
 }
 
@@ -125,9 +122,8 @@ TEST(ValueTest, IntegerDefault) {
   EXPECT_EQ(value.GetInteger(), 0);
   EXPECT_DOUBLE_EQ(value.GetFloat(), 0);
 
-  // Test `StrictlyEquals()`() against the integer value.
+  // Test `StrictlyEquals()` against same/different integer values.
   EXPECT_TRUE(value.StrictlyEquals(Value(0)));
-  EXPECT_FALSE(value.StrictlyEquals(Value()));
   EXPECT_FALSE(value.StrictlyEquals(Value(123)));
 }
 
@@ -143,10 +139,8 @@ TEST(ValueTest, Float) {
   EXPECT_FALSE(value.is_array());
   EXPECT_DOUBLE_EQ(value.GetFloat(), 123.456);
 
-  // Test `StrictlyEquals()`() against the float value.
+  // Test `StrictlyEquals()` against same/different float values.
   EXPECT_TRUE(value.StrictlyEquals(Value(123.456)));
-  EXPECT_FALSE(value.StrictlyEquals(Value()));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
   EXPECT_FALSE(value.StrictlyEquals(Value(123.4567)));
 }
 
@@ -162,10 +156,8 @@ TEST(ValueTest, FloatDefault) {
   EXPECT_FALSE(value.is_array());
   EXPECT_DOUBLE_EQ(value.GetFloat(), 0);
 
-  // Test `StrictlyEquals()`() against the float value.
+  // Test `StrictlyEquals()` against same/different float values.
   EXPECT_TRUE(value.StrictlyEquals(Value(0.0)));
-  EXPECT_FALSE(value.StrictlyEquals(Value()));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
   EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
 }
 
@@ -182,11 +174,8 @@ TEST(ValueTest, String) {
   EXPECT_FALSE(value.is_array());
   EXPECT_EQ(value.GetString(), kString);
 
-  // Test `StrictlyEquals()`() against the string value.
+  // Test `StrictlyEquals()` against same/different string values.
   EXPECT_TRUE(value.StrictlyEquals(Value(kString)));
-  EXPECT_FALSE(value.StrictlyEquals(Value()));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
   EXPECT_FALSE(value.StrictlyEquals(Value("bar")));
 }
 
@@ -203,11 +192,8 @@ TEST(ValueTest, StringFromChars) {
   EXPECT_FALSE(value.is_array());
   EXPECT_EQ(value.GetString(), kString);
 
-  // Test `StrictlyEquals()`() against the string value.
+  // Test `StrictlyEquals()` against same/different string values.
   EXPECT_TRUE(value.StrictlyEquals(Value(kString)));
-  EXPECT_FALSE(value.StrictlyEquals(Value()));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
   EXPECT_FALSE(value.StrictlyEquals(Value("bar")));
 }
 
@@ -223,11 +209,8 @@ TEST(ValueTest, StringDefault) {
   EXPECT_FALSE(value.is_array());
   EXPECT_EQ(value.GetString(), "");
 
-  // Test `StrictlyEquals()`() against the string value.
+  // Test `StrictlyEquals()` against same/different string value.
   EXPECT_TRUE(value.StrictlyEquals(Value("")));
-  EXPECT_FALSE(value.StrictlyEquals(Value()));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
   EXPECT_FALSE(value.StrictlyEquals(Value("foo")));
 }
 
@@ -244,12 +227,8 @@ TEST(ValueTest, Binary) {
   EXPECT_FALSE(value.is_array());
   EXPECT_EQ(value.GetBinary(), bytes);
 
-  // Test `StrictlyEquals()`() against the binary value.
+  // Test `StrictlyEquals()` against same/different binary values.
   EXPECT_TRUE(value.StrictlyEquals(Value(bytes)));
-  EXPECT_FALSE(value.StrictlyEquals(Value()));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
-  EXPECT_FALSE(value.StrictlyEquals(Value("foo")));
   EXPECT_FALSE(value.StrictlyEquals(Value(std::vector<uint8_t>{1, 2, 3, 4})));
 }
 
@@ -266,12 +245,8 @@ TEST(ValueTest, BinaryDefault) {
   EXPECT_FALSE(value.is_array());
   EXPECT_EQ(value.GetBinary(), bytes);
 
-  // Test `StrictlyEquals()`() against the binary value.
+  // Test `StrictlyEquals()` against same/different binary values.
   EXPECT_TRUE(value.StrictlyEquals(Value(bytes)));
-  EXPECT_FALSE(value.StrictlyEquals(Value()));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
-  EXPECT_FALSE(value.StrictlyEquals(Value("foo")));
   EXPECT_FALSE(value.StrictlyEquals(Value(std::vector<uint8_t>{1, 2, 3})));
 }
 
@@ -299,16 +274,10 @@ TEST(ValueTest, Dictionary) {
   const Value* const item_baz = value.GetDictionaryItem("baz");
   EXPECT_FALSE(item_baz);
 
-  // Test `StrictlyEquals()`() against the dictionary value.
+  // Test `StrictlyEquals()` against same/different dictionary values.
   std::map<std::string, std::unique_ptr<Value>> clone;
   clone["foo"] = MakeUnique<Value>();
   clone["bar"] = MakeUnique<Value>(123);
-  EXPECT_TRUE(value.StrictlyEquals(Value(std::move(clone))));
-  EXPECT_FALSE(value.StrictlyEquals(Value()));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
-  EXPECT_FALSE(value.StrictlyEquals(Value("foo")));
-  EXPECT_FALSE(value.StrictlyEquals(Value(std::vector<uint8_t>{1, 2, 3})));
   std::map<std::string, std::unique_ptr<Value>> other;
   other["foo"] = MakeUnique<Value>();
   other["bar"] = MakeUnique<Value>(1234);
@@ -329,13 +298,8 @@ TEST(ValueTest, DictionaryDefault) {
   const Value* const item_foo = value.GetDictionaryItem("foo");
   EXPECT_FALSE(item_foo);
 
-  // Test `StrictlyEquals()`() against the dictionary value.
+  // Test `StrictlyEquals()` against same/different dictionary values.
   EXPECT_TRUE(value.StrictlyEquals(Value(Value::Type::kDictionary)));
-  EXPECT_FALSE(value.StrictlyEquals(Value()));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
-  EXPECT_FALSE(value.StrictlyEquals(Value("foo")));
-  EXPECT_FALSE(value.StrictlyEquals(Value(std::vector<uint8_t>{1, 2, 3})));
   std::map<std::string, std::unique_ptr<Value>> other;
   other["foo"] = MakeUnique<Value>();
   other["bar"] = MakeUnique<Value>(1234);
@@ -364,24 +328,15 @@ TEST(ValueTest, Array) {
   ASSERT_TRUE(item1->is_integer());
   EXPECT_EQ(item1->GetInteger(), 123);
 
-  // Test `StrictlyEquals()`() against the array value.
+  // Test `StrictlyEquals()` against same/different array values.
   std::vector<std::unique_ptr<Value>> clone;
   clone.push_back(MakeUnique<Value>());
   clone.push_back(MakeUnique<Value>(123));
   EXPECT_TRUE(value.StrictlyEquals(Value(std::move(clone))));
-  EXPECT_FALSE(value.StrictlyEquals(Value()));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
-  EXPECT_FALSE(value.StrictlyEquals(Value("foo")));
-  EXPECT_FALSE(value.StrictlyEquals(Value(std::vector<uint8_t>{1, 2, 3})));
-  std::map<std::string, std::unique_ptr<Value>> dict;
-  dict["foo"] = MakeUnique<Value>();
-  dict["bar"] = MakeUnique<Value>(123);
-  EXPECT_FALSE(value.StrictlyEquals(Value(std::move(dict))));
-  std::vector<std::unique_ptr<Value>> array;
-  array.push_back(MakeUnique<Value>());
-  array.push_back(MakeUnique<Value>(1234));
-  EXPECT_FALSE(value.StrictlyEquals(Value(std::move(array))));
+  std::vector<std::unique_ptr<Value>> other;
+  other.push_back(MakeUnique<Value>());
+  other.push_back(MakeUnique<Value>(1234));
+  EXPECT_FALSE(value.StrictlyEquals(Value(std::move(other))));
 }
 
 TEST(ValueTest, ArrayDefault) {
@@ -396,21 +351,62 @@ TEST(ValueTest, ArrayDefault) {
   EXPECT_TRUE(value.is_array());
   EXPECT_TRUE(value.GetArray().empty());
 
-  // Test `StrictlyEquals()`() against the array value.
+  // Test `StrictlyEquals()` against same/different array values.
   EXPECT_TRUE(value.StrictlyEquals(Value(Value::Type::kArray)));
-  EXPECT_FALSE(value.StrictlyEquals(Value()));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
-  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
-  EXPECT_FALSE(value.StrictlyEquals(Value("foo")));
-  EXPECT_FALSE(value.StrictlyEquals(Value(std::vector<uint8_t>{1, 2, 3})));
-  std::map<std::string, std::unique_ptr<Value>> dict;
-  dict["foo"] = MakeUnique<Value>();
-  dict["bar"] = MakeUnique<Value>(123);
-  EXPECT_FALSE(value.StrictlyEquals(Value(std::move(dict))));
-  std::vector<std::unique_ptr<Value>> array;
-  array.push_back(MakeUnique<Value>());
-  array.push_back(MakeUnique<Value>(123));
-  EXPECT_FALSE(value.StrictlyEquals(Value(std::move(array))));
+  std::vector<std::unique_ptr<Value>> other;
+  other.push_back(MakeUnique<Value>());
+  other.push_back(MakeUnique<Value>(123));
+  EXPECT_FALSE(value.StrictlyEquals(Value(std::move(other))));
+}
+
+// Test the `StrictlyEquals` method returns false for values of different types.
+TEST(ValueTest, DifferentTypesAreNotStrictlyEqual) {
+  const Value null_value;
+  const Value boolean_value(true);
+  const Value integer_value(123);
+  const Value float_value(123.0);
+  const Value string_value("123");
+  const Value binary_value(std::vector<uint8_t>{1, 2, 3});
+  const Value dictionary_value(Value::Type::kDictionary);
+  const Value array_value(Value::Type::kArray);
+
+  // Not using loops for saving typing, because when a test assertion fails in a
+  // loop it's unclear what exactly failed.
+
+  EXPECT_FALSE(null_value.StrictlyEquals(boolean_value));
+  EXPECT_FALSE(null_value.StrictlyEquals(integer_value));
+  EXPECT_FALSE(null_value.StrictlyEquals(float_value));
+  EXPECT_FALSE(null_value.StrictlyEquals(string_value));
+  EXPECT_FALSE(null_value.StrictlyEquals(binary_value));
+  EXPECT_FALSE(null_value.StrictlyEquals(dictionary_value));
+  EXPECT_FALSE(null_value.StrictlyEquals(array_value));
+
+  EXPECT_FALSE(boolean_value.StrictlyEquals(integer_value));
+  EXPECT_FALSE(boolean_value.StrictlyEquals(float_value));
+  EXPECT_FALSE(boolean_value.StrictlyEquals(string_value));
+  EXPECT_FALSE(boolean_value.StrictlyEquals(binary_value));
+  EXPECT_FALSE(boolean_value.StrictlyEquals(dictionary_value));
+  EXPECT_FALSE(boolean_value.StrictlyEquals(array_value));
+
+  EXPECT_FALSE(integer_value.StrictlyEquals(float_value));
+  EXPECT_FALSE(integer_value.StrictlyEquals(string_value));
+  EXPECT_FALSE(integer_value.StrictlyEquals(binary_value));
+  EXPECT_FALSE(integer_value.StrictlyEquals(dictionary_value));
+  EXPECT_FALSE(integer_value.StrictlyEquals(array_value));
+
+  EXPECT_FALSE(float_value.StrictlyEquals(string_value));
+  EXPECT_FALSE(float_value.StrictlyEquals(binary_value));
+  EXPECT_FALSE(float_value.StrictlyEquals(dictionary_value));
+  EXPECT_FALSE(float_value.StrictlyEquals(array_value));
+
+  EXPECT_FALSE(string_value.StrictlyEquals(binary_value));
+  EXPECT_FALSE(string_value.StrictlyEquals(dictionary_value));
+  EXPECT_FALSE(string_value.StrictlyEquals(array_value));
+
+  EXPECT_FALSE(binary_value.StrictlyEquals(dictionary_value));
+  EXPECT_FALSE(binary_value.StrictlyEquals(array_value));
+
+  EXPECT_FALSE(dictionary_value.StrictlyEquals(array_value));
 }
 
 TEST(ValueTest, MoveConstruction) {

--- a/common/cpp/src/google_smart_card_common/value_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_unittest.cc
@@ -37,6 +37,7 @@ TEST(ValueTest, DefaultConstructed) {
   EXPECT_FALSE(value.is_binary());
   EXPECT_FALSE(value.is_dictionary());
   EXPECT_FALSE(value.is_array());
+  EXPECT_TRUE(value.StrictlyEquals(Value()));
 }
 
 TEST(ValueTest, Null) {
@@ -49,6 +50,7 @@ TEST(ValueTest, Null) {
   EXPECT_FALSE(value.is_binary());
   EXPECT_FALSE(value.is_dictionary());
   EXPECT_FALSE(value.is_array());
+  EXPECT_TRUE(value.StrictlyEquals(Value()));
 }
 
 TEST(ValueTest, Integer) {
@@ -63,6 +65,11 @@ TEST(ValueTest, Integer) {
   EXPECT_FALSE(value.is_array());
   EXPECT_EQ(value.GetInteger(), 123);
   EXPECT_DOUBLE_EQ(value.GetFloat(), 123);
+
+  // Test `StrictlyEquals()`() against the integer value.
+  EXPECT_TRUE(value.StrictlyEquals(Value(123)));
+  EXPECT_FALSE(value.StrictlyEquals(Value()));
+  EXPECT_FALSE(value.StrictlyEquals(Value(1234)));
 }
 
 TEST(ValueTest, Integer64BitMax) {
@@ -78,6 +85,11 @@ TEST(ValueTest, Integer64BitMax) {
   EXPECT_FALSE(value.is_array());
   EXPECT_EQ(value.GetInteger(), integer_value);
   EXPECT_DOUBLE_EQ(value.GetFloat(), static_cast<double>(integer_value));
+
+  // Test `StrictlyEquals()`() against the integer value.
+  EXPECT_TRUE(value.StrictlyEquals(Value(integer_value)));
+  EXPECT_FALSE(value.StrictlyEquals(Value()));
+  EXPECT_FALSE(value.StrictlyEquals(Value(0)));
 }
 
 TEST(ValueTest, Integer64BitMin) {
@@ -93,6 +105,11 @@ TEST(ValueTest, Integer64BitMin) {
   EXPECT_FALSE(value.is_array());
   EXPECT_EQ(value.GetInteger(), integer_value);
   EXPECT_DOUBLE_EQ(value.GetFloat(), integer_value);
+
+  // Test `StrictlyEquals()`() against the integer value.
+  EXPECT_TRUE(value.StrictlyEquals(Value(integer_value)));
+  EXPECT_FALSE(value.StrictlyEquals(Value()));
+  EXPECT_FALSE(value.StrictlyEquals(Value(0)));
 }
 
 TEST(ValueTest, IntegerDefault) {
@@ -107,6 +124,11 @@ TEST(ValueTest, IntegerDefault) {
   EXPECT_FALSE(value.is_array());
   EXPECT_EQ(value.GetInteger(), 0);
   EXPECT_DOUBLE_EQ(value.GetFloat(), 0);
+
+  // Test `StrictlyEquals()`() against the integer value.
+  EXPECT_TRUE(value.StrictlyEquals(Value(0)));
+  EXPECT_FALSE(value.StrictlyEquals(Value()));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
 }
 
 TEST(ValueTest, Float) {
@@ -120,6 +142,12 @@ TEST(ValueTest, Float) {
   EXPECT_FALSE(value.is_dictionary());
   EXPECT_FALSE(value.is_array());
   EXPECT_DOUBLE_EQ(value.GetFloat(), 123.456);
+
+  // Test `StrictlyEquals()`() against the float value.
+  EXPECT_TRUE(value.StrictlyEquals(Value(123.456)));
+  EXPECT_FALSE(value.StrictlyEquals(Value()));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123.4567)));
 }
 
 TEST(ValueTest, FloatDefault) {
@@ -133,6 +161,12 @@ TEST(ValueTest, FloatDefault) {
   EXPECT_FALSE(value.is_dictionary());
   EXPECT_FALSE(value.is_array());
   EXPECT_DOUBLE_EQ(value.GetFloat(), 0);
+
+  // Test `StrictlyEquals()`() against the float value.
+  EXPECT_TRUE(value.StrictlyEquals(Value(0.0)));
+  EXPECT_FALSE(value.StrictlyEquals(Value()));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
 }
 
 TEST(ValueTest, String) {
@@ -147,6 +181,13 @@ TEST(ValueTest, String) {
   EXPECT_FALSE(value.is_dictionary());
   EXPECT_FALSE(value.is_array());
   EXPECT_EQ(value.GetString(), kString);
+
+  // Test `StrictlyEquals()`() against the string value.
+  EXPECT_TRUE(value.StrictlyEquals(Value(kString)));
+  EXPECT_FALSE(value.StrictlyEquals(Value()));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
+  EXPECT_FALSE(value.StrictlyEquals(Value("bar")));
 }
 
 TEST(ValueTest, StringFromChars) {
@@ -161,6 +202,13 @@ TEST(ValueTest, StringFromChars) {
   EXPECT_FALSE(value.is_dictionary());
   EXPECT_FALSE(value.is_array());
   EXPECT_EQ(value.GetString(), kString);
+
+  // Test `StrictlyEquals()`() against the string value.
+  EXPECT_TRUE(value.StrictlyEquals(Value(kString)));
+  EXPECT_FALSE(value.StrictlyEquals(Value()));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
+  EXPECT_FALSE(value.StrictlyEquals(Value("bar")));
 }
 
 TEST(ValueTest, StringDefault) {
@@ -174,6 +222,13 @@ TEST(ValueTest, StringDefault) {
   EXPECT_FALSE(value.is_dictionary());
   EXPECT_FALSE(value.is_array());
   EXPECT_EQ(value.GetString(), "");
+
+  // Test `StrictlyEquals()`() against the string value.
+  EXPECT_TRUE(value.StrictlyEquals(Value("")));
+  EXPECT_FALSE(value.StrictlyEquals(Value()));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
+  EXPECT_FALSE(value.StrictlyEquals(Value("foo")));
 }
 
 TEST(ValueTest, Binary) {
@@ -188,6 +243,14 @@ TEST(ValueTest, Binary) {
   EXPECT_FALSE(value.is_dictionary());
   EXPECT_FALSE(value.is_array());
   EXPECT_EQ(value.GetBinary(), bytes);
+
+  // Test `StrictlyEquals()`() against the binary value.
+  EXPECT_TRUE(value.StrictlyEquals(Value(bytes)));
+  EXPECT_FALSE(value.StrictlyEquals(Value()));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
+  EXPECT_FALSE(value.StrictlyEquals(Value("foo")));
+  EXPECT_FALSE(value.StrictlyEquals(Value(std::vector<uint8_t>{1, 2, 3, 4})));
 }
 
 TEST(ValueTest, BinaryDefault) {
@@ -202,6 +265,14 @@ TEST(ValueTest, BinaryDefault) {
   EXPECT_FALSE(value.is_dictionary());
   EXPECT_FALSE(value.is_array());
   EXPECT_EQ(value.GetBinary(), bytes);
+
+  // Test `StrictlyEquals()`() against the binary value.
+  EXPECT_TRUE(value.StrictlyEquals(Value(bytes)));
+  EXPECT_FALSE(value.StrictlyEquals(Value()));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
+  EXPECT_FALSE(value.StrictlyEquals(Value("foo")));
+  EXPECT_FALSE(value.StrictlyEquals(Value(std::vector<uint8_t>{1, 2, 3})));
 }
 
 TEST(ValueTest, Dictionary) {
@@ -227,6 +298,21 @@ TEST(ValueTest, Dictionary) {
   EXPECT_EQ(item_bar->GetInteger(), 123);
   const Value* const item_baz = value.GetDictionaryItem("baz");
   EXPECT_FALSE(item_baz);
+
+  // Test `StrictlyEquals()`() against the dictionary value.
+  std::map<std::string, std::unique_ptr<Value>> clone;
+  clone["foo"] = MakeUnique<Value>();
+  clone["bar"] = MakeUnique<Value>(123);
+  EXPECT_TRUE(value.StrictlyEquals(Value(std::move(clone))));
+  EXPECT_FALSE(value.StrictlyEquals(Value()));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
+  EXPECT_FALSE(value.StrictlyEquals(Value("foo")));
+  EXPECT_FALSE(value.StrictlyEquals(Value(std::vector<uint8_t>{1, 2, 3})));
+  std::map<std::string, std::unique_ptr<Value>> other;
+  other["foo"] = MakeUnique<Value>();
+  other["bar"] = MakeUnique<Value>(1234);
+  EXPECT_FALSE(value.StrictlyEquals(Value(std::move(other))));
 }
 
 TEST(ValueTest, DictionaryDefault) {
@@ -242,6 +328,18 @@ TEST(ValueTest, DictionaryDefault) {
   EXPECT_TRUE(value.GetDictionary().empty());
   const Value* const item_foo = value.GetDictionaryItem("foo");
   EXPECT_FALSE(item_foo);
+
+  // Test `StrictlyEquals()`() against the dictionary value.
+  EXPECT_TRUE(value.StrictlyEquals(Value(Value::Type::kDictionary)));
+  EXPECT_FALSE(value.StrictlyEquals(Value()));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
+  EXPECT_FALSE(value.StrictlyEquals(Value("foo")));
+  EXPECT_FALSE(value.StrictlyEquals(Value(std::vector<uint8_t>{1, 2, 3})));
+  std::map<std::string, std::unique_ptr<Value>> other;
+  other["foo"] = MakeUnique<Value>();
+  other["bar"] = MakeUnique<Value>(1234);
+  EXPECT_FALSE(value.StrictlyEquals(Value(std::move(other))));
 }
 
 TEST(ValueTest, Array) {
@@ -265,6 +363,25 @@ TEST(ValueTest, Array) {
   ASSERT_TRUE(item1);
   ASSERT_TRUE(item1->is_integer());
   EXPECT_EQ(item1->GetInteger(), 123);
+
+  // Test `StrictlyEquals()`() against the array value.
+  std::vector<std::unique_ptr<Value>> clone;
+  clone.push_back(MakeUnique<Value>());
+  clone.push_back(MakeUnique<Value>(123));
+  EXPECT_TRUE(value.StrictlyEquals(Value(std::move(clone))));
+  EXPECT_FALSE(value.StrictlyEquals(Value()));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
+  EXPECT_FALSE(value.StrictlyEquals(Value("foo")));
+  EXPECT_FALSE(value.StrictlyEquals(Value(std::vector<uint8_t>{1, 2, 3})));
+  std::map<std::string, std::unique_ptr<Value>> dict;
+  dict["foo"] = MakeUnique<Value>();
+  dict["bar"] = MakeUnique<Value>(123);
+  EXPECT_FALSE(value.StrictlyEquals(Value(std::move(dict))));
+  std::vector<std::unique_ptr<Value>> array;
+  array.push_back(MakeUnique<Value>());
+  array.push_back(MakeUnique<Value>(1234));
+  EXPECT_FALSE(value.StrictlyEquals(Value(std::move(array))));
 }
 
 TEST(ValueTest, ArrayDefault) {
@@ -278,6 +395,22 @@ TEST(ValueTest, ArrayDefault) {
   EXPECT_FALSE(value.is_dictionary());
   EXPECT_TRUE(value.is_array());
   EXPECT_TRUE(value.GetArray().empty());
+
+  // Test `StrictlyEquals()`() against the array value.
+  EXPECT_TRUE(value.StrictlyEquals(Value(Value::Type::kArray)));
+  EXPECT_FALSE(value.StrictlyEquals(Value()));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123)));
+  EXPECT_FALSE(value.StrictlyEquals(Value(123.456)));
+  EXPECT_FALSE(value.StrictlyEquals(Value("foo")));
+  EXPECT_FALSE(value.StrictlyEquals(Value(std::vector<uint8_t>{1, 2, 3})));
+  std::map<std::string, std::unique_ptr<Value>> dict;
+  dict["foo"] = MakeUnique<Value>();
+  dict["bar"] = MakeUnique<Value>(123);
+  EXPECT_FALSE(value.StrictlyEquals(Value(std::move(dict))));
+  std::vector<std::unique_ptr<Value>> array;
+  array.push_back(MakeUnique<Value>());
+  array.push_back(MakeUnique<Value>(123));
+  EXPECT_FALSE(value.StrictlyEquals(Value(std::move(array))));
 }
 
 TEST(ValueTest, MoveConstruction) {


### PR DESCRIPTION
Implement comparison operation for the C++ Value class. To avoid any
confusion (e.g., "is floating-point 123.0 same as integer 123?") the
operation is defined as a regular method, rather than an overloaded
operator.

This new operation will be used by follow-up changes for implementing
new unit tests.