### PR TITLE
Unit-test GetAttrb for ATR

### DIFF
--- a/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
+++ b/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
@@ -26,6 +26,8 @@ SOURCES := \
 	../../../src/application_unittest.cc \
 	../../../src/testing_smart_card_simulation.cc \
 
+# Explanation:
+# -Wno-zero-length-array: Suppress warnings in the third-party reader.h file.
 CXXFLAGS := \
 	-I$(ROOT_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
@@ -36,6 +38,7 @@ CXXFLAGS := \
 	-Wall \
 	-Werror \
 	-Wextra \
+	-Wno-zero-length-array \
 	-std=$(CXX_DIALECT) \
 	$(TEST_ADDITIONAL_CXXFLAGS) \
 


### PR DESCRIPTION
Add initial unit test coverage for the SCardGetAtrrib PC/SC method. The
test checks that calling it with SCARD_ATTR_ATR_STRING returns the
card's ATR (answer-to-reset).