### PR TITLE
USB transient error workaround for claimInterface

### DIFF
--- a/third_party/libusb/webport/src/libusb_js_proxy.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy.h
@@ -138,6 +138,7 @@ class LibusbJsProxy final : public LibusbInterface {
                            int length,
                            int* actual_length,
                            unsigned timeout);
+  void TryApplyTransientAccessErrorWorkaround(libusb_device* dev);
 
   // Helpers for making requests to the JavaScript side.
   JsRequester js_requester_;

--- a/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
@@ -771,6 +771,7 @@ TEST_P(LibusbJsProxyWithDeviceTest,
           .Add(kInterfaceNumber)
           .Get(),
       /*error_to_reply_with=*/"fake error");
+  EXPECT_EQ(libusb()->LibusbGetBusNumber(devices[0]), 1);
 
   // Act.
   EXPECT_EQ(libusb()->LibusbClaimInterface(device_handle_, kInterfaceNumber),

--- a/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
@@ -771,7 +771,7 @@ TEST_P(LibusbJsProxyWithDeviceTest,
           .Add(kInterfaceNumber)
           .Get(),
       /*error_to_reply_with=*/"fake error");
-  EXPECT_EQ(libusb()->LibusbGetBusNumber(devices[0]), 1);
+  EXPECT_EQ(libusb()->LibusbGetBusNumber(device_), 1);
 
   // Act.
   EXPECT_EQ(libusb()->LibusbClaimInterface(device_handle_, kInterfaceNumber),


### PR DESCRIPTION
Extend the workaround for transient USB errors to also cover the
failures in claimInterface. This fixes flaky issues with the Smart Card
Connector on the ChromeOS Lock Screen, in case when the Connector is
also installed in-session and happens to be slow to shutdown USB
connections when the session is being locked.

For the background, this workaround existed for errors in the openDevice
function since a long time. By default, PC/SC-Lite doesn't retry the USB
connections, and adding them would introduce a complex patch that's hard
to maintain. So we implemented a trick-based workaround: each time our
Libusb wrapper sees an error, it increments the "bus_number" field for
the next time this device is listed (this field's value is anyway a
complete fake as Chrome USB APIs never exposed the real bus numbers).
This makes PC/SC-Lite retry the connection next time it polls the list
of devices (which happens every couple of seconds) as it thinks it's a
new device that appeared.

Internal tracking bug: [b/241549122](b/241549122).