### PR TITLE
Mark C++ fatal asserts as noreturn

### DIFF
--- a/common/cpp/src/google_smart_card_common/logging/logging.cc
+++ b/common/cpp/src/google_smart_card_common/logging/logging.cc
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cctype>
 #include <chrono>
+#include <cstdlib>
 #include <iostream>
 #include <thread>
 #include <utility>


### PR DESCRIPTION
Improve the LOG_FATAL/NOTREACHED C++ macros in //common/ so that
compiler knows they never return.

This suppresses warnings when these macros are used at the end of
non-void functions, and additionally might slightly reduce the binary
size.