### PR TITLE
Unit-test Connect with card protocol mismatch

### DIFF
--- a/smart_card_connector_app/src/application_unittest.cc
+++ b/smart_card_connector_app/src/application_unittest.cc
@@ -1068,7 +1068,7 @@ TEST_F(SmartCardConnectorApplicationSingleClientTest,
 
 // `SCardConnect()` call from JS successfully connects via the "T1" protocol if
 // the previous connection via the "RAW" protocol was terminated by
-// `SCardDisconnect` with `SCArD_RESET_CARD`.
+// `SCardDisconnect` with `SCARD_RESET_CARD`.
 TEST_F(SmartCardConnectorApplicationSingleClientTest,
        SCardConnectProtocolChangeAfterReset) {
   // Arrange:


### PR DESCRIPTION
Add unit tests for the Smart Card Connector receiving two SCardConnect
client requests with different protocols. The test verifies the second
call only succeeds if SCardDisconnect with SCARD_RESET_CARD is called
in between.