### PR TITLE
Gracefully handle unexpected revoked PC/SC handles

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_handles_registry.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_handles_registry.h
@@ -51,13 +51,21 @@ class PcscLiteClientHandlesRegistry final {
   ~PcscLiteClientHandlesRegistry();
 
   bool ContainsContext(SCARDCONTEXT s_card_context) const;
+  // Adds the context to the data structure. CHECKs that it wasn't already
+  // present.
   void AddContext(SCARDCONTEXT s_card_context);
+  // Removes the context from the data structure. CHECKs that it was present.
   void RemoveContext(SCARDCONTEXT s_card_context);
+  // Returns all contexts currently stored in the data structure.
   std::vector<SCARDCONTEXT> GetSnapshotOfAllContexts();
+  // Returns all contexts currently stored in the data structure and clears it.
   std::vector<SCARDCONTEXT> PopAllContexts();
 
   bool ContainsHandle(SCARDHANDLE s_card_handle) const;
+  // Adds the handle to the data structure. CHECKs that it wasn't already
+  // present.
   void AddHandle(SCARDCONTEXT s_card_context, SCARDHANDLE s_card_handle);
+  // Removes the handle from the data structure. CHECKs that it was present.
   void RemoveHandle(SCARDHANDLE s_card_handle);
 
  private:

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h
@@ -202,11 +202,21 @@ class PcscLiteClientRequestProcessor final
   GenericRequestResult SCardCancel(SCARDCONTEXT s_card_context);
   GenericRequestResult SCardIsValidContext(SCARDCONTEXT s_card_context);
 
+  // These two methods are called when the PC/SC-Lite core reports the
+  // context/handle doesn't exist, meanwhile our class thought it is. It
+  // shouldn't happen normally, but we met such bugs in the past (see
+  // <https://github.com/GoogleChromeLabs/chromeos_smart_card_connector/issues/681>).
+  void OnSCardContextRevoked(SCARDCONTEXT s_card_context);
+  void OnSCardHandleRevoked(SCARDHANDLE s_card_handle);
+
   const int64_t client_handler_id_;
   const std::string client_name_for_log_;
   const LogSeverity status_log_severity_;
   const std::string logging_prefix_;
   HandlerMap handler_map_;
+  // Stores PC/SC-Lite contexts and handles that belong to this client. This is
+  // used to implement the client isolation: one client shouldn't be able to use
+  // contexts/handles belonging to the other one.
   PcscLiteClientHandlesRegistry s_card_handles_registry_;
 };
 


### PR DESCRIPTION
Remove SCARDCONTEXT/SCARDHANDLE from internal tracking lists when
the PC/SC-Lite core responds with SCARD_E_INVALID_HANDLE.

This shouldn't happen normally, but we already hit bugs in the
PC/SC-Lite that lead to this in the past. In general, we should follow
what the PC/SC-Lite core tells us, and when our data structures diverge
we should fix our structure to follow the PC/SC-Lite's state.

This commit acts as another layer of defence against issues described
in #681.