### PR TITLE
Fix goog exports from standalone JS library

### DIFF
--- a/example_js_standalone_smart_card_client_library/Makefile
+++ b/example_js_standalone_smart_card_client_library/Makefile
@@ -25,21 +25,35 @@ include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/js_client/include.mk
 include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/common/include.mk
 
 
+# Input sources (files and directories) for the library:
 JS_COMPILER_INPUT_PATHS := \
 	$(PCSC_LITE_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \
 	$(PCSC_LITE_JS_CLIENT_COMPILER_INPUT_DIR_PATHS) \
 	$(JS_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \
 	src/exports.js \
 
-JS_COMPILER_TARGET_NAMESPACES := \
+# Namespaces and files that Closure Compiler should take into the resulting
+# library (together with their dependencies):
+JS_COMPILER_ENTRY_POINTS := \
 	GoogleSmartCard.PcscLiteClient.API \
 	GoogleSmartCard.PcscLiteClient.Context \
+	example_js_standalone_smart_card_client_library/src/exports.js \
 
 JS_COMPILER_OUTPUT_FILE_NAME := google-smart-card-client-library.js
 
+# Extra parameters passed to Closure Compiler.
+#
+# Explanation:
+# * assume_function_wrapper, output_wrapper: Enclose the produced code into an
+#   anonymous function (to avoid symbol collisions with any code outside the
+#   library);
+# * USE_SCOPED_LOGGERS: Prefix all logger names with "GoogleSmartCard.". It's
+#   done to prevent logger name/setting collision with the code outside the
+#   library (in case it uses Closure Library's logging too);
 JS_COMPILER_ADDITIONAL_FLAGS := \
 	--assume_function_wrapper \
 	--define='GoogleSmartCard.Logging.USE_SCOPED_LOGGERS=true' \
 	--output_wrapper="(function(){%output%})();" \
 
-$(eval $(call BUILD_JS_SCRIPT,$(JS_COMPILER_OUTPUT_FILE_NAME),$(JS_COMPILER_INPUT_PATHS),$(JS_COMPILER_TARGET_NAMESPACES),$(JS_COMPILER_ADDITIONAL_FLAGS)))
+# Build the library's JS file via Closure Compiler.
+$(eval $(call BUILD_JS_SCRIPT,$(JS_COMPILER_OUTPUT_FILE_NAME),$(JS_COMPILER_INPUT_PATHS),$(JS_COMPILER_ENTRY_POINTS),$(JS_COMPILER_ADDITIONAL_FLAGS)))

--- a/example_js_standalone_smart_card_client_library/src/exports.js
+++ b/example_js_standalone_smart_card_client_library/src/exports.js
@@ -35,6 +35,18 @@ goog.exportSymbol('goog.log.error', goog.log.error);
 goog.exportSymbol('goog.log.warning', goog.log.warning);
 goog.exportSymbol('goog.log.info', goog.log.info);
 goog.exportSymbol('goog.log.fine', goog.log.fine);
+goog.exportSymbol('goog.log.ROOT_LOGGER_NAME', goog.log.ROOT_LOGGER_NAME);
+goog.exportSymbol('goog.log.addHandler', goog.log.addHandler);
+goog.exportSymbol('goog.log.removeHandler', goog.log.removeHandler);
+goog.exportSymbol('goog.log.setLevel', goog.log.setLevel);
+goog.exportSymbol('goog.log.getLevel', goog.log.getLevel);
+goog.exportSymbol('goog.log.getEffectiveLevel', goog.log.getEffectiveLevel);
+goog.exportSymbol('goog.log.isLoggable', goog.log.isLoggable);
+goog.exportSymbol('goog.log.log', goog.log.log);
+goog.exportSymbol('goog.log.getLogRecord', goog.log.getLogRecord);
+goog.exportSymbol('goog.log.warning', goog.log.warning);
+goog.exportSymbol('goog.log.info', goog.log.info);
+goog.exportSymbol('goog.log.fine', goog.log.fine);
 
 goog.exportSymbol('goog.log.LogRecord', goog.log.LogRecord);
 goog.exportProperty(
@@ -99,60 +111,10 @@ goog.exportProperty(
     goog.log.Level.prototype, 'toString', goog.log.Level.prototype.toString);
 
 goog.exportSymbol('goog.log.Logger', goog.log.Logger);
-goog.exportProperty(
-    goog.log.Logger, 'ROOT_LOGGER_NAME', goog.log.Logger.ROOT_LOGGER_NAME);
 goog.exportProperty(goog.log.Logger, 'Level', goog.log.Logger.Level);
-goog.exportProperty(goog.log.Logger, 'getLogger', goog.log.Logger.getLogger);
 goog.exportProperty(
-    goog.log.Logger, 'logToProfilers', goog.log.Logger.logToProfilers);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'getName', goog.log.Logger.prototype.getName);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'addHandler',
-    goog.log.Logger.prototype.addHandler);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'removeHandler',
-    goog.log.Logger.prototype.removeHandler);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'getParent',
-    goog.log.Logger.prototype.getParent);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'getChildren',
-    goog.log.Logger.prototype.getChildren);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'setLevel', goog.log.Logger.prototype.setLevel);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'getLevel', goog.log.Logger.prototype.getLevel);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'getEffectiveLevel',
-    goog.log.Logger.prototype.getEffectiveLevel);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'isLoggable',
-    goog.log.Logger.prototype.isLoggable);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'log', goog.log.Logger.prototype.log);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'getLogRecord',
-    goog.log.Logger.prototype.getLogRecord);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'shout', goog.log.Logger.prototype.shout);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'severe', goog.log.Logger.prototype.severe);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'warning', goog.log.Logger.prototype.warning);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'info', goog.log.Logger.prototype.info);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'config', goog.log.Logger.prototype.config);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'fine', goog.log.Logger.prototype.fine);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'finer', goog.log.Logger.prototype.finer);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'finest', goog.log.Logger.prototype.finest);
-goog.exportProperty(
-    goog.log.Logger.prototype, 'logRecord',
-    goog.log.Logger.prototype.logRecord);
+    goog.log.Logger.prototype.getName, 'Level',
+    goog.log.Logger.prototype.getName);
 
 goog.exportSymbol('goog.Promise', goog.Promise);
 goog.exportProperty(goog.Promise, 'resolve', goog.Promise.resolve);


### PR DESCRIPTION
Make a few symbols (mostly related to logging) from Closure Library be
exposed as global unminified names from the standalone JavaScript smart
card client library.

We don't know if anyone uses these, but these might be useful if the
application wants to do something with the logs produced by our library.
The exposure of these symbols worked in the past, but probably broke
when we updated to a newer Closure Compiler that became more aggressive
in skipping input files; also our exports became outdated as Closure
Library reworked the logging library significantly.

This change fixes the exports to reflect the up-to-date Closure Library,
and also to make them applied indeed.