### PR TITLE
Fix Release-mode JS string bugs in example_cpp app

### DIFF
--- a/example_cpp_smart_card_client_app/src/background.js
+++ b/example_cpp_smart_card_client_app/src/background.js
@@ -209,7 +209,7 @@ executableModule.startLoading();
 // Open the UI window when the user launches the app.
 chrome.app.runtime.onLaunched.addListener(() => {
   GSC.PopupOpener.createWindow(MAIN_WINDOW_URL, MAIN_WINDOW_OPTIONS, {
-    executableModuleMessageChannel: executableModule.getMessageChannel(),
+    'executableModuleMessageChannel': executableModule.getMessageChannel(),
   });
 });
 

--- a/example_cpp_smart_card_client_app/src/window.js
+++ b/example_cpp_smart_card_client_app/src/window.js
@@ -66,7 +66,7 @@ function onCloseWindowClicked(e) {
 // executable module to start the test.
 function onRunTestClicked(e) {
   e.preventDefault();
-  executableModuleMessageChannel.send('ui_backend', {command: 'run_test'});
+  executableModuleMessageChannel.send('ui_backend', {'command': 'run_test'});
 }
 
 // Called when a "output_message" message is received from the executable


### PR DESCRIPTION
Add missing quotes for dictionary keys in the
example_cpp_smart_card_client_app code.

They were forgotten when we changed the build scripts to enable advanced
optimizations in Closure Compiler. The advanced optimizations allow the
compiler to shorten dictionary keys in situations when it thinks the
rename is safe (and the compiler doesn't know how to look into usages in
JavaScript code that runs in other pages or in C++ code).