### PR TITLE
Fix NaN timestamp in logs from window.html

### DIFF
--- a/common/js/src/logging/log-buffer.js
+++ b/common/js/src/logging/log-buffer.js
@@ -250,8 +250,7 @@ LogBuffer.prototype.addLogRecord_ = function(
     return;
 
   const logRecord = new goog.log.LogRecord(
-      logLevel, logMsg, loggerName,
-      logTime, logSequenceNumber);
+      logLevel, logMsg, loggerName, logTime, logSequenceNumber);
   for (const observer of this.observers_)
     observer(documentLocation, logRecord);
 
@@ -261,8 +260,7 @@ LogBuffer.prototype.addLogRecord_ = function(
 };
 
 goog.exportProperty(
-    LogBuffer.prototype, 'addLogRecord_',
-    LogBuffer.prototype.addLogRecord_);
+    LogBuffer.prototype, 'addLogRecord_', LogBuffer.prototype.addLogRecord_);
 
 /**
  * @param {string} formattedLogRecord


### PR DESCRIPTION
This commit removes the passing of goog.log.LogRecord objects between
windows, replacing it with passing their fields separately (message,
timestamp, etc.). The direct passing of objects can never work reliably
in Release mode due to Closure Compiler's optimizations that can rename
object fields differently for different targets.

The symptom of the problem addressed by this commit is that the log
messages from the Smart Card Connector's UI (window.html) had "NaN"
timestamps.