### PR TITLE
Chdir for unit tests in coverage mode

### DIFF
--- a/common/cpp_unit_test_runner/src/build_coverage.mk
+++ b/common/cpp_unit_test_runner/src/build_coverage.mk
@@ -43,10 +43,18 @@ GOOGLETEST_LIBS_PATTERN := \
 $(GOOGLETEST_LIBS_PATTERN):
 	$(MAKE) -C $(ROOT_PATH)/third_party/googletest/webport/build
 
-# Execute the test binary. Write the collected coverage profile into
-# ./{Debug|Release}.profraw, so that we can later merge these profiles from all
-# runs and build a summarized report. Use "CURDIR" instead of ".", so that the
-# location isn't affected if the test does chdir.
+# Execute the test binary.
+#
+# Chdir into the "out/$TARGET" directory, so that resource files are available
+# under relative paths (./executable-module-filesystem/...). (We only need this
+# for the "coverage" toolchain, because other toolchains provide built-in ways
+# of exposing resource files through a virtual file system.)
+#
+# Write the collected coverage profile into ./{Debug|Release}.profraw, so that
+# we can later merge these profiles from all runs and build a summarized report.
+# Use "CURDIR" instead of ".", to use an absolute path that doesn't depend on
+# the program's current directory.
 run_test: all
-	LLVM_PROFILE_FILE="$(CURDIR)/$(CONFIG).profraw" \
-		$(OUT_DIR_PATH)/$(TARGET)
+	cd $(OUT_DIR_PATH) && \
+		LLVM_PROFILE_FILE="$(CURDIR)/$(CONFIG).profraw" \
+			./$(TARGET)


### PR DESCRIPTION
Run the unit tests in the "out" directory when using
TOOLCHAIN=coverage.

This allows to implement unit tests that read resource files in the same
way regardless of the toolchain: using relateive file paths
(./executable-module-filesystem/...).