### PR TITLE
Migrate SingleMessageBasedChannel to ES6 class

### DIFF
--- a/common/js/src/messaging/single-message-based-channel.js
+++ b/common/js/src/messaging/single-message-based-channel.js
@@ -51,16 +51,16 @@ const PingResponder = GSC.MessageChannelPinging.PingResponder;
  * Apart from adapting the one-time communication mechanisms into the methods of
  * the goog.messaging.AbstractChannel class, this class enables pinging over
  * this message channel (see the message-channel-pinging.js file for details).
+ */
+GSC.SingleMessageBasedChannel = class extends goog.messaging.AbstractChannel {
+/**
  * @param {string} extensionId
  * @param {function()=} opt_onEstablished
  * @param {boolean=} opt_shouldPingOnPing Whether an additional ping message
  * should be sent each time a ping message is received.
- * @constructor
- * @extends goog.messaging.AbstractChannel
  */
-GSC.SingleMessageBasedChannel = function(
-    extensionId, opt_onEstablished, opt_shouldPingOnPing) {
-  SingleMessageBasedChannel.base(this, 'constructor');
+constructor(extensionId, opt_onEstablished, opt_shouldPingOnPing) {
+  super();
 
   /** @const @type {string} */
   this.extensionId = extensionId;
@@ -85,18 +85,14 @@ GSC.SingleMessageBasedChannel = function(
       this, this.logger, this.pingMessageReceivedListener_.bind(this));
 
   goog.log.fine(this.logger, 'Initialized successfully');
-};
-
-const SingleMessageBasedChannel = GSC.SingleMessageBasedChannel;
-
-goog.inherits(SingleMessageBasedChannel, goog.messaging.AbstractChannel);
+}
 
 /**
  * @override
  * @param {string} serviceName
  * @param {!Object|string} payload
  */
-SingleMessageBasedChannel.prototype.send = function(serviceName, payload) {
+send(serviceName, payload) {
   GSC.Logging.checkWithLogger(this.logger, goog.isObject(payload));
   goog.asserts.assertObject(payload);
 
@@ -115,13 +111,13 @@ SingleMessageBasedChannel.prototype.send = function(serviceName, payload) {
   }
 
   chrome.runtime.sendMessage(this.extensionId, message);
-};
+}
 
 /**
  * This method passes the message to the corresponding registered service.
  * @param {*} message
  */
-SingleMessageBasedChannel.prototype.deliverMessage = function(message) {
+deliverMessage(message) {
   goog.log.log(
       this.logger, goog.log.Level.FINEST,
       'Received a message: ' + GSC.DebugDump.debugDump(message));
@@ -135,12 +131,12 @@ SingleMessageBasedChannel.prototype.deliverMessage = function(message) {
   }
 
   this.deliver(typedMessage.type, typedMessage.data);
-};
+}
 
 /**
  * @override
  */
-SingleMessageBasedChannel.prototype.disposeInternal = function() {
+disposeInternal() {
   this.pinger_.dispose();
   this.pinger_ = null;
 
@@ -149,27 +145,27 @@ SingleMessageBasedChannel.prototype.disposeInternal = function() {
 
   goog.log.fine(this.logger, 'Disposed');
 
-  SingleMessageBasedChannel.base(this, 'disposeInternal');
-};
+  super.disposeInternal();
+}
 
 /**
  * @param {string} serviceName
  * @param {!Object|string} payload
  * @private
  */
-SingleMessageBasedChannel.prototype.defaultServiceCallback_ = function(
-    serviceName, payload) {
+defaultServiceCallback_(serviceName, payload) {
   GSC.Logging.failWithLogger(
       this.logger,
       'Unhandled message received: serviceName="' + serviceName +
           '", payload=' + GSC.DebugDump.debugDump(payload));
-};
+}
 
 /** @private */
-SingleMessageBasedChannel.prototype.pingMessageReceivedListener_ = function() {
+pingMessageReceivedListener_() {
   if (this.isDisposed())
     return;
   if (this.shouldPingOnPing_)
     this.pinger_.postPingMessage();
+}
 };
 });  // goog.scope

--- a/common/js/src/messaging/single-message-based-channel.js
+++ b/common/js/src/messaging/single-message-based-channel.js
@@ -53,119 +53,120 @@ const PingResponder = GSC.MessageChannelPinging.PingResponder;
  * this message channel (see the message-channel-pinging.js file for details).
  */
 GSC.SingleMessageBasedChannel = class extends goog.messaging.AbstractChannel {
-/**
- * @param {string} extensionId
- * @param {function()=} opt_onEstablished
- * @param {boolean=} opt_shouldPingOnPing Whether an additional ping message
- * should be sent each time a ping message is received.
- */
-constructor(extensionId, opt_onEstablished, opt_shouldPingOnPing) {
-  super();
+  /**
+   * @param {string} extensionId
+   * @param {function()=} opt_onEstablished
+   * @param {boolean=} opt_shouldPingOnPing Whether an additional ping message
+   * should be sent each time a ping message is received.
+   */
+  constructor(extensionId, opt_onEstablished, opt_shouldPingOnPing) {
+    super();
 
-  /** @const @type {string} */
-  this.extensionId = extensionId;
+    /** @const @type {string} */
+    this.extensionId = extensionId;
+
+    /**
+     * @type {!goog.log.Logger}
+     * @const
+     */
+    this.logger = GSC.Logging.getScopedLogger(
+        'SingleMessageBasedChannel<' + extensionId + '>');
+
+    /** @private @const */
+    this.shouldPingOnPing_ = !!opt_shouldPingOnPing;
+
+    this.registerDefaultService(this.defaultServiceCallback_.bind(this));
+
+    /** @private */
+    this.pinger_ = new Pinger(this, this.logger, opt_onEstablished);
+
+    /** @private */
+    this.pingResponder_ = new PingResponder(
+        this, this.logger, this.pingMessageReceivedListener_.bind(this));
+
+    goog.log.fine(this.logger, 'Initialized successfully');
+  }
 
   /**
-   * @type {!goog.log.Logger}
-   * @const
+   * @override
+   * @param {string} serviceName
+   * @param {!Object|string} payload
    */
-  this.logger = GSC.Logging.getScopedLogger(
-      'SingleMessageBasedChannel<' + extensionId + '>');
+  send(serviceName, payload) {
+    GSC.Logging.checkWithLogger(this.logger, goog.isObject(payload));
+    goog.asserts.assertObject(payload);
 
-  /** @private @const */
-  this.shouldPingOnPing_ = !!opt_shouldPingOnPing;
+    const normalizedPayload =
+        GSC.ContainerHelpers.substituteArrayBuffersRecursively(payload);
 
-  this.registerDefaultService(this.defaultServiceCallback_.bind(this));
+    const typedMessage = new GSC.TypedMessage(serviceName, normalizedPayload);
+    const message = typedMessage.makeMessage();
+    goog.log.log(
+        this.logger, goog.log.Level.FINEST,
+        'Posting a message: ' + GSC.DebugDump.debugDump(message));
 
-  /** @private */
-  this.pinger_ = new Pinger(this, this.logger, opt_onEstablished);
+    if (this.isDisposed()) {
+      GSC.Logging.failWithLogger(
+          this.logger,
+          'Failed to post message: the channel is already disposed');
+    }
 
-  /** @private */
-  this.pingResponder_ = new PingResponder(
-      this, this.logger, this.pingMessageReceivedListener_.bind(this));
-
-  goog.log.fine(this.logger, 'Initialized successfully');
-}
-
-/**
- * @override
- * @param {string} serviceName
- * @param {!Object|string} payload
- */
-send(serviceName, payload) {
-  GSC.Logging.checkWithLogger(this.logger, goog.isObject(payload));
-  goog.asserts.assertObject(payload);
-
-  const normalizedPayload =
-      GSC.ContainerHelpers.substituteArrayBuffersRecursively(payload);
-
-  const typedMessage = new GSC.TypedMessage(serviceName, normalizedPayload);
-  const message = typedMessage.makeMessage();
-  goog.log.log(
-      this.logger, goog.log.Level.FINEST,
-      'Posting a message: ' + GSC.DebugDump.debugDump(message));
-
-  if (this.isDisposed()) {
-    GSC.Logging.failWithLogger(
-        this.logger, 'Failed to post message: the channel is already disposed');
+    chrome.runtime.sendMessage(this.extensionId, message);
   }
 
-  chrome.runtime.sendMessage(this.extensionId, message);
-}
+  /**
+   * This method passes the message to the corresponding registered service.
+   * @param {*} message
+   */
+  deliverMessage(message) {
+    goog.log.log(
+        this.logger, goog.log.Level.FINEST,
+        'Received a message: ' + GSC.DebugDump.debugDump(message));
 
-/**
- * This method passes the message to the corresponding registered service.
- * @param {*} message
- */
-deliverMessage(message) {
-  goog.log.log(
-      this.logger, goog.log.Level.FINEST,
-      'Received a message: ' + GSC.DebugDump.debugDump(message));
+    const typedMessage = GSC.TypedMessage.parseTypedMessage(message);
+    if (!typedMessage) {
+      GSC.Logging.failWithLogger(
+          this.logger,
+          'Failed to parse the received message: ' +
+              GSC.DebugDump.debugDump(message));
+    }
 
-  const typedMessage = GSC.TypedMessage.parseTypedMessage(message);
-  if (!typedMessage) {
+    this.deliver(typedMessage.type, typedMessage.data);
+  }
+
+  /**
+   * @override
+   */
+  disposeInternal() {
+    this.pinger_.dispose();
+    this.pinger_ = null;
+
+    this.pingResponder_.dispose();
+    this.pingResponder_ = null;
+
+    goog.log.fine(this.logger, 'Disposed');
+
+    super.disposeInternal();
+  }
+
+  /**
+   * @param {string} serviceName
+   * @param {!Object|string} payload
+   * @private
+   */
+  defaultServiceCallback_(serviceName, payload) {
     GSC.Logging.failWithLogger(
         this.logger,
-        'Failed to parse the received message: ' +
-            GSC.DebugDump.debugDump(message));
+        'Unhandled message received: serviceName="' + serviceName +
+            '", payload=' + GSC.DebugDump.debugDump(payload));
   }
 
-  this.deliver(typedMessage.type, typedMessage.data);
-}
-
-/**
- * @override
- */
-disposeInternal() {
-  this.pinger_.dispose();
-  this.pinger_ = null;
-
-  this.pingResponder_.dispose();
-  this.pingResponder_ = null;
-
-  goog.log.fine(this.logger, 'Disposed');
-
-  super.disposeInternal();
-}
-
-/**
- * @param {string} serviceName
- * @param {!Object|string} payload
- * @private
- */
-defaultServiceCallback_(serviceName, payload) {
-  GSC.Logging.failWithLogger(
-      this.logger,
-      'Unhandled message received: serviceName="' + serviceName +
-          '", payload=' + GSC.DebugDump.debugDump(payload));
-}
-
-/** @private */
-pingMessageReceivedListener_() {
-  if (this.isDisposed())
-    return;
-  if (this.shouldPingOnPing_)
-    this.pinger_.postPingMessage();
-}
+  /** @private */
+  pingMessageReceivedListener_() {
+    if (this.isDisposed())
+      return;
+    if (this.shouldPingOnPing_)
+      this.pinger_.postPingMessage();
+  }
 };
 });  // goog.scope


### PR DESCRIPTION
Migrate the //common/js/src/messaging/single-message-based-channel.js
file from legacy Closure Compiler classes to ES6 classes.

This is a pure refactoring change. It's is part of the effort to
modernize the code base, as recent Closure Compiler versions
stopped supporting the legacy class syntax.