### PR TITLE
Write Connector logs to systemLog

### DIFF
--- a/common/js/src/logging/log-buffer-forwarder.js
+++ b/common/js/src/logging/log-buffer-forwarder.js
@@ -113,8 +113,8 @@ GSC.LogBufferForwarder = class {
         this.ignoredLoggerNames_.has(logRecord.getLoggerName())) {
       return;
     }
-    const formattedLogRecord =
-        GSC.LogFormatting.formatLogRecord(documentLocation, logRecord);
+    const formattedLogRecord = GSC.LogFormatting.formatLogRecordForNaclStderr(
+        documentLocation, logRecord);
     if (!this.messageChannel_) {
       this.postponedLogRecords_.add(formattedLogRecord);
       return;

--- a/common/js/src/logging/log-buffer.js
+++ b/common/js/src/logging/log-buffer.js
@@ -216,8 +216,8 @@ GSC.LogBuffer = class extends goog.Disposable {
     for (const observer of this.observers_)
       observer(documentLocation, logRecord);
 
-    const formattedLogRecord =
-        GSC.LogFormatting.formatLogRecordCompact(documentLocation, logRecord);
+    const formattedLogRecord = GSC.LogFormatting.formatLogRecordForExportUi(
+        documentLocation, logRecord);
     this.addFormattedLogRecord_(formattedLogRecord);
   }
 

--- a/common/js/src/logging/log-formatting.js
+++ b/common/js/src/logging/log-formatting.js
@@ -33,10 +33,18 @@ const GSC = GoogleSmartCard;
 /**
  * @type {!goog.debug.TextFormatter}
  */
-const textFormatter = new goog.debug.TextFormatter();
-textFormatter.showAbsoluteTime = true;
-textFormatter.showRelativeTime = false;
-textFormatter.showSeverityLevel = true;
+const defaultFormatter = new goog.debug.TextFormatter();
+defaultFormatter.showAbsoluteTime = true;
+defaultFormatter.showRelativeTime = false;
+defaultFormatter.showSeverityLevel = true;
+
+/**
+ * @type {!goog.debug.TextFormatter}
+ */
+const systemLogFormatter = new goog.debug.TextFormatter();
+systemLogFormatter.showAbsoluteTime = false;
+systemLogFormatter.showRelativeTime = false;
+systemLogFormatter.showSeverityLevel = true;
 
 /**
  * @param {string} documentLocation
@@ -79,30 +87,45 @@ function prefixLogRecord(documentLocation, logRecord, isCompact) {
 }
 
 /**
- * Returns a formatted representation of the log record collected at the given
- * document.
+ * Returns a formatted representation of the log record suitable for logging
+ * into NaCl stderr console.
  * @param {string} documentLocation
  * @param {!goog.log.LogRecord} logRecord
  * @return {string}
  */
-GSC.LogFormatting.formatLogRecord = function(documentLocation, logRecord) {
-  return textFormatter.formatRecord(
+GSC.LogFormatting.formatLogRecordForNaclStderr = function(
+    documentLocation, logRecord) {
+  return defaultFormatter.formatRecord(
       prefixLogRecord(documentLocation, logRecord, /*isCompact=*/ false));
 };
 
 /**
- * Returns a formatted compact representation of the log record collected at the
- * given document.
+ * Returns a formatted representation of the log record suitable for the log
+ * dump that can be accessed via the extension's UI.
  *
- * The compact representation omits detailed context information, e.g. the
- * extension ID and the background page label.
+ * The representation omits the extension ID and the background page label.
  * @param {string} documentLocation
  * @param {!goog.log.LogRecord} logRecord
  * @return {string}
  */
-GSC.LogFormatting.formatLogRecordCompact = function(
+GSC.LogFormatting.formatLogRecordForExportUi = function(
     documentLocation, logRecord) {
-  return textFormatter.formatRecord(
+  return defaultFormatter.formatRecord(
+      prefixLogRecord(documentLocation, logRecord, /*isCompact=*/ true));
+};
+
+/**
+ * Returns a formatted representation of the log record suitable for the log
+ * dump that can be accessed via the extension's UI.
+ *
+ * The representation omits time, the extension ID, the background page label.
+ * @param {string} documentLocation
+ * @param {!goog.log.LogRecord} logRecord
+ * @return {string}
+ */
+GSC.LogFormatting.formatLogRecordForSystemLog = function(
+    documentLocation, logRecord) {
+  return systemLogFormatter.formatRecord(
       prefixLogRecord(documentLocation, logRecord, /*isCompact=*/ true));
 };
 });

--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -69,6 +69,16 @@ GSC.Logging.SELF_RELOAD_ON_FATAL_ERROR =
     goog.define('GoogleSmartCard.Logging.SELF_RELOAD_ON_FATAL_ERROR', false);
 
 /**
+ * @define {boolean} Whether to additionally send logs to the system log (see
+ * the `chrome.systemLog` API).
+ *
+ * The system log can be viewed on ChromeOS at chrome://device-log and is also
+ * included into Feedback Reports sent by users.
+ */
+GSC.Logging.WRITE_TO_SYSTEM_LOG =
+    goog.define('GoogleSmartCard.Logging.WRITE_TO_SYSTEM_LOG', false);
+
+/**
  * Every logger created via this library is created as a child of this logger,
  * as long as the |USE_SCOPED_LOGGERS| constant is true. Ignored when that
  * constant is false.
@@ -150,6 +160,9 @@ GSC.Logging.setupLogging = function() {
     return;
   wasLoggingSetUp = true;
 
+  if (GSC.Logging.WRITE_TO_SYSTEM_LOG) {
+    setupSystemLogLogging();
+  }
   setupConsoleLogging();
   setupRootLoggerLevel();
 
@@ -313,6 +326,25 @@ function reloadApp() {
 
   // This method works only in kiosk mode.
   chrome.runtime.restart();
+}
+
+function setupSystemLogLogging() {
+  // Access the Extension API via string literals, to make sure the Closure
+  // Compiler won't attempt type-checking or optimizations with it.
+  const systemLog = chrome['systemLog'];
+  if (!systemLog) {
+    // The API is unavailable - bail out silently.
+    return;
+  }
+  // Cache values that are common across all invocations of the handler below.
+  const systemLogAdd = systemLog['add'];
+  const documentLocation = getDocumentLocation();
+
+  goog.log.addHandler(rootLogger, (logRecord) => {
+    const formattedLogRecord = GSC.LogFormatting.formatLogRecordForSystemLog(
+        documentLocation, logRecord);
+    systemLogAdd({'message': formattedLogRecord});
+  });
 }
 
 function setupConsoleLogging() {

--- a/smart_card_connector_app/build/Makefile
+++ b/smart_card_connector_app/build/Makefile
@@ -58,8 +58,14 @@ include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/server_clients_management/inc
 
 SOURCES_PATH := ../src
 
+# Explanation of the arguments:
+# * SELF_RELOAD_ON_FATAL_ERROR - make the Smart Card Connector automatically
+#   restart itself whenever a fatal error (e.g., a binary code crash) occurs.
+# * WRITE_TO_SYSTEM_LOG - copy the Smart Card Connector logs to the system log
+#   via the `chrome.systemLog` API (to include them into Feedback Reports).
 JS_COMPILER_FLAGS := \
 	--define='GoogleSmartCard.Logging.SELF_RELOAD_ON_FATAL_ERROR=true' \
+	--define='GoogleSmartCard.Logging.WRITE_TO_SYSTEM_LOG=true' \
 
 
 #

--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -115,7 +115,11 @@ ${endif}
 
     # Needed to answer to PCSC requests from the browser. This is part of the
     # Web Smart Card API implementation.
-    "smartCardProviderPrivate"
+    "smartCardProviderPrivate",
+
+    # Used for copying the extension's logs into the system log (visible, e.g.,
+    # in Feedback Reports sent by users from Chromebooks).
+    "systemLog"
   ],
 
   # Allow any Extension/App and the specified web page URLs to send messages to


### PR DESCRIPTION
Use chrome.systemLog, when it's available (on ChromeOS >=111), in order to include Smart Card Connector's logs into the system logs.

The main benefit is that it makes the smart card logs being present in Feedback Reports that users send from Chromebooks, simplifying interaction with affected users and making it possible to investigate login-screen issues.