### PR TITLE
Fix //common/js/ for Service Workers

### DIFF
--- a/common/js/src/logging/debug-dump.js
+++ b/common/js/src/logging/debug-dump.js
@@ -284,16 +284,18 @@ function dump(value, recursionParentObjects) {
   // meaningful for logs anyway.
   //
   // Note that goog.dom.is* methods are not used because many of them may
-  // produce thorny false positives.
-  if (Document && value instanceof Document)
+  // produce thorny false positives. We also check for the type presence before
+  // calling `instanceof`, because in some environment (like Service Workers)
+  // DOM-related types are just absent.
+  if (typeof Document !== 'undefined' && value instanceof Document)
     return '<Document>';
-  if (Window && value instanceof Window)
+  if (typeof Window !== 'undefined' && value instanceof Window)
     return '<Window>';
-  if (NodeList && value instanceof NodeList)
+  if (typeof NodeList !== 'undefined' && value instanceof NodeList)
     return '<NodeList>';
-  if (HTMLCollection && value instanceof HTMLCollection)
+  if (typeof HTMLCollection !== 'undefined' && value instanceof HTMLCollection)
     return '<HTMLCollection>';
-  if (Node && value instanceof Node) {
+  if (typeof Node !== 'undefined' && value instanceof Node) {
     // Note that this branch should go after other branches checking for
     // DOM-related types.
     return '<Node>';

--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -327,9 +327,17 @@ function setupRootLoggerLevel() {
   goog.log.setLevel(rootLogger, ROOT_LOGGER_LEVEL);
 }
 
+function getDocumentLocation() {
+  if (typeof document === 'undefined') {
+    // We're likely inside a Service Worker.
+    return self.location.href;
+  }
+  return document.location.href;
+}
+
 function setupLogBuffer() {
   GSC.LogBuffer.attachBufferToLogger(
-      logBuffer, rootLogger, document.location.href);
+      logBuffer, rootLogger, getDocumentLocation());
 
   if (!chrome || !chrome.runtime || !chrome.runtime.getBackgroundPage) {
     // We don't know whether we're running inside the background page and
@@ -369,7 +377,7 @@ function setupLogBuffer() {
     // from our page's loggers. Dispose of our log buffer to avoid storing new
     // logs twice.
     GSC.LogBuffer.attachBufferToLogger(
-        backgroundLogBuffer, rootLogger, document.location.href);
+        backgroundLogBuffer, rootLogger, getDocumentLocation());
     logBuffer.dispose();
     // Switch our reference to the background page's log buffer.
     logBuffer = backgroundLogBuffer;

--- a/common/js/src/random.js
+++ b/common/js/src/random.js
@@ -36,7 +36,12 @@ const GSC = GoogleSmartCard;
  */
 GSC.Random.randomIntegerNumber = function() {
   const randomBytes = new Uint8Array(RANDOM_INTEGER_BYTE_COUNT);
-  window.crypto.getRandomValues(randomBytes);
+  if (typeof window !== 'undefined') {
+    window.crypto.getRandomValues(randomBytes);
+  } else {
+    // We're likely inside a Service Worker.
+    self.crypto.getRandomValues(randomBytes);
+  }
   let result = 0;
   goog.array.forEach(randomBytes, function(byteValue) {
     result = result * 256 + byteValue;


### PR DESCRIPTION
Fix the common JS library to stop triggering exceptions when running in
a Service Worker environment. The main difference is that DOM-related
types (like Node) and objects (like |document|) are absent.

Specifically, we fix these places:

* The logging code that used to take the log origin from
  |document.location.href| (under Service Workers it should be
  |self.location.href|);
* The debug dumping code that should check for type presence before
  using any DOM-related type;
* The random generation helper that used to access WebCrypto via
  |window.crypto| (under Service Workers it should be |self.crypto|).

This should fix the main blockers for #696.