### PR TITLE
Add tests for libusb control transfers

### DIFF
--- a/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
@@ -384,7 +384,8 @@ class LibusbJsProxyWithDeviceTest : public LibusbJsProxyTest {
     global_context_.WillReplyToRequestWith(
         "libusb", "listDevices",
         /*arguments=*/Value(Value::Type::kArray),
-        /*result_to_reply_with=*/ArrayValueBuilder()
+        /*result_to_reply_with=*/
+        ArrayValueBuilder()
             .Add(DictValueBuilder()
                      .Add("deviceId", kJsDeviceId)
                      .Add("vendorId", 2)

--- a/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
@@ -384,8 +384,7 @@ class LibusbJsProxyWithDeviceTest : public LibusbJsProxyTest {
     global_context_.WillReplyToRequestWith(
         "libusb", "listDevices",
         /*arguments=*/Value(Value::Type::kArray),
-        /*result_to_reply_with=*/
-        ArrayValueBuilder()
+        /*result_to_reply_with=*/ArrayValueBuilder()
             .Add(DictValueBuilder()
                      .Add("deviceId", kJsDeviceId)
                      .Add("vendorId", 2)


### PR DESCRIPTION
Add unit tests for LibusbControlTransfer() method of LibusbJsProxy,
which performs synchronous control transfers to/from USB devices.