### PR TITLE
Use relative path for fake_socket_file

### DIFF
--- a/third_party/pcsc-lite/naclport/server/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server/build/Makefile
@@ -55,9 +55,10 @@ PCSC_LITE_SOURCES_PATH := $(PCSC_LITE_DIR_PATH)/src/src
 # * FAKE_PCSC_NACL_SOCKET_FILE_NAME constant points to the file containing the
 #   fake socket file (it's used for tricking the original PC/SC-Lite code which
 #   calls stat() for this file - for the details see file
-#   src/winscard_msg_nacl.cc).
+#   src/winscard_msg_nacl.cc). Use a relative path, so that it works both inside
+#   the Smart Card Connector app and in unit tests.
 COMMON_CPPFLAGS := \
-	-DFAKE_PCSC_NACL_SOCKET_FILE_NAME='"/executable-module-filesystem/pcsc/fake_socket_file"' \
+	-DFAKE_PCSC_NACL_SOCKET_FILE_NAME='"executable-module-filesystem/pcsc/fake_socket_file"' \
 	-I$(SOURCES_PATH) \
 	-I$(PCSC_LITE_ORIGINAL_HEADERS_DIR_PATH) \
 	-I$(PCSC_LITE_SOURCES_PATH) \


### PR DESCRIPTION
Update one more global file path to a relative file path: the
FAKE_PCSC_NACL_SOCKET_FILE_NAME constant that point to the
"fake_socket_file" (for the background, the only purpose of this file is
to mimick the presence of the Unix socket file that PC/SC-Lite normally
uses for IPC; we mock out the actual IPC, but the file presence checks
can't be mocked out without patching the PC/SC-Lite sources).

Using relative paths allows to run the same code in unit tests in
"coverage" mode, which doesn't have a virtual file system for exposing
files under absolute paths in "/".