### PR TITLE
Suppress emscripten linker warning in Debug

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -144,7 +144,7 @@ EMSCRIPTEN_COMMON_FLAGS += \
 # DEMANGLE_SUPPORT: Demangle C++ function names in stack traces.
 # EXCEPTION_DEBUG: Enables printing exceptions coming from the executable.
 # SAFE_HEAP: Enable memory access checks.
-# no-limited-postlink-optimizations: Suppress a warning about limited
+# Wno-limited-postlink-optimizations: Suppress a warning about limited
 #   optimizations.
 EMSCRIPTEN_LINKER_FLAGS += \
   -s ASSERTIONS=2 \

--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -144,11 +144,14 @@ EMSCRIPTEN_COMMON_FLAGS += \
 # DEMANGLE_SUPPORT: Demangle C++ function names in stack traces.
 # EXCEPTION_DEBUG: Enables printing exceptions coming from the executable.
 # SAFE_HEAP: Enable memory access checks.
+# no-limited-postlink-optimizations: Suppress a warning about limited
+#   optimizations.
 EMSCRIPTEN_LINKER_FLAGS += \
   -s ASSERTIONS=2 \
   -s DEMANGLE_SUPPORT=1 \
   -s EXCEPTION_DEBUG=1 \
   -s SAFE_HEAP=1 \
+  -Wno-limited-postlink-optimizations \
 
 else
 


### PR DESCRIPTION
Silence the following warning that's emitted when compiling in the Debug
mode with TOOLCHAIN=emscripten:

  emcc: warning: running limited binaryen optimizations because DWARF
  info requested (or indirectly required)
  [-Wlimited-postlink-optimizations]