### PR TITLE
Refactor nacl_io initialization

### DIFF
--- a/common/cpp/src/google_smart_card_common/nacl_io_utils.cc
+++ b/common/cpp/src/google_smart_card_common/nacl_io_utils.cc
@@ -36,14 +36,16 @@ void InitializeNaclIo(const pp::Instance& pp_instance) {
       ::nacl_io_init_ppapi(pp_instance.pp_instance(),
                            pp_module->get_browser_interface()) == 0);
 
+  GOOGLE_SMART_CARD_LOG_DEBUG << "[nacl_io] successfully initialized";
+}
+
+void MountNaclIoFolders() {
   GOOGLE_SMART_CARD_CHECK(::umount("/") == 0);
 
   GOOGLE_SMART_CARD_CHECK(
       ::mount("/", "/", "httpfs", 0, "manifest=/nacl_io_manifest.txt") == 0);
 
   GOOGLE_SMART_CARD_CHECK(::mount("", "/tmp", "memfs", 0, "") == 0);
-
-  GOOGLE_SMART_CARD_LOG_DEBUG << "[nacl_io] successfully initialized";
 }
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/nacl_io_utils.h
+++ b/common/cpp/src/google_smart_card_common/nacl_io_utils.h
@@ -23,14 +23,18 @@
 
 namespace google_smart_card {
 
-// Initializes NaCl nacl_io library and prepares /tmp and /crx directories.
-//
-// The /tmp directory is mounted to a temporary in-memory file system.
-//
-// The /crx directory is mounted to the extension package root.
+// Initializes NaCl nacl_io library.
 //
 // Note: This function must be called not from the main Pepper thread!
 void InitializeNaclIo(const pp::Instance& pp_instance);
+
+// Mounts / and /tmp directories.
+//
+// The / directory is mounted to the executable module's folder (which, in
+// extension/app environment, is the contents of the .crx package).
+//
+// The /tmp directory is mounted to a temporary in-memory file system.
+void MountNaclIoFolders();
 
 }  // namespace google_smart_card
 

--- a/smart_card_connector_app/src/entry_point_nacl.cc
+++ b/smart_card_connector_app/src/entry_point_nacl.cc
@@ -93,7 +93,10 @@ class PpInstance final : public pp::Instance {
   }
 
  private:
-  void InitializeOnBackgroundThread() { InitializeNaclIo(*this); }
+  void InitializeOnBackgroundThread() {
+    InitializeNaclIo(*this);
+    MountNaclIoFolders();
+  }
 
   std::unique_ptr<GlobalContextImplNacl> global_context_;
   TypedMessageRouter typed_message_router_;


### PR DESCRIPTION
Split the initialization of Native Client's nacl_io library into two
parts: one that initializes the library itself and another that uses it
for mounting folders.

The second part will be used by follow-up changes for executing it in
unit tests (they already have nacl_io initialized by the "ppapi_simple"
framework, and attempting to initialize it twice would cause a crash).