### PR TITLE
Fix client lib when there's no bg page

### DIFF
--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -353,9 +353,14 @@ function setupLogBuffer() {
   goog.global[GLOBAL_LOG_BUFFER_VARIABLE_NAME] = logBuffer;
 
   chrome.runtime.getBackgroundPage(function(backgroundPage) {
-    GSC.Logging.check(backgroundPage);
-    goog.asserts.assert(backgroundPage);
-
+    if (!backgroundPage) {
+      // There's no background page - it's expected when we're running inside an
+      // extension without a background page. No action needed for log buffers.
+      goog.log.fine(
+          rootLogger,
+          `No background page: ${chrome.runtime.lastError?.message}`);
+      return;
+    }
     if (backgroundPage === window) {
       // We're running inside the background page - no action needed.
       return;


### PR DESCRIPTION
Fix the following crash when running our JavaScript client library in a context that has chrome.runtime.* APIs but there's no background page:

  Unchecked runtime.lastError: You do not have a background page.

We should just gracefully exit the callback in that case: this code is trying to set up log forwarding from foreground to background pages, which is not needed in this case.

This fixes #755.