### PR TITLE
Migrate Requester unittest to ES6 class

### DIFF
--- a/common/js/src/requesting/requester-unittest.js
+++ b/common/js/src/requesting/requester-unittest.js
@@ -36,8 +36,8 @@ const ResponseMessageData = GSC.RequesterMessage.ResponseMessageData;
 const getRequestMessageType = GSC.RequesterMessage.getRequestMessageType;
 const getResponseMessageType = GSC.RequesterMessage.getResponseMessageType;
 
-/** @constructor */
-function PromiseTracker(promise) {
+class PromiseTracker {
+constructor(promise) {
   this.isResolved = false;
   this.isFulfilled = false;
   this.isRejected = false;
@@ -45,14 +45,17 @@ function PromiseTracker(promise) {
       this.onPromiseFulfilled_.bind(this), this.onPromiseRejected_.bind(this));
 }
 
-PromiseTracker.prototype.onPromiseFulfilled_ = function() {
+/** @private */
+onPromiseFulfilled_() {
   this.isResolved = true;
   this.isFulfilled = true;
-};
+}
 
-PromiseTracker.prototype.onPromiseRejected_ = function() {
+/** @private */
+onPromiseRejected_() {
   this.isResolved = true;
   this.isRejected = true;
+}
 };
 
 goog.exportSymbol('testRequester', function() {

--- a/common/js/src/requesting/requester-unittest.js
+++ b/common/js/src/requesting/requester-unittest.js
@@ -37,25 +37,26 @@ const getRequestMessageType = GSC.RequesterMessage.getRequestMessageType;
 const getResponseMessageType = GSC.RequesterMessage.getResponseMessageType;
 
 class PromiseTracker {
-constructor(promise) {
-  this.isResolved = false;
-  this.isFulfilled = false;
-  this.isRejected = false;
-  promise.then(
-      this.onPromiseFulfilled_.bind(this), this.onPromiseRejected_.bind(this));
-}
+  constructor(promise) {
+    this.isResolved = false;
+    this.isFulfilled = false;
+    this.isRejected = false;
+    promise.then(
+        this.onPromiseFulfilled_.bind(this),
+        this.onPromiseRejected_.bind(this));
+  }
 
-/** @private */
-onPromiseFulfilled_() {
-  this.isResolved = true;
-  this.isFulfilled = true;
-}
+  /** @private */
+  onPromiseFulfilled_() {
+    this.isResolved = true;
+    this.isFulfilled = true;
+  }
 
-/** @private */
-onPromiseRejected_() {
-  this.isResolved = true;
-  this.isRejected = true;
-}
+  /** @private */
+  onPromiseRejected_() {
+    this.isResolved = true;
+    this.isRejected = true;
+  }
 };
 
 goog.exportSymbol('testRequester', function() {


### PR DESCRIPTION
Migrate the //common/js/src/requesting/requester-unittest.js file from legacy Closure Compiler classes to ES6 classes.

This is a pure refactoring change. It's is part of the effort to modernize the code base, as recent Closure Compiler versions stopped supporting the legacy class syntax.