### PR TITLE
No eventloop in bg threads in TestingGlobalContext

### DIFF
--- a/common/cpp/src/public/testing_global_context.cc
+++ b/common/cpp/src/public/testing_global_context.cc
@@ -18,6 +18,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -122,7 +123,8 @@ void TestingGlobalContext::Waiter::Resolve(Value value,
 
 TestingGlobalContext::TestingGlobalContext(
     TypedMessageRouter* typed_message_router)
-    : typed_message_router_(typed_message_router) {
+    : typed_message_router_(typed_message_router),
+      creation_thread_id_(std::this_thread::get_id()) {
   GOOGLE_SMART_CARD_CHECK(typed_message_router_);
 }
 
@@ -137,7 +139,8 @@ void TestingGlobalContext::PostMessageToJs(Value message) {
 }
 
 bool TestingGlobalContext::IsMainEventLoopThread() const {
-  return creation_thread_is_event_loop_;
+  return std::this_thread::get_id() == creation_thread_id_ &&
+         creation_thread_is_event_loop_;
 }
 
 void TestingGlobalContext::ShutDown() {}

--- a/common/cpp/src/public/testing_global_context.h
+++ b/common/cpp/src/public/testing_global_context.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 
 #include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/messaging/typed_message.h>
@@ -74,7 +75,8 @@ class TestingGlobalContext final : public GlobalContext {
   bool IsMainEventLoopThread() const override;
   void ShutDown() override;
 
-  // Allows to configure the result of `IsMainEventLoopThread()`.
+  // Allows to configure the result of `IsMainEventLoopThread()` when it's
+  // called from the creation thread (on other threads it returns false anyway).
   void set_creation_thread_is_event_loop(bool creation_thread_is_event_loop) {
     creation_thread_is_event_loop_ = creation_thread_is_event_loop;
   }
@@ -129,6 +131,10 @@ class TestingGlobalContext final : public GlobalContext {
   bool HandleMessageToJs(Value message);
 
   TypedMessageRouter* const typed_message_router_;
+  // ID of the thread on which `this` was created.
+  const std::thread::id creation_thread_id_;
+  // The result to be returned from `IsMainEventLoopThread()` when called on the
+  // creation thread.
   bool creation_thread_is_event_loop_ = true;
   std::mutex mutex_;
   std::deque<Expectation> expectations_;


### PR DESCRIPTION
Update TestingGlobalContext::IsMainEventLoopThread() to closer match the
real-world implementation: it should always return false if called from
a background thread.

This allows us to write multi-threaded tests without silencing their
assertions of kind "this code must never be called on main thread".