### PR TITLE
Unit-test USB reply for already-canceled transfer

### DIFF
--- a/common/cpp/src/public/testing_global_context.h
+++ b/common/cpp/src/public/testing_global_context.h
@@ -52,6 +52,7 @@ class TestingGlobalContext final : public GlobalContext {
     ~Waiter();
 
     void Wait();
+    void Reply(Value result_to_reply_with);
 
     const Value& value() const;
     Value take_value() &&;
@@ -60,10 +61,13 @@ class TestingGlobalContext final : public GlobalContext {
    private:
     friend class TestingGlobalContext;
 
-    Waiter();
+    Waiter(TypedMessageRouter* typed_message_router,
+           const optional<std::string>& requester_name);
 
     void Resolve(Value value, optional<RequestId> request_id);
 
+    TypedMessageRouter* const typed_message_router_;
+    const optional<std::string> requester_name_;
     std::mutex mutex_;
     std::condition_variable condition_;
     bool resolved_ = false;

--- a/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
@@ -956,7 +956,7 @@ TEST_F(LibusbJsProxyWithDeviceTest, AsyncInputControlTransferCancellation) {
   } while (!transfer_completed);
 
   // A reply from the JS side has no effect for the already canceled transfer.
-  waiter->Reply(/*result_to_reply_with*/ DictValueBuilder()
+  waiter->Reply(/*result_to_reply_with=*/DictValueBuilder()
                     .Add("receivedData", std::vector<uint8_t>({1, 2, 3}))
                     .Get());
 

--- a/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
@@ -965,6 +965,157 @@ TEST_F(LibusbJsProxyWithDeviceTest, AsyncInputControlTransferCancellation) {
   // the callback.
 }
 
+// Test an asynchronous output control transfer successful scenario.
+TEST_F(LibusbJsProxyWithDeviceTest, AsyncOutputControlTransfer) {
+  constexpr int kTransferRequest = 1;
+  constexpr int kTransferIndex = 24;
+  constexpr int kTransferValue = 42;
+  const std::vector<uint8_t> kData = {1, 2, 3, 4, 5, 6};
+
+  // Arrange.
+  global_context_.WillReplyToRequestWith(
+      "libusb", "controlTransfer",
+      /*arguments=*/
+      ArrayValueBuilder()
+          .Add(kJsDeviceId)
+          .Add(kJsDeviceHandle)
+          .Add(DictValueBuilder()
+                   .Add("index", kTransferIndex)
+                   .Add("recipient", "endpoint")
+                   .Add("request", kTransferRequest)
+                   .Add("requestType", "standard")
+                   .Add("value", kTransferValue)
+                   .Add("dataToSend", kData)
+                   .Get())
+          .Get(),
+      /*result_to_reply_with=*/Value(Value::Type::kDictionary));
+  auto transfer_callback = [](libusb_transfer* transfer) {
+    ASSERT_TRUE(transfer);
+    // `user_data` points to `transfer_completed` (a captureless lambda has no
+    // other way of telling the test it's run).
+    *static_cast<bool*>(transfer->user_data) = true;
+  };
+
+  // Act.
+  std::vector<uint8_t> setup(LIBUSB_CONTROL_SETUP_SIZE + kData.size());
+  libusb_fill_control_setup(
+      setup.data(),
+      LIBUSB_RECIPIENT_ENDPOINT | LIBUSB_REQUEST_TYPE_STANDARD |
+          LIBUSB_ENDPOINT_OUT,
+      kTransferRequest, kTransferValue, kTransferIndex, kData.size());
+  std::copy(kData.begin(), kData.end(),
+            setup.begin() + LIBUSB_CONTROL_SETUP_SIZE);
+
+  libusb_transfer* const transfer =
+      libusb_js_proxy_.LibusbAllocTransfer(/*iso_packets=*/0);
+  ASSERT_TRUE(transfer);
+  bool transfer_completed = false;
+  libusb_fill_control_transfer(
+      transfer, device_handle_, setup.data(), transfer_callback,
+      /*user_data=*/static_cast<void*>(&transfer_completed),
+      /*timeout=*/0);
+
+  EXPECT_EQ(libusb_js_proxy_.LibusbSubmitTransfer(transfer), LIBUSB_SUCCESS);
+  EXPECT_FALSE(transfer_completed);
+  // Let the fake JS result propagate.
+  do {
+    EXPECT_EQ(libusb_js_proxy_.LibusbHandleEvents(/*ctx=*/nullptr),
+              LIBUSB_SUCCESS);
+  } while (!transfer_completed);
+
+  // Assert.
+  EXPECT_EQ(transfer->status, LIBUSB_TRANSFER_COMPLETED);
+  EXPECT_EQ(transfer->actual_length, static_cast<int>(kData.size()));
+  // Attempting to cancel a completed transfer fails.
+  EXPECT_NE(libusb_js_proxy_.LibusbCancelTransfer(transfer), LIBUSB_SUCCESS);
+
+  // Cleanup:
+  libusb_js_proxy_.LibusbFreeTransfer(transfer);
+}
+
+// Test that it's not possible to cancel an asynchronous output control transfer
+// (only cancelling input transfers is supported by our implementation).
+TEST_F(LibusbJsProxyWithDeviceTest, AsyncOutputControlTransferCancellation) {
+  constexpr int kTransferRequest = 1;
+  constexpr int kTransferIndex = 24;
+  constexpr int kTransferValue = 42;
+  const std::vector<uint8_t> kData = {1, 2, 3, 4, 5, 6};
+
+  // Arrange. Set up the expectation for the request message. We will reply to
+  // this message only after attempting to cancel the transfer.
+  auto waiter = global_context_.CreateRequestWaiter(
+      "libusb", "controlTransfer",
+      /*arguments=*/
+      ArrayValueBuilder()
+          .Add(kJsDeviceId)
+          .Add(kJsDeviceHandle)
+          .Add(DictValueBuilder()
+                   .Add("index", kTransferIndex)
+                   .Add("recipient", "endpoint")
+                   .Add("request", kTransferRequest)
+                   .Add("requestType", "standard")
+                   .Add("value", kTransferValue)
+                   .Add("dataToSend", kData)
+                   .Get())
+          .Get());
+  auto transfer_callback = [](libusb_transfer* transfer) {
+    ASSERT_TRUE(transfer);
+    EXPECT_EQ(transfer->status, LIBUSB_TRANSFER_COMPLETED);
+    // Check `actual_length` equals `kData.size()` (we can't pass it explicitly
+    // as we're a captureless lambda).
+    EXPECT_EQ(transfer->actual_length, 6);
+
+    // `user_data` points to `transfer_completed` (a captureless lambda has no
+    // other way of telling the test it's run).
+    *static_cast<bool*>(transfer->user_data) = true;
+  };
+
+  // Act.
+  std::vector<uint8_t> setup(LIBUSB_CONTROL_SETUP_SIZE + kData.size());
+  libusb_fill_control_setup(
+      setup.data(),
+      LIBUSB_RECIPIENT_ENDPOINT | LIBUSB_REQUEST_TYPE_STANDARD |
+          LIBUSB_ENDPOINT_OUT,
+      kTransferRequest, kTransferValue, kTransferIndex, kData.size());
+  std::copy(kData.begin(), kData.end(),
+            setup.begin() + LIBUSB_CONTROL_SETUP_SIZE);
+
+  libusb_transfer* const transfer =
+      libusb_js_proxy_.LibusbAllocTransfer(/*iso_packets=*/0);
+  ASSERT_TRUE(transfer);
+  bool transfer_completed = false;
+  libusb_fill_control_transfer(
+      transfer, device_handle_, setup.data(), transfer_callback,
+      /*user_data=*/static_cast<void*>(&transfer_completed),
+      /*timeout=*/0);
+  // In this test we also verify the automatic deallocation of the transfer.
+  transfer->flags = LIBUSB_TRANSFER_FREE_TRANSFER;
+
+  EXPECT_EQ(libusb_js_proxy_.LibusbSubmitTransfer(transfer), LIBUSB_SUCCESS);
+
+  // Wait for the JS request to be sent.
+  waiter->Wait();
+  EXPECT_FALSE(transfer_completed);
+
+  // Attempt to cancel the transfer - this is expected to fail.
+  EXPECT_EQ(libusb_js_proxy_.LibusbCancelTransfer(transfer),
+            LIBUSB_ERROR_NOT_FOUND);
+
+  // Simulate a successful transfer reply from the JS side.
+  waiter->Reply(/*result_to_reply_with=*/Value(Value::Type::kDictionary));
+  EXPECT_FALSE(transfer_completed);
+
+  // Let the fake JS result propagate.
+  do {
+    EXPECT_EQ(libusb_js_proxy_.LibusbHandleEvents(/*ctx=*/nullptr),
+              LIBUSB_SUCCESS);
+  } while (!transfer_completed);
+
+  // Nothing to assert here - due to the `LIBUSB_TRANSFER_FREE_TRANSFER` flag
+  // the `transfer` is already deallocated here. All assertions are done inside
+  // the callback.
+}
+
 // TODO(#429): Resurrect the tests by reimplementing them on top of the
 // libusb-to-JS adaptor instead of the chrome_usb::ApiBridge.
 #if 0


### PR DESCRIPTION
Extend the LibusbJsProxy unit tests to check there's no issue caused by
an input USB transfer reply received from the JS side after the
transfer got already canceled.