### PR TITLE
Workaround flaky ASan memory leaks in tests

### DIFF
--- a/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
+++ b/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
@@ -144,7 +144,11 @@ void PcscLiteServerDaemonThreadMain() {
   // TODO: Upstream's approach with a magic sleep is flaky: the background
   // thread might be still running after this point, causing crashes. Replace
   // this with a proper waiting mechanism.
+#ifdef __SANITIZE_ADDRESS__
+  SYS_Sleep(20);
+#else
   SYS_Sleep(10);
+#endif
   RFCleanupReaders();
   EHDeinitializeEventStructures();
   ContextsDeinitialize();


### PR DESCRIPTION
Similarly to #639, further increase the magic sleep delay when running in the ASan (Address Sanitizer) mode. It's a hack that should fix random test failures, until a proper fix is found.