### PR TITLE
Migrate MessageChannelPair to ES6 class

### DIFF
--- a/common/js/src/messaging/message-channel-pair.js
+++ b/common/js/src/messaging/message-channel-pair.js
@@ -47,11 +47,10 @@ const logger = GSC.Logging.getScopedLogger('MessageChannelPair');
  *
  * Note that messages that are sent through the channel pair are always
  * delivered asynchronously.
- * @constructor
- * @extends goog.Disposable
  */
-GSC.MessageChannelPair = function() {
-  MessageChannelPair.base(this, 'constructor');
+GSC.MessageChannelPair = class extends goog.Disposable {
+constructor() {
+  super();
 
   /**
    * @type {!Array.<!MessageChannelPairItem>}
@@ -60,43 +59,39 @@ GSC.MessageChannelPair = function() {
   this.items_ = [
     new MessageChannelPairItem(this, 0), new MessageChannelPairItem(this, 1)
   ];
-};
-
-const MessageChannelPair = GSC.MessageChannelPair;
-
-goog.inherits(MessageChannelPair, goog.Disposable);
+}
 
 /**
  * @param {number} itemIndex
  * @return {!goog.messaging.AbstractChannel}
  */
-MessageChannelPair.prototype.getItem = function(itemIndex) {
+getItem(itemIndex) {
   GSC.Logging.checkWithLogger(logger, 0 <= itemIndex && itemIndex <= 1);
   GSC.Logging.checkWithLogger(logger, !this.isDisposed());
   return this.items_[itemIndex];
-};
+}
 
 /**
  * @return {!goog.messaging.AbstractChannel}
  */
-MessageChannelPair.prototype.getFirst = function() {
+getFirst() {
   return this.getItem(0);
-};
+}
 
 /**
  * @return {!goog.messaging.AbstractChannel}
  */
-MessageChannelPair.prototype.getSecond = function() {
+getSecond() {
   return this.getItem(1);
-};
+}
 
 /** @override */
-MessageChannelPair.prototype.disposeInternal = function() {
+disposeInternal() {
   for (let item of this.items_)
     item.dispose();
   this.items_ = [];
-  MessageChannelPair.base(this, 'disposeInternal');
-};
+  super.disposeInternal();
+}
 
 /**
  * @param {number} fromItemIndex
@@ -104,8 +99,7 @@ MessageChannelPair.prototype.disposeInternal = function() {
  * @param {!Object|string} payload
  * @private
  */
-MessageChannelPair.prototype.sendFrom_ = function(
-    fromItemIndex, serviceName, payload) {
+sendFrom_(fromItemIndex, serviceName, payload) {
   // Deliver the message to the target message channel asynchronously, because
   // that's how the real message channels usually work.
   goog.async.nextTick(() => {
@@ -116,48 +110,49 @@ MessageChannelPair.prototype.sendFrom_ = function(
     const targetItem = this.items_[1 - fromItemIndex];
     targetItem.deliver_(serviceName, payload);
   });
+}
 };
 
 /**
  * A message channel which is an element of the message channel pair.
- * @param {!MessageChannelPair} messageChannelPair
- * @param {number} indexInPair
- * @constructor
- * @extends goog.messaging.AbstractChannel
  */
-const MessageChannelPairItem = function(messageChannelPair, indexInPair) {
-  MessageChannelPairItem.base(this, 'constructor');
+class MessageChannelPairItem extends goog.messaging.AbstractChannel {
+/**
+ * @param {!GSC.MessageChannelPair} messageChannelPair
+ * @param {number} indexInPair
+ */
+constructor(messageChannelPair, indexInPair) {
+  super();
 
   /** @private */
   this.messageChannelPair_ = messageChannelPair;
   /** @private @const */
   this.indexInPair_ = indexInPair;
-};
-
-goog.inherits(MessageChannelPairItem, goog.messaging.AbstractChannel);
+}
 
 /** @override */
-MessageChannelPairItem.prototype.send = function(serviceName, payload) {
+send(serviceName, payload) {
   GSC.Logging.checkWithLogger(logger, !this.isDisposed());
   this.messageChannelPair_.sendFrom_(this.indexInPair_, serviceName, payload);
-};
+}
 
 /** @override */
-MessageChannelPairItem.prototype.disposeInternal = function() {
+disposeInternal() {
   // Our disposal triggers the disposal of the whole pair and, hence, disposal
   // of the second item of the pair.
   this.messageChannelPair_.dispose();
   this.messageChannelPair_ = undefined;
-  MessageChannelPairItem.base(this, 'disposeInternal');
-};
+  super.disposeInternal();
+}
 
 /**
  * @param {string} serviceName
  * @param {!Object|string} payload
  * @private
  */
-MessageChannelPairItem.prototype.deliver_ = function(serviceName, payload) {
+deliver_(serviceName, payload) {
   GSC.Logging.checkWithLogger(logger, !this.isDisposed());
   this.deliver(serviceName, payload);
+}
 };
 });  // goog.scope

--- a/common/js/src/messaging/message-channel-pair.js
+++ b/common/js/src/messaging/message-channel-pair.js
@@ -49,110 +49,110 @@ const logger = GSC.Logging.getScopedLogger('MessageChannelPair');
  * delivered asynchronously.
  */
 GSC.MessageChannelPair = class extends goog.Disposable {
-constructor() {
-  super();
+  constructor() {
+    super();
+
+    /**
+     * @type {!Array.<!MessageChannelPairItem>}
+     * @private
+     */
+    this.items_ = [
+      new MessageChannelPairItem(this, 0), new MessageChannelPairItem(this, 1)
+    ];
+  }
 
   /**
-   * @type {!Array.<!MessageChannelPairItem>}
+   * @param {number} itemIndex
+   * @return {!goog.messaging.AbstractChannel}
+   */
+  getItem(itemIndex) {
+    GSC.Logging.checkWithLogger(logger, 0 <= itemIndex && itemIndex <= 1);
+    GSC.Logging.checkWithLogger(logger, !this.isDisposed());
+    return this.items_[itemIndex];
+  }
+
+  /**
+   * @return {!goog.messaging.AbstractChannel}
+   */
+  getFirst() {
+    return this.getItem(0);
+  }
+
+  /**
+   * @return {!goog.messaging.AbstractChannel}
+   */
+  getSecond() {
+    return this.getItem(1);
+  }
+
+  /** @override */
+  disposeInternal() {
+    for (let item of this.items_)
+      item.dispose();
+    this.items_ = [];
+    super.disposeInternal();
+  }
+
+  /**
+   * @param {number} fromItemIndex
+   * @param {string} serviceName
+   * @param {!Object|string} payload
    * @private
    */
-  this.items_ = [
-    new MessageChannelPairItem(this, 0), new MessageChannelPairItem(this, 1)
-  ];
-}
-
-/**
- * @param {number} itemIndex
- * @return {!goog.messaging.AbstractChannel}
- */
-getItem(itemIndex) {
-  GSC.Logging.checkWithLogger(logger, 0 <= itemIndex && itemIndex <= 1);
-  GSC.Logging.checkWithLogger(logger, !this.isDisposed());
-  return this.items_[itemIndex];
-}
-
-/**
- * @return {!goog.messaging.AbstractChannel}
- */
-getFirst() {
-  return this.getItem(0);
-}
-
-/**
- * @return {!goog.messaging.AbstractChannel}
- */
-getSecond() {
-  return this.getItem(1);
-}
-
-/** @override */
-disposeInternal() {
-  for (let item of this.items_)
-    item.dispose();
-  this.items_ = [];
-  super.disposeInternal();
-}
-
-/**
- * @param {number} fromItemIndex
- * @param {string} serviceName
- * @param {!Object|string} payload
- * @private
- */
-sendFrom_(fromItemIndex, serviceName, payload) {
-  // Deliver the message to the target message channel asynchronously, because
-  // that's how the real message channels usually work.
-  goog.async.nextTick(() => {
-    if (this.isDisposed()) {
-      // Bail out if we got disposed of in the meantime.
-      return;
-    }
-    const targetItem = this.items_[1 - fromItemIndex];
-    targetItem.deliver_(serviceName, payload);
-  });
-}
+  sendFrom_(fromItemIndex, serviceName, payload) {
+    // Deliver the message to the target message channel asynchronously, because
+    // that's how the real message channels usually work.
+    goog.async.nextTick(() => {
+      if (this.isDisposed()) {
+        // Bail out if we got disposed of in the meantime.
+        return;
+      }
+      const targetItem = this.items_[1 - fromItemIndex];
+      targetItem.deliver_(serviceName, payload);
+    });
+  }
 };
 
 /**
  * A message channel which is an element of the message channel pair.
  */
 class MessageChannelPairItem extends goog.messaging.AbstractChannel {
-/**
- * @param {!GSC.MessageChannelPair} messageChannelPair
- * @param {number} indexInPair
- */
-constructor(messageChannelPair, indexInPair) {
-  super();
+  /**
+   * @param {!GSC.MessageChannelPair} messageChannelPair
+   * @param {number} indexInPair
+   */
+  constructor(messageChannelPair, indexInPair) {
+    super();
 
-  /** @private */
-  this.messageChannelPair_ = messageChannelPair;
-  /** @private @const */
-  this.indexInPair_ = indexInPair;
-}
+    /** @private */
+    this.messageChannelPair_ = messageChannelPair;
+    /** @private @const */
+    this.indexInPair_ = indexInPair;
+  }
 
-/** @override */
-send(serviceName, payload) {
-  GSC.Logging.checkWithLogger(logger, !this.isDisposed());
-  this.messageChannelPair_.sendFrom_(this.indexInPair_, serviceName, payload);
-}
+  /** @override */
+  send(serviceName, payload) {
+    GSC.Logging.checkWithLogger(logger, !this.isDisposed());
+    this.messageChannelPair_.sendFrom_(this.indexInPair_, serviceName, payload);
+  }
 
-/** @override */
-disposeInternal() {
-  // Our disposal triggers the disposal of the whole pair and, hence, disposal
-  // of the second item of the pair.
-  this.messageChannelPair_.dispose();
-  this.messageChannelPair_ = undefined;
-  super.disposeInternal();
-}
+  /** @override */
+  disposeInternal() {
+    // Our disposal triggers the disposal of the whole pair and, hence, disposal
+    // of the second item of the pair.
+    this.messageChannelPair_.dispose();
+    this.messageChannelPair_ = undefined;
+    super.disposeInternal();
+  }
 
-/**
- * @param {string} serviceName
- * @param {!Object|string} payload
- * @private
- */
-deliver_(serviceName, payload) {
-  GSC.Logging.checkWithLogger(logger, !this.isDisposed());
-  this.deliver(serviceName, payload);
-}
+  /**
+   * @param {string} serviceName
+   * @param {!Object|string} payload
+   * @private
+   */
+  deliver_(serviceName, payload) {
+    GSC.Logging.checkWithLogger(logger, !this.isDisposed());
+    this.deliver(serviceName, payload);
+  }
 };
 });  // goog.scope


### PR DESCRIPTION
Migrate the //common/js/src/messaging/message-channel-pair.js file from legacy Closure Compiler classes to ES6 classes.

This is a pure refactoring change. It's is part of the effort to modernize the code base, as recent Closure Compiler versions stopped supporting the legacy class syntax.