### PR TITLE
Add missing emscripten/version.h include

### DIFF
--- a/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
+++ b/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
@@ -42,6 +42,10 @@
 
 #include "server_sockets_manager.h"
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten/version.h>
+#endif
+
 // Include the C headers after all other includes, because the preprocessor
 // definitions from them interfere with the symbols from the standard C++
 // library.


### PR DESCRIPTION
This fixes the compilation issue with Emscripten 3.1.23: the
__EMSCRIPTEN_major__ macro is undefined by default now, and
our code wrongly assumed that the Emscripten version is too old.