### PR TITLE
Autogenerate request IDs in Connector unit tests

### DIFF
--- a/smart_card_connector_app/src/application_unittest.cc
+++ b/smart_card_connector_app/src/application_unittest.cc
@@ -307,7 +307,7 @@ class SmartCardConnectorApplicationTest : public ::testing::Test {
   ReaderNotificationObserver reader_notification_observer_;
   TestingGlobalContext global_context_{&typed_message_router_};
   std::unique_ptr<Application> application_;
-  std::atomic_int request_id_counter_{1};
+  std::atomic_int request_id_counter_{0};
 };
 
 TEST_F(SmartCardConnectorApplicationTest, SmokeTest) {


### PR DESCRIPTION
Let request IDs be automatically generated from the counter instead of
hardcoding them in the test statements. Not only this makes the tests
less verbose, but it also allows to prevent potential ID conflicts
between different test helpers.