### PR TITLE
Add fake USB device skeleton code

### DIFF
--- a/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
+++ b/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
@@ -24,6 +24,7 @@ include ../../../../common/cpp_unit_test_runner/include.mk
 SOURCES := \
 	../../../src/application.cc \
 	../../../src/application_unittest.cc \
+	../../../src/testing_smart_card_simulation.cc \
 
 CXXFLAGS := \
 	-I$(ROOT_PATH) \

--- a/smart_card_connector_app/src/testing_smart_card_simulation.cc
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.cc
@@ -1,0 +1,83 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "smart_card_connector_app/src/testing_smart_card_simulation.h"
+
+#include <string>
+#include <utility>
+
+#include <google_smart_card_common/logging/logging.h>
+#include <google_smart_card_common/messaging/typed_message.h>
+#include <google_smart_card_common/messaging/typed_message_router.h>
+#include <google_smart_card_common/optional.h>
+#include <google_smart_card_common/requesting/remote_call_message.h>
+#include <google_smart_card_common/requesting/request_id.h>
+#include <google_smart_card_common/requesting/requester_message.h>
+#include <google_smart_card_common/value.h>
+#include <google_smart_card_common/value_conversion.h>
+#include <google_smart_card_common/value_debug_dumping.h>
+
+#include "common/cpp/src/public/value_builder.h"
+
+namespace google_smart_card {
+
+const char* TestingSmartCardSimulation::kRequesterName = "libusb";
+
+TestingSmartCardSimulation::TestingSmartCardSimulation(
+    TypedMessageRouter* typed_message_router)
+    : typed_message_router_(typed_message_router) {}
+
+TestingSmartCardSimulation::~TestingSmartCardSimulation() = default;
+
+void TestingSmartCardSimulation::OnRequestToJs(Value request_payload,
+                                               optional<RequestId> request_id) {
+  const std::string payload_debug_dump = DebugDumpValueFull(request_payload);
+  RemoteCallRequestPayload remote_call =
+      ConvertFromValueOrDie<RemoteCallRequestPayload>(
+          std::move(request_payload));
+  if (remote_call.function_name == "listDevices") {
+    GOOGLE_SMART_CARD_CHECK(remote_call.arguments.empty());
+    OnListDevicesCalled(*request_id);
+    return;
+  }
+  GOOGLE_SMART_CARD_LOG_FATAL << "Unexpected request: " << payload_debug_dump;
+}
+
+void TestingSmartCardSimulation::PostFakeJsReply(RequestId request_id,
+                                                 Value payload_to_reply_with) {
+  ResponseMessageData response_data;
+  response_data.request_id = request_id;
+  response_data.payload = std::move(payload_to_reply_with);
+
+  TypedMessage response;
+  response.type = GetResponseMessageType(kRequesterName);
+  response.data = ConvertToValueOrDie(std::move(response_data));
+
+  Value reply = ConvertToValueOrDie(std::move(response));
+
+  std::string error_message;
+  if (!typed_message_router_->OnMessageReceived(std::move(reply),
+                                                &error_message)) {
+    GOOGLE_SMART_CARD_LOG_FATAL << "Dispatching fake JS reply failed: "
+                                << error_message;
+  }
+}
+
+void TestingSmartCardSimulation::OnListDevicesCalled(RequestId request_id) {
+  // Pretend to have an empty list of devices.
+  PostFakeJsReply(request_id,
+                  ArrayValueBuilder().Add(Value(Value::Type::kArray)).Get());
+}
+
+}  // namespace google_smart_card

--- a/smart_card_connector_app/src/testing_smart_card_simulation.h
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.h
@@ -1,0 +1,48 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SMART_CARD_CONNECTOR_APP_TESTING_SMART_CARD_SIMULATION_H_
+#define SMART_CARD_CONNECTOR_APP_TESTING_SMART_CARD_SIMULATION_H_
+
+#include <google_smart_card_common/messaging/typed_message_router.h>
+#include <google_smart_card_common/requesting/request_id.h>
+#include <google_smart_card_common/optional.h>
+#include <google_smart_card_common/value.h>
+
+namespace google_smart_card {
+
+// Implements fake smart card reader USB devices.
+class TestingSmartCardSimulation final {
+ public:
+  static const char* kRequesterName;
+
+  explicit TestingSmartCardSimulation(TypedMessageRouter* typed_message_router);
+  TestingSmartCardSimulation(const TestingSmartCardSimulation&) = delete;
+  TestingSmartCardSimulation& operator=(const TestingSmartCardSimulation&) =
+      delete;
+  ~TestingSmartCardSimulation();
+
+  // Subscribe this to the C++-to-JS message channel.
+  void OnRequestToJs(Value request_payload, optional<RequestId> request_id);
+
+ private:
+  void PostFakeJsReply(RequestId request_id, Value payload_to_reply_with);
+  void OnListDevicesCalled(RequestId request_id);
+
+  TypedMessageRouter* const typed_message_router_;
+};
+
+}  // namespace google_smart_card
+
+#endif  // SMART_CARD_CONNECTOR_APP_TESTING_SMART_CARD_SIMULATION_H_


### PR DESCRIPTION
Add initial implementation of the TestingSmartCardSimulation class that
will allow to mock out USB communication in unit tests. The initial
implementation always returns an empty list of devices.