### PR TITLE
Add listeners for connection events of chrome.smartCardProviderPrivate API

### DIFF
--- a/smart_card_connector_app/src/chrome-api-provider.js
+++ b/smart_card_connector_app/src/chrome-api-provider.js
@@ -286,6 +286,15 @@ function convertProtocolToPci(protocol) {
 }
 
 /**
+ * Logs that that the encountered combination of connection state flags
+ * is not expected from PCSC-lite.
+ * @param {number} state
+ */
+function logUnexpectedConnectionState(state) {
+  goog.log.warning(logger, `Unexpected connection state bitmask: ${state}`)
+}
+
+/**
  * Converts from a PCSC API value to a
  * chrome.smartCardProviderPrivate.ConnectionState. We only take the highest bit
  * of the value, since it contains all the needed information, e.g.
@@ -295,18 +304,40 @@ function convertProtocolToPci(protocol) {
  * @throws {Error} Throws error if unknown connection state is encountered.
  */
 function convertConnectionStateToEnum(state) {
-  if (state & PcscApi.SCARD_SPECIFIC)
+  if (state & PcscApi.SCARD_SPECIFIC) {
+    if (state !==
+        (PcscApi.SCARD_SPECIFIC | PcscApi.SCARD_POWERED |
+         PcscApi.SCARD_PRESENT))
+      logUnexpectedConnectionState(state);
     return chrome.smartCardProviderPrivate.ConnectionState.SPECIFIC;
-  if (state & PcscApi.SCARD_NEGOTIABLE)
+  }
+  if (state & PcscApi.SCARD_NEGOTIABLE) {
+    if (state !==
+        (PcscApi.SCARD_NEGOTIABLE | PcscApi.SCARD_POWERED |
+         PcscApi.SCARD_PRESENT))
+      logUnexpectedConnectionState(state);
     return chrome.smartCardProviderPrivate.ConnectionState.NEGOTIABLE;
-  if (state & PcscApi.SCARD_POWERED)
+  }
+  if (state & PcscApi.SCARD_POWERED) {
+    if (state !== (PcscApi.SCARD_POWERED | PcscApi.SCARD_PRESENT))
+      logUnexpectedConnectionState(state);
     return chrome.smartCardProviderPrivate.ConnectionState.POWERED;
-  if (state & PcscApi.SCARD_SWALLOWED)
+  }
+  if (state & PcscApi.SCARD_SWALLOWED) {
+    if (state !== (PcscApi.SCARD_SWALLOWED | PcscApi.SCARD_PRESENT))
+      logUnexpectedConnectionState(state);
     return chrome.smartCardProviderPrivate.ConnectionState.SWALLOWED;
-  if (state & PcscApi.SCARD_PRESENT)
+  }
+  if (state & PcscApi.SCARD_PRESENT) {
+    if (state !== PcscApi.SCARD_PRESENT)
+      logUnexpectedConnectionState(state);
     return chrome.smartCardProviderPrivate.ConnectionState.PRESENT;
-  if (state & PcscApi.SCARD_ABSENT)
+  }
+  if (state & PcscApi.SCARD_ABSENT) {
+    if (state !== PcscApi.SCARD_ABSENT)
+      logUnexpectedConnectionState(state);
     return chrome.smartCardProviderPrivate.ConnectionState.ABSENT;
+  }
   throw new Error(`Unknown connection state value ${state} encountered`);
 }
 

--- a/smart_card_connector_app/src/chrome-api-provider.js
+++ b/smart_card_connector_app/src/chrome-api-provider.js
@@ -190,7 +190,7 @@ function convertReaderStateOut(readerState) {
  * to a PCSC API value.
  * @param {!chrome.smartCardProviderPrivate.ShareMode} shareMode
  * @returns {number}
- * @throws {Error} Throws if unknown share mode in encountered.
+ * @throws {Error} Throws if unknown share mode is encountered.
  */
 function convertShareModeToNumber(shareMode) {
   switch (shareMode) {
@@ -223,10 +223,10 @@ function convertProtocolsToNumber(protocols) {
 }
 
 /**
- * Converts from a PCSC API value to chrome.smartCardProviderPrivate.Protocol.
+ * Converts from a PCSC API value to a chrome.smartCardProviderPrivate.Protocol.
  * @param {number} protocol
  * @returns {!chrome.smartCardProviderPrivate.Protocol}
- * @throws {Error} Throws error if unknown protocol in encountered.
+ * @throws {Error} Throws error if unknown protocol is encountered.
  */
 function convertProtocolToEnum(protocol) {
   switch (protocol) {
@@ -248,7 +248,7 @@ function convertProtocolToEnum(protocol) {
  * to a PCSC API value.
  * @param {!chrome.smartCardProviderPrivate.Disposition} disposition
  * @returns {number}
- * @throws {Error} Throws error if unknown disposition in encountered.
+ * @throws {Error} Throws error if unknown disposition is encountered.
  */
 function convertDispositionToNumber(disposition) {
   switch (disposition) {
@@ -263,6 +263,51 @@ function convertDispositionToNumber(disposition) {
     default:
       throw new Error(`Unknown disposition value ${disposition} encountered`);
   }
+}
+
+/**
+ * Converts a chrome.smartCardProviderPrivate.Protocol to a predefined
+ * Protocol Control Information structure used in PCSC API.
+ * @param {!chrome.smartCardProviderPrivate.Protocol} protocol
+ * @returns {!PcscApi.SCARD_IO_REQUEST}
+ * @throws {Error} Throws error if unknown protocol is encountered.
+ */
+function convertProtocolToPci(protocol) {
+  switch (protocol) {
+    case chrome.smartCardProviderPrivate.Protocol.T0:
+      return PcscApi.SCARD_PCI_T0;
+    case chrome.smartCardProviderPrivate.Protocol.T1:
+      return PcscApi.SCARD_PCI_T1;
+    case chrome.smartCardProviderPrivate.Protocol.RAW:
+      return PcscApi.SCARD_PCI_RAW;
+    default:
+      throw new Error(`No predefined PCI structure for protocol ${protocol}`);
+  }
+}
+
+/**
+ * Converts from a PCSC API value to a
+ * chrome.smartCardProviderPrivate.ConnectionState. We only take the highest bit
+ * of the value, since it contains all the needed information, e.g.
+ * SCARD_NEGOTIABLE implies that SCARD_POWERED and SCARD_PRESENT are also set.
+ * @param {number} state
+ * @returns {!chrome.smartCardProviderPrivate.ConnectionState}
+ * @throws {Error} Throws error if unknown connection state is encountered.
+ */
+function convertConnectionStateToEnum(state) {
+  if (state & PcscApi.SCARD_SPECIFIC)
+    return chrome.smartCardProviderPrivate.ConnectionState.SPECIFIC;
+  if (state & PcscApi.SCARD_NEGOTIABLE)
+    return chrome.smartCardProviderPrivate.ConnectionState.NEGOTIABLE;
+  if (state & PcscApi.SCARD_POWERED)
+    return chrome.smartCardProviderPrivate.ConnectionState.POWERED;
+  if (state & PcscApi.SCARD_SWALLOWED)
+    return chrome.smartCardProviderPrivate.ConnectionState.SWALLOWED;
+  if (state & PcscApi.SCARD_PRESENT)
+    return chrome.smartCardProviderPrivate.ConnectionState.PRESENT;
+  if (state & PcscApi.SCARD_ABSENT)
+    return chrome.smartCardProviderPrivate.ConnectionState.ABSENT;
+  throw new Error(`Unknown connection state value ${state} encountered`);
 }
 
 /**
@@ -361,6 +406,27 @@ GSC.ConnectorApp.ChromeApiProvider = class extends goog.Disposable {
     this.chromeEventListeners_.push(new ChromeEventListener(
         chrome.smartCardProviderPrivate.onDisconnectRequested,
         (...args) => this.disconnectListener_(...args)));
+    this.chromeEventListeners_.push(new ChromeEventListener(
+        chrome.smartCardProviderPrivate.onTransmitRequested,
+        (...args) => this.transmitListener_(...args)));
+    this.chromeEventListeners_.push(new ChromeEventListener(
+        chrome.smartCardProviderPrivate.onControlRequested,
+        (...args) => this.controlListener_(...args)));
+    this.chromeEventListeners_.push(new ChromeEventListener(
+        chrome.smartCardProviderPrivate.onGetAttribRequested,
+        (...args) => this.getAttribListener_(...args)));
+    this.chromeEventListeners_.push(new ChromeEventListener(
+        chrome.smartCardProviderPrivate.onSetAttribRequested,
+        (...args) => this.setAttribListener_(...args)));
+    this.chromeEventListeners_.push(new ChromeEventListener(
+        chrome.smartCardProviderPrivate.onStatusRequested,
+        (...args) => this.statusListener_(...args)));
+    this.chromeEventListeners_.push(new ChromeEventListener(
+        chrome.smartCardProviderPrivate.onBeginTransactionRequested,
+        (...args) => this.beginTransactionListener_(...args)));
+    this.chromeEventListeners_.push(new ChromeEventListener(
+        chrome.smartCardProviderPrivate.onEndTransactionRequested,
+        (...args) => this.endTransactionListener_(...args)));
   }
 
   /**
@@ -642,6 +708,280 @@ GSC.ConnectorApp.ChromeApiProvider = class extends goog.Disposable {
           logger,
           this.isDisposed() ? goog.log.Level.FINE : goog.log.Level.WARNING,
           'Failed to process onDisconnectRequested event ' +
+              `with request id ${requestId}: ${error}`);
+    }
+
+    chrome.smartCardProviderPrivate.reportPlainResult(requestId, resultCode);
+  }
+
+  /**
+   * @param {number} requestId
+   * @param {number} sCardHandle
+   * @param {!chrome.smartCardProviderPrivate.Protocol} protocol
+   * @param {!ArrayBuffer} data
+   * @private
+   */
+  async transmitListener_(requestId, sCardHandle, protocol, data) {
+    let resultCode = chrome.smartCardProviderPrivate.ResultCode.INTERNAL_ERROR;
+    /** @type {!ArrayBuffer} */
+    let resultData = new ArrayBuffer(0);
+
+    try {
+      const callArguments =
+          [sCardHandle, convertProtocolToPci(protocol), data, null];
+      const remoteCallMessage =
+          new GSC.RemoteCallMessage('SCardTransmit', callArguments);
+      const responseItems =
+          await this.serverRequester_.handleRequest(remoteCallMessage);
+
+      const result = new PcscApi.SCardTransmitResult(responseItems);
+      result.get(
+          (pci, data) => {
+            resultData = data;
+            resultCode = chrome.smartCardProviderPrivate.ResultCode.SUCCESS;
+          },
+          (errorCode) => {
+            resultCode = convertErrorCodeToEnum(errorCode);
+          });
+    } catch (error) {
+      goog.log.log(
+          logger,
+          this.isDisposed() ? goog.log.Level.FINE : goog.log.Level.WARNING,
+          'Failed to process onTransmitRequested event ' +
+              `with request id ${requestId}: ${error}`);
+    }
+
+    chrome.smartCardProviderPrivate.reportDataResult(
+        requestId, resultData, resultCode);
+  }
+
+  /**
+   * @param {number} requestId
+   * @param {number} sCardHandle
+   * @param {number} controlCode
+   * @param {!ArrayBuffer} data
+   * @private
+   */
+  async controlListener_(requestId, sCardHandle, controlCode, data) {
+    let resultCode = chrome.smartCardProviderPrivate.ResultCode.INTERNAL_ERROR;
+    /** @type {!ArrayBuffer} */
+    let resultData = new ArrayBuffer(0);
+
+    try {
+      const callArguments = [sCardHandle, controlCode, data];
+      const remoteCallMessage =
+          new GSC.RemoteCallMessage('SCardControl', callArguments);
+      const responseItems =
+          await this.serverRequester_.handleRequest(remoteCallMessage);
+
+      const result = new PcscApi.SCardControlResult(responseItems);
+      result.get(
+          (data) => {
+            resultData = data;
+            resultCode = chrome.smartCardProviderPrivate.ResultCode.SUCCESS;
+          },
+          (errorCode) => {
+            resultCode = convertErrorCodeToEnum(errorCode);
+          });
+    } catch (error) {
+      goog.log.log(
+          logger,
+          this.isDisposed() ? goog.log.Level.FINE : goog.log.Level.WARNING,
+          'Failed to process onControlRequested event ' +
+              `with request id ${requestId}: ${error}`);
+    }
+
+    chrome.smartCardProviderPrivate.reportDataResult(
+        requestId, resultData, resultCode);
+  }
+
+  /**
+   * @param {number} requestId
+   * @param {number} sCardHandle
+   * @param {number} attribId
+   * @private
+   */
+  async getAttribListener_(requestId, sCardHandle, attribId) {
+    let resultCode = chrome.smartCardProviderPrivate.ResultCode.INTERNAL_ERROR;
+    /** @type {!ArrayBuffer} */
+    let resultData = new ArrayBuffer(0);
+
+    try {
+      const callArguments = [sCardHandle, attribId];
+      const remoteCallMessage =
+          new GSC.RemoteCallMessage('SCardGetAttrib', callArguments);
+      const responseItems =
+          await this.serverRequester_.handleRequest(remoteCallMessage);
+
+      const result = new PcscApi.SCardGetAttribResult(responseItems);
+      result.get(
+          (data) => {
+            resultData = data;
+            resultCode = chrome.smartCardProviderPrivate.ResultCode.SUCCESS;
+          },
+          (errorCode) => {
+            resultCode = convertErrorCodeToEnum(errorCode);
+          });
+    } catch (error) {
+      goog.log.log(
+          logger,
+          this.isDisposed() ? goog.log.Level.FINE : goog.log.Level.WARNING,
+          'Failed to process onGetAttribRequested event ' +
+              `with request id ${requestId}: ${error}`);
+    }
+
+    chrome.smartCardProviderPrivate.reportDataResult(
+        requestId, resultData, resultCode);
+  }
+
+  /**
+   * @param {number} requestId
+   * @param {number} sCardHandle
+   * @param {number} attribId
+   * @param {!ArrayBuffer} data
+   * @private
+   */
+  async setAttribListener_(requestId, sCardHandle, attribId, data) {
+    let resultCode = chrome.smartCardProviderPrivate.ResultCode.INTERNAL_ERROR;
+
+    try {
+      const callArguments = [sCardHandle, attribId, data];
+      const remoteCallMessage =
+          new GSC.RemoteCallMessage('SCardSetAttrib', callArguments);
+      const responseItems =
+          await this.serverRequester_.handleRequest(remoteCallMessage);
+
+      const result = new PcscApi.SCardSetAttribResult(responseItems);
+      result.get(
+          () => {
+            resultCode = chrome.smartCardProviderPrivate.ResultCode.SUCCESS;
+          },
+          (errorCode) => {
+            resultCode = convertErrorCodeToEnum(errorCode);
+          });
+    } catch (error) {
+      goog.log.log(
+          logger,
+          this.isDisposed() ? goog.log.Level.FINE : goog.log.Level.WARNING,
+          'Failed to process onSetAttribRequested event ' +
+              `with request id ${requestId}: ${error}`);
+    }
+
+    chrome.smartCardProviderPrivate.reportPlainResult(requestId, resultCode);
+  }
+
+  /**
+   * @param {number} requestId
+   * @param {number} sCardHandle
+   * @private
+   */
+  async statusListener_(requestId, sCardHandle) {
+    let resultCode = chrome.smartCardProviderPrivate.ResultCode.INTERNAL_ERROR;
+    /** @type {string} */
+    let resultReaderName = '';
+    /** @type {!chrome.smartCardProviderPrivate.ConnectionState} */
+    let resultState = chrome.smartCardProviderPrivate.ConnectionState.ABSENT;
+    /** @type {!chrome.smartCardProviderPrivate.Protocol} */
+    let resultProtocol = chrome.smartCardProviderPrivate.Protocol.UNDEFINED;
+    /** @type {!ArrayBuffer} */
+    let resultAtr = new ArrayBuffer(0);
+
+    try {
+      const callArguments = [sCardHandle];
+      const remoteCallMessage =
+          new GSC.RemoteCallMessage('SCardStatus', callArguments);
+      const responseItems =
+          await this.serverRequester_.handleRequest(remoteCallMessage);
+
+      const result = new PcscApi.SCardStatusResult(responseItems);
+      result.get(
+          (readerName, state, protocol, atr) => {
+            resultReaderName = readerName;
+            resultState = convertConnectionStateToEnum(state);
+            resultProtocol = convertProtocolToEnum(protocol);
+            resultAtr = atr;
+            resultCode = chrome.smartCardProviderPrivate.ResultCode.SUCCESS;
+          },
+          (errorCode) => {
+            resultCode = convertErrorCodeToEnum(errorCode);
+          });
+    } catch (error) {
+      goog.log.log(
+          logger,
+          this.isDisposed() ? goog.log.Level.FINE : goog.log.Level.WARNING,
+          'Failed to process onStatusRequested event ' +
+              `with request id ${requestId}: ${error}`);
+    }
+
+    chrome.smartCardProviderPrivate.reportStatusResult(
+        requestId, resultReaderName, resultState, resultProtocol, resultAtr,
+        resultCode);
+  }
+
+  /**
+   * @param {number} requestId
+   * @param {number} sCardHandle
+   * @private
+   */
+  async beginTransactionListener_(requestId, sCardHandle) {
+    let resultCode = chrome.smartCardProviderPrivate.ResultCode.INTERNAL_ERROR;
+
+    try {
+      const callArguments = [sCardHandle];
+      const remoteCallMessage =
+          new GSC.RemoteCallMessage('SCardBeginTransaction', callArguments);
+      const responseItems =
+          await this.serverRequester_.handleRequest(remoteCallMessage);
+
+      const result = new PcscApi.SCardBeginTransactionResult(responseItems);
+      result.get(
+          () => {
+            resultCode = chrome.smartCardProviderPrivate.ResultCode.SUCCESS;
+          },
+          (errorCode) => {
+            resultCode = convertErrorCodeToEnum(errorCode);
+          });
+    } catch (error) {
+      goog.log.log(
+          logger,
+          this.isDisposed() ? goog.log.Level.FINE : goog.log.Level.WARNING,
+          'Failed to process onBeginTransactionRequested event ' +
+              `with request id ${requestId}: ${error}`);
+    }
+
+    chrome.smartCardProviderPrivate.reportPlainResult(requestId, resultCode);
+  }
+
+  /**
+   * @param {number} requestId
+   * @param {number} sCardHandle
+   * @param {!chrome.smartCardProviderPrivate.Disposition} disposition
+   * @private
+   */
+  async endTransactionListener_(requestId, sCardHandle, disposition) {
+    let resultCode = chrome.smartCardProviderPrivate.ResultCode.INTERNAL_ERROR;
+
+    try {
+      const callArguments =
+          [sCardHandle, convertDispositionToNumber(disposition)];
+      const remoteCallMessage =
+          new GSC.RemoteCallMessage('SCardEndTransaction', callArguments);
+      const responseItems =
+          await this.serverRequester_.handleRequest(remoteCallMessage);
+
+      const result = new PcscApi.SCardEndTransactionResult(responseItems);
+      result.get(
+          () => {
+            resultCode = chrome.smartCardProviderPrivate.ResultCode.SUCCESS;
+          },
+          (errorCode) => {
+            resultCode = convertErrorCodeToEnum(errorCode);
+          });
+    } catch (error) {
+      goog.log.log(
+          logger,
+          this.isDisposed() ? goog.log.Level.FINE : goog.log.Level.WARNING,
+          'Failed to process onEndTransactionRequested event ' +
               `with request id ${requestId}: ${error}`);
     }
 

--- a/third_party/closure-compiler/src_additional/chrome_extensions.js
+++ b/third_party/closure-compiler/src_additional/chrome_extensions.js
@@ -396,6 +396,18 @@ chrome.smartCardProviderPrivate.Disposition = {
 };
 
 /**
+ * @enum {string}
+ */
+chrome.smartCardProviderPrivate.ConnectionState = {
+  ABSENT: 'ABSENT',
+  PRESENT: 'PRESENT',
+  SWALLOWED: 'SWALLOWED',
+  POWERED: 'POWERED',
+  NEGOTIABLE: 'NEGOTIABLE',
+  SPECIFIC: 'SPECIFIC',
+};
+
+/**
  * @typedef {{
  *   unaware: (boolean|undefined),
  *   ignore: (boolean|undefined),
@@ -488,6 +500,43 @@ chrome.smartCardProviderPrivate.onConnectRequested;
 chrome.smartCardProviderPrivate.onDisconnectRequested;
 
 /**
+ * @type {!ChromeBaseEvent<function(number, number,
+ *     !chrome.smartCardProviderPrivate.Protocol, !ArrayBuffer)>}
+ */
+chrome.smartCardProviderPrivate.onTransmitRequested;
+
+/**
+ * @type {!ChromeBaseEvent<function(number, number, number, !ArrayBuffer)>}
+ */
+chrome.smartCardProviderPrivate.onControlRequested;
+
+/**
+ * @type {!ChromeBaseEvent<function(number, number, number)>}
+ */
+chrome.smartCardProviderPrivate.onGetAttribRequested;
+
+/**
+ * @type {!ChromeBaseEvent<function(number, number, number, !ArrayBuffer)>}
+ */
+chrome.smartCardProviderPrivate.onSetAttribRequested;
+
+/**
+ * @type {!ChromeBaseEvent<function(number, number)>}
+ */
+chrome.smartCardProviderPrivate.onStatusRequested;
+
+/**
+ * @type {!ChromeBaseEvent<function(number, number)>}
+ */
+chrome.smartCardProviderPrivate.onBeginTransactionRequested;
+
+/**
+ * @type {!ChromeBaseEvent<function(number, number,
+ *     !chrome.smartCardProviderPrivate.Disposition)>}
+ */
+chrome.smartCardProviderPrivate.onEndTransactionRequested;
+
+/**
  * @param {number} requestId
  * @param {number} sCardContext
  * @param {!chrome.smartCardProviderPrivate.ResultCode} resultCode
@@ -532,3 +581,22 @@ chrome.smartCardProviderPrivate.reportPlainResult = function(
  */
 chrome.smartCardProviderPrivate.reportConnectResult = function(
     requestId, sCardHandle, activeProtocol, resultCode) {};
+
+/**
+ * @param {number} requestId
+ * @param {!ArrayBuffer} data
+ * @param {!chrome.smartCardProviderPrivate.ResultCode} resultCode
+ */
+chrome.smartCardProviderPrivate.reportDataResult = function(
+    requestId, data, resultCode) {};
+
+/**
+ * @param {number} requestId
+ * @param {string} readerName
+ * @param {!chrome.smartCardProviderPrivate.ConnectionState} state
+ * @param {!chrome.smartCardProviderPrivate.Protocol} protocol
+ * @param {!ArrayBuffer} atr
+ * @param {!chrome.smartCardProviderPrivate.ResultCode} resultCode
+ */
+chrome.smartCardProviderPrivate.reportStatusResult = function(
+    requestId, readerName, state, protocol, atr, resultCode) {};


### PR DESCRIPTION
This CL add listeners of the following events to the `ChromeApiProvider`:
- chrome.smartCardProviderPrivate.onTransmitRequested
- chrome.smartCardProviderPrivate.onControlRequested
- chrome.smartCardProviderPrivate.onGetAttribRequested
- chrome.smartCardProviderPrivate.onSetAttribRequested
- chrome.smartCardProviderPrivate.onStatusRequested
- chrome.smartCardProviderPrivate.onBeginTransactionRequested
- chrome.smartCardProviderPrivate.onEndTransactionRequested