### PR TITLE
Use enum class for Libusb-JS types

### DIFF
--- a/third_party/libusb/webport/src/libusb_js_proxy_data_model.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy_data_model.h
@@ -55,12 +55,12 @@ struct LibusbJsDevice {
   optional<std::string> serial_number;
 };
 
-enum LibusbJsDirection {
+enum class LibusbJsDirection {
   kIn,
   kOut,
 };
 
-enum LibusbJsEndpointType {
+enum class LibusbJsEndpointType {
   kBulk,
   kControl,
   kInterrupt,


### PR DESCRIPTION
Use "enum class" in all Libusb-JS types instead of the old unsafe enums.
It was an oversight to use the old enums for two types.