### PR TITLE
Add new paths to env/clean.sh

### DIFF
--- a/env/clean.sh
+++ b/env/clean.sh
@@ -20,9 +20,12 @@ set -eu
 
 PATHS_TO_CLEAN="
   activate
+  chromedriver
   depot_tools
   emsdk
   nacl_sdk
+  python2_venv
+  python3_venv
   webports
 "
 


### PR DESCRIPTION
There are a few new paths that we initialize in env/initialize.sh these
days, and they should also be removed by env/clean.sh.