### PR TITLE
Fix coverage flag passing

### DIFF
--- a/coverage-report.sh
+++ b/coverage-report.sh
@@ -69,8 +69,9 @@ for dir in ${UNIT_TEST_EXECUTABLE_DIRS}; do
   done
 done
 # Insert "-object" before each path, except for the first one (that's the
-# weirdness of llvm-cov's CLI).
-llvm_cov_args=$(echo "${executables}" | tr ' ' ' -object ')
+# weirdness of llvm-cov's CLI). Trim the leading whitespace via one sed
+# invocation and replace inner spaces with the flag using the second one.
+llvm_cov_args=$(echo "${executables}" | sed 's/^ //g' | sed 's/ / -object /g')
 # Print the coverage report table to stdout, so that the report can be parsed by
 # the next steps of the pipeline. (Everything above was logged to stderr.)
 llvm-cov report \


### PR DESCRIPTION
Fix coverage-report.sh to actually insert "-object" flags between paths
to analyzed binaries.

Before this fix, we were passing all binaries separated by a space (the
code in coverage-report.sh was wrong and actually a no-op), for which
llvm-cov doens't complain, however produces incorrect (lower) coverage.