### PR TITLE
Always produce nacl_io manifest in NaCl builds

### DIFF
--- a/common/make/internal/executable_building_nacl.mk
+++ b/common/make/internal/executable_building_nacl.mk
@@ -132,6 +132,22 @@ endef
 
 endif
 
+# Rule for creating a "nacl_io_manifest.txt" manifest file, which is used for
+# exposing resource files to the NaCl code through a virtual file system
+# ("httpfs", provided by nacl_io).
+#
+# Implementation note: The Python script's output is first redirected into a
+# temporary ".build" file, so that a failure in the script leaves the manifest
+# file not existing or not modified (so that next invocations of make don't skip
+# it).
+$(OUT_DIR_PATH)/nacl_io_manifest.txt: generate_out
+	$(NACL_SDK_ROOT)/tools/genhttpfs.py \
+		--srcdir "$(OUT_DIR_PATH)" \
+		--recursive . \
+		> nacl_io_manifest.txt.build
+	@mv nacl_io_manifest.txt.build $(OUT_DIR_PATH)/nacl_io_manifest.txt
+$(eval $(call CLEAN_RULE,nacl_io_manifest.txt.build))
+all: $(OUT_DIR_PATH)/nacl_io_manifest.txt
 
 #
 # By default, NaCl SDK "clean" rules leave the root output directory named as

--- a/smart_card_connector_app/build/executable_module/Makefile
+++ b/smart_card_connector_app/build/executable_module/Makefile
@@ -143,22 +143,6 @@ else ifeq ($(TOOLCHAIN),pnacl)
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(ROOT_PATH)/third_party/pcsc-lite/naclport/server/src/fake_socket_file,executable-module-filesystem/pcsc/))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(ROOT_PATH)/third_party/ccid/webport/build/Info.plist,executable-module-filesystem/pcsc/drivers/ifd-ccid.bundle/Contents/))
 
-# Create the manifest file that is used by the nacl_io library in order to
-# support operations like listing directories in the "httpfs" file system.
-#
-# Implementation note: The Python script's output is first redirected into a
-# temporary ".build" file, so that a failure in the script leaves the manifest
-# file not existing or not modified (so that next invocations of make don't skip
-# it).
-$(OUT_DIR_PATH)/nacl_io_manifest.txt: generate_out
-	$(NACL_SDK_ROOT)/tools/genhttpfs.py \
-		--srcdir "$(OUT_DIR_PATH)" \
-		--recursive . \
-		> nacl_io_manifest.txt.build
-	@mv nacl_io_manifest.txt.build $(OUT_DIR_PATH)/nacl_io_manifest.txt
-$(eval $(call CLEAN_RULE,nacl_io_manifest.txt.build))
-all: $(OUT_DIR_PATH)/nacl_io_manifest.txt
-
 endif
 
 


### PR DESCRIPTION
Make nacl_io manifest be created in NaCl builds by default, and not only
for the //smart_card_connector_app/ builds. This will allow a follow-up
change to enable the resource files in unit tests.

In order to access resource files through a virtual file system under
NaCl, one needs a nacl_io manifest file (basically, a text file that
contains a list of present file names and their sizes).