### PR TITLE
Fix JS minification bug in PC/SC Context JS class

### DIFF
--- a/third_party/pcsc-lite/naclport/js_client/src/context.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/context.js
@@ -172,6 +172,10 @@ goog.exportProperty(
     Context.prototype, 'addOnInitializedCallback',
     Context.prototype.addOnInitializedCallback);
 
+goog.exportProperty(
+    Context.prototype, 'addOnDisposeCallback',
+    Context.prototype.addOnDisposeCallback);
+
 /**
  * Returns the API object, or null if the initialization didn't succeed.
  * @return {GSC.PcscLiteClient.API?}


### PR DESCRIPTION
Make sure the addOnDisposeCallback() method is exposed as unminifed
method name on the GoogleSmartCard.PcscLiteClient.Context class.

That way, it can be used by unminifed code, which is one scenario that
we support: the example_js_standalone_client_library that we distribute,
built in Release mode. The regression probably happened in #420, when
we enabled aggressive optimizations in Closure Compiler.