### PR TITLE
Use relative path to PC/SC-Lite config files

### DIFF
--- a/third_party/ccid/webport/build/Makefile
+++ b/third_party/ccid/webport/build/Makefile
@@ -46,12 +46,13 @@ CCID_NACL_SOURCES_PATH := ../src
 # * log_msg and log_xxd are redefined in order to not collide with the symbols
 #   from the PC/SC-Lite server-side libraries;
 # * PCSCLITE_HP_DROPDIR constant points to the directory containing the configs
-#   for all PC/SC-Lite server drivers;
+#   for all PC/SC-Lite server drivers; use a relative path, so that it works
+#   both inside the Smart Card Connector app and in unit tests;
 COMMON_CPPFLAGS := \
 	-DHAVE_PTHREAD=1 \
 	-Dlog_msg=ccid_log_msg \
 	-Dlog_xxd=ccid_log_xxd \
-	-DPCSCLITE_HP_DROPDIR='"/executable-module-filesystem/pcsc/drivers"' \
+	-DPCSCLITE_HP_DROPDIR='"executable-module-filesystem/pcsc/drivers"' \
 	-I$(CCID_SOURCES_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-Wall \

--- a/third_party/pcsc-lite/naclport/server/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server/build/Makefile
@@ -74,7 +74,8 @@ COMMON_CPPFLAGS := \
 #   (actually, in the current NaCl port no functionality is influenced by this
 #   constant);
 # * PCSCLITE_HP_DROPDIR constant points to the directory containing the configs
-#   for all PC/SC-Lite server drivers;
+#   for all PC/SC-Lite server drivers; use a relative path, so that it works
+#   both inside the Smart Card Connector app and in unit tests;
 # * USE_IPCDIR constant is just a stub for making the original PC/SC-Lite code
 #   compiling;
 # * USE_USB definition enables the PC/SC-Lite support of USB readers (as
@@ -85,7 +86,7 @@ PCSC_LITE_COMMON_CPPFLAGS := \
 	-DHAVE_LIBUSB \
 	-DHAVE_SYSLOG_H \
 	-DPCSC_ARCH='"Linux"' \
-	-DPCSCLITE_HP_DROPDIR='"/executable-module-filesystem/pcsc/drivers"' \
+	-DPCSCLITE_HP_DROPDIR='"executable-module-filesystem/pcsc/drivers"' \
 	-DUSE_IPCDIR='"IPCDIR_is_not_expected_to_be_used"' \
 	-DUSE_USB \
 	-I$(ROOT_PATH)/common/cpp/src/google_smart_card_common/logging/syslog \


### PR DESCRIPTION
Change the PCSCLITE_HP_DROPDIR constant to specify a relative file path
(without a leading slash).

This is needed in order to be able to run the PC/SC-Lite code in unit
tests, where, unlike running without a Chrome Extension/App, we can't
create a virtual file system with this folder in root. We also don't
want to conditionally change this constant depending on test/non-test
environment, hence using this trick with a relative file path.