### PR TITLE
Suppress Allstar reports on trusted binaries

### DIFF
--- a/.allstar/README.md
+++ b/.allstar/README.md
@@ -1,0 +1,8 @@
+Allstar (https://github.com/ossf/allstar/) is a GitHub App to set and enforce
+security policies.
+
+All Google managed GitHub repositories are subject to the default Allstar
+configuration.
+
+Files in this directory provide overrides to the default configuration in our
+repository.

--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -1,0 +1,5 @@
+ignoreFiles:
+# Suppress spurious "Security Policy violation" reports on files taken from
+# trusted upstream repositories as-is:
+- third_party/closure-compiler-binary/src/compiler.jar
+- third_party/closure-library/src/scripts/ci/CloseAdobeDialog.exe


### PR DESCRIPTION
Add Allstar config override in order to suppress spurious bug reports about binary files stored in our repository. Those binary files are fetched as-is from trusted upstream repositories.

This fixes #786.