### PR TITLE
Add ArrayValueBuilder, DictValueBuilder

### DIFF
--- a/common/cpp/build/Makefile
+++ b/common/cpp/build/Makefile
@@ -50,6 +50,7 @@ SOURCES := \
 	$(SOURCES_PATH)/value.cc \
 	$(SOURCES_PATH)/value_conversion.cc \
 	$(SOURCES_PATH)/value_debug_dumping.cc \
+	../src/public/value_builder.cc \
 
 ifeq ($(TOOLCHAIN),pnacl)
 
@@ -71,6 +72,7 @@ SOURCES += \
 endif
 
 CXXFLAGS := \
+	-I$(ROOT_PATH) \
 	-I$(ROOT_SOURCES_PATH)/ \
 	-pedantic \
 	-Wall \

--- a/common/cpp/build/tests/Makefile
+++ b/common/cpp/build/tests/Makefile
@@ -35,6 +35,7 @@ SOURCES := \
 	$(SOURCES_PATH)/value_conversion_unittest.cc \
 	$(SOURCES_PATH)/value_debug_dumping_unittest.cc \
 	$(SOURCES_PATH)/value_unittest.cc \
+	../../src/public/value_builder_unittest.cc \
 
 ifeq ($(TOOLCHAIN),emscripten)
 
@@ -49,6 +50,7 @@ SOURCES += \
 endif
 
 CXXFLAGS := \
+	-I$(ROOT_PATH) \
 	-I$(ROOT_SOURCES_PATH)/ \
 	-pedantic \
 	-Wall \

--- a/common/cpp/src/public/value_builder.cc
+++ b/common/cpp/src/public/value_builder.cc
@@ -1,0 +1,86 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/cpp/src/public/value_builder.h"
+
+#include <string>
+#include <utility>
+
+#include <google_smart_card_common/formatting.h>
+#include <google_smart_card_common/logging/logging.h>
+#include <google_smart_card_common/unique_ptr_utils.h>
+#include <google_smart_card_common/value.h>
+
+namespace google_smart_card {
+
+ArrayValueBuilder::ArrayValueBuilder() = default;
+
+ArrayValueBuilder::~ArrayValueBuilder() = default;
+
+void ArrayValueBuilder::AddConverted(
+    bool conversion_success,
+    const std::string& conversion_error_message,
+    Value converted) {
+  if (!succeeded_)
+    return;
+  if (!conversion_success) {
+    succeeded_ = false;
+    error_message_ = FormatPrintfTemplate("Failed to convert item#%d: %s",
+                                          static_cast<int>(items_.size()),
+                                          conversion_error_message.c_str());
+    return;
+  }
+  items_.push_back(MakeUnique<Value>(std::move(converted)));
+}
+
+Value ArrayValueBuilder::Get() && {
+  if (!succeeded_)
+    GOOGLE_SMART_CARD_LOG_FATAL << "Array building failed: " << error_message_;
+  return Value(std::move(items_));
+}
+
+DictValueBuilder::DictValueBuilder() = default;
+
+DictValueBuilder::~DictValueBuilder() = default;
+
+void DictValueBuilder::AddConverted(bool conversion_success,
+                                    const std::string& conversion_error_message,
+                                    const std::string& key,
+                                    Value converted_value) {
+  if (!succeeded_)
+    return;
+  if (!conversion_success) {
+    succeeded_ = false;
+    error_message_ =
+        FormatPrintfTemplate(R"(Failed to convert key "%s": %s)", key.c_str(),
+                             conversion_error_message.c_str());
+    return;
+  }
+  if (items_.count(key)) {
+    succeeded_ = false;
+    error_message_ = FormatPrintfTemplate(R"(Duplicate key "%s")", key.c_str());
+    return;
+  }
+  items_[key] = MakeUnique<Value>(std::move(converted_value));
+}
+
+Value DictValueBuilder::Get() && {
+  if (!succeeded_) {
+    GOOGLE_SMART_CARD_LOG_FATAL << "Dictionary building failed: "
+                                << error_message_;
+  }
+  return Value(std::move(items_));
+}
+
+}  // namespace google_smart_card

--- a/common/cpp/src/public/value_builder.h
+++ b/common/cpp/src/public/value_builder.h
@@ -1,0 +1,110 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_SMART_CARD_COMMON_VALUE_BUILDER_H_
+#define GOOGLE_SMART_CARD_COMMON_VALUE_BUILDER_H_
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <google_smart_card_common/value.h>
+#include <google_smart_card_common/value_conversion.h>
+
+namespace google_smart_card {
+
+// Helper for simplifying code that creates an array `Value`.
+//
+// Usage example:
+//   Value x = ArrayValueBuilder().Add("x").Add(123).Get();
+class ArrayValueBuilder final {
+ public:
+  ArrayValueBuilder();
+  ArrayValueBuilder(const ArrayValueBuilder&) = delete;
+  ArrayValueBuilder& operator=(const ArrayValueBuilder&) = delete;
+  ~ArrayValueBuilder();
+
+  // Adds a new item with the given value (converted into a `Value` if needed).
+  template <typename T>
+  ArrayValueBuilder&& Add(T item) && {
+    std::string conversion_error_message;
+    Value converted;
+    bool conversion_success =
+        ConvertToValue(std::move(item), &converted, &conversion_error_message);
+    AddConverted(conversion_success, conversion_error_message,
+                 std::move(converted));
+    return std::move(*this);
+  }
+
+  bool succeeded() const { return succeeded_; }
+  const std::string& error_message() const { return error_message_; }
+
+  // Returns the built array value. Dies if a conversion failure happened.
+  Value Get() &&;
+
+ private:
+  void AddConverted(bool conversion_success,
+                    const std::string& conversion_error_message,
+                    Value converted);
+
+  bool succeeded_ = true;
+  std::string error_message_;
+  Value::ArrayStorage items_;
+};
+
+// Helper for simplifying code that creates a dictionary `Value`.
+//
+// Usage example:
+//   Value x = DictValueBuilder().Add("name", "x").Add("length", 123).Get();
+class DictValueBuilder final {
+ public:
+  DictValueBuilder();
+  DictValueBuilder(const DictValueBuilder&) = delete;
+  DictValueBuilder& operator=(const DictValueBuilder&) = delete;
+  ~DictValueBuilder();
+
+  // Adds the given key and value (converted into a `Value` if needed).
+  template <typename T>
+  DictValueBuilder&& Add(const std::string& key, T value) && {
+    std::string conversion_error_message;
+    Value converted;
+    bool conversion_success =
+        ConvertToValue(std::move(value), &converted, &conversion_error_message);
+    AddConverted(conversion_success, conversion_error_message, key,
+                 std::move(converted));
+    return std::move(*this);
+  }
+
+  bool succeeded() const { return succeeded_; }
+  const std::string& error_message() const { return error_message_; }
+
+  // Returns the built dictionary value. Dies if a conversion failure happened.
+  Value Get() &&;
+
+ private:
+  void AddConverted(bool conversion_success,
+                    const std::string& conversion_error_message,
+                    const std::string& key,
+                    Value converted_value);
+
+  bool succeeded_ = true;
+  std::string error_message_;
+  Value::DictionaryStorage items_;
+};
+
+}  // namespace google_smart_card
+
+#endif  // GOOGLE_SMART_CARD_COMMON_VALUE_BUILDER_H_

--- a/common/cpp/src/public/value_builder_unittest.cc
+++ b/common/cpp/src/public/value_builder_unittest.cc
@@ -1,0 +1,118 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/cpp/src/public/value_builder.h"
+
+#include <stdint.h>
+
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <google_smart_card_common/value.h>
+
+namespace google_smart_card {
+
+TEST(ValueBuilderTest, ArrayEmpty) {
+  ArrayValueBuilder builder;
+
+  ASSERT_TRUE(builder.succeeded());
+  Value result = std::move(builder).Get();
+  ASSERT_TRUE(result.is_array());
+  EXPECT_TRUE(result.GetArray().empty());
+}
+
+TEST(ValueBuilderTest, ArrayIntegerItem) {
+  ArrayValueBuilder builder;
+  std::move(builder).Add(123);
+
+  ASSERT_TRUE(builder.succeeded());
+  Value result = std::move(builder).Get();
+  ASSERT_TRUE(result.is_array());
+  ASSERT_EQ(result.GetArray().size(), 1U);
+  ASSERT_TRUE(result.GetArray()[0]->is_integer());
+  EXPECT_EQ(result.GetArray()[0]->GetInteger(), 123);
+}
+
+TEST(ValueBuilderTest, ArrayStringItem) {
+  ArrayValueBuilder builder;
+  std::move(builder).Add("foo");
+
+  ASSERT_TRUE(builder.succeeded());
+  Value result = std::move(builder).Get();
+  ASSERT_TRUE(result.is_array());
+  ASSERT_EQ(result.GetArray().size(), 1U);
+  ASSERT_TRUE(result.GetArray()[0]->is_string());
+  EXPECT_EQ(result.GetArray()[0]->GetString(), "foo");
+}
+
+TEST(ValueBuilderTest, ArrayMultipleItems) {
+  ArrayValueBuilder builder;
+  std::move(builder).Add(false).Add(Value());
+
+  ASSERT_TRUE(builder.succeeded());
+  Value result = std::move(builder).Get();
+  ASSERT_TRUE(result.is_array());
+  ASSERT_EQ(result.GetArray().size(), 2U);
+  ASSERT_TRUE(result.GetArray()[0]->is_boolean());
+  EXPECT_EQ(result.GetArray()[0]->GetBoolean(), false);
+  EXPECT_TRUE(result.GetArray()[1]->is_null());
+}
+
+TEST(ValueBuilderTest, DictEmpty) {
+  DictValueBuilder builder;
+
+  ASSERT_TRUE(builder.succeeded());
+  Value result = std::move(builder).Get();
+  ASSERT_TRUE(result.is_dictionary());
+  EXPECT_TRUE(result.GetDictionary().empty());
+}
+
+TEST(ValueBuilderTest, DictFloatItem) {
+  DictValueBuilder builder;
+  std::move(builder).Add("foo", 123.456);
+
+  ASSERT_TRUE(builder.succeeded());
+  Value result = std::move(builder).Get();
+  ASSERT_TRUE(result.is_dictionary());
+  EXPECT_EQ(result.GetDictionary().size(), 1U);
+  ASSERT_TRUE(result.GetDictionaryItem("foo"));
+  ASSERT_TRUE(result.GetDictionaryItem("foo")->is_float());
+  EXPECT_EQ(result.GetDictionaryItem("foo")->GetFloat(), 123.456);
+}
+
+TEST(ValueBuilderTest, DictBinaryItem) {
+  const std::vector<uint8_t> kBytes = {1, 2, 3};
+  DictValueBuilder builder;
+  std::move(builder).Add("foo", kBytes);
+
+  ASSERT_TRUE(builder.succeeded());
+  Value result = std::move(builder).Get();
+  ASSERT_TRUE(result.is_dictionary());
+  EXPECT_EQ(result.GetDictionary().size(), 1U);
+  ASSERT_TRUE(result.GetDictionaryItem("foo"));
+  ASSERT_TRUE(result.GetDictionaryItem("foo")->is_binary());
+  EXPECT_EQ(result.GetDictionaryItem("foo")->GetBinary(), kBytes);
+}
+
+TEST(ValueBuilderTest, DictFailureDuplicate) {
+  DictValueBuilder builder;
+  std::move(builder).Add("foo", 1).Add("foo", 2);
+
+  EXPECT_FALSE(builder.succeeded());
+  EXPECT_EQ(builder.error_message(), R"(Duplicate key "foo")");
+}
+
+}  // namespace google_smart_card


### PR DESCRIPTION
Add helper "builder" classes that simplify coding the construction of
Value objects.

These builders will be used by follow-up changes for implementing new
unit tests.