### PR TITLE
Smoke test for Connector Application

### DIFF
--- a/common/cpp/src/google_smart_card_common/requesting/requester_message.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/requester_message.cc
@@ -24,11 +24,12 @@ namespace google_smart_card {
 
 namespace {
 
-constexpr char kRequestMessageTypeSuffix[] = "::request";
-constexpr char kResponseMessageTypeSuffix[] = "::response";
 constexpr char kCanceledErrorMessage[] = "The request was canceled";
 
 }  // namespace
+
+const char kRequestMessageTypeSuffix[] = "::request";
+const char kResponseMessageTypeSuffix[] = "::response";
 
 std::string GetRequestMessageType(const std::string& name) {
   return name + kRequestMessageTypeSuffix;

--- a/common/cpp/src/google_smart_card_common/requesting/requester_message.h
+++ b/common/cpp/src/google_smart_card_common/requesting/requester_message.h
@@ -33,6 +33,9 @@
 
 namespace google_smart_card {
 
+extern const char kRequestMessageTypeSuffix[];
+extern const char kResponseMessageTypeSuffix[];
+
 // Returns the message type for the requests for the requester with the
 // specified name.
 std::string GetRequestMessageType(const std::string& name);

--- a/common/cpp/src/public/testing_global_context.cc
+++ b/common/cpp/src/public/testing_global_context.cc
@@ -14,6 +14,8 @@
 
 #include "common/cpp/src/public/testing_global_context.h"
 
+#include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <utility>
@@ -32,6 +34,92 @@
 #include <google_smart_card_common/value_debug_dumping.h>
 
 namespace google_smart_card {
+
+namespace {
+
+optional<std::string> GetRequesterName(const std::string& message_type) {
+  const std::string suffix = kRequestMessageTypeSuffix;
+  if (message_type.length() <= suffix.length() ||
+      message_type.substr(message_type.length() - suffix.length()) != suffix) {
+    // Not a requester message.
+    return {};
+  }
+  return message_type.substr(0, message_type.length() - suffix.length());
+}
+
+// `payload_to_reply_with` is passed via shared_ptr in order to workaround
+// std::function's lack of support for move-only bounds.
+void PostFakeJsReply(TypedMessageRouter* typed_message_router,
+                     const std::string& requester_name,
+                     std::shared_ptr<Value> payload_to_reply_with,
+                     const optional<std::string>& error_to_reply_with,
+                     optional<RequestId> request_id) {
+  ResponseMessageData response_data;
+  response_data.request_id = *request_id;
+  if (payload_to_reply_with)
+    response_data.payload = std::move(*payload_to_reply_with);
+  response_data.error_message = std::move(error_to_reply_with);
+
+  TypedMessage response;
+  response.type = GetResponseMessageType(requester_name);
+  response.data = ConvertToValueOrDie(std::move(response_data));
+
+  Value reply = ConvertToValueOrDie(std::move(response));
+
+  std::string error_message;
+  if (!typed_message_router->OnMessageReceived(std::move(reply),
+                                               &error_message)) {
+    GOOGLE_SMART_CARD_LOG_FATAL << "Dispatching fake JS reply failed: "
+                                << error_message;
+  }
+}
+
+}  // namespace
+
+TestingGlobalContext::Waiter::Waiter(Waiter&&) = default;
+
+TestingGlobalContext::Waiter& TestingGlobalContext::Waiter::operator=(
+    Waiter&&) = default;
+
+TestingGlobalContext::Waiter::~Waiter() = default;
+
+void TestingGlobalContext::Waiter::Wait() {
+  std::unique_lock<std::mutex> lock(*mutex_);
+  condition_->wait(lock, [&] { return resolved_; });
+}
+
+const Value& TestingGlobalContext::Waiter::GetValue() const {
+  // No mutex locks, as it's only alllowed to call us after `Wait()` completes.
+  GOOGLE_SMART_CARD_CHECK(resolved_);
+  return value_;
+}
+
+Value TestingGlobalContext::Waiter::TakeValue() && {
+  // No mutex locks, as it's only alllowed to call us after `Wait()` completes.
+  GOOGLE_SMART_CARD_CHECK(resolved_);
+  return std::move(value_);
+}
+
+optional<RequestId> TestingGlobalContext::Waiter::GetRequestId() const {
+  // No mutex locks, as it's only alllowed to call us after `Wait()` completes.
+  GOOGLE_SMART_CARD_CHECK(resolved_);
+  return request_id_;
+}
+
+TestingGlobalContext::Waiter::Waiter()
+    : mutex_(MakeUnique<std::mutex>()),
+      condition_(MakeUnique<std::condition_variable>()) {}
+
+void TestingGlobalContext::Waiter::Resolve(Value value,
+                                           optional<RequestId> request_id) {
+  std::unique_lock<std::mutex> lock(*mutex_);
+
+  GOOGLE_SMART_CARD_CHECK(!resolved_);
+  resolved_ = true;
+  value_ = std::move(value);
+  request_id_ = request_id;
+  condition_->notify_one();
+}
 
 TestingGlobalContext::TestingGlobalContext(
     TypedMessageRouter* typed_message_router)
@@ -54,6 +142,17 @@ bool TestingGlobalContext::IsMainEventLoopThread() const {
 }
 
 void TestingGlobalContext::ShutDown() {}
+
+TestingGlobalContext::Waiter TestingGlobalContext::CreateMessageWaiter(
+    const std::string& awaited_message_type) {
+  Waiter waiter;
+  Expectation expectation;
+  expectation.awaited_message_type = awaited_message_type;
+  expectation.callback_to_run = std::bind(
+      &Waiter::Resolve, &waiter, std::placeholders::_1, std::placeholders::_2);
+  AddExpectation(std::move(expectation));
+  return waiter;
+}
 
 void TestingGlobalContext::WillReplyToRequestWith(
     const std::string& requester_name,
@@ -80,7 +179,6 @@ void TestingGlobalContext::WillReplyToRequestWithError(
       /*payload_to_reply_with=*/{}, error_to_reply_with));
 }
 
-// static
 TestingGlobalContext::Expectation TestingGlobalContext::MakeRequestExpectation(
     const std::string& requester_name,
     const std::string& function_name,
@@ -99,34 +197,46 @@ TestingGlobalContext::Expectation TestingGlobalContext::MakeRequestExpectation(
   request_payload.arguments =
       ConvertFromValueOrDie<std::vector<Value>>(std::move(arguments));
 
+  // Work around std::function's inability to bind a move-only argument.
+  std::shared_ptr<Value> payload_shared_ptr;
+  if (payload_to_reply_with) {
+    payload_shared_ptr =
+        std::make_shared<Value>(std::move(*payload_to_reply_with));
+  }
+
   Expectation expectation;
-  expectation.requester_name = requester_name;
+  expectation.awaited_message_type = GetRequestMessageType(requester_name);
   expectation.awaited_request_payload =
       ConvertToValueOrDie(std::move(request_payload));
-  expectation.payload_to_reply_with = std::move(payload_to_reply_with);
-  expectation.error_to_reply_with = error_to_reply_with;
+  expectation.callback_to_run =
+      std::bind(&PostFakeJsReply, typed_message_router_, requester_name,
+                payload_shared_ptr, error_to_reply_with,
+                /*request_id=*/std::placeholders::_2);
   return expectation;
 }
 
 void TestingGlobalContext::AddExpectation(Expectation expectation) {
-  std::unique_lock<std::mutex> lock(mutex_);
+  const std::unique_lock<std::mutex> lock(mutex_);
 
   expectations_.push_back(std::move(expectation));
 }
 
 optional<TestingGlobalContext::Expectation>
 TestingGlobalContext::PopMatchingExpectation(const std::string& message_type,
-                                             const Value& request_payload) {
+                                             const Value* request_payload) {
   std::unique_lock<std::mutex> lock(mutex_);
 
   for (auto iter = expectations_.begin(); iter != expectations_.end(); ++iter) {
-    if (message_type == GetRequestMessageType(iter->requester_name) &&
-        request_payload.StrictlyEquals(iter->awaited_request_payload)) {
-      // A match found. The expectation is a one of, so remove it.
-      Expectation match = std::move(*iter);
-      expectations_.erase(iter);
-      return std::move(match);
+    if (message_type != iter->awaited_message_type)
+      continue;
+    if (request_payload &&
+        !request_payload->StrictlyEquals(*iter->awaited_request_payload)) {
+      continue;
     }
+    // A match found. The expectation is a one of, so remove it.
+    Expectation match = std::move(*iter);
+    expectations_.erase(iter);
+    return std::move(match);
   }
   // No match found.
   return {};
@@ -135,42 +245,30 @@ TestingGlobalContext::PopMatchingExpectation(const std::string& message_type,
 bool TestingGlobalContext::HandleMessageToJs(Value message) {
   TypedMessage typed_message =
       ConvertFromValueOrDie<TypedMessage>(std::move(message));
-  RequestMessageData request_data =
-      ConvertFromValueOrDie<RequestMessageData>(std::move(typed_message.data));
 
+  optional<std::string> requester_name = GetRequesterName(typed_message.type);
+  if (requester_name) {
+    // It's a request message - parse its payload and use it to find the
+    // expectation.
+    RequestMessageData request_data = ConvertFromValueOrDie<RequestMessageData>(
+        std::move(typed_message.data));
+    optional<Expectation> expectation =
+        PopMatchingExpectation(typed_message.type, &request_data.payload);
+    if (!expectation)
+      return false;
+    expectation->callback_to_run(std::move(request_data.payload),
+                                 request_data.request_id);
+    return true;
+  }
+
+  // It's a regular message - find the expectation using just the type.
   optional<Expectation> expectation =
-      PopMatchingExpectation(typed_message.type, request_data.payload);
+      PopMatchingExpectation(typed_message.type, /*request_payload=*/nullptr);
   if (!expectation)
     return false;
-
-  PostFakeJsReply(request_data.request_id, expectation->requester_name,
-                  std::move(expectation->payload_to_reply_with),
-                  expectation->error_to_reply_with);
+  expectation->callback_to_run(std::move(typed_message.data),
+                               /*request_id*/ optional<RequestId>());
   return true;
-}
-
-void TestingGlobalContext::PostFakeJsReply(
-    RequestId request_id,
-    const std::string& requester_name,
-    optional<Value> payload_to_reply_with,
-    const optional<std::string>& error_to_reply_with) {
-  ResponseMessageData response_data;
-  response_data.request_id = request_id;
-  response_data.payload = std::move(payload_to_reply_with);
-  response_data.error_message = std::move(error_to_reply_with);
-
-  TypedMessage response;
-  response.type = GetResponseMessageType(requester_name);
-  response.data = ConvertToValueOrDie(std::move(response_data));
-
-  Value reply = ConvertToValueOrDie(std::move(response));
-
-  std::string error_message;
-  if (!typed_message_router_->OnMessageReceived(std::move(reply),
-                                                &error_message)) {
-    GOOGLE_SMART_CARD_LOG_FATAL << "Dispatching fake JS reply failed: "
-                                << error_message;
-  }
 }
 
 }  // namespace google_smart_card

--- a/smart_card_connector_app/src/application_unittest.cc
+++ b/smart_card_connector_app/src/application_unittest.cc
@@ -35,9 +35,8 @@ class SmartCardConnectorApplicationTest : public ::testing::Test {
  private:
   void StartApplication() {
     // Set up the expectation on the first C++-to-JS message.
-    TestingGlobalContext::Waiter pcsc_lite_ready_message_waiter =
-        global_context_.CreateMessageWaiter(
-            /*awaited_message_type=*/"pcsc_lite_ready");
+    auto pcsc_lite_ready_message_waiter = global_context_.CreateMessageWaiter(
+        /*awaited_message_type=*/"pcsc_lite_ready");
     // Set up the expectation for the application to run the provided callback.
     ::testing::MockFunction<void()> background_initialization_callback;
     EXPECT_CALL(background_initialization_callback, Call());
@@ -48,8 +47,8 @@ class SmartCardConnectorApplicationTest : public ::testing::Test {
         background_initialization_callback.AsStdFunction());
     // Wait until the daemon's background thread completes the initialization
     // and notifies the JS side.
-    pcsc_lite_ready_message_waiter.Wait();
-    EXPECT_TRUE(pcsc_lite_ready_message_waiter.GetValue().StrictlyEquals(
+    pcsc_lite_ready_message_waiter->Wait();
+    EXPECT_TRUE(pcsc_lite_ready_message_waiter->value().StrictlyEquals(
         Value(Value::Type::kDictionary)));
   }
 

--- a/smart_card_connector_app/src/application_unittest.cc
+++ b/smart_card_connector_app/src/application_unittest.cc
@@ -14,12 +14,50 @@
 
 #include "smart_card_connector_app/src/application.h"
 
+#include <memory>
+
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include <google_smart_card_common/messaging/typed_message_router.h>
+#include <google_smart_card_common/unique_ptr_utils.h>
+
+#include "common/cpp/src/public/testing_global_context.h"
 
 namespace google_smart_card {
 
-TEST(SmartCardConnectorApplicationTest, SmokeTest) {
-  // TODO: Implement the actual test.
-}
+class SmartCardConnectorApplicationTest : public ::testing::Test {
+ protected:
+  SmartCardConnectorApplicationTest() { StartApplication(); }
+
+  ~SmartCardConnectorApplicationTest() { application_->ShutDownAndWait(); }
+
+ private:
+  void StartApplication() {
+    // Set up the expectation on the first C++-to-JS message.
+    TestingGlobalContext::Waiter pcsc_lite_ready_message_waiter =
+        global_context_.CreateMessageWaiter(
+            /*awaited_message_type=*/"pcsc_lite_ready");
+    // Set up the expectation for the application to run the provided callback.
+    ::testing::MockFunction<void()> background_initialization_callback;
+    EXPECT_CALL(background_initialization_callback, Call());
+    // Create the application, which spawns the background initialization
+    // thread.
+    application_ = MakeUnique<Application>(
+        &global_context_, &typed_message_router_,
+        background_initialization_callback.AsStdFunction());
+    // Wait until the daemon's background thread completes the initialization
+    // and notifies the JS side.
+    pcsc_lite_ready_message_waiter.Wait();
+    EXPECT_TRUE(pcsc_lite_ready_message_waiter.GetValue().StrictlyEquals(
+        Value(Value::Type::kDictionary)));
+  }
+
+  TypedMessageRouter typed_message_router_;
+  TestingGlobalContext global_context_{&typed_message_router_};
+  std::unique_ptr<Application> application_;
+};
+
+TEST_F(SmartCardConnectorApplicationTest, SmokeTest) {}
 
 }  // namespace google_smart_card


### PR DESCRIPTION
Add a smoke unit test that starts the smart_card_connector_app's
Application object, and checks it successfully completes the
background initialization.

Note that the test is still half-complete because the started
PC/SC-Lite daemon is unable to find the config files. A follow-up
change will fix that later.