### PR TITLE
Simulate Cosmo ID 7.0 card presence in unit tests

### DIFF
--- a/smart_card_connector_app/src/application_unittest.cc
+++ b/smart_card_connector_app/src/application_unittest.cc
@@ -57,7 +57,13 @@ namespace google_smart_card {
 
 namespace {
 
+// The constant from the PC/SC-Lite API docs.
 constexpr char kPnpNotification[] = R"(\\?PnP?\Notification)";
+// Name of `TestingSmartCardSimulation::DeviceType::kGemaltoPcTwinReader` as it
+// appears in the PC/SC-Lite API. The "0" suffix corresponds to the "00 00" part
+// that contains nonzeroes in case there are multiple devices with the same
+// name.
+constexpr char kGemaltoPcTwinReaderPcscName0[] = "Gemalto PC Twin Reader 00 00";
 
 // Records reader_* messages sent to JS and allows to inspect them in tests.
 class ReaderNotificationObserver final {
@@ -442,7 +448,7 @@ TEST_F(SmartCardConnectorApplicationTest, InternalApiSingleDeviceListing) {
 
   // Assert:
 
-  EXPECT_THAT(readers, ElementsAre("Gemalto PC Twin Reader 00 00"));
+  EXPECT_THAT(readers, ElementsAre(kGemaltoPcTwinReaderPcscName0));
 }
 
 // The direct C function call `SCardGetStatusChange()` detects when a reader is
@@ -485,7 +491,7 @@ TEST_F(SmartCardConnectorApplicationTest,
 
   EXPECT_EQ(reader_states[0].dwEventState,
             static_cast<DWORD>(SCARD_STATE_CHANGED));
-  EXPECT_THAT(readers, ElementsAre("Gemalto PC Twin Reader 00 00"));
+  EXPECT_THAT(readers, ElementsAre(kGemaltoPcTwinReaderPcscName0));
   EXPECT_EQ(reader_notification_observer().WaitAndPop(),
             "reader_init_add:Gemalto PC Twin Reader");
   EXPECT_EQ(reader_notification_observer().WaitAndPop(),
@@ -522,7 +528,7 @@ TEST_F(SmartCardConnectorApplicationTest,
             SCARD_S_SUCCESS);
 
   EXPECT_THAT(DirectCallSCardListReaders(scard_context),
-              ElementsAre("Gemalto PC Twin Reader 00 00"));
+              ElementsAre(kGemaltoPcTwinReaderPcscName0));
 
   // Simulate disconnecting the reader.
   SetUsbDevices({});
@@ -743,7 +749,7 @@ TEST_F(SmartCardConnectorApplicationSingleClientTest,
             SCARD_S_SUCCESS);
 
   // Assert:
-  EXPECT_THAT(readers, ElementsAre("Gemalto PC Twin Reader 00 00"));
+  EXPECT_THAT(readers, ElementsAre(kGemaltoPcTwinReaderPcscName0));
 }
 
 // `SCardGetStatusChange()` call from JS detects when a reader is plugged in.
@@ -807,7 +813,7 @@ TEST_F(SmartCardConnectorApplicationSingleClientTest,
                 /*timeout=*/INFINITE,
                 ArrayValueBuilder()
                     .Add(DictValueBuilder()
-                             .Add("reader_name", "Gemalto PC Twin Reader 00 00")
+                             .Add("reader_name", kGemaltoPcTwinReaderPcscName0)
                              .Add("current_state", SCARD_STATE_EMPTY)
                              .Get())
                     .Get(),
@@ -818,7 +824,7 @@ TEST_F(SmartCardConnectorApplicationSingleClientTest,
   ASSERT_THAT(reader_states, SizeIs(1));
   ASSERT_THAT(reader_states[0], DictSizeIs(4));
   EXPECT_THAT(reader_states[0],
-              DictContains("reader_name", "Gemalto PC Twin Reader 00 00"));
+              DictContains("reader_name", kGemaltoPcTwinReaderPcscName0));
   EXPECT_THAT(reader_states[0],
               DictContains("current_state", SCARD_STATE_EMPTY));
   EXPECT_THAT(reader_states[0], DictContains("atr", Value::Type::kBinary));
@@ -859,7 +865,7 @@ TEST_F(SmartCardConnectorApplicationSingleClientTest,
                 /*timeout=*/INFINITE,
                 ArrayValueBuilder()
                     .Add(DictValueBuilder()
-                             .Add("reader_name", "Gemalto PC Twin Reader 00 00")
+                             .Add("reader_name", kGemaltoPcTwinReaderPcscName0)
                              .Add("current_state", SCARD_STATE_UNKNOWN)
                              .Get())
                     .Get(),
@@ -870,7 +876,7 @@ TEST_F(SmartCardConnectorApplicationSingleClientTest,
   ASSERT_THAT(reader_states, SizeIs(1));
   EXPECT_THAT(reader_states[0], DictSizeIs(4));
   EXPECT_THAT(reader_states[0],
-              DictContains("reader_name", "Gemalto PC Twin Reader 00 00"));
+              DictContains("reader_name", kGemaltoPcTwinReaderPcscName0));
   EXPECT_THAT(reader_states[0],
               DictContains("current_state", SCARD_STATE_UNKNOWN));
   EXPECT_THAT(
@@ -878,10 +884,9 @@ TEST_F(SmartCardConnectorApplicationSingleClientTest,
       DictContains("event_state", SCARD_STATE_CHANGED | SCARD_STATE_PRESENT));
   EXPECT_THAT(
       reader_states[0],
-      DictContains("atr", std::vector<uint8_t>{
-                              0x3B, 0xDB, 0x96, 0x00, 0x80, 0xB1, 0xFE, 0x45,
-                              0x1F, 0x83, 0x00, 0x31, 0xC0, 0x64, 0xC7, 0xFC,
-                              0x10, 0x00, 0x01, 0x90, 0x00, 0x74}));
+      DictContains("atr",
+                   TestingSmartCardSimulation::GetCardAtr(
+                       TestingSmartCardSimulation::CardType::kCosmoId70)));
 }
 
 // `SCardConnect()` call from JS fails when there's no card inserted.
@@ -899,7 +904,7 @@ TEST_F(SmartCardConnectorApplicationSingleClientTest, SCardConnectErrorNoCard) {
   SCARDHANDLE scard_handle = 0;
   DWORD active_protocol = 0;
   EXPECT_EQ(SimulateConnectCallFromJsClient(
-                kFakeHandlerId, scard_context(), "Gemalto PC Twin Reader 00 00",
+                kFakeHandlerId, scard_context(), kGemaltoPcTwinReaderPcscName0,
                 SCARD_SHARE_SHARED, SCARD_PROTOCOL_ANY, scard_handle,
                 active_protocol),
             SCARD_E_NO_SMARTCARD);
@@ -921,7 +926,7 @@ TEST_F(SmartCardConnectorApplicationSingleClientTest, SCardConnectDirect) {
   SCARDHANDLE scard_handle = 0;
   DWORD active_protocol = 0;
   EXPECT_EQ(SimulateConnectCallFromJsClient(
-                kFakeHandlerId, scard_context(), "Gemalto PC Twin Reader 00 00",
+                kFakeHandlerId, scard_context(), kGemaltoPcTwinReaderPcscName0,
                 SCARD_SHARE_DIRECT,
                 /*preferred_protocols=*/0, scard_handle, active_protocol),
             SCARD_S_SUCCESS);

--- a/smart_card_connector_app/src/testing_smart_card_simulation.cc
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.cc
@@ -40,6 +40,8 @@
 
 namespace google_smart_card {
 
+using CardType = TestingSmartCardSimulation::CardType;
+using CcidIccStatus = TestingSmartCardSimulation::CcidIccStatus;
 using DeviceType = TestingSmartCardSimulation::DeviceType;
 
 const char* TestingSmartCardSimulation::kRequesterName = "libusb";
@@ -116,6 +118,17 @@ MakeLibusbJsConfigurationDescriptors(DeviceType device_type) {
   GOOGLE_SMART_CARD_NOTREACHED;
 }
 
+// Returns an ATR (answer-to-reset) for the given card. The hardcoded constants
+// are taken from real cards.
+std::vector<uint8_t> GetCardAtr(CardType card_type) {
+  switch (card_type) {
+    case CardType::kCosmoId70:
+      return {0x3B, 0xDB, 0x96, 0x00, 0x80, 0xB1, 0xFE, 0x45, 0x1F, 0x83, 0x00,
+              0x31, 0xC0, 0x64, 0xC7, 0xFC, 0x10, 0x00, 0x01, 0x90, 0x00, 0x74};
+  }
+  GOOGLE_SMART_CARD_NOTREACHED;
+}
+
 bool DeviceInterfaceExists(DeviceType device_type, int64_t interface_number) {
   for (const auto& config : MakeLibusbJsConfigurationDescriptors(device_type)) {
     for (const auto& interface : config.interfaces) {
@@ -169,20 +182,95 @@ std::vector<uint8_t> MakeGetDataRatesResponse(DeviceType device_type) {
 }
 
 // Builds a fake RDR_to_PC_SlotStatus message.
-std::vector<uint8_t> MakeSlotStatusTransferReply(uint8_t sequence_number) {
-  // Currently, the status always says "no ICC present".
-  const uint8_t status = 0x2;
-  return {0x81,   0x00, 0x00, 0x00, 0x00, 0x00, sequence_number,
-          status, 0x00, 0x00};
+std::vector<uint8_t> MakeSlotStatusTransferReply(uint8_t sequence_number,
+                                                 CcidIccStatus icc_status) {
+  // The message format is per CCID specs.
+  return {0x81,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          sequence_number,
+          static_cast<uint8_t>(icc_status),
+          0x00,
+          0x00};
 }
 
 // Builds a fake RDR_to_PC_Escape message.
-std::vector<uint8_t> MakeEscapeTransferReply(uint8_t sequence_number) {
+std::vector<uint8_t> MakeEscapeTransferReply(uint8_t sequence_number,
+                                             CcidIccStatus icc_status) {
+  // The message format is per CCID specs.
   // Currently, the status always says "escape command failed" and "no ICC
   // present".
-  const uint8_t status = 0x42;
+  const uint8_t kStatusFailed = 0x40;
+  const uint8_t status = kStatusFailed + static_cast<uint8_t>(icc_status);
   return {0x83,   0x00, 0x00, 0x00, 0x00, 0x00, sequence_number,
           status, 0x0A, 0x00};
+}
+
+// Builds a fake RDR_to_PC_DataBlock message.
+std::vector<uint8_t> MakeDataBlockTransferReply(
+    uint8_t sequence_number,
+    CcidIccStatus icc_status,
+    const std::vector<uint8_t>& data) {
+  // The message format is per CCID specs.
+  // The code below that encodes the data length only supports single-byte
+  // length at the moment, for simplicity.
+  GOOGLE_SMART_CARD_CHECK(data.size() < 256);
+  std::vector<uint8_t> transfer_reply = {0x80,
+                                         (uint8_t)data.size(),
+                                         0x00,
+                                         0x00,
+                                         0x00,
+                                         0x00,
+                                         sequence_number,
+                                         static_cast<uint8_t>(icc_status),
+                                         0x00,
+                                         0x00};
+  transfer_reply.insert(transfer_reply.end(), data.begin(), data.end());
+  return transfer_reply;
+}
+
+// Builds a fake RDR_to_PC_DataBlock message for replying to
+// PC_to_RDR_IccPowerOn.
+std::vector<uint8_t> MakePowerOnTransferReply(uint8_t sequence_number,
+                                              CcidIccStatus icc_status,
+                                              optional<CardType> card_type) {
+  std::vector<uint8_t> response_data;
+  if (card_type)
+    response_data = GetCardAtr(*card_type);
+  return MakeDataBlockTransferReply(sequence_number, icc_status, response_data);
+}
+
+// Builds a fake RDR_to_PC_Parameters message for replying to
+// PC_to_RDR_SetParameters.
+std::vector<uint8_t> MakeParametersTransferReply(
+    uint8_t sequence_number,
+    CcidIccStatus icc_status,
+    optional<CardType> card_type,
+    const std::vector<uint8_t>& protocol_data_structure) {
+  // The message format is per CCID specs.
+  GOOGLE_SMART_CARD_CHECK(card_type);
+  // For now we always simulate success, in which case the reply contains the
+  // same "abProtocolDataStructure" as the request.
+  // The code below that encodes the data length only supports single-byte
+  // length at the moment, for simplicity.
+  GOOGLE_SMART_CARD_CHECK(protocol_data_structure.size() < 256);
+  std::vector<uint8_t> transfer_reply = {
+      0x82,
+      (uint8_t)protocol_data_structure.size(),
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      sequence_number,
+      static_cast<uint8_t>(icc_status),
+      0x00,
+      0x00};
+  transfer_reply.insert(transfer_reply.end(), protocol_data_structure.begin(),
+                        protocol_data_structure.end());
+  return transfer_reply;
 }
 
 }  // namespace
@@ -283,9 +371,10 @@ void TestingSmartCardSimulation::ThreadSafeHandler::SetDevices(
       if (old_state.device.id == device.id)
         state = old_state;
     }
-    // Update the `device` field unconditionally, to reflect any changes the
-    // caller might've provided in it.
-    state.device = device;
+    // Apply the new `Device` value. This also triggers state transitions (e.g.,
+    // whether a card is inserted) and notifications (e.g., replying to a
+    // pending interrupt transfer).
+    UpdateDeviceState(device, state);
     device_states_.push_back(state);
   }
 }
@@ -453,33 +542,66 @@ GenericRequestResult
 TestingSmartCardSimulation::ThreadSafeHandler::HandleOutputBulkTransfer(
     const std::vector<uint8_t>& data_to_send,
     DeviceState& device_state) {
+  // The message format is per CCID specs.
   // Extract the command's sequence number ("bSeq").
   if (data_to_send.size() < 7)
     GOOGLE_SMART_CARD_LOG_FATAL << "Missing bulk transfer sequence number";
   uint8_t sequence_number = data_to_send[6];
 
   switch (data_to_send[0]) {
-    case 0x65:
-      // It's a PC_to_RDR_GetSlotStatus request to the reader. Prepare a reply
-      // for the next input bulk transfer.
-      device_state.next_bulk_transfer_reply =
-          MakeSlotStatusTransferReply(sequence_number);
+    case 0x61: {
+      // It's a PC_to_RDR_SetParameters request to the reader. Parse the
+      // "abProtocolDataStructure" field (which, per specs, starts from offset
+      // 10).
+      GOOGLE_SMART_CARD_CHECK(data_to_send.size() >= 10);
+      const std::vector<uint8_t> protocol_data_structure(
+          data_to_send.begin() + 10, data_to_send.end());
+      // Prepare a RDR_to_PC_Parameters reply for the next input bulk transfer.
+      device_state.next_bulk_transfer_reply = MakeParametersTransferReply(
+          sequence_number, device_state.icc_status,
+          device_state.device.card_type, protocol_data_structure);
       return GenericRequestResult::CreateSuccessful(
           ConvertToValueOrDie(LibusbJsTransferResult()));
-    case 0x63:
-      // It's a PC_to_RDR_IccPowerOff request to the reader. Prepare a reply for
-      // the next input bulk transfer.
+    }
+    case 0x62: {
+      // It's a PC_to_RDR_IccPowerOn request to the reader. If the card was
+      // present and inactive, it needs to be transitioned into "active" state.
+      if (device_state.icc_status == CcidIccStatus::kPresentInactive)
+        device_state.icc_status = CcidIccStatus::kPresentActive;
+      // Prepare a RDR_to_PC_DataBlock reply for the next input bulk transfer.
       device_state.next_bulk_transfer_reply =
-          MakeSlotStatusTransferReply(sequence_number);
+          MakePowerOnTransferReply(sequence_number, device_state.icc_status,
+                                   device_state.device.card_type);
       return GenericRequestResult::CreateSuccessful(
           ConvertToValueOrDie(LibusbJsTransferResult()));
-    case 0x6B:
-      // It's a PC_to_RDR_Escape request to the reader. Prepare a reply for the
-      // next input bulk transfer.
+    }
+    case 0x63: {
+      // It's a PC_to_RDR_IccPowerOff request to the reader. If the card was
+      // present, it needs to be transitioned into "inactive" state.
+      if (device_state.icc_status == CcidIccStatus::kPresentActive)
+        device_state.icc_status = CcidIccStatus::kPresentInactive;
+      // Prepare a RDR_to_PC_SlotStatus reply for the next input bulk transfer.
       device_state.next_bulk_transfer_reply =
-          MakeEscapeTransferReply(sequence_number);
+          MakeSlotStatusTransferReply(sequence_number, device_state.icc_status);
       return GenericRequestResult::CreateSuccessful(
           ConvertToValueOrDie(LibusbJsTransferResult()));
+    }
+    case 0x65: {
+      // It's a PC_to_RDR_GetSlotStatus request to the reader. Prepare a
+      // RDR_to_PC_SlotStatus reply for the next input bulk transfer.
+      device_state.next_bulk_transfer_reply =
+          MakeSlotStatusTransferReply(sequence_number, device_state.icc_status);
+      return GenericRequestResult::CreateSuccessful(
+          ConvertToValueOrDie(LibusbJsTransferResult()));
+    }
+    case 0x6B: {
+      // It's a PC_to_RDR_Escape request to the reader. Prepare a
+      // RDR_to_PC_Escape reply for the next input bulk transfer.
+      device_state.next_bulk_transfer_reply =
+          MakeEscapeTransferReply(sequence_number, device_state.icc_status);
+      return GenericRequestResult::CreateSuccessful(
+          ConvertToValueOrDie(LibusbJsTransferResult()));
+    }
   }
   // Unknown command.
   GOOGLE_SMART_CARD_LOG_FATAL << "Unexpected output bulk transfer: "
@@ -521,6 +643,28 @@ TestingSmartCardSimulation::ThreadSafeHandler::FindDeviceStateByIdAndHandle(
   if (device_state && device_state->opened_device_handle == device_handle)
     return device_state;
   return nullptr;
+}
+
+void TestingSmartCardSimulation::ThreadSafeHandler::UpdateDeviceState(
+    const Device& device,
+    DeviceState& device_state) {
+  // Special handling for transitioning from the old `device_state.device` to
+  // the new `device`.
+  if (device_state.icc_status == CcidIccStatus::kNotPresent &&
+      device.card_type) {
+    // Simulate card insertion.
+    device_state.icc_status = CcidIccStatus::kPresentInactive;
+    // TODO: Resolve pending interrupt transfers with the slot change.
+  } else if (device_state.icc_status != CcidIccStatus::kNotPresent &&
+             !device.card_type) {
+    // Simulate card removal.
+    device_state.icc_status = CcidIccStatus::kNotPresent;
+    // TODO: Resolve pending interrupt transfers with the slot change.
+  }
+
+  // Apply the whole `device`, including the fields that didn't require special
+  // handling above.
+  device_state.device = device;
 }
 
 void TestingSmartCardSimulation::PostFakeJsResponse(

--- a/smart_card_connector_app/src/testing_smart_card_simulation.h
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.h
@@ -73,6 +73,10 @@ class TestingSmartCardSimulation final {
 
   void SetDevices(const std::vector<Device>& devices);
 
+  // Returns an ATR (answer-to-reset) for the given simulated card. The
+  // hardcoded constants are taken from real cards.
+  static std::vector<uint8_t> GetCardAtr(CardType card_type);
+
  private:
   // The simulation state of a device.
   struct DeviceState {

--- a/smart_card_connector_app/src/testing_smart_card_simulation.h
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.h
@@ -42,12 +42,22 @@ class TestingSmartCardSimulation final {
  public:
   // Fake device to simulate.
   enum class DeviceType { kGemaltoPcTwinReader };
+  enum class CardType { kCosmoId70 };
+
+  // Represents whether an ICC (a smart card) is inserted into the reader and is
+  // powered. Corresponds to "bmICCStatus" from CCID specs.
+  enum class CcidIccStatus : uint8_t {
+    kPresentActive = 0,
+    kPresentInactive = 1,
+    kNotPresent = 2,
+  };
 
   // Parameters of the simulated device.
   struct Device {
     // Unique device identifier to be used in the fake JS replies.
     int64_t id = -1;
     DeviceType type;
+    optional<CardType> card_type;
   };
 
   static const char* kRequesterName;
@@ -70,6 +80,7 @@ class TestingSmartCardSimulation final {
     optional<int64_t> opened_device_handle;
     std::set<int64_t> claimed_interfaces;
     std::vector<uint8_t> next_bulk_transfer_reply;
+    CcidIccStatus icc_status = CcidIccStatus::kNotPresent;
   };
 
   // Helper class that provides thread-safe operations with reader states.
@@ -112,6 +123,7 @@ class TestingSmartCardSimulation final {
     DeviceState* FindDeviceStateById(int64_t device_id);
     DeviceState* FindDeviceStateByIdAndHandle(int64_t device_id,
                                               int64_t device_handle);
+    void UpdateDeviceState(const Device& device, DeviceState& device_state);
 
     GenericRequestResult HandleOutputBulkTransfer(
         const std::vector<uint8_t>& data_to_send,


### PR DESCRIPTION
Add the most basic simulation of an arbitrary smart card (Cosmo ID 7.0
currently) into the Smart Card Connector unit tests. All we simulate at
the moment is the presence of the card and its ATR (answer-to-reset).