### PR TITLE
Emulate Gemalto reader in unit tests

### DIFF
--- a/common/cpp/src/public/testing_global_context.cc
+++ b/common/cpp/src/public/testing_global_context.cc
@@ -145,6 +145,16 @@ bool TestingGlobalContext::IsMainEventLoopThread() const {
 
 void TestingGlobalContext::ShutDown() {}
 
+void TestingGlobalContext::RegisterMessageHandler(
+    const std::string& message_type,
+    Callback callback_to_run) {
+  Expectation expectation;
+  expectation.awaited_message_type = message_type;
+  expectation.callback_to_run = callback_to_run;
+  expectation.once = false;
+  AddExpectation(std::move(expectation));
+}
+
 void TestingGlobalContext::RegisterRequestHandler(
     const std::string& requester_name,
     Callback callback_to_run) {

--- a/common/cpp/src/public/testing_global_context.h
+++ b/common/cpp/src/public/testing_global_context.h
@@ -87,6 +87,10 @@ class TestingGlobalContext final : public GlobalContext {
     creation_thread_is_event_loop_ = creation_thread_is_event_loop;
   }
 
+  // Set a callback to be called whenever a message with the given type is sent
+  // to JS.
+  void RegisterMessageHandler(const std::string& message_type,
+                              Callback callback_to_run);
   // Set a callback to be called whenever a request is sent to JS.
   void RegisterRequestHandler(const std::string& requester_name,
                               Callback callback_to_run);

--- a/smart_card_connector_app/src/application_unittest.cc
+++ b/smart_card_connector_app/src/application_unittest.cc
@@ -16,12 +16,15 @@
 
 #include <functional>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <winscard.h>
 
 #include <google_smart_card_common/messaging/typed_message_router.h>
+#include <google_smart_card_common/multi_string.h>
 #include <google_smart_card_common/unique_ptr_utils.h>
 #include <google_smart_card_common/value.h>
 
@@ -36,6 +39,8 @@
 #include <google_smart_card_common/nacl_io_utils.h>
 #endif  // __native_client__
 
+using testing::ElementsAre;
+
 namespace google_smart_card {
 
 class SmartCardConnectorApplicationTest : public ::testing::Test {
@@ -46,19 +51,10 @@ class SmartCardConnectorApplicationTest : public ::testing::Test {
     MountNaclIoFolders();
 #endif  // __native_client__
     SetUpUsbSimulation();
-    StartApplication();
+    SetUpReaderMessageObserving();
   }
 
   ~SmartCardConnectorApplicationTest() { application_->ShutDownAndWait(); }
-
- private:
-  void SetUpUsbSimulation() {
-    global_context_.RegisterRequestHandler(
-        TestingSmartCardSimulation::kRequesterName,
-        std::bind(&TestingSmartCardSimulation::OnRequestToJs,
-                  &smart_card_simulation_, std::placeholders::_1,
-                  std::placeholders::_2));
-  }
 
   void StartApplication() {
     // Set up the expectation on the first C++-to-JS message.
@@ -79,24 +75,126 @@ class SmartCardConnectorApplicationTest : public ::testing::Test {
         Value(Value::Type::kDictionary)));
   }
 
+  // Enables the specified fake USB devices.
+  void SetUsbDevices(
+      const std::vector<TestingSmartCardSimulation::Device>& devices) {
+    smart_card_simulation_.SetDevices(devices);
+  }
+
+  // Returns all "reader_init_add" messages that were sent to JS (they are sent
+  // when a new reader starts to be initialized).
+  const std::vector<std::string>& reader_init_add_messages() const {
+    return reader_init_add_messages_;
+  }
+  // Returns all "reader_finish_add" messages that were sent to JS (they are
+  // sent when a reader initialization finishes).
+  const std::vector<std::string>& reader_finish_add_messages() const {
+    return reader_finish_add_messages_;
+  }
+
+ private:
+  void SetUpUsbSimulation() {
+    global_context_.RegisterRequestHandler(
+        TestingSmartCardSimulation::kRequesterName,
+        std::bind(&TestingSmartCardSimulation::OnRequestToJs,
+                  &smart_card_simulation_,
+                  /*request_payload=*/std::placeholders::_1,
+                  /*request_id=*/std::placeholders::_2));
+  }
+
+  void SetUpReaderMessageObserving() {
+    global_context_.RegisterMessageHandler(
+        "reader_init_add",
+        std::bind(&SmartCardConnectorApplicationTest::OnReaderInitAddPosted,
+                  this, /*request_payload=*/std::placeholders::_1,
+                  /*request_id=*/std::placeholders::_2));
+    global_context_.RegisterMessageHandler(
+        "reader_finish_add",
+        std::bind(&SmartCardConnectorApplicationTest::OnReaderFinishAddPosted,
+                  this, /*request_payload=*/std::placeholders::_1,
+                  /*request_id=*/std::placeholders::_2));
+  }
+
+  // Called when the code-under-test sends a "reader_init_add" message to JS.
+  void OnReaderInitAddPosted(Value request_payload,
+                             optional<RequestId> /*request_id*/) {
+    reader_init_add_messages_.push_back(
+        request_payload.GetDictionaryItem("readerName")->GetString());
+  }
+
+  // Called when the code-under-test sends a "reader_finish_add" message to JS.
+  void OnReaderFinishAddPosted(Value request_payload,
+                               optional<RequestId> /*request_id*/) {
+    reader_finish_add_messages_.push_back(
+        request_payload.GetDictionaryItem("readerName")->GetString());
+  }
+
   TypedMessageRouter typed_message_router_;
   TestingSmartCardSimulation smart_card_simulation_{&typed_message_router_};
   TestingGlobalContext global_context_{&typed_message_router_};
   std::unique_ptr<Application> application_;
+  std::vector<std::string> reader_init_add_messages_;
+  std::vector<std::string> reader_finish_add_messages_;
 };
 
-TEST_F(SmartCardConnectorApplicationTest, SmokeTest) {}
+TEST_F(SmartCardConnectorApplicationTest, SmokeTest) {
+  StartApplication();
+}
 
 // Test a PC/SC-Lite context can be established and freed, via direct C function
 // calls `SCardEstablishContext()` and `SCardReleaseContext()`.
 // This is an extended version of the "smoke test" as it verifies the daemon
 // successfully started and replies to calls sent over (fake) sockets.
 TEST_F(SmartCardConnectorApplicationTest, InternalApiContextEstablishing) {
+  // Arrange:
+  StartApplication();
+
+  // Act:
+
   SCARDCONTEXT scard_context = 0;
   EXPECT_EQ(SCardEstablishContext(SCARD_SCOPE_SYSTEM, /*pvReserved1=*/nullptr,
                                   /*pvReserved2=*/nullptr, &scard_context),
             SCARD_S_SUCCESS);
   EXPECT_NE(scard_context, 0);
+
+  EXPECT_EQ(SCardReleaseContext(scard_context), SCARD_S_SUCCESS);
+}
+
+// Test a single reader is successfully initialized by PC/SC-Lite and is
+// returned via the direct C function call `SCardListReaders()`.
+TEST_F(SmartCardConnectorApplicationTest, InternalApiSingleDeviceListing) {
+  // Arrange:
+
+  TestingSmartCardSimulation::Device device;
+  device.id = 123;
+  device.type = TestingSmartCardSimulation::DeviceType::kGemaltoPcTwinReader;
+  SetUsbDevices({device});
+
+  StartApplication();
+  EXPECT_THAT(reader_init_add_messages(),
+              ElementsAre("Gemalto PC Twin Reader"));
+  EXPECT_THAT(reader_finish_add_messages(),
+              ElementsAre("Gemalto PC Twin Reader"));
+
+  // Act:
+
+  SCARDCONTEXT scard_context = 0;
+  EXPECT_EQ(SCardEstablishContext(SCARD_SCOPE_SYSTEM, /*pvReserved1=*/nullptr,
+                                  /*pvReserved2=*/nullptr, &scard_context),
+            SCARD_S_SUCCESS);
+
+  DWORD readers_size = 0;
+  EXPECT_EQ(SCardListReaders(scard_context, /*mszGroups=*/nullptr,
+                             /*mszReaders=*/nullptr, &readers_size),
+            SCARD_S_SUCCESS);
+
+  std::string readers_multistring;
+  readers_multistring.resize(readers_size);
+  EXPECT_EQ(SCardListReaders(scard_context, /*mszGroups=*/nullptr,
+                             &readers_multistring[0], &readers_size),
+            SCARD_S_SUCCESS);
+  EXPECT_THAT(ExtractMultiStringElements(readers_multistring),
+              ElementsAre("Gemalto PC Twin Reader 00 00"));
 
   EXPECT_EQ(SCardReleaseContext(scard_context), SCARD_S_SUCCESS);
 }

--- a/smart_card_connector_app/src/testing_smart_card_simulation.cc
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.cc
@@ -14,8 +14,13 @@
 
 #include "smart_card_connector_app/src/testing_smart_card_simulation.h"
 
+#include <stdint.h>
+
+#include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <google_smart_card_common/logging/logging.h>
 #include <google_smart_card_common/messaging/typed_message.h>
@@ -24,15 +29,156 @@
 #include <google_smart_card_common/requesting/remote_call_message.h>
 #include <google_smart_card_common/requesting/request_id.h>
 #include <google_smart_card_common/requesting/requester_message.h>
+#include <google_smart_card_common/unique_ptr_utils.h>
 #include <google_smart_card_common/value.h>
 #include <google_smart_card_common/value_conversion.h>
 #include <google_smart_card_common/value_debug_dumping.h>
 
 #include "common/cpp/src/public/value_builder.h"
+#include "third_party/libusb/webport/src/libusb_js_proxy_data_model.h"
 
 namespace google_smart_card {
 
+using DeviceType = TestingSmartCardSimulation::DeviceType;
+
 const char* TestingSmartCardSimulation::kRequesterName = "libusb";
+
+namespace {
+
+LibusbJsDevice MakeLibusbJsDevice(
+    const TestingSmartCardSimulation::Device& device) {
+  LibusbJsDevice js_device;
+  js_device.device_id = device.id;
+  switch (device.type) {
+    case DeviceType::kGemaltoPcTwinReader:
+      // Numbers are for a real device.
+      js_device.vendor_id = 0x08E6;
+      js_device.product_id = 0x3437;
+      return js_device;
+  }
+  GOOGLE_SMART_CARD_NOTREACHED;
+}
+
+std::vector<LibusbJsConfigurationDescriptor>
+MakeLibusbJsConfigurationDescriptors(DeviceType device_type) {
+  switch (device_type) {
+    case DeviceType::kGemaltoPcTwinReader: {
+      // Values are taken from a real device.
+
+      LibusbJsEndpointDescriptor endpoint1;
+      endpoint1.endpoint_address = 1;
+      endpoint1.direction = LibusbJsDirection::kOut;
+      endpoint1.type = LibusbJsEndpointType::kBulk;
+      endpoint1.max_packet_size = 64;
+
+      LibusbJsEndpointDescriptor endpoint2;
+      endpoint2.endpoint_address = 0x82;
+      endpoint2.direction = LibusbJsDirection::kIn;
+      endpoint2.type = LibusbJsEndpointType::kBulk;
+      endpoint2.max_packet_size = 64;
+
+      LibusbJsEndpointDescriptor endpoint3;
+      endpoint3.endpoint_address = 0x83;
+      endpoint3.direction = LibusbJsDirection::kIn;
+      endpoint3.type = LibusbJsEndpointType::kInterrupt;
+      endpoint3.max_packet_size = 8;
+
+      LibusbJsInterfaceDescriptor interface;
+      interface.interface_number = 0;
+      interface.interface_class = 0xB;
+      interface.interface_subclass = 0;
+      interface.interface_protocol = 0;
+      interface.extra_data = std::vector<uint8_t>(
+          {0x36, 0x21, 0x01, 0x01, 0x00, 0x07, 0x03, 0x00, 0x00, 0x00, 0xC0,
+           0x12, 0x00, 0x00, 0xC0, 0x12, 0x00, 0x00, 0x00, 0x67, 0x32, 0x00,
+           0x00, 0xCE, 0x99, 0x0C, 0x00, 0x35, 0xFE, 0x00, 0x00, 0x00, 0x00,
+           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x02, 0x01, 0x00,
+           0x0F, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01});
+      interface.endpoints.push_back(std::move(endpoint1));
+      interface.endpoints.push_back(std::move(endpoint2));
+      interface.endpoints.push_back(std::move(endpoint3));
+
+      LibusbJsConfigurationDescriptor config;
+      config.active = true;
+      config.configuration_value = 1;
+      config.interfaces.push_back(std::move(interface));
+
+      return {config};
+    }
+  }
+  GOOGLE_SMART_CARD_NOTREACHED;
+}
+
+bool DeviceInterfaceExists(DeviceType device_type, int64_t interface_number) {
+  for (const auto& config : MakeLibusbJsConfigurationDescriptors(device_type)) {
+    for (const auto& interface : config.interfaces) {
+      if (interface.interface_number == interface_number)
+        return true;
+    }
+  }
+  return false;
+}
+
+bool DeviceEndpointExists(DeviceType device_type, uint8_t endpoint_address) {
+  for (const auto& config : MakeLibusbJsConfigurationDescriptors(device_type)) {
+    for (const auto& interface : config.interfaces) {
+      for (const auto& endpoint : interface.endpoints) {
+        if (endpoint.endpoint_address == endpoint_address)
+          return true;
+      }
+    }
+  }
+  return false;
+}
+
+// Builds a fake response to the GET_DATA_RATES control transfer.
+std::vector<uint8_t> MakeGetDataRatesResponse(DeviceType device_type) {
+  switch (device_type) {
+    case DeviceType::kGemaltoPcTwinReader: {
+      // Values are taken from a real device.
+      return {0x67, 0x32, 0x00, 0x00, 0xCE, 0x64, 0x00, 0x00, 0x9D, 0xC9, 0x00,
+              0x00, 0x3A, 0x93, 0x01, 0x00, 0x74, 0x26, 0x03, 0x00, 0xE7, 0x4C,
+              0x06, 0x00, 0xCE, 0x99, 0x0C, 0x00, 0xD7, 0x5C, 0x02, 0x00, 0x11,
+              0xF0, 0x03, 0x00, 0x34, 0x43, 0x00, 0x00, 0x69, 0x86, 0x00, 0x00,
+              0xD1, 0x0C, 0x01, 0x00, 0xA2, 0x19, 0x02, 0x00, 0x45, 0x33, 0x04,
+              0x00, 0x8A, 0x66, 0x08, 0x00, 0x0B, 0xA0, 0x02, 0x00, 0x73, 0x30,
+              0x00, 0x00, 0xE6, 0x60, 0x00, 0x00, 0xCC, 0xC1, 0x00, 0x00, 0x99,
+              0x83, 0x01, 0x00, 0x32, 0x07, 0x03, 0x00, 0x63, 0x0E, 0x06, 0x00,
+              0xB3, 0x22, 0x01, 0x00, 0x7F, 0xE4, 0x01, 0x00, 0x06, 0x50, 0x01,
+              0x00, 0x36, 0x97, 0x00, 0x00, 0x04, 0xFC, 0x00, 0x00, 0x53, 0x28,
+              0x00, 0x00, 0xA5, 0x50, 0x00, 0x00, 0x4A, 0xA1, 0x00, 0x00, 0x95,
+              0x42, 0x01, 0x00, 0x29, 0x85, 0x02, 0x00, 0xF8, 0x78, 0x00, 0x00,
+              0x3E, 0x49, 0x00, 0x00, 0x7C, 0x92, 0x00, 0x00, 0xF8, 0x24, 0x01,
+              0x00, 0xF0, 0x49, 0x02, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xC0, 0x27,
+              0x09, 0x00, 0x74, 0xB7, 0x01, 0x00, 0x6C, 0xDC, 0x02, 0x00, 0xD4,
+              0x30, 0x00, 0x00, 0xA8, 0x61, 0x00, 0x00, 0x50, 0xC3, 0x00, 0x00,
+              0xA0, 0x86, 0x01, 0x00, 0x40, 0x0D, 0x03, 0x00, 0x80, 0x1A, 0x06,
+              0x00, 0x48, 0xE8, 0x01, 0x00, 0xBA, 0xDB, 0x00, 0x00, 0x36, 0x6E,
+              0x01, 0x00, 0x24, 0xF4, 0x00, 0x00, 0xDD, 0x6D, 0x00, 0x00, 0x1B,
+              0xB7, 0x00, 0x00};
+    }
+  }
+  GOOGLE_SMART_CARD_NOTREACHED;
+}
+
+// Builds a fake RDR_to_PC_SlotStatus message.
+std::vector<uint8_t> MakeSlotStatusTransferReply(uint8_t sequence_number) {
+  // Currently, the status always says "no ICC present".
+  const uint8_t status = 0x2;
+  return {0x81,   0x00, 0x00, 0x00, 0x00, 0x00, sequence_number,
+          status, 0x00, 0x00};
+}
+
+// Builds a fake RDR_to_PC_Escape message.
+std::vector<uint8_t> MakeEscapeTransferReply(uint8_t sequence_number) {
+  // Currently, the status always says "escape command failed" and "no ICC
+  // present".
+  const uint8_t status = 0x42;
+  return {0x83,   0x00, 0x00, 0x00, 0x00, 0x00, sequence_number,
+          status, 0x0A, 0x00};
+}
+
+}  // namespace
 
 TestingSmartCardSimulation::TestingSmartCardSimulation(
     TypedMessageRouter* typed_message_router)
@@ -54,15 +200,114 @@ void TestingSmartCardSimulation::OnRequestToJs(Value request_payload,
     OnListDevicesCalled(*request_id);
     return;
   }
+  if (remote_call.function_name == "getConfigurations") {
+    GOOGLE_SMART_CARD_CHECK(remote_call.arguments.size() == 1);
+    OnGetConfigurationsCalled(
+        /*device_id=*/remote_call.arguments[0].GetInteger(), *request_id);
+    return;
+  }
+  if (remote_call.function_name == "openDeviceHandle") {
+    GOOGLE_SMART_CARD_CHECK(remote_call.arguments.size() == 1);
+    OnOpenDeviceHandleCalled(
+        /*device_id=*/remote_call.arguments[0].GetInteger(), *request_id);
+    return;
+  }
+  if (remote_call.function_name == "closeDeviceHandle") {
+    GOOGLE_SMART_CARD_CHECK(remote_call.arguments.size() == 2);
+    OnCloseDeviceHandleCalled(
+        /*device_id=*/remote_call.arguments[0].GetInteger(),
+        /*device_handle=*/remote_call.arguments[1].GetInteger(), *request_id);
+    return;
+  }
+  if (remote_call.function_name == "claimInterface") {
+    GOOGLE_SMART_CARD_CHECK(remote_call.arguments.size() == 3);
+    OnClaimInterfaceCalled(
+        /*device_id=*/remote_call.arguments[0].GetInteger(),
+        /*device_handle=*/remote_call.arguments[1].GetInteger(),
+        /*interface_number=*/remote_call.arguments[2].GetInteger(),
+        *request_id);
+    return;
+  }
+  if (remote_call.function_name == "releaseInterface") {
+    GOOGLE_SMART_CARD_CHECK(remote_call.arguments.size() == 3);
+    OnReleaseInterfaceCalled(
+        /*device_id=*/remote_call.arguments[0].GetInteger(),
+        /*device_handle=*/remote_call.arguments[1].GetInteger(),
+        /*interface_number=*/remote_call.arguments[2].GetInteger(),
+        *request_id);
+    return;
+  }
+  if (remote_call.function_name == "controlTransfer") {
+    GOOGLE_SMART_CARD_CHECK(remote_call.arguments.size() == 3);
+    OnControlTransferCalled(
+        /*device_id=*/remote_call.arguments[0].GetInteger(),
+        /*device_handle=*/remote_call.arguments[1].GetInteger(),
+        ConvertFromValueOrDie<LibusbJsControlTransferParameters>(
+            std::move(remote_call.arguments[2])),
+        *request_id);
+    return;
+  }
+  if (remote_call.function_name == "bulkTransfer") {
+    GOOGLE_SMART_CARD_CHECK(remote_call.arguments.size() == 3);
+    OnBulkTransferCalled(
+        /*device_id=*/remote_call.arguments[0].GetInteger(),
+        /*device_handle=*/remote_call.arguments[1].GetInteger(),
+        ConvertFromValueOrDie<LibusbJsGenericTransferParameters>(
+            std::move(remote_call.arguments[2])),
+        *request_id);
+    return;
+  }
+  if (remote_call.function_name == "interruptTransfer") {
+    GOOGLE_SMART_CARD_CHECK(remote_call.arguments.size() == 3);
+    OnInterruptTransferCalled(
+        /*device_id=*/remote_call.arguments[0].GetInteger(),
+        /*device_handle=*/remote_call.arguments[1].GetInteger(),
+        ConvertFromValueOrDie<LibusbJsGenericTransferParameters>(
+            std::move(remote_call.arguments[2])),
+        *request_id);
+    return;
+  }
   GOOGLE_SMART_CARD_LOG_FATAL << "Unexpected request: " << payload_debug_dump;
 }
 
-void TestingSmartCardSimulation::PostFakeJsReply(RequestId request_id,
-                                                 Value payload_to_reply_with) {
+void TestingSmartCardSimulation::SetDevices(
+    const std::vector<Device>& devices) {
+  std::unique_lock<std::mutex> lock(mutex_);
+
+  std::vector<DeviceState> old_device_states = device_states_;
+  device_states_.clear();
+  for (const auto& device : devices) {
+    DeviceState state;
+    // If this device was already present, reuse its state.
+    for (const auto& old_state : old_device_states) {
+      if (old_state.device.id == device.id)
+        state = old_state;
+    }
+    // Update the `device` field unconditionally, to reflect any changes the
+    // caller might've provided in it.
+    state.device = device;
+    device_states_.push_back(state);
+  }
+}
+
+void TestingSmartCardSimulation::PostFakeJsResult(RequestId request_id,
+                                                  Value result) {
   ResponseMessageData response_data;
   response_data.request_id = request_id;
-  response_data.payload = std::move(payload_to_reply_with);
+  response_data.payload = ArrayValueBuilder().Add(std::move(result)).Get();
+  PostResponseMessage(std::move(response_data));
+}
 
+void TestingSmartCardSimulation::PostFakeJsError(RequestId request_id,
+                                                 const std::string& error) {
+  ResponseMessageData response_data;
+  response_data.request_id = request_id;
+  response_data.error_message = error;
+  PostResponseMessage(std::move(response_data));
+}
+
+void TestingSmartCardSimulation::PostResponseMessage(
+    ResponseMessageData response_data) {
   TypedMessage response;
   response.type = GetResponseMessageType(kRequesterName);
   response.data = ConvertToValueOrDie(std::move(response_data));
@@ -77,10 +322,322 @@ void TestingSmartCardSimulation::PostFakeJsReply(RequestId request_id,
   }
 }
 
+TestingSmartCardSimulation::DeviceState*
+TestingSmartCardSimulation::FindDeviceStateByIdLocked(int64_t device_id) {
+  for (auto& device_state : device_states_) {
+    if (device_state.device.id == device_id)
+      return &device_state;
+  }
+  return nullptr;
+}
+
+TestingSmartCardSimulation::DeviceState*
+TestingSmartCardSimulation::FindDeviceStateByIdAndHandleLocked(
+    int64_t device_id,
+    int64_t device_handle) {
+  DeviceState* device_state = FindDeviceStateByIdLocked(device_id);
+  if (device_state && device_state->opened_device_handle == device_handle)
+    return device_state;
+  return nullptr;
+}
+
 void TestingSmartCardSimulation::OnListDevicesCalled(RequestId request_id) {
-  // Pretend to have an empty list of devices.
-  PostFakeJsReply(request_id,
-                  ArrayValueBuilder().Add(Value(Value::Type::kArray)).Get());
+  std::vector<std::unique_ptr<Value>> libusb_js_devices;
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    for (const auto& device_state : device_states_) {
+      libusb_js_devices.push_back(MakeUnique<Value>(
+          ConvertToValueOrDie(MakeLibusbJsDevice(device_state.device))));
+    }
+  }
+
+  // Reply outside mutex, to prevent potential deadlocks in case the libusb
+  // caller makes another request in the callback.
+  PostFakeJsResult(request_id, Value(std::move(libusb_js_devices)));
+}
+
+void TestingSmartCardSimulation::OnGetConfigurationsCalled(
+    int64_t device_id,
+    RequestId request_id) {
+  optional<DeviceType> device_type;
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    DeviceState* device_state = FindDeviceStateByIdLocked(device_id);
+    if (device_state)
+      device_type = device_state->device.type;
+  }
+
+  // Reply outside mutex, to prevent potential deadlocks in case the libusb
+  // caller makes another request in the callback.
+  if (!device_type) {
+    PostFakeJsError(request_id, "Unknown device");
+    return;
+  }
+  PostFakeJsResult(
+      request_id,
+      ConvertToValueOrDie(MakeLibusbJsConfigurationDescriptors(*device_type)));
+}
+
+void TestingSmartCardSimulation::OnOpenDeviceHandleCalled(
+    int64_t device_id,
+    RequestId request_id) {
+  optional<int> handle;
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    DeviceState* device_state = FindDeviceStateByIdLocked(device_id);
+    if (device_state) {
+      GOOGLE_SMART_CARD_CHECK(!device_state->opened_device_handle);
+      device_state->opened_device_handle = next_free_device_handle_;
+      handle = next_free_device_handle_;
+      ++next_free_device_handle_;
+    }
+  }
+
+  // Reply outside mutex, to prevent potential deadlocks in case the libusb
+  // caller makes another request in the callback.
+  if (!handle) {
+    PostFakeJsError(request_id, "Unknown device");
+    return;
+  }
+  PostFakeJsResult(request_id, Value(*handle));
+}
+
+void TestingSmartCardSimulation::OnCloseDeviceHandleCalled(
+    int64_t device_id,
+    int64_t device_handle,
+    RequestId request_id) {
+  bool device_found = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    DeviceState* device_state =
+        FindDeviceStateByIdAndHandleLocked(device_id, device_handle);
+    if (device_state) {
+      device_found = true;
+      device_state->opened_device_handle = {};
+    }
+  }
+
+  // Reply outside mutex, to prevent potential deadlocks in case the libusb
+  // caller makes another request in the callback.
+  if (!device_found) {
+    PostFakeJsError(request_id, "Unknown device");
+    return;
+  }
+  PostFakeJsResult(request_id, Value());
+}
+
+void TestingSmartCardSimulation::OnClaimInterfaceCalled(
+    int64_t device_id,
+    int64_t device_handle,
+    int64_t interface_number,
+    RequestId request_id) {
+  bool device_found = false;
+  bool interface_claimed = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    DeviceState* device_state =
+        FindDeviceStateByIdAndHandleLocked(device_id, device_handle);
+    if (device_state) {
+      device_found = true;
+      GOOGLE_SMART_CARD_CHECK(
+          DeviceInterfaceExists(device_state->device.type, interface_number));
+      if (!device_state->claimed_interfaces.count(interface_number)) {
+        device_state->claimed_interfaces.insert(interface_number);
+        interface_claimed = true;
+      }
+    }
+  }
+
+  // Reply outside mutex, to prevent potential deadlocks in case the libusb
+  // caller makes another request in the callback.
+  if (!device_found) {
+    PostFakeJsError(request_id, "Unknown device");
+    return;
+  }
+  if (!interface_claimed) {
+    PostFakeJsError(request_id, "Already claimed interface");
+    return;
+  }
+  PostFakeJsResult(request_id, Value());
+}
+
+void TestingSmartCardSimulation::OnReleaseInterfaceCalled(
+    int64_t device_id,
+    int64_t device_handle,
+    int64_t interface_number,
+    RequestId request_id) {
+  bool device_found = false;
+  bool interface_released = false;
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    DeviceState* device_state =
+        FindDeviceStateByIdAndHandleLocked(device_id, device_handle);
+    if (device_state) {
+      device_found = true;
+      GOOGLE_SMART_CARD_CHECK(
+          DeviceInterfaceExists(device_state->device.type, interface_number));
+      if (device_state->claimed_interfaces.count(interface_number)) {
+        device_state->claimed_interfaces.erase(interface_number);
+        interface_released = true;
+      }
+    }
+  }
+
+  // Reply outside mutex, to prevent potential deadlocks in case the libusb
+  // caller makes another request in the callback.
+  if (!device_found) {
+    PostFakeJsError(request_id, "Unknown device");
+    return;
+  }
+  if (!interface_released) {
+    PostFakeJsError(request_id, "Unclaimed interface");
+    return;
+  }
+  PostFakeJsResult(request_id, Value());
+}
+
+void TestingSmartCardSimulation::OnControlTransferCalled(
+    int64_t device_id,
+    int64_t device_handle,
+    LibusbJsControlTransferParameters params,
+    RequestId request_id) {
+  optional<DeviceType> device_type;
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    DeviceState* device_state =
+        FindDeviceStateByIdAndHandleLocked(device_id, device_handle);
+    if (device_state)
+      device_type = device_state->device.type;
+  }
+
+  // Reply outside mutex, to prevent potential deadlocks in case the libusb
+  // caller makes another request in the callback.
+  if (!device_type) {
+    PostFakeJsError(request_id, "Unknown device");
+    return;
+  }
+  if (params.request_type == LibusbJsTransferRequestType::kClass &&
+      params.recipient == LibusbJsTransferRecipient::kInterface &&
+      params.request == 3) {
+    // GET_DATA_RATES request to the reader.
+    GOOGLE_SMART_CARD_CHECK(!params.data_to_send);
+    LibusbJsTransferResult result;
+    result.received_data = MakeGetDataRatesResponse(*device_type);
+    GOOGLE_SMART_CARD_CHECK(*params.length_to_receive >=
+                            result.received_data->size());
+    PostFakeJsResult(request_id, ConvertToValueOrDie(std::move(result)));
+    return;
+  }
+  PostFakeJsError(request_id, "Unknown control command");
+}
+
+void TestingSmartCardSimulation::OnBulkTransferCalled(
+    int64_t device_id,
+    int64_t device_handle,
+    LibusbJsGenericTransferParameters params,
+    RequestId request_id) {
+  bool device_found = false;
+  optional<LibusbJsTransferResult> result;
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    DeviceState* device_state =
+        FindDeviceStateByIdAndHandleLocked(device_id, device_handle);
+    if (device_state) {
+      device_found = true;
+      GOOGLE_SMART_CARD_CHECK(DeviceEndpointExists(device_state->device.type,
+                                                   params.endpoint_address));
+      if (params.data_to_send) {
+        result =
+            HandleOutputBulkTransferLocked(*params.data_to_send, *device_state);
+      } else {
+        result = HandleInputBulkTransferLocked(*params.length_to_receive,
+                                               *device_state);
+      }
+    }
+  }
+
+  // Reply outside mutex, to prevent potential deadlocks in case the libusb
+  // caller makes another request in the callback.
+  if (!device_found) {
+    PostFakeJsError(request_id, "Unknown device");
+    return;
+  }
+  if (!result) {
+    PostFakeJsError(request_id, "Transfer failed");
+    return;
+  }
+  PostFakeJsResult(request_id, ConvertToValueOrDie(std::move(*result)));
+}
+
+void TestingSmartCardSimulation::OnInterruptTransferCalled(
+    int64_t device_id,
+    int64_t device_handle,
+    LibusbJsGenericTransferParameters params,
+    RequestId request_id) {
+  optional<DeviceType> device_type;
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    DeviceState* device_state =
+        FindDeviceStateByIdAndHandleLocked(device_id, device_handle);
+    if (device_state)
+      device_type = device_state->device.type;
+    GOOGLE_SMART_CARD_CHECK(DeviceEndpointExists(device_state->device.type,
+                                                 params.endpoint_address));
+  }
+
+  // Reply outside mutex, to prevent potential deadlocks in case the libusb
+  // caller makes another request in the callback.
+  if (!device_type) {
+    PostFakeJsError(request_id, "Unknown device");
+    return;
+  }
+  // TODO: Remember the request ID and reply to the transfer when a card
+  // insertion/removal is simulated.
+}
+
+optional<LibusbJsTransferResult>
+TestingSmartCardSimulation::HandleOutputBulkTransferLocked(
+    const std::vector<uint8_t>& data_to_send,
+    DeviceState& device_state) {
+  // Extract the command's sequence number ("bSeq").
+  GOOGLE_SMART_CARD_CHECK(data_to_send.size() >= 7);
+  uint8_t sequence_number = data_to_send[6];
+
+  switch (data_to_send[0]) {
+    case 0x65:
+      // PC_to_RDR_GetSlotStatus request to the reader.
+      device_state.next_bulk_transfer_reply =
+          MakeSlotStatusTransferReply(sequence_number);
+      return LibusbJsTransferResult();
+    case 0x63:
+      // PC_to_RDR_IccPowerOff request to the reader.
+      device_state.next_bulk_transfer_reply =
+          MakeSlotStatusTransferReply(sequence_number);
+      return LibusbJsTransferResult();
+    case 0x6B:
+      // PC_to_RDR_Escape request to the reader.
+      device_state.next_bulk_transfer_reply =
+          MakeEscapeTransferReply(sequence_number);
+      return LibusbJsTransferResult();
+  }
+  // Unknown command.
+  return {};
+}
+
+optional<LibusbJsTransferResult>
+TestingSmartCardSimulation::HandleInputBulkTransferLocked(
+    int64_t length_to_receive,
+    DeviceState& device_state) {
+  if (device_state.next_bulk_transfer_reply.empty()) {
+    // Unexpected command - we have no reply prepared.
+    return {};
+  }
+  GOOGLE_SMART_CARD_CHECK(device_state.next_bulk_transfer_reply.size() <=
+                          length_to_receive);
+  LibusbJsTransferResult result;
+  result.received_data = std::move(device_state.next_bulk_transfer_reply);
+  device_state.next_bulk_transfer_reply.clear();
+  return result;
 }
 
 }  // namespace google_smart_card

--- a/smart_card_connector_app/src/testing_smart_card_simulation.cc
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.cc
@@ -412,6 +412,7 @@ void TestingSmartCardSimulation::OnCloseDeviceHandleCalled(
     DeviceState* device_state =
         FindDeviceStateByIdAndHandleLocked(device_id, device_handle);
     if (device_state) {
+      GOOGLE_SMART_CARD_CHECK(device_state->opened_device_handle);
       device_found = true;
       device_state->opened_device_handle = {};
     }

--- a/smart_card_connector_app/src/testing_smart_card_simulation.cc
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.cc
@@ -29,7 +29,6 @@
 #include <google_smart_card_common/requesting/remote_call_message.h>
 #include <google_smart_card_common/requesting/request_id.h>
 #include <google_smart_card_common/requesting/requester_message.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
 #include <google_smart_card_common/value.h>
 #include <google_smart_card_common/value_conversion.h>
 #include <google_smart_card_common/value_debug_dumping.h>
@@ -342,12 +341,12 @@ TestingSmartCardSimulation::FindDeviceStateByIdAndHandleLocked(
 }
 
 void TestingSmartCardSimulation::OnListDevicesCalled(RequestId request_id) {
-  std::vector<std::unique_ptr<Value>> libusb_js_devices;
+  std::vector<Value> libusb_js_devices;
   {
     std::unique_lock<std::mutex> lock(mutex_);
     for (const auto& device_state : device_states_) {
-      libusb_js_devices.push_back(MakeUnique<Value>(
-          ConvertToValueOrDie(MakeLibusbJsDevice(device_state.device))));
+      libusb_js_devices.push_back(
+          ConvertToValueOrDie(MakeLibusbJsDevice(device_state.device)));
     }
   }
 

--- a/smart_card_connector_app/src/testing_smart_card_simulation.h
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.h
@@ -35,7 +35,7 @@ namespace google_smart_card {
 // Implements fake smart card reader USB devices.
 class TestingSmartCardSimulation final {
  public:
-  // Fake device to semulate.
+  // Fake device to simulate.
   enum class DeviceType { kGemaltoPcTwinReader };
 
   // Parameters of the simulated device.

--- a/smart_card_connector_app/src/testing_smart_card_simulation.h
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.h
@@ -73,14 +73,14 @@ class TestingSmartCardSimulation final {
   };
 
   // Helper class that provides thread-safe operations with reader states.
-  class Core final {
+  class ThreadSafeHandler final {
    public:
     using DeviceState = TestingSmartCardSimulation::DeviceState;
 
-    Core();
-    Core(const Core&) = delete;
-    Core& operator=(const Core&) = delete;
-    ~Core();
+    ThreadSafeHandler();
+    ThreadSafeHandler(const ThreadSafeHandler&) = delete;
+    ThreadSafeHandler& operator=(const ThreadSafeHandler&) = delete;
+    ~ThreadSafeHandler();
 
     void SetDevices(const std::vector<Device>& devices);
 
@@ -127,7 +127,7 @@ class TestingSmartCardSimulation final {
   void PostFakeJsResponse(RequestId request_id, GenericRequestResult result);
 
   TypedMessageRouter* const typed_message_router_;
-  Core core_;
+  ThreadSafeHandler handler_;
 };
 
 }  // namespace google_smart_card


### PR DESCRIPTION
Implement fake USB simulation of an arbitrary smart card reader (we took
Gemalto), and write a test that verifies PC/SC-Lite successfully
initializes it and returns via SCardListReaders.