### PR TITLE
Update format in Allstar config

### DIFF
--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -1,4 +1,4 @@
-ignoreFiles:
+ignorePaths:
 # Suppress spurious "Security Policy violation" reports on files taken from
 # trusted upstream repositories as-is:
 - third_party/closure-compiler-binary/src/compiler.jar


### PR DESCRIPTION
Presumably, there was a format error that led to Allstar ignoring our config: repo-level ignore lists should be called `ignorePaths`, not `ignoreFiles` (apparently the latter is only for org-level configs).

This fixes #786.