### PR TITLE
Backport PC/SC-Lite upstream shutdown fixes

### DIFF
--- a/third_party/pcsc-lite/patches/0001-memory-leak-sReadersContexts.patch
+++ b/third_party/pcsc-lite/patches/0001-memory-leak-sReadersContexts.patch
@@ -1,0 +1,33 @@
+From 615160ff2f1e6f0f0ee324f7442b0068552d0068 Mon Sep 17 00:00:00 2001
+From: Maksim Ivanov <emaxx@chromium.org>
+Date: Wed, 18 May 2022 21:38:13 +0200
+Subject: [PATCH] Fix shutdown memory leak of sReadersContexts
+
+RFCleanupReaders() should always free memory of sReadersContexts
+(allocated in RFAllocateReaderSpace()), not only when the reader was
+active.
+
+This was only a minor, shutdown-only, issue.
+---
+ src/readerfactory.c | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/src/readerfactory.c b/src/readerfactory.c
+index 50ff96d1..d6041f30 100644
+--- a/src/readerfactory.c
++++ b/src/readerfactory.c
+@@ -1396,11 +1396,10 @@ void RFCleanupReaders(void)
+ 
+ 			if (rv != SCARD_S_SUCCESS)
+ 				Log2(PCSC_LOG_ERROR, "RFRemoveReader error: 0x%08lX", rv);
+-
+-			free(sReadersContexts[i]);
+-
+-			sReadersContexts[i] = NULL;
+ 		}
++
++		free(sReadersContexts[i]);
++		sReadersContexts[i] = NULL;
+ 	}
+ 
+ #ifdef USE_SERIAL

--- a/third_party/pcsc-lite/patches/0002-memory-leak-libusb-device-list.patch
+++ b/third_party/pcsc-lite/patches/0002-memory-leak-libusb-device-list.patch
@@ -1,0 +1,35 @@
+From 1ab596a91032f0f4ce8d73454c33cae9129ab358 Mon Sep 17 00:00:00 2001
+From: Maksim Ivanov <emaxx@google.com>
+Date: Fri, 27 May 2022 17:17:37 +0200
+Subject: [PATCH] Fix libusb_device list leak on shutdown (#133)
+
+Call libusb_free_device_list() before exiting the hotplug thread in
+hotplug_libusb.c.
+---
+ src/hotplug_libusb.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/hotplug_libusb.c b/src/hotplug_libusb.c
+index b9be4496..b0a9d1ac 100644
+--- a/src/hotplug_libusb.c
++++ b/src/hotplug_libusb.c
+@@ -443,6 +443,9 @@ static void HPRescanUsbBus(void)
+ 			HPRemoveHotPluggable(i);
+ 	}
+ 
++	/* free the libusb allocated list & devices */
++	libusb_free_device_list(devs, 1);
++
+ 	if (AraKiriHotPlug)
+ 	{
+ 		int retval;
+@@ -460,9 +463,6 @@ static void HPRescanUsbBus(void)
+ 		Log1(PCSC_LOG_INFO, "Hotplug stopped");
+ 		pthread_exit(&retval);
+ 	}
+-
+-	/* free the libusb allocated list & devices */
+-	libusb_free_device_list(devs, 1);
+ }
+ 
+ static void * HPEstablishUSBNotifications(int pipefd[2])

--- a/third_party/pcsc-lite/patches/0003-double-free-CFBundleName-on-shutdown.patch
+++ b/third_party/pcsc-lite/patches/0003-double-free-CFBundleName-on-shutdown.patch
@@ -1,0 +1,36 @@
+From accaa9738ad6091603ead68e85d2217944624cee Mon Sep 17 00:00:00 2001
+From: Maksim Ivanov <emaxx@google.com>
+Date: Fri, 27 May 2022 17:19:21 +0200
+Subject: [PATCH] Fix double-free of CFBundleName on shutdown (#132)
+
+Fix the double-free of the _driverTracker::CFBundleName field in
+HPRescanUsbBus() in hotplug_libusb on the shutdown path. The root cause
+was reusing the same string pointer for multiple entries in the
+driverTracker array.
+---
+ src/hotplug_libusb.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/hotplug_libusb.c b/src/hotplug_libusb.c
+index b0a9d1ac..7462c863 100644
+--- a/src/hotplug_libusb.c
++++ b/src/hotplug_libusb.c
+@@ -212,7 +212,7 @@ static LONG HPReadBundleValues(void)
+ 			if (rv)
+ 				CFBundleName = NULL;
+ 			else
+-				CFBundleName = strdup(list_get_at(values, 0));
++				CFBundleName = list_get_at(values, 0);
+ 
+ 			/* while we find a nth ifdVendorID in Info.plist */
+ 			for (alias=0; alias<list_size(manuIDs); alias++)
+@@ -232,7 +232,8 @@ static LONG HPReadBundleValues(void)
+ 				driverTracker[listCount].bundleName = strdup(currFP->d_name);
+ 				driverTracker[listCount].libraryPath = strdup(fullLibPath);
+ 				driverTracker[listCount].ifdCapabilities = ifdCapabilities;
+-				driverTracker[listCount].CFBundleName = CFBundleName;
++				driverTracker[listCount].CFBundleName =
++				   CFBundleName ? strdup(CFBundleName) : NULL;
+ 
+ #ifdef DEBUG_HOTPLUG
+ 				Log2(PCSC_LOG_INFO, "Found driver for: %s",

--- a/third_party/pcsc-lite/patches/0004-reset-ara-kiri-hot-plug-flag.patch
+++ b/third_party/pcsc-lite/patches/0004-reset-ara-kiri-hot-plug-flag.patch
@@ -1,0 +1,28 @@
+From 9879d1c2b78caafc757b883b0fe8ccc8e7c4548f Mon Sep 17 00:00:00 2001
+From: Maksim Ivanov <emaxx@google.com>
+Date: Sun, 29 May 2022 16:24:39 +0200
+Subject: [PATCH] Make sure AraKiriHotPlug false on libusb startup (#135)
+
+Reset the AraKiriHotPlug flag to false when starting libusb hotplug
+search.
+
+This is not needed on the initial process startup, because the flag is
+initialized to false, but allows to implement unit tests that need to
+restart the previously stopped threads within the memory of the same
+process.
+---
+ src/hotplug_libusb.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/hotplug_libusb.c b/src/hotplug_libusb.c
+index 7462c863..3c50f526 100644
+--- a/src/hotplug_libusb.c
++++ b/src/hotplug_libusb.c
+@@ -550,6 +550,7 @@ LONG HPSearchHotPluggables(void)
+ {
+ 	int i;
+ 
++	AraKiriHotPlug = FALSE;
+ 	for (i=0; i<PCSCLITE_MAX_READERS_CONTEXTS; i++)
+ 	{
+ 		readerTracker[i].status = READER_ABSENT;

--- a/third_party/pcsc-lite/patches/0005-memory-leak-reader-ful-name.patch
+++ b/third_party/pcsc-lite/patches/0005-memory-leak-reader-ful-name.patch
@@ -1,0 +1,61 @@
+From 210efa525f50e99821a10d91b8c861825e470d8b Mon Sep 17 00:00:00 2001
+From: Maksim Ivanov <emaxx@google.com>
+Date: Sun, 29 May 2022 16:31:19 +0200
+Subject: [PATCH] Fix leak of fullName on shutdown (#134)
+
+Free _readerTracker::fullName strings on shutdown in hotplug_libusb.
+---
+ src/hotplug_libusb.c | 20 ++++++++++++++++----
+ 1 file changed, 16 insertions(+), 4 deletions(-)
+
+diff --git a/src/hotplug_libusb.c b/src/hotplug_libusb.c
+index 3c50f526..e8af90a4 100644
+--- a/src/hotplug_libusb.c
++++ b/src/hotplug_libusb.c
+@@ -129,6 +129,7 @@ static LONG HPAddHotPluggable(struct libusb_device *dev,
+ 	struct _driverTracker *driver,
+ 	struct _driverTracker *classdriver);
+ static LONG HPRemoveHotPluggable(int reader_index);
++static void HPCleanupHotPluggable(int reader_index);
+ 
+ static LONG HPReadBundleValues(void)
+ {
+@@ -451,6 +452,12 @@ static void HPRescanUsbBus(void)
+ 	{
+ 		int retval;
+ 
++		for (i=0; i<PCSCLITE_MAX_READERS_CONTEXTS; i++)
++		{
++			if (readerTracker[i].fullName != NULL)
++				HPCleanupHotPluggable(i);
++		}
++
+ 		for (i=0; i<driverSize; i++)
+ 		{
+ 			/* free strings allocated by strdup() */
+@@ -771,16 +778,21 @@ static LONG HPRemoveHotPluggable(int reader_index)
+ 
+ 	RFRemoveReader(readerTracker[reader_index].fullName,
+ 		PCSCLITE_HP_BASE_PORT + reader_index, REMOVE_READER_FLAG_REMOVED);
+-	free(readerTracker[reader_index].fullName);
+-	readerTracker[reader_index].status = READER_ABSENT;
+-	readerTracker[reader_index].bus_device[0] = '\0';
+-	readerTracker[reader_index].fullName = NULL;
++	HPCleanupHotPluggable(reader_index);
+ 
+ 	pthread_mutex_unlock(&usbNotifierMutex);
+ 
+ 	return 1;
+ }	/* End of function */
+ 
++static void HPCleanupHotPluggable(int reader_index)
++{
++	free(readerTracker[reader_index].fullName);
++	readerTracker[reader_index].status = READER_ABSENT;
++	readerTracker[reader_index].bus_device[0] = '\0';
++	readerTracker[reader_index].fullName = NULL;
++}	/* End of function */
++
+ /**
+  * Sets up callbacks for device hotplug events.
+  */

--- a/third_party/pcsc-lite/src/src/readerfactory.c
+++ b/third_party/pcsc-lite/src/src/readerfactory.c
@@ -1396,11 +1396,10 @@ void RFCleanupReaders(void)
 
 			if (rv != SCARD_S_SUCCESS)
 				Log2(PCSC_LOG_ERROR, "RFRemoveReader error: 0x%08lX", rv);
-
-			free(sReadersContexts[i]);
-
-			sReadersContexts[i] = NULL;
 		}
+
+		free(sReadersContexts[i]);
+		sReadersContexts[i] = NULL;
 	}
 
 #ifdef USE_SERIAL


### PR DESCRIPTION
Pull several fixes that we committed into the upstream PC/SC-Lite
project. These make it possible to have unit tests that exercise the
PC/SC-Lite daemon code without leaking or corrupting memory and without
one test affecting the results of subsequent ones.

We also commit the .patch files in order to track the changes we're
doing with original 1.9.7 sources locally. The .patch files can be
deleted after the upstream releases a new version and we import it.