### PR TITLE
Bulletproof C++-to-JS test's tearDown

### DIFF
--- a/common/integration_testing/src/google_smart_card_integration_testing/integration-test-controller.js
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration-test-controller.js
@@ -57,16 +57,17 @@ GSC.IntegrationTestController = class {
     return this.naclModule.getLoadPromise();
   }
 
-  /**
-   * @return {!goog.Promise<void>}
-   */
-  disposeAsync() {
-    return this.callCpp_('TearDownAll', /*functionArguments=*/[])
-        .thenAlways(() => {
-          this.naclModuleRequester_.dispose();
-          this.naclModule.dispose();
-          this.propertyReplacer.reset();
-        });
+  async disposeAsync() {
+    try {
+      if (!this.naclModule.isDisposed()) {
+        await this.callCpp_('TearDownAll', /*functionArguments=*/[]);
+      }
+    }
+    finally {
+      this.naclModuleRequester_.dispose();
+      this.naclModule.dispose();
+      this.propertyReplacer.reset();
+    }
   }
 
   /**


### PR DESCRIPTION
Avoid crashing in the integration test's tearDown in case setUp didn't succeed and the binary module wasn't loaded successfully.

We shouldn't attempt to make C++ calls in case the module isn't loaded.