### PR TITLE
Downgrade GetActiveConfigDescriptor warning log

### DIFF
--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -1175,7 +1175,7 @@ void LibusbJsProxy::ObtainActiveConfigDescriptor(libusb_device* dev) {
   }
 
   if (!active_js_config) {
-    GOOGLE_SMART_CARD_LOG_WARNING
+    GOOGLE_SMART_CARD_LOG_DEBUG
         << "LibusbGetActiveConfigDescriptor request failed: No active config "
            "descriptors were returned by JS API";
     dev->set_js_config({});


### PR DESCRIPTION
Make following log debug-only instead of a WARNING:

  "LibusbGetActiveConfigDescriptor request failed: No active config
  descriptors were returned by JS API"

This log can be triggered when the USB device disappears suddenly (e.g., when transitioning to the ChromeOS Lock Screen). This is normal and doesn't deserve a warning log (which, e.g., results in showing a red "Errors" button at chrome://extensions).