### PR TITLE
Fix CI errors due to --experimental-wasm-bulk-memory

### DIFF
--- a/common/cpp_unit_test_runner/src/build_emscripten.mk
+++ b/common/cpp_unit_test_runner/src/build_emscripten.mk
@@ -86,11 +86,6 @@ $(GOOGLETEST_LIBS_PATTERN):
 #
 # Explanation of arguments:
 # DISPLAY: Workaround against "Permission denied" Node.js issue.
-# experimental-wasm-threads, experimental-wasm-bulk-memory: Needed for Pthreads
-#   (multi-threading) support.
 run_test: all
 	cd $(OUT_DIR_PATH) && DISPLAY= \
-		node \
-		--experimental-wasm-threads \
-		--experimental-wasm-bulk-memory \
-		$(TARGET).js
+		node $(TARGET).js


### PR DESCRIPTION
Don't pass the "--experimental-wasm-bulk-memory" and "--experimental-wasm-threads" flags to Node.JS when running unit tests of WebAssembly-compiled code. These flags are obsolete and cause errors when passed to recent Node.JS versions.

This fixes #796.