### PR TITLE
Use Emscripten 3.1.12

### DIFF
--- a/env/constants.sh
+++ b/env/constants.sh
@@ -18,7 +18,7 @@
 DEPOT_TOOLS_REPOSITORY_URL="https://chromium.googlesource.com/chromium/tools/depot_tools.git"
 
 EMSCRIPTEN_SDK_REPOSITORY_URL="https://github.com/emscripten-core/emsdk.git"
-EMSCRIPTEN_VERSION="3.1.2"
+EMSCRIPTEN_VERSION="3.1.12"
 
 NACL_SDK_VERSION="47"
 


### PR DESCRIPTION
Update the pinned version of Emscripten to 3.1.12.

We don't look for any particular fix, but the Emscripten team seems to
have made a big number of general improvements.