### PR TITLE
Increase stack size in Emscripten+Debug mode

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -144,6 +144,10 @@ EMSCRIPTEN_COMMON_FLAGS += \
 # DEMANGLE_SUPPORT: Demangle C++ function names in stack traces.
 # EXCEPTION_DEBUG: Enables printing exceptions coming from the executable.
 # SAFE_HEAP: Enable memory access checks.
+# TOTAL_STACK: Increase the initial stack size (Emscripten's default 64KB are
+#   very tight for Debug builds, and while some code in this project calls
+#   pthread_attr_setstacksize() its parameters aren't chosen with Emscripten
+#   Debug's heavy stack consumption in mind).
 # Wno-limited-postlink-optimizations: Suppress a warning about limited
 #   optimizations.
 EMSCRIPTEN_LINKER_FLAGS += \
@@ -151,6 +155,7 @@ EMSCRIPTEN_LINKER_FLAGS += \
   -s DEMANGLE_SUPPORT=1 \
   -s EXCEPTION_DEBUG=1 \
   -s SAFE_HEAP=1 \
+  -s TOTAL_STACK=1048576 \
   -Wno-limited-postlink-optimizations \
 
 else


### PR DESCRIPTION
Use 1MiB of stack for all threads in C/C++ code when compiled in TOOLCHAIN=emscripten CONFIG=Debug. This should fix the stack overflow issues that were surfaced when trying to uprev Emscripten to 3.1.42 (either the stack consumption increased because of compiler change, or Emscripten became better at catching stack overflows).

By default recent Emscripten versions use very small stack (64KiB). The PC/SC-Lite code is actually trying to handle such tight environments by calling pthread_attr_setstacksize() with 256KiB for the "heavy" threads, however this turns out to be insufficient for Emscripten Debug builds.

Our fix doesn't touch this logic (assuming it's not ideal to patch PC/SC-Lite with Emscripten-specific things), and instead we tweak our build scripnts to pass an extra STACK_SIZE flag when compiled in the specific mode.