### PR TITLE
Clean up PC/SC request receiver JS logs

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
@@ -441,10 +441,8 @@ ClientHandler.prototype.clientMessageChannelDisposedListener_ = function() {
  * @private
  */
 ClientHandler.prototype.postRequestToServer_ = function(remoteCallMessage) {
-  goog.log.fine(
-      this.logger,
-      'Started processing the remote call request: ' +
-          remoteCallMessage.getDebugRepresentation());
+  const requestDump = remoteCallMessage.getDebugRepresentation();
+  goog.log.fine(this.logger, `Processing PC/SC call: ${requestDump}`);
 
   this.createServerRequesterIfNeed_();
 
@@ -452,23 +450,18 @@ ClientHandler.prototype.postRequestToServer_ = function(remoteCallMessage) {
       .postRequest(remoteCallMessage.makeRequestPayload())
       .then(
           function(result) {
+            const resultDump = GSC.DebugDump.debugDump(result);
             goog.log.fine(
                 this.logger,
-                'The remote call request ' +
-                    remoteCallMessage.getDebugRepresentation() +
-                    ' finished successfully' +
-                    (goog.DEBUG ? ' with the following result: ' +
-                             GSC.DebugDump.debugDump(result) :
-                                  ''));
+                `PC/SC call ${requestDump} completed: ${resultDump}`);
             return result;
           },
           function(error) {
-            goog.log.warning(
+            goog.log.log(
                 this.logger,
-                'The remote call request ' +
-                    remoteCallMessage.getDebugRepresentation() +
-                    ' failed with the ' +
-                    'following error: ' + error);
+                this.isDisposed() ? goog.log.Level.FINE :
+                                    goog.log.Level.WARNING,
+                `PC/SC call ${requestDump} failed: ${error}`);
             throw error;
           },
           this);


### PR DESCRIPTION
Shorten some log messages printed by the JavaScript client-handler and
request-receiver code. Downgrade some of them to "info" or "fine" levels
to avoid spamming the log dumps with spurious errors and stop confusing
users who see "errors" displayed at chrome://extensions.

This commit contributes to the log clutter reduction tracked by #146.