### PR TITLE
Install toolchain-specific deps in CI

### DIFF
--- a/.github/actions/build-dependencies-installation/action.yml
+++ b/.github/actions/build-dependencies-installation/action.yml
@@ -21,7 +21,7 @@ runs:
 
   - name: Initialize env
     shell: bash
-    run: env/initialize.sh
+    run: env/initialize.sh --toolchain=${{ inputs.toolchain }}
 
   # Building in the coverage mode requires LLVM and Clang, as well as 32-bit
   # cross-compile versions of standard C and C++ libraries (needed as we're

--- a/.github/actions/build-dependencies-installation/action.yml
+++ b/.github/actions/build-dependencies-installation/action.yml
@@ -21,7 +21,7 @@ runs:
 
   - name: Initialize env
     shell: bash
-    run: env/initialize.sh --toolchain=${{ inputs.toolchain }}
+    run: env/initialize.sh -t ${{ inputs.toolchain }}
 
   # Building in the coverage mode requires LLVM and Clang, as well as 32-bit
   # cross-compile versions of standard C and C++ libraries (needed as we're


### PR DESCRIPTION
Further optimize the Continuous Integration jobs to skip installing
irrelevant build dependencies in the env/initialize.sh script. For
example, Emscripten installation is not needed when building for
Coverage.