### PR TITLE
Fix application_unittest setup under PNaCl

### DIFF
--- a/common/cpp/src/google_smart_card_common/nacl_io_utils.cc
+++ b/common/cpp/src/google_smart_card_common/nacl_io_utils.cc
@@ -50,7 +50,13 @@ void MountNaclIoFolders() {
 }
 
 bool UnmountNaclIoFolders() {
-  return ::umount("/tmp") == 0 && ::umount("/") == 0;
+  bool success = true;
+  // Try unmounting both even if one failed.
+  if (::umount("/") != 0)
+    success = false;
+  if (::umount("/tmp") != 0)
+    success = false;
+  return success;
 }
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/nacl_io_utils.cc
+++ b/common/cpp/src/google_smart_card_common/nacl_io_utils.cc
@@ -40,12 +40,19 @@ void InitializeNaclIo(const pp::Instance& pp_instance) {
 }
 
 void MountNaclIoFolders() {
-  GOOGLE_SMART_CARD_CHECK(::umount("/") == 0);
+  // Undo previous mounts in case there were any. The errors here are non-fatal.
+  ::umount("/");
+  ::umount("/tmp");
 
   GOOGLE_SMART_CARD_CHECK(
       ::mount("/", "/", "httpfs", 0, "manifest=/nacl_io_manifest.txt") == 0);
 
   GOOGLE_SMART_CARD_CHECK(::mount("", "/tmp", "memfs", 0, "") == 0);
+}
+
+void UnmountNaclIoFolders() {
+  GOOGLE_SMART_CARD_CHECK(::umount("/tmp") == 0);
+  GOOGLE_SMART_CARD_CHECK(::umount("/") == 0);
 }
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/nacl_io_utils.cc
+++ b/common/cpp/src/google_smart_card_common/nacl_io_utils.cc
@@ -41,8 +41,7 @@ void InitializeNaclIo(const pp::Instance& pp_instance) {
 
 void MountNaclIoFolders() {
   // Undo previous mounts in case there were any. The errors here are non-fatal.
-  ::umount("/");
-  ::umount("/tmp");
+  UnmountNaclIoFolders();
 
   GOOGLE_SMART_CARD_CHECK(
       ::mount("/", "/", "httpfs", 0, "manifest=/nacl_io_manifest.txt") == 0);
@@ -50,9 +49,8 @@ void MountNaclIoFolders() {
   GOOGLE_SMART_CARD_CHECK(::mount("", "/tmp", "memfs", 0, "") == 0);
 }
 
-void UnmountNaclIoFolders() {
-  GOOGLE_SMART_CARD_CHECK(::umount("/tmp") == 0);
-  GOOGLE_SMART_CARD_CHECK(::umount("/") == 0);
+bool UnmountNaclIoFolders() {
+  return ::umount("/tmp") == 0 && ::umount("/") == 0;
 }
 
 }  // namespace google_smart_card

--- a/common/cpp/src/google_smart_card_common/nacl_io_utils.h
+++ b/common/cpp/src/google_smart_card_common/nacl_io_utils.h
@@ -37,7 +37,7 @@ void InitializeNaclIo(const pp::Instance& pp_instance);
 void MountNaclIoFolders();
 
 // Unmounts directories mounted by `MountNaclIoFolders()`.
-void UnmountNaclIoFolders();
+bool UnmountNaclIoFolders();
 
 }  // namespace google_smart_card
 

--- a/common/cpp/src/google_smart_card_common/nacl_io_utils.h
+++ b/common/cpp/src/google_smart_card_common/nacl_io_utils.h
@@ -36,6 +36,9 @@ void InitializeNaclIo(const pp::Instance& pp_instance);
 // The /tmp directory is mounted to a temporary in-memory file system.
 void MountNaclIoFolders();
 
+// Unmounts directories mounted by `MountNaclIoFolders()`.
+void UnmountNaclIoFolders();
+
 }  // namespace google_smart_card
 
 #endif  // GOOGLE_SMART_CARD_COMMON_NACL_IO_UTILS_H_

--- a/smart_card_connector_app/src/application_unittest.cc
+++ b/smart_card_connector_app/src/application_unittest.cc
@@ -193,7 +193,12 @@ class SmartCardConnectorApplicationTest : public ::testing::Test {
     reader_notification_observer_.Init(global_context_);
   }
 
-  ~SmartCardConnectorApplicationTest() { application_->ShutDownAndWait(); }
+  ~SmartCardConnectorApplicationTest() {
+    application_->ShutDownAndWait();
+#ifdef __native_client__
+    UnmountNaclIoFolders();
+#endif  // __native_client__
+  }
 
   void StartApplication() {
     // Set up the expectation on the first C++-to-JS message.

--- a/smart_card_connector_app/src/application_unittest.cc
+++ b/smart_card_connector_app/src/application_unittest.cc
@@ -196,7 +196,7 @@ class SmartCardConnectorApplicationTest : public ::testing::Test {
   ~SmartCardConnectorApplicationTest() {
     application_->ShutDownAndWait();
 #ifdef __native_client__
-    UnmountNaclIoFolders();
+    EXPECT_TRUE(UnmountNaclIoFolders());
 #endif  // __native_client__
   }
 


### PR DESCRIPTION
Fix crashes in smart_card_connector_app's application unittests due to
attempts to repeatedly remount / and /tmp directories. Before this
commit, only one test was passing and the subsequent ones were crashing
due to the leftover mounts.

Now we're unmounting the directories in each test's teardown. Also we
ignore the unmount() errors because they're fine in these test
scenarios, and in general there's little value to crash on these.