### PR TITLE
Unit test for establishing SCardContext internally

### DIFF
--- a/common/cpp_unit_test_runner/src/build_emscripten.mk
+++ b/common/cpp_unit_test_runner/src/build_emscripten.mk
@@ -80,15 +80,17 @@ $(GOOGLETEST_LIBS_PATTERN):
 # Documented in ../include.mk.
 #
 # Implementation notes:
-# The execution is performed via Node.js.
+# The execution is performed via Node.js. We chdir into the out directory, so
+# that the .data file can be loaded at runtime without specifying any path (the
+# .data file is only used when the test uses resource files).
 #
 # Explanation of arguments:
 # DISPLAY: Workaround against "Permission denied" Node.js issue.
 # experimental-wasm-threads, experimental-wasm-bulk-memory: Needed for Pthreads
 #   (multi-threading) support.
 run_test: all
-	DISPLAY= \
+	cd $(OUT_DIR_PATH) && DISPLAY= \
 		node \
 		--experimental-wasm-threads \
 		--experimental-wasm-bulk-memory \
-		$(OUT_DIR_PATH)/$(TARGET).js
+		$(TARGET).js

--- a/common/make/executable_building.mk
+++ b/common/make/executable_building.mk
@@ -47,6 +47,14 @@
 #   $3 ("DEPS", optional): Libraries whose building will be added as
 #     dependencies of this target.
 #   $4 ("LDFLAGS", optional): Linker flags.
+#
+# * ADD_RESOURCE_RULE macro:
+#   Puts the specified resource file into the location from which it can be
+#   loaded by the executable module at runtime.
+#   Arguments:
+#   $1 ("RESOURCE_FILE"): Path to the input resource file,
+#   $2 ("TARGET_PATH"): Path under which the resource file should be exposed at
+#     runtime.
 
 # Load the toolchain-specific file.
 ifeq ($(TOOLCHAIN),emscripten)

--- a/common/make/internal/executable_building_coverage.mk
+++ b/common/make/internal/executable_building_coverage.mk
@@ -169,6 +169,18 @@ all: $(BUILD_DIR)/$(TARGET)
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(BUILD_DIR)/$(TARGET)))
 endef
 
+# Documented at ../executable_building.mk.
+#
+# Implementation notes:
+# The resource file just needs to be copied into the out directory. The C++ code
+# will read the files directly from the file system. Note that the macro
+# arguments are stripped, so that COPY_TO_OUT_DIR_RULE can't break due to
+# leading/trailing spaces. Also we drop the file name from the second argument,
+# because COPY_TO_OUT_DIR_RULE receives the name of the target directory.
+define ADD_RESOURCE_RULE
+$(eval $(call COPY_TO_OUT_DIR_RULE,$(strip $(1)),$(dir $(strip $(2)))))
+endef
+
 # Rules for cleaning build files on "make clean".
 .PHONY: clean_out_artifacts_coverage
 clean_out_artifacts_coverage:

--- a/common/make/internal/executable_building_nacl.mk
+++ b/common/make/internal/executable_building_nacl.mk
@@ -81,6 +81,18 @@ $(eval $(call COPY_TO_OUT_DIR_RULE,$(OUTDIR)/$(TARGET).nmf))
 
 endef
 
+# Documented at ../executable_building.mk.
+#
+# Implementation notes:
+# The resource file just needs to be copied into the out directory. The C++ code
+# uses the nacl_io library (with the "httpfs" virtual file system) in order to
+# access these files at runtime. Note that the macro arguments are stripped, so
+# that COPY_TO_OUT_DIR_RULE can't break due to leading/trailing spaces. Also we
+# drop the file name from the second argument, because COPY_TO_OUT_DIR_RULE
+# receives the name of the target directory.
+define ADD_RESOURCE_RULE
+$(eval $(call COPY_TO_OUT_DIR_RULE,$(strip $(1)),$(dir $(strip $(2)))))
+endef
 
 #
 # Auxiliary macro rule that adds rules for linking the resulting NaCl binaries.

--- a/smart_card_connector_app/build/executable_module/Makefile
+++ b/smart_card_connector_app/build/executable_module/Makefile
@@ -101,50 +101,13 @@ SOURCES += \
 
 endif
 
-
-# Preparation of static files for the executable module file system:
-
-ifeq ($(TOOLCHAIN),emscripten)
-
-# On Emscripten, the files that need to be exposed to the executable module have
-# to be packaged ("preloaded") into a .data file.
-
-# Add a flag to the Emscripten linker to package the specified directory into a
-# .data file. The "@" character is used in order to specify the paths inside the
-# archive.
-LDFLAGS += \
-	--preload-file \
-	$(ROOT_PATH)/third_party/pcsc-lite/naclport/server/src/fake_socket_file@/executable-module-filesystem/pcsc/fake_socket_file \
-	--preload-file \
-	$(ROOT_PATH)/third_party/ccid/webport/build/Info.plist@/executable-module-filesystem/pcsc/drivers/ifd-ccid.bundle/Contents/Info.plist \
-
-# Make sure the changes in the packaged files trigger re-linking.
-DEPS += \
-	$(ROOT_PATH)/third_party/pcsc-lite/naclport/server/src/fake_socket_file \
-	$(ROOT_PATH)/third_party/ccid/webport/build/Info.plist \
-
-# Declare the target for the .data file to depend on the .wasm file, so that
-# targets that depend on the .data file only run after the file gets created by
-# the linker.
-$(BUILD_DIR)/$(TARGET).data: $(BUILD_DIR)/$(TARGET).wasm
-
-# Copy the .data file into the out directory, so that it's put into the
-# resulting app directory by the parent makefile.
-$(eval $(call COPY_TO_OUT_DIR_RULE,$(BUILD_DIR)/$(TARGET).data))
-
-else ifeq ($(TOOLCHAIN),pnacl)
-
-# On Native Client, the files that need to be exposed to the executable module
-# have to be copied into the resulting extension/app as-is. The nacl_io
-# library's "httpfs" file system is used by the C++ initialization code in order
-# to set up access to these files at runtime.
-
-# Add rules for copying the files into the out directory.
-$(eval $(call COPY_TO_OUT_DIR_RULE,$(ROOT_PATH)/third_party/pcsc-lite/naclport/server/src/fake_socket_file,executable-module-filesystem/pcsc/))
-$(eval $(call COPY_TO_OUT_DIR_RULE,$(ROOT_PATH)/third_party/ccid/webport/build/Info.plist,executable-module-filesystem/pcsc/drivers/ifd-ccid.bundle/Contents/))
-
-endif
-
+# Package resource files that the executable module needs at runtime:
+$(eval $(call ADD_RESOURCE_RULE, \
+	$(ROOT_PATH)/third_party/pcsc-lite/naclport/server/src/fake_socket_file, \
+	executable-module-filesystem/pcsc/fake_socket_file))
+$(eval $(call ADD_RESOURCE_RULE, \
+	$(ROOT_PATH)/third_party/ccid/webport/build/Info.plist, \
+	executable-module-filesystem/pcsc/drivers/ifd-ccid.bundle/Contents/Info.plist))
 
 # Rules for compiling source files and linking them into an executable binary.
 $(foreach src,$(SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))

--- a/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
+++ b/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
@@ -47,6 +47,14 @@ LIBS := \
   google_smart_card_libusb \
   google_smart_card_common \
 
+# Package resource files that the tested code needs at runtime:
+$(eval $(call ADD_RESOURCE_RULE, \
+	$(ROOT_PATH)/third_party/pcsc-lite/naclport/server/src/fake_socket_file, \
+	executable-module-filesystem/pcsc/fake_socket_file))
+$(eval $(call ADD_RESOURCE_RULE, \
+	$(ROOT_PATH)/third_party/ccid/webport/build/Info.plist, \
+	executable-module-filesystem/pcsc/drivers/ifd-ccid.bundle/Contents/Info.plist))
+
 # Rules for compiling the test source files and linking them into a resulting
 # executable binary.
 $(foreach src,$(SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))

--- a/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
+++ b/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
@@ -30,6 +30,7 @@ CXXFLAGS := \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-I$(ROOT_PATH)/third_party/pcsc-lite/naclport/server/src \
 	-I$(ROOT_PATH)/third_party/pcsc-lite/naclport/server_clients_management/src \
+	-I$(ROOT_PATH)/third_party/pcsc-lite/src/src/PCSC \
 	-pedantic \
 	-Wall \
 	-Werror \

--- a/smart_card_connector_app/src/application_unittest.cc
+++ b/smart_card_connector_app/src/application_unittest.cc
@@ -18,6 +18,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <winscard.h>
 
 #include <google_smart_card_common/messaging/typed_message_router.h>
 #include <google_smart_card_common/unique_ptr_utils.h>
@@ -80,5 +81,19 @@ class SmartCardConnectorApplicationTest : public ::testing::Test {
 };
 
 TEST_F(SmartCardConnectorApplicationTest, SmokeTest) {}
+
+// Test a PC/SC-Lite context can be established and freed, via direct C function
+// calls `SCardEstablishContext()` and `SCardReleaseContext()`.
+// This is an extended version of the "smoke test" as it verifies the daemon
+// successfully started and replies to calls sent over (fake) sockets.
+TEST_F(SmartCardConnectorApplicationTest, InternalApiContextEstablishing) {
+  SCARDCONTEXT scard_context = 0;
+  EXPECT_EQ(SCardEstablishContext(SCARD_SCOPE_SYSTEM, /*pvReserved1=*/nullptr,
+                                  /*pvReserved2=*/nullptr, &scard_context),
+            SCARD_S_SUCCESS);
+  EXPECT_NE(scard_context, 0);
+
+  EXPECT_EQ(SCardReleaseContext(scard_context), SCARD_S_SUCCESS);
+}
 
 }  // namespace google_smart_card


### PR DESCRIPTION
Add an extended version of the smoke test for the Smart Card Connector,
which additionally exercises the code for establishing and releasing an
SCARDCONTEXT. We use direct C function calls in this test, as we don't
aim to test the JS-to-C++ pipe for PC/SC commands here.