### PR TITLE
Migrate BuiltInPinDialog.Backend to ES6 class

### DIFF
--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog-backend.js
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog-backend.js
@@ -66,18 +66,18 @@ const logger = GSC.Logging.getLogger('SmartCardClientApp.BuiltInPinDialog');
  * Once the message with the PIN request is received, opens the built-in PIN
  * dialog and, once it finishes, sends its result as a message through the
  * message channel.
- * @param {!goog.messaging.AbstractChannel} executableModuleMessageChannel
- * @constructor
  */
-SmartCardClientApp.BuiltInPinDialog.Backend = function(
-    executableModuleMessageChannel) {
-  // Note: the request receiver instance is not stored anywhere, as it makes
-  // itself being owned by the message channel.
-  new GSC.RequestReceiver(
-      REQUESTER_NAME, executableModuleMessageChannel, handleRequest);
+SmartCardClientApp.BuiltInPinDialog.Backend = class {
+  /**
+   * @param {!goog.messaging.AbstractChannel} executableModuleMessageChannel
+   */
+  constructor(executableModuleMessageChannel) {
+    // Note: the request receiver instance is not stored anywhere, as it makes
+    // itself being owned by the message channel.
+    new GSC.RequestReceiver(
+        REQUESTER_NAME, executableModuleMessageChannel, handleRequest);
+  }
 };
-
-const Backend = SmartCardClientApp.BuiltInPinDialog.Backend;
 
 /**
  * @param {!Object} payload


### PR DESCRIPTION
Migrate the
//example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog-backend.js file from legacy Closure Compiler classes to ES6 classes.

This is a pure refactoring change. It's is part of the effort to modernize the code base, as recent Closure Compiler versions stopped supporting the legacy class syntax.