### PR TITLE
Run CI on all PRs regardless of the base branch

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 env:
   # The version of libstdc++ to install for coverage builds.


### PR DESCRIPTION
Enable Continuous Integration for all Pull Requests regardless of their
base branch.

Previously, we used to enable it only for the PRs into the "main"
branch, which precluded using CI for chains of PRs.