### PR TITLE
Allowlist Ujambo Kiosk apps

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/known_client_apps.json
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/known_client_apps.json
@@ -89,5 +89,17 @@
   },
   "chrome-extension://nebchommhahdcpcnbjbgmhnodjhnjnpd": {
     "name": "DriveLock Smart Card Middleware Beta"
+  },
+  "chrome-extension://kghimeaijcapoakcbhbelgkcdoiigbmn": {
+    "name": "Ujambo Kiosk App",
+    "autoapprove": true
+  },
+  "chrome-extension://oialdphpkhfcnjooecmochkdfmhhnelp": {
+    "name": "Ujambo Kiosk App (acceptance)",
+    "autoapprove": true
+  },
+  "chrome-extension://gpnmjjdkmdfmccnpepmianiomfahpbcc": {
+    "name": "Ujambo Kiosk App (development)",
+    "autoapprove": true
   }
 }


### PR DESCRIPTION
Add the Kiosk apps from Ujambo (in its different flavors: production, development, "acceptance") to the list of trusted client IDs, and autoallow the permission to talk to smart cards.

This allows, in particular, to use the Smart Card Connector together with them as a secondary kiosk app (in this mode it has neither any UI nor access to admin policies).