### PR TITLE
Pull upstream PC/SC-Lite fixes for orphan handles

### DIFF
--- a/third_party/pcsc-lite/patches/0001-Fix-SCardReleaseContext-failure-on-orphan-handles.patch
+++ b/third_party/pcsc-lite/patches/0001-Fix-SCardReleaseContext-failure-on-orphan-handles.patch
@@ -1,0 +1,110 @@
+From 2735a6d1b7ffa5ca81e602417516a9c0702c0fcd Mon Sep 17 00:00:00 2001
+From: Maksim Ivanov <emaxx@google.com>
+Date: Sat, 18 Jun 2022 13:46:38 +0200
+Subject: [PATCH] Fix SCardReleaseContext failure on orphan handles
+
+Fix returning a spurious error from SCardReleaseContext() for a
+correct SCARDCONTEXT, in case there was an orphan SCARDHANDLE left after
+disconnecting a reader.
+
+The error was caused by the fact that SCardReleaseContext attempts to do
+SCardDisconnect for all active SCARDHANDLEs stored in SCARDCONTEXT,
+which fails when the handle was already deleted by the hotplug code from
+READER_CONTEXT or the reader got zero reference count.
+---
+ src/winscard_svc.c | 59 ++++++++++++++++++++++++++--------------------
+ 1 file changed, 33 insertions(+), 26 deletions(-)
+
+diff --git a/src/winscard_svc.c b/src/winscard_svc.c
+index 01408320..f4583124 100644
+--- a/src/winscard_svc.c
++++ b/src/winscard_svc.c
+@@ -886,47 +886,52 @@ static LONG MSGRemoveContext(SCARDCONTEXT hContext, SCONTEXT * threadContext)
+ 		hCard = *(int32_t *)ptr;
+ 
+ 		/*
+-		 * Unlock the sharing
++		 * Unlock the sharing. If the reader or handle already
++		 * disappeared, skip the disconnection part and just delete the
++		 * orphan handle.
+ 		 */
+ 		rv = RFReaderInfoById(hCard, &rContext);
+-		if (rv != SCARD_S_SUCCESS)
++		if (rv != SCARD_S_SUCCESS && rv != SCARD_E_INVALID_VALUE)
+ 		{
+ 			(void)pthread_mutex_unlock(&threadContext->cardsList_lock);
+ 			return rv;
+ 		}
+ 
+-		if (0 == rContext->hLockId)
++		if (rContext)
+ 		{
+-			/* no lock. Just leave the card */
+-			(void)SCardDisconnect(hCard, SCARD_LEAVE_CARD);
+-		}
+-		else
+-		{
+-			if (hCard != rContext->hLockId)
++			if (0 == rContext->hLockId)
+ 			{
+-				/*
+-				 * if the card is locked by someone else we do not reset it
+-				 */
+-
+-				/* decrement card use */
++				/* no lock. Just leave the card */
+ 				(void)SCardDisconnect(hCard, SCARD_LEAVE_CARD);
+ 			}
+ 			else
+ 			{
+-				/* release the lock */
+-				rContext->hLockId = 0;
+-
+-				/*
+-				 * We will use SCardStatus to see if the card has been
+-				 * reset there is no need to reset each time
+-				 * Disconnect is called
+-				 */
+-				rv = SCardStatus(hCard, NULL, NULL, NULL, NULL, NULL, NULL);
++				if (hCard != rContext->hLockId)
++				{
++					/*
++					 * if the card is locked by someone else we do not reset it
++					 */
+ 
+-				if (rv == SCARD_W_RESET_CARD || rv == SCARD_W_REMOVED_CARD)
++					/* decrement card use */
+ 					(void)SCardDisconnect(hCard, SCARD_LEAVE_CARD);
++				}
+ 				else
+-					(void)SCardDisconnect(hCard, SCARD_RESET_CARD);
++				{
++					/* release the lock */
++					rContext->hLockId = 0;
++
++					/*
++					 * We will use SCardStatus to see if the card has been
++					 * reset there is no need to reset each time
++					 * Disconnect is called
++					 */
++					rv = SCardStatus(hCard, NULL, NULL, NULL, NULL, NULL, NULL);
++
++					if (rv == SCARD_W_RESET_CARD || rv == SCARD_W_REMOVED_CARD)
++						(void)SCardDisconnect(hCard, SCARD_LEAVE_CARD);
++					else
++						(void)SCardDisconnect(hCard, SCARD_RESET_CARD);
++				}
+ 			}
+ 		}
+ 
+@@ -936,7 +941,9 @@ static LONG MSGRemoveContext(SCARDCONTEXT hContext, SCONTEXT * threadContext)
+ 			Log2(PCSC_LOG_CRITICAL,
+ 				"list_delete_at failed with return value: %d", lrv);
+ 
+-		UNREF_READER(rContext)
++		if (rContext) {
++			UNREF_READER(rContext)
++		}
+ 	}
+ 	(void)pthread_mutex_unlock(&threadContext->cardsList_lock);
+ 

--- a/third_party/pcsc-lite/patches/0002-Fix-SCardDisconnect-on-orphan-handle.patch
+++ b/third_party/pcsc-lite/patches/0002-Fix-SCardDisconnect-on-orphan-handle.patch
@@ -1,0 +1,30 @@
+From a4e5bf41ae652fd3837cc446a5a8cce0f4249845 Mon Sep 17 00:00:00 2001
+From: Ludovic Rousseau <ludovic.rousseau@free.fr>
+Date: Sun, 19 Jun 2022 18:49:42 +0200
+Subject: [PATCH] Fix SCardDisconnect on orphan handle
+
+If the reader is removed between SCardConnect() and SCardDisconnect()
+then SCardDisconnect() should not fail with SCARD_E_INVALID_VALUE.
+
+We now have the same behavior as on Windows 10.
+
+This patch is quiet similar to the previous one from Maksim Ivanov.
+Thanks for the idea.
+---
+ src/winscard.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/winscard.c b/src/winscard.c
+index e6f4c674..e411ca56 100644
+--- a/src/winscard.c
++++ b/src/winscard.c
+@@ -840,6 +840,9 @@ LONG SCardDisconnect(SCARDHANDLE hCard, DWORD dwDisposition)
+ 
+ 	/* get rContext corresponding to hCard */
+ 	rv = RFReaderInfoById(hCard, &rContext);
++	/* ignore reader removal */
++	if (SCARD_E_INVALID_VALUE == rv)
++		return SCARD_S_SUCCESS;
+ 	if (rv != SCARD_S_SUCCESS)
+ 		return rv;
+ 

--- a/third_party/pcsc-lite/patches/0003-Improve-SCardReleaseContext-fix.patch
+++ b/third_party/pcsc-lite/patches/0003-Improve-SCardReleaseContext-fix.patch
@@ -1,0 +1,34 @@
+From d7a08877c3f1d423f8fcfcb5b60f2cf6fefeceda Mon Sep 17 00:00:00 2001
+From: Ludovic Rousseau <ludovic.rousseau@free.fr>
+Date: Sun, 19 Jun 2022 21:27:46 +0200
+Subject: [PATCH] Improve SCardReleaseContext fix
+
+From Maksim Ivanov:
+SCARD_E_READER_UNAVAILABLE can be returned by RFReaderInfoById(): it's a
+corner case when the reader context is still there, but has a zero
+reference count.
+
+See RFReaderInfoById() using the REF_READER macro, which calls
+_RefReader() (and returns its error code on error), which in turn has
+this code:
+
+  if (0 == sReader->reference)
+    return SCARD_E_READER_UNAVAILABLE;
+---
+ src/winscard_svc.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/winscard_svc.c b/src/winscard_svc.c
+index f4583124..461ceabd 100644
+--- a/src/winscard_svc.c
++++ b/src/winscard_svc.c
+@@ -891,7 +891,8 @@ static LONG MSGRemoveContext(SCARDCONTEXT hContext, SCONTEXT * threadContext)
+ 		 * orphan handle.
+ 		 */
+ 		rv = RFReaderInfoById(hCard, &rContext);
+-		if (rv != SCARD_S_SUCCESS && rv != SCARD_E_INVALID_VALUE)
++		if (rv != SCARD_S_SUCCESS && rv != SCARD_E_INVALID_VALUE
++			&& rv != SCARD_E_READER_UNAVAILABLE)
+ 		{
+ 			(void)pthread_mutex_unlock(&threadContext->cardsList_lock);
+ 			return rv;

--- a/third_party/pcsc-lite/patches/0004-Improve-SCardDisconnect-fix.patch
+++ b/third_party/pcsc-lite/patches/0004-Improve-SCardDisconnect-fix.patch
@@ -1,0 +1,24 @@
+From c35130f2215b75c6d54c4f0162d68548a6de4bab Mon Sep 17 00:00:00 2001
+From: Ludovic Rousseau <ludovic.rousseau@free.fr>
+Date: Sun, 19 Jun 2022 21:32:20 +0200
+Subject: [PATCH] Improve SCardDisconnect fix
+
+Same justification as for the previous patch. RFReaderInfoById() may
+return SCARD_E_READER_UNAVAILABLE.
+---
+ src/winscard.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/winscard.c b/src/winscard.c
+index e411ca56..f2697707 100644
+--- a/src/winscard.c
++++ b/src/winscard.c
+@@ -841,7 +841,7 @@ LONG SCardDisconnect(SCARDHANDLE hCard, DWORD dwDisposition)
+ 	/* get rContext corresponding to hCard */
+ 	rv = RFReaderInfoById(hCard, &rContext);
+ 	/* ignore reader removal */
+-	if (SCARD_E_INVALID_VALUE == rv)
++	if (SCARD_E_INVALID_VALUE == rv || SCARD_E_READER_UNAVAILABLE == rv)
+ 		return SCARD_S_SUCCESS;
+ 	if (rv != SCARD_S_SUCCESS)
+ 		return rv;

--- a/third_party/pcsc-lite/src/src/winscard.c
+++ b/third_party/pcsc-lite/src/src/winscard.c
@@ -840,6 +840,9 @@ LONG SCardDisconnect(SCARDHANDLE hCard, DWORD dwDisposition)
 
 	/* get rContext corresponding to hCard */
 	rv = RFReaderInfoById(hCard, &rContext);
+	/* ignore reader removal */
+	if (SCARD_E_INVALID_VALUE == rv || SCARD_E_READER_UNAVAILABLE == rv)
+		return SCARD_S_SUCCESS;
 	if (rv != SCARD_S_SUCCESS)
 		return rv;
 

--- a/third_party/pcsc-lite/src/src/winscard_svc.c
+++ b/third_party/pcsc-lite/src/src/winscard_svc.c
@@ -886,47 +886,53 @@ static LONG MSGRemoveContext(SCARDCONTEXT hContext, SCONTEXT * threadContext)
 		hCard = *(int32_t *)ptr;
 
 		/*
-		 * Unlock the sharing
+		 * Unlock the sharing. If the reader or handle already
+		 * disappeared, skip the disconnection part and just delete the
+		 * orphan handle.
 		 */
 		rv = RFReaderInfoById(hCard, &rContext);
-		if (rv != SCARD_S_SUCCESS)
+		if (rv != SCARD_S_SUCCESS && rv != SCARD_E_INVALID_VALUE
+			&& rv != SCARD_E_READER_UNAVAILABLE)
 		{
 			(void)pthread_mutex_unlock(&threadContext->cardsList_lock);
 			return rv;
 		}
 
-		if (0 == rContext->hLockId)
+		if (rContext)
 		{
-			/* no lock. Just leave the card */
-			(void)SCardDisconnect(hCard, SCARD_LEAVE_CARD);
-		}
-		else
-		{
-			if (hCard != rContext->hLockId)
+			if (0 == rContext->hLockId)
 			{
-				/*
-				 * if the card is locked by someone else we do not reset it
-				 */
-
-				/* decrement card use */
+				/* no lock. Just leave the card */
 				(void)SCardDisconnect(hCard, SCARD_LEAVE_CARD);
 			}
 			else
 			{
-				/* release the lock */
-				rContext->hLockId = 0;
+				if (hCard != rContext->hLockId)
+				{
+					/*
+					 * if the card is locked by someone else we do not reset it
+					 */
 
-				/*
-				 * We will use SCardStatus to see if the card has been
-				 * reset there is no need to reset each time
-				 * Disconnect is called
-				 */
-				rv = SCardStatus(hCard, NULL, NULL, NULL, NULL, NULL, NULL);
-
-				if (rv == SCARD_W_RESET_CARD || rv == SCARD_W_REMOVED_CARD)
+					/* decrement card use */
 					(void)SCardDisconnect(hCard, SCARD_LEAVE_CARD);
+				}
 				else
-					(void)SCardDisconnect(hCard, SCARD_RESET_CARD);
+				{
+					/* release the lock */
+					rContext->hLockId = 0;
+
+					/*
+					 * We will use SCardStatus to see if the card has been
+					 * reset there is no need to reset each time
+					 * Disconnect is called
+					 */
+					rv = SCardStatus(hCard, NULL, NULL, NULL, NULL, NULL, NULL);
+
+					if (rv == SCARD_W_RESET_CARD || rv == SCARD_W_REMOVED_CARD)
+						(void)SCardDisconnect(hCard, SCARD_LEAVE_CARD);
+					else
+						(void)SCardDisconnect(hCard, SCARD_RESET_CARD);
+				}
 			}
 		}
 
@@ -936,7 +942,9 @@ static LONG MSGRemoveContext(SCARDCONTEXT hContext, SCONTEXT * threadContext)
 			Log2(PCSC_LOG_CRITICAL,
 				"list_delete_at failed with return value: %d", lrv);
 
-		UNREF_READER(rContext)
+		if (rContext) {
+			UNREF_READER(rContext)
+		}
 	}
 	(void)pthread_mutex_unlock(&threadContext->cardsList_lock);
 


### PR DESCRIPTION
Cherry-pick the fixes that I and the upstream maintainers made in
PC/SC-Lite in order to fix spurious SCardDisconnect() and
SCardReleaseContext() errors when a reader is unplugged (as described
at #681).