### PR TITLE
Fix PC/SC-Lite build_configuration file removing

### DIFF
--- a/third_party/pcsc-lite/naclport/build_configuration/Makefile
+++ b/third_party/pcsc-lite/naclport/build_configuration/Makefile
@@ -45,7 +45,7 @@ all: build.stamp
 # detect changes.
 build.stamp: $(shell find ../../src)
 	@rm -f build.stamp
-	@git status --ignored ../../src | xargs rm -rf
+	@git clean -fX ../../src
 	cd ../../src && ./bootstrap && ./configure
 	@touch build.stamp
 
@@ -53,4 +53,4 @@ build.stamp: $(shell find ../../src)
 .PHONY: clean
 clean:
 	@rm -f build.stamp
-	@git status --ignored ../../src | xargs rm -rf
+	@git clean -fX ../../src


### PR DESCRIPTION
Fix a bug in the pcsc-lite/naclport/build_configuration makefile that
was causing unrelated files to be removed. The issue was that we were
piping the output of "git status --ignored" to "rm", however git status
emits output in a human-readable format that mentions other files as
well (and, generally speaking, other words that can accidentally
coincide with real file names).

Instead, just use "git clean" to do the right thing.