### PR TITLE
Implement proper shutdown for Application class

### DIFF
--- a/smart_card_connector_app/src/application.cc
+++ b/smart_card_connector_app/src/application.cc
@@ -48,14 +48,12 @@ Application::Application(
   ScheduleServicesInitialization();
 }
 
-Application::~Application() {
-  // Intentionally leak objects that might still be used by background threads.
-  // Only shut them down (which makes them stop referring to `this` and stop
-  // sending requests to the JavaScript side).
+void Application::ShutDownAndWait() {
+  pcsc_lite_server_web_port_service_->ShutDownAndWait();
   libusb_web_port_service_->ShutDown();
-  (void)libusb_web_port_service_.release();
-  (void)pcsc_lite_server_web_port_service_.release();
 }
+
+Application::~Application() = default;
 
 void Application::ScheduleServicesInitialization() {
   // TODO(emaxx): Ensure the correct lifetime of `this`.

--- a/smart_card_connector_app/src/application.h
+++ b/smart_card_connector_app/src/application.h
@@ -53,6 +53,11 @@ class Application final {
   // used to run the executable may end it instantly.
   ~Application();
 
+  // Must be called before destroying the object.
+  // Shuts down the application's daemon threads and stops using
+  // `global_context` and `typed_message_router`.
+  void ShutDownAndWait();
+
  private:
   void ScheduleServicesInitialization();
   void InitializeServicesOnBackgroundThread();

--- a/smart_card_connector_app/src/entry_point_emscripten.cc
+++ b/smart_card_connector_app/src/entry_point_emscripten.cc
@@ -21,6 +21,7 @@
 #error "This file should only be used in Emscripten builds"
 #endif  // __EMSCRIPTEN__
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <thread>


### PR DESCRIPTION
Implement a way to shut down the smart_card_connector_app's Application
object without leaking any memory.

This won't be used in production code, as the Smart Card Connector
app/extension never shuts down (and even if some flow triggers the
executable module graceful shutdown, we intentionally leak the objects
to avoid shutdown crashes in background threads). But this proper
shutdown will be used in unit tests of the Application class.