### PR TITLE
Release Connector App 1.3.8.0

### DIFF
--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -6,7 +6,7 @@ ${endif}
   "name": "__MSG_appName__",
   "short_name": "__MSG_appShortName__",
   "description": "__MSG_appDesc__",
-  "version": "1.3.7.2",
+  "version": "1.3.8.0",
 ${if PACKAGING=app}
   "app": {
 ${endif}


### PR DESCRIPTION
We'll likely not deploy this version on WebStore, however a new release
is made for distributing a fixed standalone smart card client library
(for the regression #699).