### PR TITLE
Migrate NaclModuleMessageChannel to ES6 class

### DIFF
--- a/common/js/src/nacl-module/nacl-module-messaging-channel.js
+++ b/common/js/src/nacl-module/nacl-module-messaging-channel.js
@@ -42,13 +42,14 @@ const GSC = GoogleSmartCard;
  * <https://developer.chrome.com/native-client/devguide/coding/message-system>)
  * that transforms them into Closure-style message channels (see
  * <http://google.github.io/closure-library/api/interface_goog_messaging_MessageChannel.html>).
+ */
+GSC.NaclModuleMessageChannel = class extends goog.messaging.AbstractChannel {
+/**
  * @param {!Element} naclModuleElement
  * @param {!goog.log.Logger} parentLogger
- * @constructor
- * @extends goog.messaging.AbstractChannel
  */
-GSC.NaclModuleMessageChannel = function(naclModuleElement, parentLogger) {
-  NaclModuleMessageChannel.base(this, 'constructor');
+constructor(naclModuleElement, parentLogger) {
+  super();
 
   /** @private @const */
   this.logger_ = parentLogger;
@@ -68,14 +69,10 @@ GSC.NaclModuleMessageChannel = function(naclModuleElement, parentLogger) {
   this.registerDefaultService(this.defaultServiceCallback_.bind(this));
 
   goog.log.fine(this.logger_, 'Initialized');
-};
-
-const NaclModuleMessageChannel = GSC.NaclModuleMessageChannel;
-
-goog.inherits(NaclModuleMessageChannel, goog.messaging.AbstractChannel);
+}
 
 /** @override */
-NaclModuleMessageChannel.prototype.send = function(serviceName, payload) {
+send(serviceName, payload) {
   GSC.Logging.checkWithLogger(this.logger_, goog.isObject(payload));
   goog.asserts.assertObject(payload);
   const typedMessage = new GSC.TypedMessage(serviceName, payload);
@@ -86,21 +83,21 @@ NaclModuleMessageChannel.prototype.send = function(serviceName, payload) {
       this.logger_, goog.log.Level.FINEST,
       'Sending message to NaCl module: ' + GSC.DebugDump.debugDump(message));
   this.naclModuleElement_['postMessage'](message);
-};
+}
 
 /** @override */
-NaclModuleMessageChannel.prototype.disposeInternal = function() {
+disposeInternal() {
   this.naclModuleElement_.removeEventListener(
       'message', this.boundMessageEventListener_, true);
   this.boundMessageEventListener_ = null;
 
   this.naclModuleElement_ = null;
 
-  NaclModuleMessageChannel.base(this, 'disposeInternal');
-};
+  super.disposeInternal();
+}
 
 /** @private */
-NaclModuleMessageChannel.prototype.messageEventListener_ = function(message) {
+messageEventListener_(message) {
   const messageData = message['data'];
 
   const typedMessage = GSC.TypedMessage.parseTypedMessage(messageData);
@@ -116,14 +113,14 @@ NaclModuleMessageChannel.prototype.messageEventListener_ = function(message) {
       'Received a message from NaCl module: ' +
           GSC.DebugDump.debugDump(messageData));
   this.deliver(typedMessage.type, typedMessage.data);
-};
+}
 
 /** @private */
-NaclModuleMessageChannel.prototype.defaultServiceCallback_ = function(
-    serviceName, payload) {
+defaultServiceCallback_(serviceName, payload) {
   GSC.Logging.failWithLogger(
       this.logger_,
       'Unhandled message received from NaCl module: serviceName="' +
           serviceName + '", payload=' + GSC.DebugDump.debugDump(payload));
+}
 };
 });  // goog.scope

--- a/common/js/src/nacl-module/nacl-module-messaging-channel.js
+++ b/common/js/src/nacl-module/nacl-module-messaging-channel.js
@@ -44,83 +44,83 @@ const GSC = GoogleSmartCard;
  * <http://google.github.io/closure-library/api/interface_goog_messaging_MessageChannel.html>).
  */
 GSC.NaclModuleMessageChannel = class extends goog.messaging.AbstractChannel {
-/**
- * @param {!Element} naclModuleElement
- * @param {!goog.log.Logger} parentLogger
- */
-constructor(naclModuleElement, parentLogger) {
-  super();
-
-  /** @private @const */
-  this.logger_ = parentLogger;
-
   /**
-   * @type {Element?}
-   * @private
+   * @param {!Element} naclModuleElement
+   * @param {!goog.log.Logger} parentLogger
    */
-  this.naclModuleElement_ = naclModuleElement;
+  constructor(naclModuleElement, parentLogger) {
+    super();
 
-  /** @private */
-  this.boundMessageEventListener_ = this.messageEventListener_.bind(this);
+    /** @private @const */
+    this.logger_ = parentLogger;
 
-  this.naclModuleElement_.addEventListener(
-      'message', this.boundMessageEventListener_, true);
+    /**
+     * @type {Element?}
+     * @private
+     */
+    this.naclModuleElement_ = naclModuleElement;
 
-  this.registerDefaultService(this.defaultServiceCallback_.bind(this));
+    /** @private */
+    this.boundMessageEventListener_ = this.messageEventListener_.bind(this);
 
-  goog.log.fine(this.logger_, 'Initialized');
-}
+    this.naclModuleElement_.addEventListener(
+        'message', this.boundMessageEventListener_, true);
 
-/** @override */
-send(serviceName, payload) {
-  GSC.Logging.checkWithLogger(this.logger_, goog.isObject(payload));
-  goog.asserts.assertObject(payload);
-  const typedMessage = new GSC.TypedMessage(serviceName, payload);
-  const message = typedMessage.makeMessage();
-  if (this.isDisposed())
-    return;
-  goog.log.log(
-      this.logger_, goog.log.Level.FINEST,
-      'Sending message to NaCl module: ' + GSC.DebugDump.debugDump(message));
-  this.naclModuleElement_['postMessage'](message);
-}
+    this.registerDefaultService(this.defaultServiceCallback_.bind(this));
 
-/** @override */
-disposeInternal() {
-  this.naclModuleElement_.removeEventListener(
-      'message', this.boundMessageEventListener_, true);
-  this.boundMessageEventListener_ = null;
-
-  this.naclModuleElement_ = null;
-
-  super.disposeInternal();
-}
-
-/** @private */
-messageEventListener_(message) {
-  const messageData = message['data'];
-
-  const typedMessage = GSC.TypedMessage.parseTypedMessage(messageData);
-  if (!typedMessage) {
-    GSC.Logging.failWithLogger(
-        this.logger_,
-        'Failed to parse message received from NaCl module: ' +
-            GSC.DebugDump.debugDump(messageData));
+    goog.log.fine(this.logger_, 'Initialized');
   }
 
-  goog.log.log(
-      this.logger_, goog.log.Level.FINEST,
-      'Received a message from NaCl module: ' +
-          GSC.DebugDump.debugDump(messageData));
-  this.deliver(typedMessage.type, typedMessage.data);
-}
+  /** @override */
+  send(serviceName, payload) {
+    GSC.Logging.checkWithLogger(this.logger_, goog.isObject(payload));
+    goog.asserts.assertObject(payload);
+    const typedMessage = new GSC.TypedMessage(serviceName, payload);
+    const message = typedMessage.makeMessage();
+    if (this.isDisposed())
+      return;
+    goog.log.log(
+        this.logger_, goog.log.Level.FINEST,
+        'Sending message to NaCl module: ' + GSC.DebugDump.debugDump(message));
+    this.naclModuleElement_['postMessage'](message);
+  }
 
-/** @private */
-defaultServiceCallback_(serviceName, payload) {
-  GSC.Logging.failWithLogger(
-      this.logger_,
-      'Unhandled message received from NaCl module: serviceName="' +
-          serviceName + '", payload=' + GSC.DebugDump.debugDump(payload));
-}
+  /** @override */
+  disposeInternal() {
+    this.naclModuleElement_.removeEventListener(
+        'message', this.boundMessageEventListener_, true);
+    this.boundMessageEventListener_ = null;
+
+    this.naclModuleElement_ = null;
+
+    super.disposeInternal();
+  }
+
+  /** @private */
+  messageEventListener_(message) {
+    const messageData = message['data'];
+
+    const typedMessage = GSC.TypedMessage.parseTypedMessage(messageData);
+    if (!typedMessage) {
+      GSC.Logging.failWithLogger(
+          this.logger_,
+          'Failed to parse message received from NaCl module: ' +
+              GSC.DebugDump.debugDump(messageData));
+    }
+
+    goog.log.log(
+        this.logger_, goog.log.Level.FINEST,
+        'Received a message from NaCl module: ' +
+            GSC.DebugDump.debugDump(messageData));
+    this.deliver(typedMessage.type, typedMessage.data);
+  }
+
+  /** @private */
+  defaultServiceCallback_(serviceName, payload) {
+    GSC.Logging.failWithLogger(
+        this.logger_,
+        'Unhandled message received from NaCl module: serviceName="' +
+            serviceName + '", payload=' + GSC.DebugDump.debugDump(payload));
+  }
 };
 });  // goog.scope


### PR DESCRIPTION
Migrate the
//common/js/src/nacl-module/nacl-module-messaging-channel.js file from legacy Closure Compiler classes to ES6 classes.

This is a pure refactoring change. It's is part of the effort to modernize the code base, as recent Closure Compiler versions stopped supporting the legacy class syntax.