### PR TITLE
Fix Selenium desired_capabilities obsolete flag

### DIFF
--- a/common/js_test_runner/run-js-tests.py
+++ b/common/js_test_runner/run-js-tests.py
@@ -46,7 +46,7 @@ def create_driver(chromedriver_path):
   service = webdriver.chrome.service.Service(executable_path=chromedriver_path)
   options = webdriver.chrome.options.Options()
   # Collect all JS logs, not only warnings/errors which is the default.
-  options.set_capability('goog:loggingPrefs'], {'browser': 'ALL'})
+  options.set_capability('goog:loggingPrefs', {'browser': 'ALL'})
   return webdriver.Chrome(service=service, options=options)
 
 def load_test_page(driver, test_html_page_path):

--- a/common/js_test_runner/run-js-tests.py
+++ b/common/js_test_runner/run-js-tests.py
@@ -45,12 +45,9 @@ def create_driver(chromedriver_path):
   """Launches Chrome (Chromedriver) and returns the Selenium driver object."""
   service = webdriver.chrome.service.Service(executable_path=chromedriver_path)
   options = webdriver.chrome.options.Options()
-  capabilities = \
-      webdriver.common.desired_capabilities.DesiredCapabilities.CHROME.copy()
   # Collect all JS logs, not only warnings/errors which is the default.
-  capabilities['goog:loggingPrefs'] = {'browser': 'ALL'}
-  return webdriver.Chrome(service=service, options=options,
-                          desired_capabilities=capabilities)
+  options.set_capability('goog:loggingPrefs'], {'browser': 'ALL'})
+  return webdriver.Chrome(service=service, options=options)
 
 def load_test_page(driver, test_html_page_path):
   """Navigates the Chromedriver to the given page."""


### PR DESCRIPTION
Fix our test launcher helpers to stop using the "desired_capabilities"
parameter that was deprecated in Selenium 3.

This fixes #797.