### PR TITLE
Add event count to the reader state

### DIFF
--- a/third_party/closure-compiler/src_additional/chrome_extensions.js
+++ b/third_party/closure-compiler/src_additional/chrome_extensions.js
@@ -447,6 +447,7 @@ chrome.smartCardProviderPrivate.Protocol = {
  * @typedef {{
  *   reader: string,
  *   currentState: !chrome.smartCardProviderPrivate.ReaderStateFlags,
+ *   currentCount: number,
  * }}
  */
 chrome.smartCardProviderPrivate.ReaderStateIn;
@@ -455,6 +456,7 @@ chrome.smartCardProviderPrivate.ReaderStateIn;
  * @typedef {{
  *   reader: string,
  *   eventState: !chrome.smartCardProviderPrivate.ReaderStateFlags,
+ *   eventCount: number,
  *   atr: !ArrayBuffer,
  * }}
  */


### PR DESCRIPTION
Added event count to the chrome.smartCardProviderPrivate.ReaderStateIn/Out, as was discussed [here](https://github.com/GoogleChromeLabs/chromeos_smart_card_connector/pull/806#discussion_r1239633625).