### PR TITLE
Fix build on Github Actions jammy

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -45,7 +45,7 @@ jobs:
       env:
         TOOLCHAIN: emscripten
         CONFIG: ${{ matrix.build-config }}
-      timeout-minutes: 10
+      timeout-minutes: 15
       run: >
         source env/activate && make test
 
@@ -131,7 +131,7 @@ jobs:
       env:
         TOOLCHAIN: asan_testing
         CONFIG: ${{ matrix.build-config }}
-      timeout-minutes: 10
+      timeout-minutes: 15
       run: >
         source env/activate && make test
 

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   # The version of libstdc++ to install for analysis builds.
-  ANALYSIS_LIBSTDCPP_VERSION: 10
+  ANALYSIS_LIBSTDCPP_VERSION: 12
 
 jobs:
   # Build and test in WebAssembly mode.

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       LINE_COVERAGE_PERCENT: ${{ steps.build-coverage.outputs.LINE_COVERAGE_PERCENT }}
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
     - name: Check out sources
       uses: actions/checkout@v3

--- a/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
+++ b/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
@@ -144,7 +144,7 @@ void PcscLiteServerDaemonThreadMain() {
   // TODO: Upstream's approach with a magic sleep is flaky: the background
   // thread might be still running after this point, causing crashes. Replace
   // this with a proper waiting mechanism.
-  SYS_Sleep(5);
+  SYS_Sleep(10);
   RFCleanupReaders();
   EHDeinitializeEventStructures();
   ContextsDeinitialize();


### PR DESCRIPTION
Fix compilation errors and timeouts in ASan and coverage jobs
in Continuous Integration. They started after Github Actions
updated to newer Ubuntu jammy.

Specifically, we bump `libstdc++-10-dev-i386-cross` to
`libstdc++-12-dev-i386-cross`. Also we increase test timeouts as
for some reason Debug builds got much slower.