### PR TITLE
Avoid warning logs on USB device unplugging

### DIFF
--- a/common/cpp/src/google_smart_card_common/logging/syslog/syslog.cc
+++ b/common/cpp/src/google_smart_card_common/logging/syslog/syslog.cc
@@ -43,16 +43,16 @@ void syslog(int priority, const char* format, ...) {
       google_smart_card::FormatPrintfTemplate(format, var_args);
   va_end(var_args);
 
+  // Use the INFO log level for all non-debug logs, because the callsites
+  // sometimes use excessively high priority levels (like "LOG_CRIT" for USB
+  // errors that are normal when a reader gets unplugged). As any warning/error
+  // log is surfaced as a red "Errors" button in chrome://extensions and leads
+  // users to think there's some real problem, we stick to INFO here.
   switch (priority) {
     case LOG_EMERG:
     case LOG_ALERT:
     case LOG_CRIT:
     case LOG_ERR:
-      GOOGLE_SMART_CARD_LOG_ERROR << message;
-      return;
-    case LOG_WARNING:
-      GOOGLE_SMART_CARD_LOG_WARNING << message;
-      return;
     case LOG_NOTICE:
     case LOG_INFO:
       GOOGLE_SMART_CARD_LOG_INFO << message;

--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -1,5 +1,7 @@
 {
+${if CONFIG=Debug}
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlc6hy5++uljMusXcpXspmA3UH5t9ppVHj3FfxvVMPOFX0RLrDvXtfH3f/TkdyPsAzk1QDDQ1++lDatRa3xc4rOGa2ynXljOR9y6rWoqB5wwMOjB42AWSVZWNwpccRsYkMhML5s7uur+B4SERWeMasXuJUhTPweS48Mz0mvp9wZMQB9+xPNm93iUeUZvVtB63ksibx5B3UJUCBz1wSUXLnEoTjy6TR9XsQ+boZlRsk/jY79A+iMQZw72QBBXvWSfJRaeDj266Dz+Jyp0h4lxZJjg/pnL0Rp5s0zlhlSNm6zyrQ6lWMzagjP/2G95LWMNvLTE95oKqhP4hNaxYrI/pUQIDAQAB",
+${endif}
   "manifest_version": 2,
   "name": "__MSG_appName__",
   "short_name": "__MSG_appShortName__",

--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -1,7 +1,5 @@
 {
-${if CONFIG=Debug}
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlc6hy5++uljMusXcpXspmA3UH5t9ppVHj3FfxvVMPOFX0RLrDvXtfH3f/TkdyPsAzk1QDDQ1++lDatRa3xc4rOGa2ynXljOR9y6rWoqB5wwMOjB42AWSVZWNwpccRsYkMhML5s7uur+B4SERWeMasXuJUhTPweS48Mz0mvp9wZMQB9+xPNm93iUeUZvVtB63ksibx5B3UJUCBz1wSUXLnEoTjy6TR9XsQ+boZlRsk/jY79A+iMQZw72QBBXvWSfJRaeDj266Dz+Jyp0h4lxZJjg/pnL0Rp5s0zlhlSNm6zyrQ6lWMzagjP/2G95LWMNvLTE95oKqhP4hNaxYrI/pUQIDAQAB",
-${endif}
   "manifest_version": 2,
   "name": "__MSG_appName__",
   "short_name": "__MSG_appShortName__",

--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -533,7 +533,9 @@ void LibusbJsProxy::LibusbClose(libusb_device_handle* handle) {
   if (!request_result.is_successful()) {
     // It's essential to not crash in this case, because this may happen during
     // shutdown process.
-    GOOGLE_SMART_CARD_LOG_ERROR << "Failed to close USB device";
+    // Logging at the INFO level, since the error is normal in case the device
+    // was unplugged.
+    GOOGLE_SMART_CARD_LOG_INFO << "Failed to close USB device";
   }
 
   delete handle;
@@ -563,7 +565,9 @@ int LibusbJsProxy::LibusbReleaseInterface(libusb_device_handle* dev,
       kJsRequestReleaseInterface, dev->device()->js_device().device_id,
       dev->js_device_handle(), interface_number);
   if (!request_result.is_successful()) {
-    GOOGLE_SMART_CARD_LOG_WARNING << "LibusbReleaseInterface request failed: "
+    // Logging at the INFO level, since the error is normal in case the device
+    // was unplugged.
+    GOOGLE_SMART_CARD_LOG_INFO << "LibusbReleaseInterface request failed: "
                                   << request_result.error_message();
     return LIBUSB_ERROR_OTHER;
   }

--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -568,7 +568,7 @@ int LibusbJsProxy::LibusbReleaseInterface(libusb_device_handle* dev,
     // Logging at the INFO level, since the error is normal in case the device
     // was unplugged.
     GOOGLE_SMART_CARD_LOG_INFO << "LibusbReleaseInterface request failed: "
-                                  << request_result.error_message();
+                               << request_result.error_message();
     return LIBUSB_ERROR_OTHER;
   }
   return LIBUSB_SUCCESS;


### PR DESCRIPTION
Downgrade a bunch of logs to the INFO level, so that when a smart card
reader is unplugged there are no warnings/errors appearing in the
application log. This is mainly to avoid confusing users who see a red
"Errors" button in chrome://extensions whenever we log a warning/error
and might interpret it as a real problem (which in this case it's not).