### PR TITLE
Bail out loading NaCl module if unsupported env

### DIFF
--- a/common/js/src/nacl-module/nacl-module.js
+++ b/common/js/src/nacl-module/nacl-module.js
@@ -131,6 +131,12 @@ GSC.NaclModule = class extends GSC.ExecutableModule {
     GSC.Logging.checkWithLogger(this.logger_, document.body);
     document.body.appendChild(this.element_);
     this.forceElementLoading_();
+    if (!this.isElementProperlyCreated_()) {
+      goog.log.error(
+          this.logger_,
+          'NaCl embed construction failed: Native Client is likely disabled');
+      this.dispose();
+    }
   }
 
   /** @override */
@@ -258,6 +264,20 @@ GSC.NaclModule = class extends GSC.ExecutableModule {
     // Assign the result to a random property, so that Closure Compiler doesn't
     // optimize the "useless" expression away.
     this.element_.style.top = this.element_.offsetTop;
+  }
+
+  /**
+   * @private
+   * @return {boolean}
+   */
+  isElementProperlyCreated_() {
+    if (!this.element_) {
+      return false;
+    }
+    // If the browser doesn't have NaCl plugin installed, it'll silently fall
+    // back to creating the <embed> without any functionality. Detect this case
+    // by checking for an arbitrary NaCl-specific property.
+    return this.element_.hasOwnProperty('postMessage');
   }
 };
 


### PR DESCRIPTION
Detect the case when the NaCl module loading was silently ignored, and return an explicit error. This allows to clearly indicate error, e.g., when running tests in "pnacl" mode on desktop Chrome, as opposed to behaving as if the initialization takes infinitely long time.

We detect the error case by checking whether the `<embed>` that we create actually has NaCl-specific properties populated by the browser, i.e., "postMessage". That seems to be the simplest programmatic detection.