### PR TITLE
Add DriveLock Beta extension to the allowlist

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/known_client_apps.json
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/known_client_apps.json
@@ -86,5 +86,8 @@
   },
   "chrome-untrusted://terminal": {
     "name": "ChromeOS Terminal"
+  },
+  "chrome-extension://nebchommhahdcpcnbjbgmhnodjhnjnpd": {
+    "name": "DriveLock Smart Card Middleware Beta"
   }
 }


### PR DESCRIPTION
Add DriveLock Smart Card Middleware (CSSI) [BETA] to the list of the trusted clients.