### PR TITLE
Boilerplate C++ tests in smart_card_connector_app/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,13 @@ smart_card_connector_app/build: third_party/pcsc-lite/naclport/server_clients_ma
 TEST_TARGETS := \
 	common/cpp/build/tests \
 	common/js/build/unittests \
+	smart_card_connector_app/build/executable_module/cpp_unittests \
 	third_party/libusb/webport/build/js_unittests \
 	third_party/libusb/webport/build/tests \
 	third_party/pcsc-lite/naclport/server_clients_management/build/js_unittests \
 
 common/cpp/build/tests: common/cpp/build
+smart_card_connector_app/build/executable_module/cpp_unittests: smart_card_connector_app/build
 third_party/libusb/webport/build/tests: common/cpp/build
 third_party/libusb/webport/build/tests: third_party/libusb/webport/build
 

--- a/coverage-report.sh
+++ b/coverage-report.sh
@@ -17,13 +17,11 @@
 set -eu
 
 CONFIGS="Release Debug"
-COVERAGE_PROFILE_DIRS="
-  common/cpp/build/tests
-  third_party/libusb/webport/build/tests"
 EXECUTABLE_MODULE_DIRS="
   smart_card_connector_app/build/executable_module"
 UNIT_TEST_EXECUTABLE_DIRS="
   common/cpp/build/tests
+  smart_card_connector_app/build/executable_module/cpp_unittests
   third_party/libusb/webport/build/tests"
 IGNORE_FILENAME_REGEX="
   third_party/googletest"
@@ -47,7 +45,7 @@ done
 
 log_message "Merging coverage profiles..."
 profile_files=
-for dir in ${COVERAGE_PROFILE_DIRS}; do
+for dir in ${UNIT_TEST_EXECUTABLE_DIRS}; do
   for config in ${CONFIGS}; do
     profile_files="${profile_files} ${dir}/${config}.profraw"
   done

--- a/smart_card_connector_app/build/Makefile
+++ b/smart_card_connector_app/build/Makefile
@@ -154,9 +154,12 @@ endif
 
 
 # Rules for running unit tests.
-
+# We run C++ and JS tests sequentially to avoid any runtime conflict.
 test:: all
+	+$(MAKE) --directory executable_module test
 	+$(MAKE) --directory js_unittests run_test
 
-tests_clean::
+# Rules for cleaning unit test build artifacts on "make clean".
+js_unittests_clean::
 	+$(MAKE) --directory js_unittests clean
+clean: js_unittests_clean

--- a/smart_card_connector_app/build/executable_module/Makefile
+++ b/smart_card_connector_app/build/executable_module/Makefile
@@ -162,11 +162,19 @@ all: $(OUT_DIR_PATH)/nacl_io_manifest.txt
 endif
 
 
-# Common build rules:
-
+# Rules for compiling source files and linking them into an executable binary.
 $(foreach src,$(SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
-
 $(eval $(call LINK_EXECUTABLE_RULE,$(SOURCES),$(LIBS),$(DEPS),$(LDFLAGS)))
 
-
+# Rules for copyin
 $(eval $(call COLLECT_DEPENDENCY_OUT,$(PCSC_LITE_SERVER_CLIENTS_MANAGEMENT_OUT)))
+
+
+# Rules for running unit tests.
+test:: all
+	+$(MAKE) --directory cpp_unittests run_test
+
+# Rules for cleaning unit test build artifacts on "make clean".
+tests_clean::
+	+$(MAKE) --directory cpp_unittests clean
+clean: tests_clean

--- a/smart_card_connector_app/build/executable_module/Makefile
+++ b/smart_card_connector_app/build/executable_module/Makefile
@@ -166,7 +166,7 @@ endif
 $(foreach src,$(SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
 $(eval $(call LINK_EXECUTABLE_RULE,$(SOURCES),$(LIBS),$(DEPS),$(LDFLAGS)))
 
-# Rules for copyin
+# Rules for copying PC/SC-Lite config files into the resulting out/ folder.
 $(eval $(call COLLECT_DEPENDENCY_OUT,$(PCSC_LITE_SERVER_CLIENTS_MANAGEMENT_OUT)))
 
 

--- a/smart_card_connector_app/build/executable_module/cpp_unittests/.gitignore
+++ b/smart_card_connector_app/build/executable_module/cpp_unittests/.gitignore
@@ -1,0 +1,5 @@
+/*.profraw
+/out/
+/out-artifacts-coverage/
+/out-artifacts-emscripten/
+/pnacl/

--- a/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
+++ b/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
@@ -1,0 +1,51 @@
+# Copyright 2022 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This makefile builds C++ unit tests from the Smart Card Connector's code.
+#
+# The makefile is based on the helper definitions provided by
+# "cpp_unit_test_runner".
+
+include ../../../../common/cpp_unit_test_runner/include.mk
+
+SOURCES := \
+	../../../src/application.cc \
+	../../../src/application_unittest.cc \
+
+CXXFLAGS := \
+	-I$(ROOT_PATH) \
+	-I$(ROOT_PATH)/common/cpp/src \
+	-I$(ROOT_PATH)/third_party/pcsc-lite/naclport/server/src \
+	-I$(ROOT_PATH)/third_party/pcsc-lite/naclport/server_clients_management/src \
+	-pedantic \
+	-Wall \
+	-Werror \
+	-Wextra \
+	-std=$(CXX_DIALECT) \
+	$(TEST_ADDITIONAL_CXXFLAGS) \
+
+# The libraries are listed in the topological order: a library should only use
+# symbols from subsequent ones.
+LIBS := \
+  google_smart_card_pcsc_lite_server_clients_management \
+  google_smart_card_pcsc_lite_server \
+  google_smart_card_pcsc_lite_common \
+  google_smart_card_ccid \
+  google_smart_card_libusb \
+  google_smart_card_common \
+
+$(foreach src,$(SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
+
+$(eval $(call LINK_EXECUTABLE_RULE,$(SOURCES) $(TEST_RUNNER_SOURCES),\
+	$(LIBS) $(TEST_RUNNER_LIBS),$(TEST_RUNNER_DEPS),$(TEST_ADDITIONAL_LDFLAGS)))

--- a/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
+++ b/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
@@ -47,7 +47,8 @@ LIBS := \
   google_smart_card_libusb \
   google_smart_card_common \
 
+# Rules for compiling the test source files and linking them into a resulting
+# executable binary.
 $(foreach src,$(SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
-
 $(eval $(call LINK_EXECUTABLE_RULE,$(SOURCES) $(TEST_RUNNER_SOURCES),\
 	$(LIBS) $(TEST_RUNNER_LIBS),$(TEST_RUNNER_DEPS),$(TEST_ADDITIONAL_LDFLAGS)))

--- a/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
+++ b/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
@@ -19,6 +19,8 @@
 
 include ../../../../common/cpp_unit_test_runner/include.mk
 
+# TODO: application.cc is also compiled by ../Makefile; consider avoiding the
+# duplication.
 SOURCES := \
 	../../../src/application.cc \
 	../../../src/application_unittest.cc \

--- a/smart_card_connector_app/src/application_unittest.cc
+++ b/smart_card_connector_app/src/application_unittest.cc
@@ -1,0 +1,25 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "smart_card_connector_app/src/application.h"
+
+#include <gtest/gtest.h>
+
+namespace google_smart_card {
+
+TEST(SmartCardConnectorApplicationTest, SmokeTest) {
+  // TODO: Implement the actual test.
+}
+
+}  // namespace google_smart_card


### PR DESCRIPTION
Add build infra boilerplate for building C++ unit tests in the
smart_card_connector_app/ folder. The tests themselves will be
implemented in follow-up changes.

We'll use this test location for half-integration tests that start the
PC/SC-Lite daemon with fake USB devices and exercise PC/SC commands.