### PR TITLE
Delete unused code

### DIFF
--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.cc
@@ -41,11 +41,4 @@ GenericAsyncRequest RemoteCallAdaptor::StartAsyncRequest(
                                        callback);
 }
 
-void RemoteCallAdaptor::StartAsyncRequest(RemoteCallRequestPayload payload,
-                                          GenericAsyncRequestCallback callback,
-                                          GenericAsyncRequest* async_request) {
-  requester_->StartAsyncRequest(ConvertToValueOrDie(std::move(payload)),
-                                callback, async_request);
-}
-
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.h
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.h
@@ -105,10 +105,6 @@ class RemoteCallAdaptor final {
   GenericAsyncRequest StartAsyncRequest(RemoteCallRequestPayload payload,
                                         GenericAsyncRequestCallback callback);
 
-  void StartAsyncRequest(RemoteCallRequestPayload payload,
-                         GenericAsyncRequestCallback callback,
-                         GenericAsyncRequest* async_request);
-
   Requester* const requester_;
 };
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h
@@ -143,7 +143,6 @@ class PcscLiteServerClientsManager final {
 
     ~Handler() override;
 
-    int64_t handler_id() const { return handler_id_; }
     const std::string& client_name_for_log() const {
       return client_name_for_log_;
     }


### PR DESCRIPTION
Delete a few unused C++ functions from RemoteCallAdaptor and
ClientsManager. These were found via coverage reports.