### PR TITLE
Fix spurious openct warnings

### DIFF
--- a/third_party/pcsc-lite/naclport/server/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server/build/Makefile
@@ -103,7 +103,6 @@ PCSC_LITE_SERVER_SOURCES := \
 	$(PCSC_LITE_SOURCES_PATH)/eventhandler.c \
 	$(PCSC_LITE_SOURCES_PATH)/ifdwrapper.c \
 	$(PCSC_LITE_SOURCES_PATH)/prothandler.c \
-	$(PCSC_LITE_SOURCES_PATH)/utils.c \
 	$(PCSC_LITE_SOURCES_PATH)/winscard.c \
 
 # * PCSCD definition is required to enable compilation of the code that is
@@ -147,6 +146,18 @@ PCSC_LITE_SERVER_SVC_CPPFLAGS := \
 	-Wno-return-type \
 
 $(foreach src,$(PCSC_LITE_SERVER_SVC_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_SVC_CPPFLAGS))))
+
+# Special group just for utils.c.
+PCSC_LITE_SERVER_UTILS_SOURCES := \
+	$(PCSC_LITE_SOURCES_PATH)/utils.c \
+
+# * DCheckForOpenCT: Redefine the CheckForOpenCT() function name, to let the
+#   webport inject its own implementation.
+PCSC_LITE_SERVER_UTILS_CPPFLAGS := \
+	$(PCSC_LITE_SERVER_CPPFLAGS) \
+	-DCheckForOpenCT=CheckForOpenCTOriginal \
+
+$(foreach src,$(PCSC_LITE_SERVER_UTILS_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_UTILS_CPPFLAGS))))
 
 # Special group just for debuglog.c.
 PCSC_LITE_SERVER_DEBUGLOG_SOURCES := \
@@ -216,6 +227,7 @@ PCSC_LITE_SERVER_NACL_SOURCES := \
 	$(SOURCES_PATH)/server_sockets_manager.cc \
 	$(SOURCES_PATH)/sys_nacl.cc \
 	$(SOURCES_PATH)/unistd_nacl.cc \
+	$(SOURCES_PATH)/utils_webport.cc \
 	$(SOURCES_PATH)/winscard_msg_nacl.cc \
 
 PCSC_LITE_SERVER_NACL_CXXFLAGS := \
@@ -231,6 +243,7 @@ $(foreach src,$(PCSC_LITE_SERVER_NACL_SOURCES),$(eval $(call COMPILE_RULE,$(src)
 SOURCES := \
 	$(PCSC_LITE_SERVER_SOURCES) \
 	$(PCSC_LITE_SERVER_SVC_SOURCES) \
+	$(PCSC_LITE_SERVER_UTILS_SOURCES) \
 	$(PCSC_LITE_SERVER_DEBUGLOG_SOURCES) \
 	$(PCSC_LITE_SERVER_HOTPLUG_LIBUSB_SOURCES) \
 	$(PCSC_LITE_CLIENT_SOURCES) \

--- a/third_party/pcsc-lite/naclport/server/src/utils_webport.cc
+++ b/third_party/pcsc-lite/naclport/server/src/utils_webport.cc
@@ -1,0 +1,26 @@
+/* Copyright (C) 1991-2014 Free Software Foundation, Inc.
+   Copyright (C) 2022 Google Inc.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+// Custom implementation of some functions from the ../src/utils.h file.
+
+extern "C" int CheckForOpenCT() {
+  // This is a stub implementation that always returns success, which means
+  // there's no OpenCT daemon (PC/SC-Lite exits when it detects it to be
+  // present). We don't run the original code in a webport as it'd trigger
+  // spurios warnings in JavaScript console about non-existing files.
+  return 0;
+}


### PR DESCRIPTION
Fix spurious error logs about attempting to read a non-existing
"/var/run/openct/status" file.

This file was read by the PC/SC-Lite as an attempt to troubleshoot USB
errors, because the OpenCT daemon on Linux grabs access to USB devices
and therefore conflicts with the PC/SC-Lite daemon. These checks don't
make sense in ChromeOS, and while harmless they were triggering file
access error logs in the JavaScript console. The commit suppresses all
this by substituting the original CheckForOpenCT() function with our
own stub.