### PR TITLE
Workaround PC/SC-Lite shutdown timing issues

### DIFF
--- a/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
+++ b/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
@@ -137,7 +137,10 @@ void PcscLiteServerDaemonThreadMain() {
   // code. This follows the code in the "if (AraKiri)" block in the
   // `SVCServiceRunLoop()` function in pcsc-lite/src/src/pcscdaemon.c.
   HPStopHotPluggables();
-  SYS_Sleep(1);
+  // TODO: Upstream's approach with a magic sleep is flaky: the background
+  // thread might be still running after this point, causing crashes. Replace
+  // this with a proper waiting mechanism.
+  SYS_Sleep(5);
   RFCleanupReaders();
   EHDeinitializeEventStructures();
   ContextsDeinitialize();


### PR DESCRIPTION
Increase the sleep timeout in the PC/SC-Lite shutdown code that we
copied from upstream. This should make it much less likely that we exit
the shutdown function before the background "hotplug_libusb" thread
actually finishes, which was causing flakiness with some probability.

A proper fix will need to be found later.