### PR TITLE
Don't sleep before abort() in coverage builds

### DIFF
--- a/common/cpp/src/google_smart_card_common/logging/logging.cc
+++ b/common/cpp/src/google_smart_card_common/logging/logging.cc
@@ -160,11 +160,13 @@ LogMessage::~LogMessage() {
   if (ShouldLogWithSeverity(severity_)) {
     EmitLogMessage(severity_, stream_.str());
     if (severity_ == LogSeverity::kFatal) {
+#if defined(__EMSCRIPTEN__) || defined(__native_client__)
       // Wait for some time before crashing, to leave a chance for the log
       // message with the crash reason to be delivered to the JavaScript side.
       // This is not a 100%-reliable solution, but the logging functionality in
       // the fatal error case is best-effort anyway.
       std::this_thread::sleep_for(std::chrono::seconds(1));
+#endif
       std::abort();
     }
   }


### PR DESCRIPTION
Crash immediatelywhen some assertion fails, instead of sleeping
for 1 second, in TOOLCHAIN=coverage builds. This makes it much
simpler to investigate test failures.

We continue to use sleeping in WebAssembly/NaCl builds, because there it
increases the chances that logs of the event that led to the crash reach
the JavaScript side.