### PR TITLE
Connector warns on concurrent PC/SC calls

### DIFF
--- a/common/cpp/build/tests/Makefile
+++ b/common/cpp/build/tests/Makefile
@@ -26,6 +26,7 @@ SOURCES_PATH := $(ROOT_SOURCES_PATH)/$(ROOT_SOURCES_SUBDIR)
 SOURCES := \
 	$(SOURCES_PATH)/formatting_unittest.cc \
 	$(SOURCES_PATH)/ipc_emulation_unittest.cc \
+	$(SOURCES_PATH)/join_string_unittest.cc \
 	$(SOURCES_PATH)/logging/hex_dumping_unittest.cc \
 	$(SOURCES_PATH)/logging/logging_unittest.cc \
 	$(SOURCES_PATH)/messaging/typed_message_router_unittest.cc \

--- a/common/cpp/src/google_smart_card_common/join_string.h
+++ b/common/cpp/src/google_smart_card_common/join_string.h
@@ -1,0 +1,49 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_SMART_CARD_COMMON_JOIN_STRING_H_
+#define GOOGLE_SMART_CARD_COMMON_JOIN_STRING_H_
+
+#include <string>
+
+namespace google_smart_card {
+
+template <typename Container>
+std::string JoinStrings(const Container& container,
+                        const std::string& separator) {
+  if (container.empty()) {
+    return "";
+  }
+
+  size_t need_size = separator.size() * (container.size() - 1);
+  for (const auto& item : container) {
+    need_size += item.length();
+  }
+
+  std::string joined;
+  joined.reserve(need_size);
+  bool is_first = true;
+  for (const auto& item : container) {
+    if (!is_first) {
+      joined += separator;
+    }
+    is_first = false;
+    joined += item;
+  }
+  return joined;
+}
+
+}  // namespace google_smart_card
+
+#endif  // GOOGLE_SMART_CARD_COMMON_JOIN_STRING_H_

--- a/common/cpp/src/google_smart_card_common/join_string_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/join_string_unittest.cc
@@ -1,0 +1,62 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google_smart_card_common/join_string.h>
+
+#include <set>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace google_smart_card {
+namespace {
+
+TEST(JoinString, EmptyVector) {
+  std::vector<std::string> vec;
+  EXPECT_EQ(JoinStrings(vec, /*separator=*/","), "");
+}
+
+TEST(JoinString, OneItemVector) {
+  std::vector<std::string> vec = {"foo"};
+  EXPECT_EQ(JoinStrings(vec, /*separator=*/","), "foo");
+}
+
+TEST(JoinString, TwoItemsVector) {
+  std::vector<std::string> vec = {"foo", "bar"};
+  EXPECT_EQ(JoinStrings(vec, /*separator=*/","), "foo,bar");
+}
+
+TEST(JoinString, TwoItemsSet) {
+  std::set<std::string> vec = {"a", "b"};
+  EXPECT_EQ(JoinStrings(vec, /*separator=*/" - "), "a - b");
+}
+
+TEST(JoinString, EmptySeparator) {
+  std::vector<std::string> vec = {"foo", "bar", "foo"};
+  EXPECT_EQ(JoinStrings(vec, /*separator=*/""), "foobarfoo");
+}
+
+TEST(JoinString, EmptyItem) {
+  std::vector<std::string> vec = {"foo", "", "bar"};
+  EXPECT_EQ(JoinStrings(vec, /*separator=*/","), "foo,,bar");
+}
+
+TEST(JoinString, EmptyItemsOnly) {
+  std::vector<std::string> vec = {"", "", ""};
+  EXPECT_EQ(JoinStrings(vec, /*separator=*/","), ",,");
+}
+
+}  // namespace
+}  // namespace google_smart_card

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_handles_registry.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_handles_registry.cc
@@ -103,6 +103,17 @@ bool PcscLiteClientHandlesRegistry::ContainsHandle(
   return handle_to_context_map_.count(s_card_handle);
 }
 
+SCARDCONTEXT PcscLiteClientHandlesRegistry::FindContextByHandle(
+    SCARDHANDLE s_card_handle) const {
+  const std::unique_lock<std::mutex> lock(mutex_);
+
+  auto iter = handle_to_context_map_.find(s_card_handle);
+  if (iter == handle_to_context_map_.end()) {
+    return 0;
+  }
+  return iter->second;
+}
+
 void PcscLiteClientHandlesRegistry::AddHandle(SCARDCONTEXT s_card_context,
                                               SCARDHANDLE s_card_handle) {
   const std::unique_lock<std::mutex> lock(mutex_);

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_handles_registry.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_handles_registry.h
@@ -62,6 +62,8 @@ class PcscLiteClientHandlesRegistry final {
   std::vector<SCARDCONTEXT> PopAllContexts();
 
   bool ContainsHandle(SCARDHANDLE s_card_handle) const;
+  // Returns the context that this handle refers to, or zero if none found.
+  SCARDCONTEXT FindContextByHandle(SCARDHANDLE s_card_handle) const;
   // Adds the handle to the data structure. CHECKs that it wasn't already
   // present.
   void AddHandle(SCARDCONTEXT s_card_context, SCARDHANDLE s_card_handle);

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.cc
@@ -249,7 +249,9 @@ PcscLiteClientRequestProcessor::ScopedConcurrencyGuard::ScopedConcurrencyGuard(
         << owner_.logging_prefix_
         << "Client violates threading: concurrent calls of " << function_name_
         << ", " << concurrent_functions_dump
-        << ". Future releases of Smart Card Connector will forbid this.";
+        << " against the same SCARDCONTEXT. Future releases of Smart Card "
+           "Connector will forbid this: every call referring to some "
+           "SCARDCONTEXT must come after the previous one completed.";
   }
 }
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.cc
@@ -1156,7 +1156,7 @@ void PcscLiteClientRequestProcessor::EnterConcurrencyCheckScope(
 
   GOOGLE_SMART_CARD_LOG_WARNING
       << logging_prefix_ << "Client violates threading: concurrent calls of "
-      << starting_function_name << concurrent_functions
+      << starting_function_name << ", " << concurrent_functions
       << ". Future releases of Smart Card Connector will forbid this.";
 }
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h
@@ -252,9 +252,6 @@ class PcscLiteClientRequestProcessor final
   void OnSCardContextRevoked(SCARDCONTEXT s_card_context);
   void OnSCardHandleRevoked(SCARDHANDLE s_card_handle);
 
-  void EnterConcurrencyCheckScope(const std::string& starting_function_name);
-  void LeaveConcurrencyCheckScope(const std::string& finished_function_name);
-
   const int64_t client_handler_id_;
   const std::string client_name_for_log_;
   const LogSeverity status_log_severity_;

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h
@@ -31,6 +31,8 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <mutex>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -228,6 +230,9 @@ class PcscLiteClientRequestProcessor final
   void OnSCardContextRevoked(SCARDCONTEXT s_card_context);
   void OnSCardHandleRevoked(SCARDHANDLE s_card_handle);
 
+  void EnterConcurrencyCheckScope(const std::string& starting_function_name);
+  void LeaveConcurrencyCheckScope(const std::string& finished_function_name);
+
   const int64_t client_handler_id_;
   const std::string client_name_for_log_;
   const LogSeverity status_log_severity_;
@@ -238,6 +243,9 @@ class PcscLiteClientRequestProcessor final
   // used to implement the client isolation: one client shouldn't be able to use
   // contexts/handles belonging to the other one.
   PcscLiteClientHandlesRegistry s_card_handles_registry_;
+
+  mutable std::mutex mutex_;
+  std::multiset<std::string> currently_running_functions_;
 };
 
 }  // namespace google_smart_card

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h
@@ -145,11 +145,13 @@ class PcscLiteClientRequestProcessor final
       std::function<GenericRequestResult(std::vector<Value> arguments)>;
   using HandlerMap = std::unordered_map<std::string, Handler>;
 
+  // Helper class for making updates to `context_to_running_functions_`. On
+  // construction, adds the given function name and logs a warning if misuse
+  // detected. On destruction, undoes the change.
   class ScopedConcurrencyGuard final {
    public:
     ScopedConcurrencyGuard(const std::string& function_name,
                            SCARDCONTEXT s_card_context,
-                           SCARDHANDLE s_card_handle,
                            PcscLiteClientRequestProcessor& owner);
 
     ScopedConcurrencyGuard(const ScopedConcurrencyGuard&) = delete;
@@ -159,8 +161,8 @@ class PcscLiteClientRequestProcessor final
 
    private:
     const std::string function_name_;
+    const SCARDCONTEXT s_card_context_;
     PcscLiteClientRequestProcessor& owner_;
-    SCARDCONTEXT s_card_context_ = 0;
   };
 
   friend class ScopedConcurrencyGuard;


### PR DESCRIPTION
Add warning logs into Smart Card Connector whenever a client application emits illegal concurrent PC/SC requests: an SCARDCONTEXT must only be used from a single thread (with the only exception of SCardCancel that can be called concurrently).

This is preparation for disallowing concurrent PC/SC calls in the future as planned in #136. Concurrent calls are not allowed by the PC/SC API specification, and the PC/SC-Lite's implementation breaks in subtle ways when this is violated.