### PR TITLE
Fix build ordering for Connector unittests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ LIBRARY_TARGETS += \
 	third_party/googletest/webport/build \
 
 common/cpp/build/tests: third_party/googletest/webport/build
+smart_card_connector_app/build/executable_module/cpp_unittests: third_party/googletest/webport/build
 third_party/libusb/webport/build/tests: third_party/googletest/webport/build
 
 else ifeq ($(TOOLCHAIN),pnacl)
@@ -110,6 +111,7 @@ LIBRARY_TARGETS += \
 	third_party/googletest/webport/build \
 
 common/cpp/build/tests: third_party/googletest/webport/build
+smart_card_connector_app/build/executable_module/cpp_unittests: third_party/googletest/webport/build
 third_party/libusb/webport/build/tests: third_party/googletest/webport/build
 
 else


### PR DESCRIPTION
Googletest is needed to be built before building Smart Card Connector's
C++ unit tests (in build configurations in which we have to build
Googletest ourselves: emscripten and coverage).

This commit guarantees this is the case, preventing a potential build
flakiness.