### PR TITLE
Reapply CCID patch for ifdLogLevel

### DIFF
--- a/third_party/ccid/src/src/Info.plist.src
+++ b/third_party/ccid/src/src/Info.plist.src
@@ -51,7 +51,7 @@
 	-->
 
 	<key>ifdDriverOptions</key>
-	<string>0x0000</string>
+	<string>0x0004</string>
 
 	<!-- Possible values for ifdDriverOptions
 	0x01: DRIVER_OPTION_CCID_EXCHANGE_AUTHORIZED


### PR DESCRIPTION
Apply the 0001-Patch-ccid-tweak-ifdDriverOptions-option.patch patch to
our CCID fork. It was forgotten during the last CCID uprev.