### PR TITLE
Use RUNTIME_DEBUG=0 in Emscripten+Debug

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -143,6 +143,7 @@ EMSCRIPTEN_COMMON_FLAGS += \
 # ASSERTIONS: Enable runtime checks, like for memory allocation errors.
 # DEMANGLE_SUPPORT: Demangle C++ function names in stack traces.
 # EXCEPTION_DEBUG: Enables printing exceptions coming from the executable.
+# RUNTIME_DEBUG: Disables verbose tracing logs.
 # SAFE_HEAP: Enable memory access checks.
 # TOTAL_STACK: Increase the initial stack size (Emscripten's default 64KB are
 #   very tight for Debug builds, and while some code in this project calls
@@ -154,6 +155,7 @@ EMSCRIPTEN_LINKER_FLAGS += \
   -s ASSERTIONS=2 \
   -s DEMANGLE_SUPPORT=1 \
   -s EXCEPTION_DEBUG=1 \
+  -s RUNTIME_DEBUG=0 \
   -s SAFE_HEAP=1 \
   -s TOTAL_STACK=1048576 \
   -Wno-limited-postlink-optimizations \


### PR DESCRIPTION
Pass "-s RUNTIME_DEBUG=0" when linking Emscripten
code in Debug mode.

This is to suppress the very verbose logging that
recent versions of Emscripten runtime emit on some internal events (e.g., each time stack size changes). The RUNTIME_DEBUG flag, if not explicitly specified, gets auto-enabled when other *_DEBUG flags are,
which happened in our case as we use EXCEPTION_DEBUG.