### PR TITLE
Migrate RequestReceiver to ES6 class

### DIFF
--- a/common/js/src/requesting/request-receiver.js
+++ b/common/js/src/requesting/request-receiver.js
@@ -48,13 +48,15 @@ const ResponseMessageData = RequesterMessage.ResponseMessageData;
  * The actual request handling is delegated to the specified request handler.
  * The results it returns (either successful or not) are transformed by this
  * class into response messages and sent back through the message channel.
+ */
+GSC.RequestReceiver = class {
+/**
  * @param {string} name Name of the requester whose requests will be handled by
  * this instance.
  * @param {!goog.messaging.AbstractChannel} messageChannel
  * @param {function(!Object):(!goog.Promise|!Promise)} requestHandler
- * @constructor
  */
-GSC.RequestReceiver = function(name, messageChannel, requestHandler) {
+constructor(name, messageChannel, requestHandler) {
   /**
    * @type {!goog.log.Logger}
    * @const
@@ -77,9 +79,7 @@ GSC.RequestReceiver = function(name, messageChannel, requestHandler) {
   this.shouldDisposeOnInvalidMessage_ = false;
 
   this.registerRequestMessagesService_();
-};
-
-const RequestReceiver = GSC.RequestReceiver;
+}
 
 /**
  * Sets whether the message channel should be disposed when an invalid message
@@ -89,24 +89,22 @@ const RequestReceiver = GSC.RequestReceiver;
  * message, and a fatal error is raised instead.
  * @param {boolean} shouldDisposeOnInvalidMessage
  */
-RequestReceiver.prototype.setShouldDisposeOnInvalidMessage = function(
-    shouldDisposeOnInvalidMessage) {
+setShouldDisposeOnInvalidMessage(shouldDisposeOnInvalidMessage) {
   this.shouldDisposeOnInvalidMessage_ = shouldDisposeOnInvalidMessage;
-};
+}
 
 /** @private */
-RequestReceiver.prototype.registerRequestMessagesService_ = function() {
+registerRequestMessagesService_() {
   const serviceName = RequesterMessage.getRequestMessageType(this.name_);
   this.messageChannel_.registerService(
       serviceName, this.requestMessageReceivedListener_.bind(this), true);
-};
+}
 
 /**
  * @param {string|!Object} messageData
  * @private
  */
-RequestReceiver.prototype.requestMessageReceivedListener_ = function(
-    messageData) {
+requestMessageReceivedListener_(messageData) {
   GSC.Logging.checkWithLogger(this.logger, goog.isObject(messageData));
   goog.asserts.assertObject(messageData);
 
@@ -136,15 +134,14 @@ RequestReceiver.prototype.requestMessageReceivedListener_ = function(
   promise.then(
       this.responseResolvedListener_.bind(this, requestMessageData),
       this.responseRejectedListener_.bind(this, requestMessageData));
-};
+}
 
 /**
  * @param {!RequestMessageData} requestMessageData
  * @param {*} payload
  * @private
  */
-RequestReceiver.prototype.responseResolvedListener_ = function(
-    requestMessageData, payload) {
+responseResolvedListener_(requestMessageData, payload) {
   if (this.messageChannel_.isDisposed()) {
     // Discard the response if it's impossible to send it anymore.
     goog.log.fine(
@@ -161,15 +158,14 @@ RequestReceiver.prototype.responseResolvedListener_ = function(
           `${debugDump}`);
   this.sendResponse_(
       new ResponseMessageData(requestMessageData.requestId, payload));
-};
+}
 
 /**
  * @param {!RequestMessageData} requestMessageData
  * @param {*} error
  * @private
  */
-RequestReceiver.prototype.responseRejectedListener_ = function(
-    requestMessageData, error) {
+responseRejectedListener_(requestMessageData, error) {
   if (this.messageChannel_.isDisposed()) {
     // Discard the response if it's impossible to send it anymore.
     goog.log.fine(
@@ -187,17 +183,18 @@ RequestReceiver.prototype.responseRejectedListener_ = function(
   this.sendResponse_(new ResponseMessageData(
       requestMessageData.requestId, /*opt_payload=*/ undefined,
       stringifiedError));
-};
+}
 
 /**
  * @param {!ResponseMessageData} responseMessageData
  * @private
  */
-RequestReceiver.prototype.sendResponse_ = function(responseMessageData) {
+sendResponse_(responseMessageData) {
   GSC.Logging.checkWithLogger(this.logger, !this.messageChannel_.isDisposed());
 
   const messageData = responseMessageData.makeMessageData();
   const serviceName = RequesterMessage.getResponseMessageType(this.name_);
   this.messageChannel_.send(serviceName, messageData);
+}
 };
 });  // goog.scope

--- a/common/js/src/requesting/request-receiver.js
+++ b/common/js/src/requesting/request-receiver.js
@@ -50,151 +50,154 @@ const ResponseMessageData = RequesterMessage.ResponseMessageData;
  * class into response messages and sent back through the message channel.
  */
 GSC.RequestReceiver = class {
-/**
- * @param {string} name Name of the requester whose requests will be handled by
- * this instance.
- * @param {!goog.messaging.AbstractChannel} messageChannel
- * @param {function(!Object):(!goog.Promise|!Promise)} requestHandler
- */
-constructor(name, messageChannel, requestHandler) {
   /**
-   * @type {!goog.log.Logger}
-   * @const
+   * @param {string} name Name of the requester whose requests will be handled
+   *     by
+   * this instance.
+   * @param {!goog.messaging.AbstractChannel} messageChannel
+   * @param {function(!Object):(!goog.Promise|!Promise)} requestHandler
    */
-  this.logger = GSC.Logging.getScopedLogger(`RequestReceiver<"${name}">`);
+  constructor(name, messageChannel, requestHandler) {
+    /**
+     * @type {!goog.log.Logger}
+     * @const
+     */
+    this.logger = GSC.Logging.getScopedLogger(`RequestReceiver<"${name}">`);
 
-  /** @private @const */
-  this.name_ = name;
+    /** @private @const */
+    this.name_ = name;
 
-  /** @private @const */
-  this.messageChannel_ = messageChannel;
+    /** @private @const */
+    this.messageChannel_ = messageChannel;
 
-  /** @private @const */
-  this.requestHandler_ = requestHandler;
+    /** @private @const */
+    this.requestHandler_ = requestHandler;
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.shouldDisposeOnInvalidMessage_ = false;
+
+    this.registerRequestMessagesService_();
+  }
 
   /**
-   * @type {boolean}
+   * Sets whether the message channel should be disposed when an invalid message
+   * is received.
+   *
+   * By default, the message channel is not disposed in case of an invalid
+   * message, and a fatal error is raised instead.
+   * @param {boolean} shouldDisposeOnInvalidMessage
+   */
+  setShouldDisposeOnInvalidMessage(shouldDisposeOnInvalidMessage) {
+    this.shouldDisposeOnInvalidMessage_ = shouldDisposeOnInvalidMessage;
+  }
+
+  /** @private */
+  registerRequestMessagesService_() {
+    const serviceName = RequesterMessage.getRequestMessageType(this.name_);
+    this.messageChannel_.registerService(
+        serviceName, this.requestMessageReceivedListener_.bind(this), true);
+  }
+
+  /**
+   * @param {string|!Object} messageData
    * @private
    */
-  this.shouldDisposeOnInvalidMessage_ = false;
+  requestMessageReceivedListener_(messageData) {
+    GSC.Logging.checkWithLogger(this.logger, goog.isObject(messageData));
+    goog.asserts.assertObject(messageData);
 
-  this.registerRequestMessagesService_();
-}
+    const debugDump = GSC.DebugDump.debugDump(messageData);
 
-/**
- * Sets whether the message channel should be disposed when an invalid message
- * is received.
- *
- * By default, the message channel is not disposed in case of an invalid
- * message, and a fatal error is raised instead.
- * @param {boolean} shouldDisposeOnInvalidMessage
- */
-setShouldDisposeOnInvalidMessage(shouldDisposeOnInvalidMessage) {
-  this.shouldDisposeOnInvalidMessage_ = shouldDisposeOnInvalidMessage;
-}
-
-/** @private */
-registerRequestMessagesService_() {
-  const serviceName = RequesterMessage.getRequestMessageType(this.name_);
-  this.messageChannel_.registerService(
-      serviceName, this.requestMessageReceivedListener_.bind(this), true);
-}
-
-/**
- * @param {string|!Object} messageData
- * @private
- */
-requestMessageReceivedListener_(messageData) {
-  GSC.Logging.checkWithLogger(this.logger, goog.isObject(messageData));
-  goog.asserts.assertObject(messageData);
-
-  const debugDump = GSC.DebugDump.debugDump(messageData);
-
-  const requestMessageData = RequestMessageData.parseMessageData(messageData);
-  if (requestMessageData === null) {
-    if (this.shouldDisposeOnInvalidMessage_) {
-      goog.log.warning(
+    const requestMessageData = RequestMessageData.parseMessageData(messageData);
+    if (requestMessageData === null) {
+      if (this.shouldDisposeOnInvalidMessage_) {
+        goog.log.warning(
+            this.logger,
+            `Failed to parse the received request message: ${debugDump}, ` +
+                `disposing of the message channel...`);
+        this.messageChannel_.dispose();
+        return;
+      }
+      GSC.Logging.failWithLogger(
           this.logger,
-          `Failed to parse the received request message: ${debugDump}, ` +
-              `disposing of the message channel...`);
-      this.messageChannel_.dispose();
+          `Failed to parse the received request message: ${debugDump}`);
+    }
+
+    goog.log.fine(
+        this.logger,
+        `Received a request with requestId ${requestMessageData.requestId}, ` +
+            `the payload is: ${debugDump}`);
+
+    const promise = this.requestHandler_(requestMessageData.payload);
+    promise.then(
+        this.responseResolvedListener_.bind(this, requestMessageData),
+        this.responseRejectedListener_.bind(this, requestMessageData));
+  }
+
+  /**
+   * @param {!RequestMessageData} requestMessageData
+   * @param {*} payload
+   * @private
+   */
+  responseResolvedListener_(requestMessageData, payload) {
+    if (this.messageChannel_.isDisposed()) {
+      // Discard the response if it's impossible to send it anymore.
+      goog.log.fine(
+          this.logger,
+          `Cannot send result for requestId ${requestMessageData.requestId} ` +
+              `as message channel is shutdown`);
       return;
     }
-    GSC.Logging.failWithLogger(
-        this.logger,
-        `Failed to parse the received request message: ${debugDump}`);
-  }
 
-  goog.log.fine(
-      this.logger,
-      `Received a request with requestId ${requestMessageData.requestId}, ` +
-          `the payload is: ${debugDump}`);
-
-  const promise = this.requestHandler_(requestMessageData.payload);
-  promise.then(
-      this.responseResolvedListener_.bind(this, requestMessageData),
-      this.responseRejectedListener_.bind(this, requestMessageData));
-}
-
-/**
- * @param {!RequestMessageData} requestMessageData
- * @param {*} payload
- * @private
- */
-responseResolvedListener_(requestMessageData, payload) {
-  if (this.messageChannel_.isDisposed()) {
-    // Discard the response if it's impossible to send it anymore.
+    const debugDump = GSC.DebugDump.debugDump(payload);
     goog.log.fine(
         this.logger,
-        `Cannot send result for requestId ${requestMessageData.requestId} ` +
-            `as message channel is shutdown`);
-    return;
+        `Sending result for requestId ${requestMessageData.requestId}: ` +
+            `${debugDump}`);
+    this.sendResponse_(
+        new ResponseMessageData(requestMessageData.requestId, payload));
   }
 
-  const debugDump = GSC.DebugDump.debugDump(payload);
-  goog.log.fine(
-      this.logger,
-      `Sending result for requestId ${requestMessageData.requestId}: ` +
-          `${debugDump}`);
-  this.sendResponse_(
-      new ResponseMessageData(requestMessageData.requestId, payload));
-}
+  /**
+   * @param {!RequestMessageData} requestMessageData
+   * @param {*} error
+   * @private
+   */
+  responseRejectedListener_(requestMessageData, error) {
+    if (this.messageChannel_.isDisposed()) {
+      // Discard the response if it's impossible to send it anymore.
+      goog.log.fine(
+          this.logger,
+          `Cannot send error for requestId ${
+              requestMessageData.requestId} as ` +
+              `message channel is shutdown`);
+      return;
+    }
 
-/**
- * @param {!RequestMessageData} requestMessageData
- * @param {*} error
- * @private
- */
-responseRejectedListener_(requestMessageData, error) {
-  if (this.messageChannel_.isDisposed()) {
-    // Discard the response if it's impossible to send it anymore.
+    const stringifiedError = String(error);
     goog.log.fine(
         this.logger,
-        `Cannot send error for requestId ${requestMessageData.requestId} as ` +
-            `message channel is shutdown`);
-    return;
+        `Sending error for requestId ${requestMessageData.requestId}: ` +
+            `${stringifiedError}`);
+    this.sendResponse_(new ResponseMessageData(
+        requestMessageData.requestId, /*opt_payload=*/ undefined,
+        stringifiedError));
   }
 
-  const stringifiedError = String(error);
-  goog.log.fine(
-      this.logger,
-      `Sending error for requestId ${requestMessageData.requestId}: ` +
-          `${stringifiedError}`);
-  this.sendResponse_(new ResponseMessageData(
-      requestMessageData.requestId, /*opt_payload=*/ undefined,
-      stringifiedError));
-}
+  /**
+   * @param {!ResponseMessageData} responseMessageData
+   * @private
+   */
+  sendResponse_(responseMessageData) {
+    GSC.Logging.checkWithLogger(
+        this.logger, !this.messageChannel_.isDisposed());
 
-/**
- * @param {!ResponseMessageData} responseMessageData
- * @private
- */
-sendResponse_(responseMessageData) {
-  GSC.Logging.checkWithLogger(this.logger, !this.messageChannel_.isDisposed());
-
-  const messageData = responseMessageData.makeMessageData();
-  const serviceName = RequesterMessage.getResponseMessageType(this.name_);
-  this.messageChannel_.send(serviceName, messageData);
-}
+    const messageData = responseMessageData.makeMessageData();
+    const serviceName = RequesterMessage.getResponseMessageType(this.name_);
+    this.messageChannel_.send(serviceName, messageData);
+  }
 };
 });  // goog.scope


### PR DESCRIPTION
Migrate the
//common/js/src/requesting/request-receiver.js
file from legacy Closure Compiler classes to ES6 classes.

This is a pure refactoring change. It's is part of the effort to modernize the code base, as recent Closure Compiler versions stopped supporting the legacy class syntax.