### PR TITLE
Fix for inbound USB transfer overflow

### DIFF
--- a/third_party/libusb/webport/src/libusb_js_proxy.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy.h
@@ -139,6 +139,9 @@ class LibusbJsProxy final : public LibusbInterface {
                            int* actual_length,
                            unsigned timeout);
   void TryApplyTransientAccessErrorWorkaround(libusb_device* dev);
+  // Fetches the descriptor from the JS side and stores it in
+  // `libusb_device::js_config`.
+  void ObtainActiveConfigDescriptor(libusb_device* dev);
 
   // Helpers for making requests to the JavaScript side.
   JsRequester js_requester_;

--- a/third_party/libusb/webport/src/libusb_opaque_types.h
+++ b/third_party/libusb/webport/src/libusb_opaque_types.h
@@ -26,7 +26,6 @@
 
 #include <stdint.h>
 
-#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <map>
@@ -192,6 +191,14 @@ struct libusb_device final {
   libusb_context* context() const;
   const google_smart_card::LibusbJsDevice& js_device() const;
 
+  // Cached active config that was received by the most recent JS call.
+  google_smart_card::optional<
+      google_smart_card::LibusbJsConfigurationDescriptor>
+  js_config() const;
+  void set_js_config(
+      google_smart_card::optional<
+          google_smart_card::LibusbJsConfigurationDescriptor> new_js_config);
+
   // Increments the reference counter.
   void AddReference();
   // Decrements the reference counter. If it becomes equal to zero, then deletes
@@ -201,7 +208,12 @@ struct libusb_device final {
  private:
   libusb_context* const context_;
   const google_smart_card::LibusbJsDevice js_device_;
-  std::atomic_int reference_count_{1};
+
+  mutable std::mutex mutex_;
+  int reference_count_ = 1;
+  google_smart_card::optional<
+      google_smart_card::LibusbJsConfigurationDescriptor>
+      js_config_;
 };
 
 // Definition of the libusb_device_handle type declared in the libusb headers.


### PR DESCRIPTION
When making an inbound USB transfer request to the JavaScript side (chrome.usb or WebUSB), try to avoid using excessively small transfer lengths. Specifically, round up the transfer length to the nearest multiple of the packet size.

The background for this issue is that the JS APIs don't support timeouts and cancellation properly, which is why it can sometimes happen that an early API call is resolved with the data that was logically intended for a later call. If the early call specified a shorter expected length, it'd fail completely with an error ("babble" in WebUSB or "Inbound transfer overflow" in chrome.usb), leading to a loss of that data.

This is intended to mitigate (partially or fully) #779.