### PR TITLE
Fix warnings on asprintf calls in PC/SC-Lite

### DIFF
--- a/third_party/pcsc-lite/naclport/server/src/config.h
+++ b/third_party/pcsc-lite/naclport/server/src/config.h
@@ -29,6 +29,16 @@
 #ifndef GOOGLE_SMART_CARD_THIRD_PARTY_PCSC_LITE_SERVER_CONFIG_H_
 #define GOOGLE_SMART_CARD_THIRD_PARTY_PCSC_LITE_SERVER_CONFIG_H_
 
+// Enable GNU-specific extensions of Standard Library, as they're called by
+// PC/SC-Lite's original code. This define must precede any include of a
+// standard header, which is why we have to replicate it here (the original
+// PC/SC-Lite's config.h doesn't include standard headers).
+// In some configurations (e.g., NaCl), this macro is already predefined, hence
+// wrap this code into an ifndef.
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <sys/select.h>
 #include <sys/time.h>
 #include <sys/types.h>


### PR DESCRIPTION
Work around warnings from compiling original PC/SC-Lite sources:

  warning: implicit declaration of function 'asprintf' is invalid in C99

The reason they appeared in our builds (but not in upstream) is that
asprintf is a GNU extension. In order to have it declared, one has to
define "_GNU_SOURCE" before including any standard library headers. The
original PC/SC-Lite code satisfies this, but our webport violated it by
adding includes into our version of config.h that's included before
the "#define _GNU_SOURCE" line in hotplug_libusb.c.

The fix is to simply replicate "#define _GNU_SOURCE" at the top of our
config.h file.