### PR TITLE
Fix shutdown sleep for ASan builds

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -102,7 +102,7 @@ jobs:
   # Run unit tests under ASan.
   test-asan:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       matrix:
         build-config: [Release, Debug]
@@ -131,7 +131,7 @@ jobs:
       env:
         TOOLCHAIN: asan_testing
         CONFIG: ${{ matrix.build-config }}
-      timeout-minutes: 15
+      timeout-minutes: 30
       run: >
         source env/activate && make test
 

--- a/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
+++ b/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
@@ -144,9 +144,7 @@ void PcscLiteServerDaemonThreadMain() {
   // TODO: Upstream's approach with a magic sleep is flaky: the background
   // thread might be still running after this point, causing crashes. Replace
   // this with a proper waiting mechanism.
-#if defined(__SANITIZE_ADDRESS__) && !defined(NDEBUG)
-  SYS_Sleep(30);
-#elif defined(__SANITIZE_ADDRESS__) && defined(NDEBUG)
+#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
   SYS_Sleep(20);
 #else
   SYS_Sleep(10);

--- a/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
+++ b/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
@@ -144,7 +144,9 @@ void PcscLiteServerDaemonThreadMain() {
   // TODO: Upstream's approach with a magic sleep is flaky: the background
   // thread might be still running after this point, causing crashes. Replace
   // this with a proper waiting mechanism.
-#ifdef __SANITIZE_ADDRESS__
+#if defined(__SANITIZE_ADDRESS__) && !defined(NDEBUG)
+  SYS_Sleep(30);
+#elif defined(__SANITIZE_ADDRESS__) && defined(NDEBUG)
   SYS_Sleep(20);
 #else
   SYS_Sleep(10);


### PR DESCRIPTION
Fix the magic constant in the test shutdown logic to actually
wait for 2x as long when running under Address Sanitizer.

The old code was incorrectly determining ASan, and in result
was waiting for the same timeout regardless of the ASan.

This fixes #799.