### PR TITLE
Support building standalone JS lib as ES module

### DIFF
--- a/example_js_standalone_smart_card_client_library/Makefile
+++ b/example_js_standalone_smart_card_client_library/Makefile
@@ -43,3 +43,15 @@ JS_COMPILER_ADDITIONAL_FLAGS := \
 	--output_wrapper="(function(){%output%})();" \
 
 $(eval $(call BUILD_JS_SCRIPT,$(JS_COMPILER_OUTPUT_FILE_NAME),$(JS_COMPILER_INPUT_PATHS),$(JS_COMPILER_TARGET_NAMESPACES),$(JS_COMPILER_ADDITIONAL_FLAGS)))
+
+# Build an "ES module" flavor of the library. It's a concatenation of the
+# Closure Compiler output that's built above and the es-module-exports.js file.
+$(JS_BUILD_DIR_PATH)/google-smart-card-client-library-es-module.js: $(JS_BUILD_DIR_PATH) $(OUT_DIR_PATH)/$(JS_COMPILER_OUTPUT_FILE_NAME)
+	cat \
+		$(JS_BUILD_DIR_PATH)/$(JS_COMPILER_OUTPUT_FILE_NAME) \
+		src/es-module-exports.js \
+		> $(JS_BUILD_DIR_PATH)/google-smart-card-client-library-es-module.js
+
+# Copy the created ES module .js file into ./out/.
+$(eval $(call COPY_TO_OUT_DIR_RULE,\
+	$(JS_BUILD_DIR_PATH)/google-smart-card-client-library-es-module.js))

--- a/example_js_standalone_smart_card_client_library/README.rst
+++ b/example_js_standalone_smart_card_client_library/README.rst
@@ -3,62 +3,30 @@ Example JavaScript Standalone Smart Card Client Library
 
 
 This library allows to use the API exposed by the Smart Card Connector
-App. The library is built as a standalone script, that allows to use it
-without compiling all of the client code through the Google Closure
-Compiler or without the need to plug the Google Closure Library
-manually.
+App. The library is prebuilt, allowing you to use it in your
+application without having to deal with the library's build process
+(which is currently based on Closure Compiler). The prebuilt library
+comes in two flavours:
 
-The resulting JS code in the library is wrapped into an anonymous
-wrapper function, but all the library interface definitions (namely the
-``GoogleSmartCard.PcscLiteClient.Context`` and the
-``GoogleSmartCard.PcscLiteClient.API`` classes) and several crucial
-definitions from the Closure Library (``goog.Promise``,
-``goog.log.Logger``, etc.) are exported into the global ``window``
-object properties.
-
-
-Building
---------
-
-First, please make sure that all building prerequisites are provided and
-the building environment is set up - please refer to *Common building
-prerequisites* and *Building* sections of the ``README`` file located in
-the project root.
-
-After that, the library can be built by the following command::
-
-    make
-
-The resulting script file will be located in the ``out/`` directory.
-
-For the details of the code compilation, refer to the Closure Compiler
-documentation:
-<https://developers.google.com/closure/compiler/docs/limitations>.
+* As a standalone script ``google-smart-card-client-library.js`` (which
+  can be directly executed to get the necessary
+  ``GoogleSmartCard``/``goog`` definitions in the global scope; all
+  other library's internal definitions are hidden in an anonymous
+  wrapper function to avoid symbol collision);
+* As an ES module script
+  ``google-smart-card-client-library-es-module.js`` (from which the
+  ``GoogleSmartCard``/``goog`` definitions can be imported).
 
 
-Debug and Release building modes
---------------------------------
+Obtaining the library .JS files
+-------------------------------
 
-For the general discussion, please refer to the *Debug and Release
-building modes* section of the ``README`` file located in the project
-root.
+Even though you can build the library yourself, the recommended flow is
+to download a prebuilt library from
+<https://github.com/GoogleChromeLabs/chromeos_smart_card_connector/releases>.
 
-Additional notes:
-
-*   The Release mode triggers more advanced JavaScript compilation
-    modes, which result in renaming and removing of some of the symbols.
-
-    However, all the publicly available exported definitions and their
-    internal dependencies are always kept by the compiler (or, at least,
-    should be).
-
-*   When building in Debug mode, in addition to the resulting script, a
-    source map and a copy of all participated source files is put into
-    the ``out/`` directory.
-
-    These files are not required for the library functionality, but, if
-    put into the App next to the library script, may simplify the
-    debugging.
+You have a choice between 4 variations: ES module or non ES module, and
+each in either Release (recommended for production) or Debug variant.
 
 
 Usage

--- a/example_js_standalone_smart_card_client_library/src/es-module-exports.js
+++ b/example_js_standalone_smart_card_client_library/src/es-module-exports.js
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2022 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const goog = globalThis.goog;
+export const GoogleSmartCard = globalThis.GoogleSmartCard;

--- a/prepare-binaries-for-github-release.py
+++ b/prepare-binaries-for-github-release.py
@@ -49,6 +49,12 @@ PATHS_TO_COPY = [
   ['example_js_standalone_smart_card_client_library/js_build/'
    'app_emscripten_Release/google-smart-card-client-library.js',
    'google-smart-card-client-library.js'],
+  ['example_js_standalone_smart_card_client_library/js_build/'
+   'app_emscripten_Debug/google-smart-card-client-library-es-module.js',
+   'google-smart-card-client-library-es-module.debug.js'],
+  ['example_js_standalone_smart_card_client_library/js_build/'
+   'app_emscripten_Release/google-smart-card-client-library-es-module.js',
+   'google-smart-card-client-library-es-module.js'],
 ]
 
 def main():


### PR DESCRIPTION
Change //example_js_standalone_smart_card_client_library/ to produce a
new flavor of the library: an ES module that can be import'ed in other
code.

This new flavor provides the same functionality as before, but can be
loaded in environments in which ES modules are preferred (e.g., Chrome
Manifest V3 Extension Service Workers).

This resolves the main blocker for #700.