### PR TITLE
Refactor Value constructors to use less unique_ptr

### DIFF
--- a/common/cpp/src/google_smart_card_common/value.h
+++ b/common/cpp/src/google_smart_card_common/value.h
@@ -71,7 +71,9 @@ class Value final {
   explicit Value(std::string string_value);
   explicit Value(BinaryStorage binary_value);
   explicit Value(DictionaryStorage dictionary_value);
+  explicit Value(std::map<std::string, Value> dictionary_value);
   explicit Value(ArrayStorage array_value);
+  explicit Value(std::vector<Value> array_value);
   // Forbid construction from pointers other than `const char*`. Without this
   // deleted overload, the `bool`-argument version would be silently picked up.
   explicit Value(const void*) = delete;

--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -552,11 +552,10 @@ template <typename T>
 bool ConvertToValue(std::vector<T> objects,
                     Value* value,
                     std::string* error_message = nullptr) {
-  std::vector<std::unique_ptr<Value>> converted_items(objects.size());
+  std::vector<Value> converted_items(objects.size());
   std::string local_error_message;
   for (size_t i = 0; i < objects.size(); ++i) {
-    converted_items[i] = MakeUnique<Value>();
-    if (!ConvertToValue(std::move(objects[i]), converted_items[i].get(),
+    if (!ConvertToValue(std::move(objects[i]), &converted_items[i],
                         &local_error_message)) {
       FormatPrintfTemplateAndSet(
           error_message, internal::kErrorToArrayValueConversion,

--- a/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
@@ -1502,9 +1502,9 @@ TEST(ValueConversion, ValueToVector) {
 
   {
     const std::vector<int> kNumbers = {123, -1, 1024};
-    std::vector<std::unique_ptr<Value>> items;
+    std::vector<Value> items;
     for (int number : kNumbers)
-      items.push_back(MakeUnique<Value>(number));
+      items.emplace_back(number);
     Value value(std::move(items));
 
     std::vector<int> converted;
@@ -1514,9 +1514,9 @@ TEST(ValueConversion, ValueToVector) {
 
   {
     const std::vector<uint8_t> kBytes = {1, 2, 255};
-    std::vector<std::unique_ptr<Value>> items;
+    std::vector<Value> items;
     for (uint8_t byte : kBytes)
-      items.push_back(MakeUnique<Value>(byte));
+      items.emplace_back(byte);
     Value value(std::move(items));
 
     std::vector<uint8_t> converted;
@@ -1534,9 +1534,9 @@ TEST(ValueConversion, ValueToVector) {
   }
 
   {
-    std::vector<std::unique_ptr<Value>> items;
-    items.push_back(MakeUnique<Value>("second"));
-    items.push_back(MakeUnique<Value>("first"));
+    std::vector<Value> items;
+    items.emplace_back("second");
+    items.emplace_back("first");
     Value value(std::move(items));
 
     std::vector<SomeEnum> converted;
@@ -1546,10 +1546,9 @@ TEST(ValueConversion, ValueToVector) {
   }
 
   {
-    std::unique_ptr<Value> dict_value =
-        MakeUnique<Value>(Value::Type::kDictionary);
-    dict_value->SetDictionaryItem("intField", 123);
-    std::vector<std::unique_ptr<Value>> items;
+    Value dict_value(Value::Type::kDictionary);
+    dict_value.SetDictionaryItem("intField", 123);
+    std::vector<Value> items;
     items.push_back(std::move(dict_value));
     Value value(std::move(items));
 
@@ -1561,14 +1560,14 @@ TEST(ValueConversion, ValueToVector) {
   }
 
   {
-    std::vector<std::unique_ptr<Value>> nested_items0;
-    nested_items0.push_back(MakeUnique<Value>(1));
-    nested_items0.push_back(MakeUnique<Value>(2));
-    std::vector<std::unique_ptr<Value>> nested_items1;
-    nested_items1.push_back(MakeUnique<Value>(1LL << 40));
-    std::vector<std::unique_ptr<Value>> items;
-    items.push_back(MakeUnique<Value>(std::move(nested_items0)));
-    items.push_back(MakeUnique<Value>(std::move(nested_items1)));
+    std::vector<Value> nested_items0;
+    nested_items0.emplace_back(1);
+    nested_items0.emplace_back(2);
+    std::vector<Value> nested_items1;
+    nested_items1.emplace_back(1LL << 40);
+    std::vector<Value> items;
+    items.emplace_back(std::move(nested_items0));
+    items.emplace_back(std::move(nested_items1));
     Value value(std::move(items));
 
     std::vector<std::vector<int64_t>> converted;
@@ -1599,8 +1598,8 @@ TEST(ValueConversion, VectorFromValueError) {
   }
 
   {
-    std::vector<std::unique_ptr<Value>> items;
-    items.push_back(MakeUnique<Value>(256));
+    std::vector<Value> items;
+    items.emplace_back(256);
     Value value(std::move(items));
 
     std::string error_message;
@@ -1613,8 +1612,8 @@ TEST(ValueConversion, VectorFromValueError) {
   }
 
   {
-    std::vector<std::unique_ptr<Value>> items;
-    items.push_back(MakeUnique<Value>("foo"));
+    std::vector<Value> items;
+    items.emplace_back("foo");
     Value value(std::move(items));
 
     std::string error_message;
@@ -1633,9 +1632,9 @@ TEST(ValueConversion, VectorFromValueError) {
   }
 
   {
-    std::vector<std::unique_ptr<Value>> items;
-    items.push_back(MakeUnique<Value>("second"));
-    items.push_back(MakeUnique<Value>("nonExisting"));
+    std::vector<Value> items;
+    items.emplace_back("second");
+    items.emplace_back("nonExisting");
     Value value(std::move(items));
 
     std::string error_message;

--- a/common/cpp/src/google_smart_card_common/value_debug_dumping_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_debug_dumping_unittest.cc
@@ -160,9 +160,9 @@ TEST(ValueDebugDumpingTest, Array) {
   const Value kBlank(Value::Type::kArray);
 
   const int64_t kInteger = 123;
-  Value::ArrayStorage array_items;
-  array_items.push_back(MakeUnique<Value>());
-  array_items.push_back(MakeUnique<Value>(kInteger));
+  std::vector<Value> array_items;
+  array_items.emplace_back();
+  array_items.emplace_back(kInteger);
   const Value kArray(std::move(array_items));  // [null, 123]
 
   const std::string full_blank = DebugDumpValueFull(kBlank);

--- a/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.cc
@@ -155,7 +155,8 @@ Value CreateValueFromDataViewVal(const emscripten::val& val) {
 optional<Value> CreateValueFromArrayLikeVal(const emscripten::val& val,
                                             std::string* error_message) {
   const size_t size = val["length"].as<size_t>();
-  std::vector<std::unique_ptr<Value>> converted_items(size);
+  std::vector<Value> converted_items;
+  converted_items.reserve(size);
   std::string local_error_message;
   for (size_t index = 0; index < size; ++index) {
     optional<Value> converted_item =
@@ -166,7 +167,7 @@ optional<Value> CreateValueFromArrayLikeVal(const emscripten::val& val,
           static_cast<int>(index), local_error_message.c_str());
       return {};
     }
-    converted_items[index] = MakeUnique<Value>(std::move(*converted_item));
+    converted_items.push_back(std::move(*converted_item));
   }
   return Value(std::move(converted_items));
 }

--- a/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion_unittest.cc
@@ -183,11 +183,11 @@ TEST(ValueEmscriptenValConversion, DictionaryValue) {
 
   {
     // The test data is: {"xyz": {"foo": null, "bar": 123}}.
-    std::map<std::string, std::unique_ptr<Value>> inner_items;
-    inner_items["foo"] = MakeUnique<Value>();
-    inner_items["bar"] = MakeUnique<Value>(123);
-    std::map<std::string, std::unique_ptr<Value>> items;
-    items["xyz"] = MakeUnique<Value>(std::move(inner_items));
+    std::map<std::string, Value> inner_items;
+    inner_items["foo"] = Value();
+    inner_items["bar"] = Value(123);
+    std::map<std::string, Value> items;
+    items["xyz"] = Value(std::move(inner_items));
     const Value value(std::move(items));
 
     const optional<emscripten::val> converted =
@@ -209,8 +209,8 @@ TEST(ValueEmscriptenValConversion, DictionaryValue) {
 TEST(ValueEmscriptenValConversion, DictionaryValueError) {
   {
     constexpr int64_t k64BitMax = std::numeric_limits<int64_t>::max();
-    std::map<std::string, std::unique_ptr<Value>> items;
-    items["foo"] = MakeUnique<Value>(k64BitMax);
+    std::map<std::string, Value> items;
+    items["foo"] = Value(k64BitMax);
     const Value value(std::move(items));
 
     const optional<emscripten::val> converted =
@@ -220,9 +220,9 @@ TEST(ValueEmscriptenValConversion, DictionaryValueError) {
 
   {
     constexpr int64_t k64BitMin = std::numeric_limits<int64_t>::min();
-    std::map<std::string, std::unique_ptr<Value>> items;
-    items["abc"] = MakeUnique<Value>();
-    items["def"] = MakeUnique<Value>(k64BitMin);
+    std::map<std::string, Value> items;
+    items["abc"] = Value();
+    items["def"] = Value(k64BitMin);
     const Value value(std::move(items));
 
     std::string error_message;
@@ -249,11 +249,11 @@ TEST(ValueEmscriptenValConversion, ArrayValue) {
 
   {
     // The test data is: [[null, 123]].
-    std::vector<std::unique_ptr<Value>> inner_items;
-    inner_items.push_back(MakeUnique<Value>());
-    inner_items.push_back(MakeUnique<Value>(123));
-    std::vector<std::unique_ptr<Value>> items;
-    items.push_back(MakeUnique<Value>(std::move(inner_items)));
+    std::vector<Value> inner_items;
+    inner_items.empalce_back();
+    inner_items.emplace_back(123);
+    std::vector<Value> items;
+    items.emplace_back(std::move(inner_items));
     const Value value(std::move(items));
 
     const optional<emscripten::val> converted =
@@ -275,8 +275,8 @@ TEST(ValueEmscriptenValConversion, ArrayValue) {
 TEST(ValueEmscriptenValConversion, ArrayValueError) {
   {
     constexpr int64_t k64BitMax = std::numeric_limits<int64_t>::max();
-    std::vector<std::unique_ptr<Value>> items;
-    items.push_back(MakeUnique<Value>(k64BitMax));
+    std::vector<Value> items;
+    items.emplace_back(k64BitMax);
     const Value value(std::move(items));
 
     const optional<emscripten::val> converted =
@@ -286,9 +286,9 @@ TEST(ValueEmscriptenValConversion, ArrayValueError) {
 
   {
     constexpr int64_t k64BitMin = std::numeric_limits<int64_t>::min();
-    std::vector<std::unique_ptr<Value>> items;
-    items.push_back(MakeUnique<Value>());
-    items.push_back(MakeUnique<Value>(k64BitMin));
+    std::vector<Value> items;
+    items.emplace_back();
+    items.emplace_back(k64BitMin);
     const Value value(std::move(items));
 
     std::string error_message;

--- a/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion_unittest.cc
@@ -250,7 +250,7 @@ TEST(ValueEmscriptenValConversion, ArrayValue) {
   {
     // The test data is: [[null, 123]].
     std::vector<Value> inner_items;
-    inner_items.empalce_back();
+    inner_items.emplace_back();
     inner_items.emplace_back(123);
     std::vector<Value> items;
     items.emplace_back(std::move(inner_items));

--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.cc
@@ -82,7 +82,8 @@ pp::VarArray CreateVarArray(const Value::ArrayStorage& array_storage) {
 optional<Value> CreateValueFromPpVarArray(const pp::VarArray& var,
                                           std::string* error_message) {
   std::string local_error_message;
-  Value::ArrayStorage array_storage;
+  std::vector<Value> converted_items;
+  converted_items.reserve(var.GetLength());
   for (uint32_t index = 0; index < var.GetLength(); ++index) {
     optional<Value> converted_item =
         ConvertPpVarToValue(var.Get(index), &local_error_message);
@@ -92,9 +93,9 @@ optional<Value> CreateValueFromPpVarArray(const pp::VarArray& var,
           static_cast<int>(index), local_error_message.c_str());
       return {};
     }
-    array_storage.push_back(MakeUnique<Value>(std::move(*converted_item)));
+    converted_items.push_back(std::move(*converted_item));
   }
-  return Value(std::move(array_storage));
+  return Value(std::move(converted_items));
 }
 
 optional<Value> CreateValueFromPpVarDictionary(const pp::VarDictionary& var,

--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion_unittest.cc
@@ -143,7 +143,7 @@ TEST(ValueNaclPpVarConversion, DictionaryValue) {
     inner_items["foo"] = Value();
     inner_items["bar"] = Value(123);
     std::map<std::string, Value> items;
-    items["xyz"] = std::move(inner_items);
+    items["xyz"] = Value(std::move(inner_items));
     const Value value(std::move(items));
 
     const pp::Var var = ConvertValueToPpVar(value);
@@ -176,7 +176,7 @@ TEST(ValueNaclPpVarConversion, ArrayValue) {
     inner_items.push_back(Value());
     inner_items.push_back(Value(123));
     std::vector<Value> items;
-    items.push_back(std::move(inner_items));
+    items.emplace_back(std::move(inner_items));
     const Value value(std::move(items));
 
     const pp::Var var = ConvertValueToPpVar(value);

--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion_unittest.cc
@@ -139,11 +139,11 @@ TEST(ValueNaclPpVarConversion, DictionaryValue) {
 
   {
     // The test data is: {"xyz": {"foo": null, "bar": 123}}.
-    std::map<std::string, std::unique_ptr<Value>> inner_items;
-    inner_items["foo"] = MakeUnique<Value>();
-    inner_items["bar"] = MakeUnique<Value>(123);
-    std::map<std::string, std::unique_ptr<Value>> items;
-    items["xyz"] = MakeUnique<Value>(std::move(inner_items));
+    std::map<std::string, Value> inner_items;
+    inner_items["foo"] = Value();
+    inner_items["bar"] = Value(123);
+    std::map<std::string, Value> items;
+    items["xyz"] = std::move(inner_items);
     const Value value(std::move(items));
 
     const pp::Var var = ConvertValueToPpVar(value);
@@ -172,11 +172,11 @@ TEST(ValueNaclPpVarConversion, ArrayValue) {
 
   {
     // The test data is: [[null, 123]].
-    std::vector<std::unique_ptr<Value>> inner_items;
-    inner_items.push_back(MakeUnique<Value>());
-    inner_items.push_back(MakeUnique<Value>(123));
-    std::vector<std::unique_ptr<Value>> items;
-    items.push_back(MakeUnique<Value>(std::move(inner_items)));
+    std::vector<Value> inner_items;
+    inner_items.push_back(Value());
+    inner_items.push_back(Value(123));
+    std::vector<Value> items;
+    items.push_back(std::move(inner_items));
     const Value value(std::move(items));
 
     const pp::Var var = ConvertValueToPpVar(value);

--- a/common/cpp/src/public/value_builder.cc
+++ b/common/cpp/src/public/value_builder.cc
@@ -41,7 +41,7 @@ void ArrayValueBuilder::AddConverted(
                                           conversion_error_message.c_str());
     return;
   }
-  items_.push_back(MakeUnique<Value>(std::move(converted)));
+  items_.push_back(std::move(converted));
 }
 
 Value ArrayValueBuilder::Get() && {
@@ -72,7 +72,7 @@ void DictValueBuilder::AddConverted(bool conversion_success,
     error_message_ = FormatPrintfTemplate(R"(Duplicate key "%s")", key.c_str());
     return;
   }
-  items_[key] = MakeUnique<Value>(std::move(converted_value));
+  items_[key] = std::move(converted_value);
 }
 
 Value DictValueBuilder::Get() && {

--- a/common/cpp/src/public/value_builder.h
+++ b/common/cpp/src/public/value_builder.h
@@ -63,7 +63,7 @@ class ArrayValueBuilder final {
 
   bool encountered_error_ = false;
   std::string error_message_;
-  Value::ArrayStorage items_;
+  std::vector<Value> items_;
 };
 
 // Helper for simplifying code that creates a dictionary `Value`.
@@ -104,7 +104,7 @@ class DictValueBuilder final {
 
   bool encountered_error_ = false;
   std::string error_message_;
-  Value::DictionaryStorage items_;
+  std::map<std::string, Value> items_;
 };
 
 }  // namespace google_smart_card

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.cc
@@ -51,21 +51,19 @@ namespace google_smart_card {
 
 namespace {
 
-void ConvertToValueVectorOrDie(
-    std::vector<std::unique_ptr<Value>>* value_vector) {}
+void ConvertToValueVectorOrDie(std::vector<Value>* value_vector) {}
 
 template <typename FirstArg, typename... Args>
-void ConvertToValueVectorOrDie(
-    std::vector<std::unique_ptr<Value>>* value_vector,
-    const FirstArg& first_arg,
-    const Args&... args) {
-  value_vector->push_back(MakeUnique<Value>(ConvertToValueOrDie(first_arg)));
+void ConvertToValueVectorOrDie(std::vector<Value>* value_vector,
+                               const FirstArg& first_arg,
+                               const Args&... args) {
+  value_vector->push_back(ConvertToValueOrDie(first_arg));
   ConvertToValueVectorOrDie(value_vector, args...);
 }
 
 template <typename... Args>
 GenericRequestResult ReturnValues(const Args&... args) {
-  std::vector<std::unique_ptr<Value>> converted_args;
+  std::vector<Value> converted_args;
   ConvertToValueVectorOrDie(&converted_args, args...);
   return GenericRequestResult::CreateSuccessful(
       Value(std::move(converted_args)));


### PR DESCRIPTION
Add more convenient constructors for array/dictionary values that accept
Value instances by value, instead of having them wrapped into
unique_ptr.