### PR TITLE
Don't skip CI jobs if some failed

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         build-config: [Release, Debug]
+      fail-fast: false
 
     steps:
     - name: Check out sources
@@ -51,6 +52,7 @@ jobs:
     strategy:
       matrix:
         build-config: [Release, Debug]
+      fail-fast: false
 
     steps:
     - name: Check out sources


### PR DESCRIPTION
Change the Continuous Integration config to disable the "fail-fast"
default behavior. It's useful to see the results from all configurations
even if one failed (especially because Release builds usually fail
faster but leave less useful logs than Debug ones).