### PR TITLE
Fix USB tracing wrapper: cancel completed transfer

### DIFF
--- a/third_party/libusb/webport/src/libusb_tracing_wrapper.h
+++ b/third_party/libusb/webport/src/libusb_tracing_wrapper.h
@@ -88,6 +88,8 @@ class LibusbTracingWrapper : public LibusbInterface {
   int LibusbHandleEventsCompleted(libusb_context* ctx, int* completed) override;
 
  private:
+  class LibusbTransferTracingWrapper;
+
   void AddOriginalToWrappedTransferMapItem(libusb_transfer* original_transfer,
                                            libusb_transfer* wrapped_transfer);
   libusb_transfer* GetWrappedTransfer(libusb_transfer* original_transfer) const;


### PR DESCRIPTION
Fix LibusbTracingWrapper hitting use-after-free errors when canceling an
already completed (but not destroyed yet) transfer.

The problem was caused by leaving a dangling pointer to the wrapped
transfer in the LibusbTracingWrapper. Before this fix, we were cleaning
the dangling pointer when LibusbFreeTransfer is called, but that left a
time window during which the dangling pointer is still here and can lead
to use-after-free: after the transfer is completed but before it's
freed.

This bugfix contributes to the bugfixes tracked by #685. The
regression unit test is part of #684.