### PR TITLE
Fix USB tracing wrapper on unsent transfer cancel

### DIFF
--- a/third_party/libusb/webport/src/libusb_tracing_wrapper.cc
+++ b/third_party/libusb/webport/src/libusb_tracing_wrapper.cc
@@ -850,7 +850,7 @@ int LibusbTracingWrapper::LibusbCancelTransfer(libusb_transfer* transfer) {
   // here the actual cancellation should be called with the wrapper transfer.
   libusb_transfer* const wrapped_transfer = GetWrappedTransfer(transfer);
   if (!wrapped_transfer) {
-    // The original transfer not submitted yet or already completed.
+    // The original transfer is either not yet submitted or already completed.
     return LIBUSB_ERROR_NOT_FOUND;
   }
 

--- a/third_party/libusb/webport/src/libusb_tracing_wrapper.cc
+++ b/third_party/libusb/webport/src/libusb_tracing_wrapper.cc
@@ -849,7 +849,10 @@ int LibusbTracingWrapper::LibusbCancelTransfer(libusb_transfer* transfer) {
   // wrapped transfer (see the LibusbSubmitTransfer method implementation). So
   // here the actual cancellation should be called with the wrapper transfer.
   libusb_transfer* const wrapped_transfer = GetWrappedTransfer(transfer);
-  GOOGLE_SMART_CARD_CHECK(wrapped_transfer);
+  if (!wrapped_transfer) {
+    // The original transfer not submitted yet or already completed.
+    return LIBUSB_ERROR_NOT_FOUND;
+  }
 
   const int return_code =
       wrapped_libusb_->LibusbCancelTransfer(wrapped_transfer);


### PR DESCRIPTION
Fix the LibusbTracingWrapper class to not crash on a debug assertion
when a cancellation of a not-yet-submitted transfer is requested.

The callsites shouldn't normally trigger such calls, but apparently the
original Libusb interface does support them, and we also support that in
the real LibusbJsProxy implementation.

This bugfix contributes to the bugfixes tracked by #685. The
regression unit test is part of #684.