### PR TITLE
Emulate full description of Gemalto device

### DIFF
--- a/smart_card_connector_app/src/testing_smart_card_simulation.cc
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.cc
@@ -56,7 +56,7 @@ LibusbJsDevice MakeLibusbJsDevice(
       js_device.product_id = 0x3437;
       js_device.version = 0x200;
       // TODO: Remove explicit `std::string` construction after switching to
-      // feature-complete `srd::optional` (after dropping NaCl support).
+      // feature-complete `std::optional` (after dropping NaCl support).
       js_device.product_name = std::string("USB SmartCard Reader");
       js_device.manufacturer_name = std::string("Gemalto");
       js_device.serial_number = std::string("E00E0000");  // redacted

--- a/smart_card_connector_app/src/testing_smart_card_simulation.cc
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.cc
@@ -54,6 +54,12 @@ LibusbJsDevice MakeLibusbJsDevice(
       // Numbers are for a real device.
       js_device.vendor_id = 0x08E6;
       js_device.product_id = 0x3437;
+      js_device.version = 0x200;
+      // TODO: Remove explicit `std::string` construction after switching to
+      // feature-complete `srd::optional` (after dropping NaCl support).
+      js_device.product_name = std::string("USB SmartCard Reader");
+      js_device.manufacturer_name = std::string("Gemalto");
+      js_device.serial_number = std::string("E00E0000");  // redacted
       return js_device;
   }
   GOOGLE_SMART_CARD_NOTREACHED;


### PR DESCRIPTION
Populate all fields in the unit-test fake Gemalto device description
(version, names, serials).

While it's not strictly required for making the test fully functional,
it's useful to keep the test closer to real-world devices.