### PR TITLE
Unit-test Connector unknown PC/SC function call

### DIFF
--- a/common/cpp/src/google_smart_card_common/optional_test_utils.h
+++ b/common/cpp/src/google_smart_card_common/optional_test_utils.h
@@ -1,0 +1,44 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_SMART_CARD_COMMON_OPTIONAL_TEST_UTILS_H_
+#define GOOGLE_SMART_CARD_COMMON_OPTIONAL_TEST_UTILS_H_
+
+#include <sstream>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <google_smart_card_common/optional.h>
+
+namespace google_smart_card {
+
+template <typename T>
+inline void PrintTo(const optional<T>& value, std::ostream* os) {
+  if (!value) {
+    *os << "<null optional>";
+    return;
+  }
+  *os << ::testing::PrintToString(*value);
+}
+
+// This is similar to `testing::IsFalse`, but is more self-explanatory at
+// callsites.
+MATCHER(IsNullOptional, /*description_string=*/"is null optional") {
+  return !arg;
+}
+
+}  // namespace google_smart_card
+
+#endif  // GOOGLE_SMART_CARD_COMMON_OPTIONAL_TEST_UTILS_H_

--- a/common/cpp/src/public/testing_global_context.cc
+++ b/common/cpp/src/public/testing_global_context.cc
@@ -48,14 +48,12 @@ bool EndsWith(const std::string& string, const std::string& suffix) {
   return true;
 }
 
-// Parses out the requester name from "<requester>::request", or returns a null
-// optional if the format doesn't match.
+// Checks the message type against the "...::request" pattern.
 bool LooksLikeRequestMessage(const std::string& message_type) {
   return EndsWith(message_type, kRequestMessageTypeSuffix);
 }
 
-// Parses out the requester name from "<requester>::response", or returns a null
-// optional if the format doesn't match.
+// Checks the message type against the "...::response" pattern.
 bool LooksLikeResponseMessage(const std::string& message_type) {
   return EndsWith(message_type, kResponseMessageTypeSuffix);
 }

--- a/common/cpp/src/public/testing_global_context.cc
+++ b/common/cpp/src/public/testing_global_context.cc
@@ -40,27 +40,24 @@ namespace google_smart_card {
 
 namespace {
 
-optional<std::string> StripSuffix(const std::string& string,
-                                  const std::string& suffix) {
+bool EndsWith(const std::string& string, const std::string& suffix) {
   if (string.length() <= suffix.length() ||
       string.substr(string.length() - suffix.length()) != suffix) {
-    return {};
+    return false;
   }
-  return string.substr(0, string.length() - suffix.length());
+  return true;
 }
 
-// Parses out the requester name from "<requester>::request" or
-// "<requester>::response", or returns a null optional if the format doesn't
-// match.
-optional<std::string> GetRequesterName(const std::string& message_type) {
-  auto stripped = StripSuffix(message_type, kRequestMessageTypeSuffix);
-  if (stripped)
-    return *stripped;
-  stripped = StripSuffix(message_type, kResponseMessageTypeSuffix);
-  if (stripped)
-    return *stripped;
-  // Not a request/response message.
-  return {};
+// Parses out the requester name from "<requester>::request", or returns a null
+// optional if the format doesn't match.
+bool LooksLikeRequestMessage(const std::string& message_type) {
+  return EndsWith(message_type, kRequestMessageTypeSuffix);
+}
+
+// Parses out the requester name from "<requester>::response", or returns a null
+// optional if the format doesn't match.
+bool LooksLikeResponseMessage(const std::string& message_type) {
+  return EndsWith(message_type, kResponseMessageTypeSuffix);
 }
 
 // `payload_to_reply_with` is passed via shared_ptr in order to workaround
@@ -69,7 +66,7 @@ void PostFakeJsReply(TypedMessageRouter* typed_message_router,
                      const std::string& requester_name,
                      std::shared_ptr<Value> payload_to_reply_with,
                      const optional<std::string>& error_to_reply_with,
-                     Value /*request_payload*/,
+                     optional<Value> /*request_payload*/,
                      optional<RequestId> request_id) {
   ResponseMessageData response_data;
   response_data.request_id = *request_id;
@@ -115,13 +112,13 @@ void TestingGlobalContext::Waiter::Reply(Value result_to_reply_with) {
                   /*request_payload=*/{}, *request_id_);
 }
 
-const Value& TestingGlobalContext::Waiter::value() const {
+const optional<Value>& TestingGlobalContext::Waiter::value() const {
   // No mutex locks, as it's only allowed to call us after `Wait()` completes.
   GOOGLE_SMART_CARD_CHECK(resolved_);
   return value_;
 }
 
-Value TestingGlobalContext::Waiter::take_value() && {
+optional<Value> TestingGlobalContext::Waiter::take_value() && {
   // No mutex locks, as it's only allowed to call us after `Wait()` completes.
   GOOGLE_SMART_CARD_CHECK(resolved_);
   return std::move(value_);
@@ -139,7 +136,7 @@ TestingGlobalContext::Waiter::Waiter(
     : typed_message_router_(typed_message_router),
       requester_name_(requester_name) {}
 
-void TestingGlobalContext::Waiter::Resolve(Value value,
+void TestingGlobalContext::Waiter::Resolve(optional<Value> value,
                                            optional<RequestId> request_id) {
   std::unique_lock<std::mutex> lock(mutex_);
 
@@ -279,7 +276,7 @@ TestingGlobalContext::Expectation TestingGlobalContext::MakeRequestExpectation(
     const std::string& requester_name,
     const std::string& function_name,
     Value arguments,
-    std::function<void(Value, optional<RequestId>)> callback_to_run) {
+    Callback callback_to_run) {
   GOOGLE_SMART_CARD_CHECK(arguments.is_array());
 
   RemoteCallRequestPayload request_payload;
@@ -328,7 +325,7 @@ TestingGlobalContext::FindMatchingExpectation(const std::string& message_type,
       continue;
     }
     if (expectation.awaited_request_payload && !request_payload) {
-      // Skip - expected a message with a payload, but none got.
+      // Skip - expected a request message with a payload, but none got.
       continue;
     }
     if (expectation.awaited_request_payload &&
@@ -351,28 +348,46 @@ bool TestingGlobalContext::HandleMessageToJs(Value message) {
   TypedMessage typed_message =
       ConvertFromValueOrDie<TypedMessage>(std::move(message));
 
-  optional<std::string> requester_name = GetRequesterName(typed_message.type);
-  if (requester_name) {
-    // It's a request/response message - parse its payload and use it to find
-    // the expectation.
+  optional<RequestId> request_id;
+  // Only one of these variables will be filled below - depending on the message
+  // type.
+  optional<Value> request_payload, response_payload, message_data;
+
+  if (LooksLikeRequestMessage(typed_message.type)) {
+    // It's a request message; parse its ID and payload for finding the
+    // expectation and passing them to the callback.
     RequestMessageData request_data = ConvertFromValueOrDie<RequestMessageData>(
         std::move(typed_message.data));
-    optional<Callback> callback_to_run = FindMatchingExpectation(
-        typed_message.type, request_data.request_id, &request_data.payload);
-    if (!callback_to_run)
-      return false;
-    (*callback_to_run)(std::move(request_data.payload),
-                       request_data.request_id);
-    return true;
+    request_id = request_data.request_id;
+    request_payload = std::move(request_data.payload);
+  } else if (LooksLikeResponseMessage(typed_message.type)) {
+    // It's a response message; parse ID for finding the expectation and the
+    // payload (which can be null if the response contains a failure) for
+    // passing to the callback.
+    ResponseMessageData response_data =
+        ConvertFromValueOrDie<ResponseMessageData>(
+            std::move(typed_message.data));
+    request_id = response_data.request_id;
+    response_payload = std::move(response_data.payload);
+  } else {
+    // It's a regular message; find the expectation using just the type.
+    message_data = std::move(typed_message.data);
   }
 
-  // It's a regular message - find the expectation using just the type.
-  optional<Callback> callback_to_run = FindMatchingExpectation(
-      typed_message.type, /*request_id=*/{}, /*request_payload=*/nullptr);
+  // Find the callback for the message type, request ID and, if it's a request
+  // message, the request payload.
+  optional<Callback> callback_to_run =
+      FindMatchingExpectation(typed_message.type, request_id,
+                              request_payload ? &*request_payload : nullptr);
   if (!callback_to_run)
     return false;
-  (*callback_to_run)(std::move(typed_message.data),
-                     /*request_id=*/optional<RequestId>());
+
+  // Run the callback and pass the value (taken from one of three variables,
+  // depending on the branch taken above) to it.
+  (*callback_to_run)(request_payload    ? std::move(request_payload)
+                     : response_payload ? std::move(response_payload)
+                                        : std::move(message_data),
+                     request_id);
   return true;
 }
 

--- a/common/cpp/src/public/testing_global_context.cc
+++ b/common/cpp/src/public/testing_global_context.cc
@@ -68,6 +68,8 @@ void PostFakeJsReply(TypedMessageRouter* typed_message_router,
                      const optional<std::string>& error_to_reply_with,
                      optional<Value> /*request_payload*/,
                      optional<RequestId> request_id) {
+  GOOGLE_SMART_CARD_CHECK(request_id);
+
   ResponseMessageData response_data;
   response_data.request_id = *request_id;
   if (payload_to_reply_with)

--- a/common/cpp/src/public/testing_global_context.cc
+++ b/common/cpp/src/public/testing_global_context.cc
@@ -105,8 +105,8 @@ void TestingGlobalContext::Waiter::Reply(Value result_to_reply_with) {
   // No mutex locks, as it's only allowed to call us after `Wait()` completes.
   GOOGLE_SMART_CARD_CHECK(resolved_);
   GOOGLE_SMART_CARD_CHECK(request_id_);
-  // The request result is always wrapped into a single-item array. Do it
-  // here, so that the test bodies are easier to read.
+  // The request result is always wrapped into a single-item array. Do it here,
+  // so that the test bodies are easier to read.
   Value array = ArrayValueBuilder().Add(std::move(result_to_reply_with)).Get();
   PostFakeJsReply(typed_message_router_, *requester_name_,
                   std::make_shared<Value>(std::move(array)),

--- a/common/cpp/src/public/testing_global_context.h
+++ b/common/cpp/src/public/testing_global_context.h
@@ -41,7 +41,7 @@ class TestingGlobalContext final : public GlobalContext {
   // request/response messages, the parameters are `RequestMessageData::payload`
   // and `RequestMessageData::request_id`. For other messages, only
   // `TypedMessage::data` is passed.
-  using Callback = std::function<void(Value, optional<RequestId>)>;
+  using Callback = std::function<void(optional<Value>, optional<RequestId>)>;
 
   // Helper returned by `Create...Waiter()` methods. Allows to wait until the
   // specified C++-to-JS message is sent.
@@ -54,8 +54,8 @@ class TestingGlobalContext final : public GlobalContext {
     void Wait();
     void Reply(Value result_to_reply_with);
 
-    const Value& value() const;
-    Value take_value() &&;
+    const optional<Value>& value() const;
+    optional<Value> take_value() &&;
     optional<RequestId> request_id() const;
 
    private:
@@ -64,14 +64,14 @@ class TestingGlobalContext final : public GlobalContext {
     Waiter(TypedMessageRouter* typed_message_router,
            const optional<std::string>& requester_name);
 
-    void Resolve(Value value, optional<RequestId> request_id);
+    void Resolve(optional<Value> value, optional<RequestId> request_id);
 
     TypedMessageRouter* const typed_message_router_;
     const optional<std::string> requester_name_;
     std::mutex mutex_;
     std::condition_variable condition_;
     bool resolved_ = false;
-    Value value_;
+    optional<Value> value_;
     optional<RequestId> request_id_;
   };
 
@@ -146,11 +146,10 @@ class TestingGlobalContext final : public GlobalContext {
     bool once = true;
   };
 
-  Expectation MakeRequestExpectation(
-      const std::string& requester_name,
-      const std::string& function_name,
-      Value arguments,
-      std::function<void(Value, optional<RequestId>)> callback_to_run);
+  Expectation MakeRequestExpectation(const std::string& requester_name,
+                                     const std::string& function_name,
+                                     Value arguments,
+                                     Callback callback_to_run);
   void AddExpectation(Expectation expectation);
   optional<Callback> FindMatchingExpectation(const std::string& message_type,
                                              optional<RequestId> request_id,

--- a/smart_card_connector_app/src/application_unittest.cc
+++ b/smart_card_connector_app/src/application_unittest.cc
@@ -109,6 +109,7 @@ class ReaderNotificationObserver final {
   void OnMessageToJs(const std::string& event_name,
                      optional<Value> message_data,
                      optional<RequestId> /*request_id*/) {
+    ASSERT_TRUE(message_data);
     std::string notification =
         event_name + ":" +
         message_data->GetDictionaryItem("readerName")->GetString();

--- a/smart_card_connector_app/src/application_unittest.cc
+++ b/smart_card_connector_app/src/application_unittest.cc
@@ -33,6 +33,7 @@
 #include <google_smart_card_common/messaging/typed_message_router.h>
 #include <google_smart_card_common/multi_string.h>
 #include <google_smart_card_common/optional.h>
+#include <google_smart_card_common/optional_test_utils.h>
 #include <google_smart_card_common/requesting/remote_call_message.h>
 #include <google_smart_card_common/requesting/requester_message.h>
 #include <google_smart_card_common/unique_ptr_utils.h>
@@ -106,11 +107,11 @@ class ReaderNotificationObserver final {
 
  private:
   void OnMessageToJs(const std::string& event_name,
-                     Value message_data,
+                     optional<Value> message_data,
                      optional<RequestId> /*request_id*/) {
     std::string notification =
         event_name + ":" +
-        message_data.GetDictionaryItem("readerName")->GetString();
+        message_data->GetDictionaryItem("readerName")->GetString();
 
     std::unique_lock<std::mutex> lock(mutex_);
     recorded_notifications_.push(notification);
@@ -152,18 +153,22 @@ std::vector<std::string> DirectCallSCardListReaders(
   return ExtractMultiStringElements(readers_multistring);
 }
 
-LONG ExtractReturnCodeAndResults(Value reply) {
-  GOOGLE_SMART_CARD_CHECK(reply.is_array());
-  auto& reply_array = reply.GetArray();
+LONG ExtractReturnCodeAndResults(optional<Value> reply) {
+  GOOGLE_SMART_CARD_CHECK(reply);
+  GOOGLE_SMART_CARD_CHECK(reply->is_array());
+  auto& reply_array = reply->GetArray();
   GOOGLE_SMART_CARD_CHECK(reply_array.size() == 1);
   LONG return_code = ConvertFromValueOrDie<LONG>(std::move(*reply_array[0]));
   return return_code;
 }
 
 template <typename Arg, typename... Args>
-LONG ExtractReturnCodeAndResults(Value reply, Arg& out_arg, Args&... out_args) {
-  GOOGLE_SMART_CARD_CHECK(reply.is_array());
-  auto& reply_array = reply.GetArray();
+LONG ExtractReturnCodeAndResults(optional<Value> reply,
+                                 Arg& out_arg,
+                                 Args&... out_args) {
+  GOOGLE_SMART_CARD_CHECK(reply);
+  GOOGLE_SMART_CARD_CHECK(reply->is_array());
+  auto& reply_array = reply->GetArray();
   if (reply_array.size() == 1) {
     // The reply contains only a return code - extract it.
     return ExtractReturnCodeAndResults(std::move(reply));
@@ -204,7 +209,7 @@ class SmartCardConnectorApplicationTest : public ::testing::Test {
     // Wait until the daemon's background thread completes the initialization
     // and notifies the JS side.
     pcsc_lite_ready_message_waiter->Wait();
-    EXPECT_TRUE(pcsc_lite_ready_message_waiter->value().StrictlyEquals(
+    EXPECT_TRUE(pcsc_lite_ready_message_waiter->value()->StrictlyEquals(
         Value(Value::Type::kDictionary)));
   }
 
@@ -270,9 +275,9 @@ class SmartCardConnectorApplicationTest : public ::testing::Test {
                           ConvertToValueOrDie(std::move(request_data)));
   }
 
-  Value SimulateSyncCallFromJsClient(int handler_id,
-                                     const std::string& function_name,
-                                     Value arguments) {
+  optional<Value> SimulateSyncCallFromJsClient(int handler_id,
+                                               const std::string& function_name,
+                                               Value arguments) {
     const RequestId request_id = ++request_id_counter_;
     const std::string requester_name = GetJsClientRequesterName(handler_id);
     auto waiter =
@@ -1019,6 +1024,22 @@ TEST_F(SmartCardConnectorApplicationSingleClientTest, SCardConnectT1) {
   EXPECT_EQ(SimulateDisconnectCallFromJsClient(kFakeHandlerId, scard_handle,
                                                SCARD_LEAVE_CARD),
             SCARD_S_SUCCESS);
+}
+
+TEST_F(SmartCardConnectorApplicationSingleClientTest, NonExistingFunctionCall) {
+  // Arrange:
+  StartApplication();
+  SetUpJsClient();
+
+  // Act:
+  optional<Value> response =
+      SimulateSyncCallFromJsClient(kFakeHandlerId,
+                                   /*function_name=*/"foo",
+                                   /*arguments=*/Value(Value::Type::kArray));
+
+  // Assert: the response is null as it only contains an error message (we don't
+  // verify the message here).
+  EXPECT_THAT(response, IsNullOptional());
 }
 
 }  // namespace google_smart_card

--- a/smart_card_connector_app/src/testing_smart_card_simulation.cc
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.cc
@@ -357,15 +357,15 @@ TestingSmartCardSimulation::TestingSmartCardSimulation(
 
 TestingSmartCardSimulation::~TestingSmartCardSimulation() = default;
 
-void TestingSmartCardSimulation::OnRequestToJs(Value request_payload,
+void TestingSmartCardSimulation::OnRequestToJs(optional<Value> request_payload,
                                                optional<RequestId> request_id) {
   // Make the debug dump in advance, before we know whether we need to crash,
   // because we can't dump the value after std::move()'ing it.
-  const std::string payload_debug_dump = DebugDumpValueFull(request_payload);
+  const std::string payload_debug_dump = DebugDumpValueFull(*request_payload);
 
   RemoteCallRequestPayload remote_call =
       ConvertFromValueOrDie<RemoteCallRequestPayload>(
-          std::move(request_payload));
+          std::move(*request_payload));
   optional<GenericRequestResult> response;
   if (remote_call.function_name == "listDevices") {
     GOOGLE_SMART_CARD_CHECK(remote_call.arguments.empty());

--- a/smart_card_connector_app/src/testing_smart_card_simulation.cc
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.cc
@@ -359,6 +359,8 @@ TestingSmartCardSimulation::~TestingSmartCardSimulation() = default;
 
 void TestingSmartCardSimulation::OnRequestToJs(optional<Value> request_payload,
                                                optional<RequestId> request_id) {
+  GOOGLE_SMART_CARD_CHECK(request_payload);
+  GOOGLE_SMART_CARD_CHECK(request_id);
   // Make the debug dump in advance, before we know whether we need to crash,
   // because we can't dump the value after std::move()'ing it.
   const std::string payload_debug_dump = DebugDumpValueFull(*request_payload);

--- a/smart_card_connector_app/src/testing_smart_card_simulation.h
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.h
@@ -70,7 +70,8 @@ class TestingSmartCardSimulation final {
   ~TestingSmartCardSimulation();
 
   // Subscribe this to the C++-to-JS message channel.
-  void OnRequestToJs(Value request_payload, optional<RequestId> request_id);
+  void OnRequestToJs(optional<Value> request_payload,
+                     optional<RequestId> request_id);
 
   void SetDevices(const std::vector<Device>& devices);
 


### PR DESCRIPTION
Add unit test for the Smart Card Connector for the scenario in which it
receives a PC/SC request with an unknown function name.

This change includes the refactoring that was needed in order to
properly parse failure response messages (previously the tests were
parsing both requests and response messages in the same way, assuming
that the "payload" field is always present).