### PR TITLE
Workaround std::locale crash in unittest on NaCl

### DIFF
--- a/smart_card_connector_app/src/application_unittest.cc
+++ b/smart_card_connector_app/src/application_unittest.cc
@@ -860,9 +860,15 @@ TEST_F(SmartCardConnectorApplicationSingleClientTest, SCardEstablishContext) {
 MATCHER(IsPrintableNonEmptyString, "") {
   if (arg.empty())
     return false;
+#ifdef __native_client__
+  // Constructing a locale object causes a crash under NaCl, hence we use the C
+  // library function when on NaCl toolchain.
+  return std::all_of(arg.begin(), arg.end(), [](char c) { return isprint(c); });
+#else
   std::locale c_locale("C");
   return std::all_of(arg.begin(), arg.end(),
                      [&](char c) { return std::isprint(c, c_locale); });
+#endif
 }
 
 // `pcsc_stringify_error()` calls from JS succeed with reasonable results for


### PR DESCRIPTION
For some reason, constructing std::locale causes a crash on NaCl toolchain. This leads to failures in the
SmartCardConnectorApplicationSingleClientTest.StringifyError unit test.

Work this around by using an analog from the C library that doesn't specify the locale. At this point it makes no sense to investigate a NaCl-specific test-specific issue.