### PR TITLE
Run CI in background once a day

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,9 +1,15 @@
 name: CI
 
 on:
+  # Run CI on every commit to the "main" branch.
   push:
     branches: [ main ]
+  # Run CI on every PR.
   pull_request:
+  # Run CI on the "main" branch every day (to catch random flakiness or CI
+  # environment regressions).
+  schedule:
+    - cron: "0 0 * * *"
 
 env:
   # The version of libstdc++ to install for coverage builds.


### PR DESCRIPTION
Schedule an additional invocation of Continuous Integration every day at
midnight. The first goal is to increase chances of catching test
flakiness in the landed code. The second goal is to detect any
regressions in the CI script (e.g., due to GitHub's Ubuntu uprev) before
the next person will upload a PR.