### PR TITLE
Use LTO in Emscripten builds

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -113,8 +113,11 @@ ifeq ($(CONFIG),Release)
 #
 # Explanation:
 # O3: Enable advanced optimizations.
+# flto: Use link-time optimizations. Note: this typically produces larger
+#   executables, however they should presumably be faster.
 EMSCRIPTEN_COMMON_FLAGS += \
   -O3 \
+  -flto \
 
 # Add compiler flags specific to release builds.
 #


### PR DESCRIPTION
Enable link-time optimizations when building for WebAssembly via
Emscripten.

Despite that this causes the 5% increase of the resulting binary size,
we're presumably winning on performance. And the 5% size regression is
negligible at our sizes at the order-of-several-hundreds-KBs (especially
given that PNaCl binaries used to be typically about 100% bigger).