### PR TITLE
Shorten PcscLiteServerClientsManagement in logs

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/admin-policy-service.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/admin-policy-service.js
@@ -74,8 +74,7 @@ GSC.PcscLiteServerClientsManagement.AdminPolicyService = function(
    * @type {!goog.log.Logger}
    * @const
    */
-  this.logger = GSC.Logging.getScopedLogger(
-      'PcscLiteServerClientsManagement.AdminPolicyService');
+  this.logger = GSC.Logging.getScopedLogger('Pcsc.AdminPolicyService');
 
   /** @private */
   this.serverMessageChannel_ = serverMessageChannel;

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
@@ -216,8 +216,7 @@ GSC.PcscLiteServerClientsManagement.ClientHandler = function(
    * @const
    */
   this.logger = GSC.Logging.getScopedLogger(
-      `PcscLiteServerClientsManagement.ClientHandler<${nameForJsLog}, id=${
-          this.id}>`);
+      `Pcsc.ClientHandler<${nameForJsLog}, id=${this.id}>`);
 
   /** @private */
   this.requestReceiver_ = new GSC.RequestReceiver(

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/checker.js
@@ -72,8 +72,8 @@ const Checker = PermissionsChecking.Checker;
  * @type {!goog.log.Logger}
  * @const
  */
-Checker.prototype.logger = GSC.Logging.getScopedLogger(
-    'PcscLiteServerClientsManagement.PermissionsChecking.Checker');
+Checker.prototype.logger =
+    GSC.Logging.getScopedLogger('Pcsc.PermissionsChecker');
 
 /**
  * Starts the permission check for the given client application.

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
@@ -70,8 +70,8 @@ const ManagedRegistry = PermissionsChecking.ManagedRegistry;
  * @type {!goog.log.Logger}
  * @const
  */
-ManagedRegistry.prototype.logger = GSC.Logging.getScopedLogger(
-    'PcscLiteServerClientsManagement.PermissionsChecking.ManagedRegistry');
+ManagedRegistry.prototype.logger =
+    GSC.Logging.getScopedLogger('Pcsc.ManagedPermissionsRegistry');
 
 /**
  * Starts the permission check for the given client app against the managed

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompt-dialog-main.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompt-dialog-main.js
@@ -61,9 +61,7 @@ const GSC = GoogleSmartCard;
 const urlParams = new URLSearchParams(window.location.search);
 
 /** @type {!goog.log.Logger} */
-const logger = GSC.Logging.getScopedLogger(
-    'PcscLiteServerClientsManagement.PermissionsChecking.UserPromptDialog.' +
-    'Main');
+const logger = GSC.Logging.getScopedLogger('Pcsc.PermissionsDialog');
 
 const data = GSC.InPopupMainScript.getData();
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
@@ -110,8 +110,8 @@ UserPromptingChecker.overrideModalDialogRunnerForTesting = function(
  * @type {!goog.log.Logger}
  * @const
  */
-UserPromptingChecker.prototype.logger = GSC.Logging.getScopedLogger(
-    'PcscLiteServerClientsManagement.PermissionsChecking.UserPromptingChecker');
+UserPromptingChecker.prototype.logger =
+    GSC.Logging.getScopedLogger('Pcsc.PermissionsPromptingChecker');
 
 /**
  * Starts the permission check for the given client app - against the previously

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/readiness-tracker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/readiness-tracker.js
@@ -62,8 +62,7 @@ GSC.PcscLiteServerClientsManagement.ReadinessTracker = function(
    * @const
    * @private
    */
-  this.logger_ = GSC.Logging.getScopedLogger(
-      'PcscLiteServerClientsManagement.ReadinessTracker');
+  this.logger_ = GSC.Logging.getScopedLogger('Pcsc.ServerReadinessTracker');
 
   /** @type {!goog.promise.Resolver.<null>} @private @const */
   this.promiseResolver_ = goog.Promise.withResolver();


### PR DESCRIPTION
Make logs slightly more readable by shortening some of PC/SC-related
PcscLiteServerClientsManagement.* logger names.