### PR TITLE
Migrate NaclModuleLogMessagesReceiver to ES6 class

### DIFF
--- a/common/js/src/nacl-module/nacl-module-log-messages-receiver.js
+++ b/common/js/src/nacl-module/nacl-module-log-messages-receiver.js
@@ -47,11 +47,13 @@ const TEXT_MESSAGE_KEY = 'text';
  * The NaCl module sends the emitted log messages as messages of some special
  * structure. This class handles these messages, extracts their fields and
  * transforms them into emitting log messages into the given logger.
+ */
+GSC.NaclModuleLogMessagesReceiver = class {
+/**
  * @param {!goog.messaging.AbstractChannel} messageChannel
  * @param {!goog.log.Logger} logger
- * @constructor
  */
-GSC.NaclModuleLogMessagesReceiver = function(messageChannel, logger) {
+constructor(messageChannel, logger) {
   messageChannel.registerService(
       SERVICE_NAME, this.onMessageReceived_.bind(this), true);
 
@@ -60,31 +62,27 @@ GSC.NaclModuleLogMessagesReceiver = function(messageChannel, logger) {
    * @const
    */
   this.logger = logger;
-};
-
-const NaclModuleLogMessagesReceiver = GSC.NaclModuleLogMessagesReceiver;
+}
 
 /**
  * @param {string|!Object} messageData
  * @private
  */
-NaclModuleLogMessagesReceiver.prototype.onMessageReceived_ = function(
-    messageData) {
+onMessageReceived_(messageData) {
   GSC.Logging.checkWithLogger(this.logger, goog.isObject(messageData));
   goog.asserts.assertObject(messageData);
 
   goog.log.log(
       this.logger, this.extractLogMessageLevel_(messageData),
       this.extractLogMessageText_(messageData));
-};
+}
 
 /**
  * @param {!Object} messageData
  * @return {!goog.log.Level}
  * @private
  */
-NaclModuleLogMessagesReceiver.prototype.extractLogMessageLevel_ = function(
-    messageData) {
+extractLogMessageLevel_(messageData) {
   GSC.Logging.checkWithLogger(
       this.logger, goog.object.containsKey(messageData, LOG_LEVEL_MESSAGE_KEY));
   const value = messageData[LOG_LEVEL_MESSAGE_KEY];
@@ -99,15 +97,14 @@ NaclModuleLogMessagesReceiver.prototype.extractLogMessageLevel_ = function(
   goog.asserts.assert(result);
 
   return result;
-};
+}
 
 /**
  * @param {!Object} messageData
  * @return {string}
  * @private
  */
-NaclModuleLogMessagesReceiver.prototype.extractLogMessageText_ = function(
-    messageData) {
+extractLogMessageText_(messageData) {
   GSC.Logging.checkWithLogger(
       this.logger, goog.object.containsKey(messageData, TEXT_MESSAGE_KEY));
   const value = messageData[TEXT_MESSAGE_KEY];
@@ -116,5 +113,6 @@ NaclModuleLogMessagesReceiver.prototype.extractLogMessageText_ = function(
   goog.asserts.assertString(value);
 
   return value;
+}
 };
 });  // goog.scope

--- a/common/js/src/nacl-module/nacl-module-log-messages-receiver.js
+++ b/common/js/src/nacl-module/nacl-module-log-messages-receiver.js
@@ -49,70 +49,71 @@ const TEXT_MESSAGE_KEY = 'text';
  * transforms them into emitting log messages into the given logger.
  */
 GSC.NaclModuleLogMessagesReceiver = class {
-/**
- * @param {!goog.messaging.AbstractChannel} messageChannel
- * @param {!goog.log.Logger} logger
- */
-constructor(messageChannel, logger) {
-  messageChannel.registerService(
-      SERVICE_NAME, this.onMessageReceived_.bind(this), true);
+  /**
+   * @param {!goog.messaging.AbstractChannel} messageChannel
+   * @param {!goog.log.Logger} logger
+   */
+  constructor(messageChannel, logger) {
+    messageChannel.registerService(
+        SERVICE_NAME, this.onMessageReceived_.bind(this), true);
+
+    /**
+     * @type {!goog.log.Logger}
+     * @const
+     */
+    this.logger = logger;
+  }
 
   /**
-   * @type {!goog.log.Logger}
-   * @const
+   * @param {string|!Object} messageData
+   * @private
    */
-  this.logger = logger;
-}
+  onMessageReceived_(messageData) {
+    GSC.Logging.checkWithLogger(this.logger, goog.isObject(messageData));
+    goog.asserts.assertObject(messageData);
 
-/**
- * @param {string|!Object} messageData
- * @private
- */
-onMessageReceived_(messageData) {
-  GSC.Logging.checkWithLogger(this.logger, goog.isObject(messageData));
-  goog.asserts.assertObject(messageData);
+    goog.log.log(
+        this.logger, this.extractLogMessageLevel_(messageData),
+        this.extractLogMessageText_(messageData));
+  }
 
-  goog.log.log(
-      this.logger, this.extractLogMessageLevel_(messageData),
-      this.extractLogMessageText_(messageData));
-}
+  /**
+   * @param {!Object} messageData
+   * @return {!goog.log.Level}
+   * @private
+   */
+  extractLogMessageLevel_(messageData) {
+    GSC.Logging.checkWithLogger(
+        this.logger,
+        goog.object.containsKey(messageData, LOG_LEVEL_MESSAGE_KEY));
+    const value = messageData[LOG_LEVEL_MESSAGE_KEY];
 
-/**
- * @param {!Object} messageData
- * @return {!goog.log.Level}
- * @private
- */
-extractLogMessageLevel_(messageData) {
-  GSC.Logging.checkWithLogger(
-      this.logger, goog.object.containsKey(messageData, LOG_LEVEL_MESSAGE_KEY));
-  const value = messageData[LOG_LEVEL_MESSAGE_KEY];
+    GSC.Logging.checkWithLogger(this.logger, typeof value === 'string');
+    goog.asserts.assertString(value);
 
-  GSC.Logging.checkWithLogger(this.logger, typeof value === 'string');
-  goog.asserts.assertString(value);
+    const result = goog.log.Level.getPredefinedLevel(value);
+    GSC.Logging.checkWithLogger(
+        this.logger, result,
+        'Unknown log level specified in the received message: "' + value + '"');
+    goog.asserts.assert(result);
 
-  const result = goog.log.Level.getPredefinedLevel(value);
-  GSC.Logging.checkWithLogger(
-      this.logger, result,
-      'Unknown log level specified in the received message: "' + value + '"');
-  goog.asserts.assert(result);
+    return result;
+  }
 
-  return result;
-}
+  /**
+   * @param {!Object} messageData
+   * @return {string}
+   * @private
+   */
+  extractLogMessageText_(messageData) {
+    GSC.Logging.checkWithLogger(
+        this.logger, goog.object.containsKey(messageData, TEXT_MESSAGE_KEY));
+    const value = messageData[TEXT_MESSAGE_KEY];
 
-/**
- * @param {!Object} messageData
- * @return {string}
- * @private
- */
-extractLogMessageText_(messageData) {
-  GSC.Logging.checkWithLogger(
-      this.logger, goog.object.containsKey(messageData, TEXT_MESSAGE_KEY));
-  const value = messageData[TEXT_MESSAGE_KEY];
+    GSC.Logging.checkWithLogger(this.logger, typeof value === 'string');
+    goog.asserts.assertString(value);
 
-  GSC.Logging.checkWithLogger(this.logger, typeof value === 'string');
-  goog.asserts.assertString(value);
-
-  return value;
-}
+    return value;
+  }
 };
 });  // goog.scope


### PR DESCRIPTION
Migrate the
//common/js/src/nacl-module/nacl-module-log-messages-receiver.js
file from legacy Closure Compiler classes to ES6 classes.

This is a pure refactoring change. It's is part of the effort to
modernize the code base, as recent Closure Compiler versions
stopped supporting the legacy class syntax.