### PR TITLE
Release Connector 1.3.14.0

### DIFF
--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -23,7 +23,7 @@ ${endif}
   "short_name": "__MSG_appShortName__",
   "description": "__MSG_appDesc__",
 
-  "version": "1.3.10.0",
+  "version": "1.3.14.0",
 
   # Whether an application is an App or an Extension is determined by nesting or
   # not nesting the background script information under the "app" key.


### PR DESCRIPTION
Note that this release is forked from the old 1.3.10.1 branch, so that we can perform the rollback on WebStore (i.e., publish 1.3.10.1's code under the new version 1.3.14.0).