### PR TITLE
Add GTest matchers and log printer for C++ Value

### DIFF
--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -428,6 +428,13 @@ class StructValueDescriptor<optional<T>>;
 // and the last one isn't useful in this context (as helpers in this file are
 // about converting between a `Value` and a non-`Value` object).
 
+inline bool ConvertToValue(Value::Type value_type,
+                           Value* value,
+                           std::string* /*error_message*/ = nullptr) {
+  *value = Value(value_type);
+  return true;
+}
+
 inline bool ConvertToValue(Value source_value,
                            Value* target_value,
                            std::string* /*error_message*/ = nullptr) {

--- a/common/cpp/src/google_smart_card_common/value_test_utils.h
+++ b/common/cpp/src/google_smart_card_common/value_test_utils.h
@@ -1,0 +1,59 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sstream>
+#include <string>
+#include <utility>
+
+#include <gmock/gmock.h>
+
+#include <google_smart_card_common/value.h>
+#include <google_smart_card_common/value_conversion.h>
+#include <google_smart_card_common/value_debug_dumping.h>
+
+namespace google_smart_card {
+
+inline void PrintTo(const Value& value, std::ostream* os) {
+  *os << DebugDumpValueFull(value);
+}
+
+MATCHER_P(StrictlyEquals,
+          value,
+          /*description_string=*/std::string("strictly equals to ") +
+              ::testing::PrintToString(value)) {
+  return arg.StrictlyEquals(ConvertToValueOrDie(std::move(value)));
+}
+
+MATCHER_P(DictSizeIs,
+          size,
+          /*description_string=*/std::string("dictionary is of size ") +
+              ::testing::PrintToString(size)) {
+  // Cast both sizes to `int` to avoid compiler warnings when the test passes a
+  // signed `size` (not casting to `size_t` in order to fail if the test goes
+  // wild and passes a negative size).
+  return arg.is_dictionary() &&
+         static_cast<int>(arg.GetDictionary().size()) == static_cast<int>(size);
+}
+
+MATCHER_P2(DictContains,
+           key,
+           value,
+           /*description_string=*/std::string("dictionary has key \"") + key +
+               "\" with value " + ::testing::PrintToString(value)) {
+  return arg.is_dictionary() && arg.GetDictionaryItem(key) &&
+         arg.GetDictionaryItem(key)->StrictlyEquals(
+             ConvertToValueOrDie(std::move(value)));
+}
+
+}  // namespace google_smart_card


### PR DESCRIPTION
Provide test helpers for the Value C++ class that teach GTest how to
properly log Value objects and how to test for expected values.

These greately increase test readability for tests that work with
nontrivial values, and also produce much more informative logs on test
failures.