### PR TITLE
Add abstract PermissionsChecker interface

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
@@ -31,6 +31,7 @@ goog.provide('GoogleSmartCard.PcscLiteServerClientsManagement.ClientHandler');
 goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.DeferredProcessor');
 goog.require('GoogleSmartCard.Logging');
+goog.require('GoogleSmartCard.Pcsc.PermissionsChecker');
 goog.require('GoogleSmartCard.Pcsc.PolicyOrPromptingPermissionsChecker');
 goog.require('GoogleSmartCard.PcscLiteCommon.Constants');
 goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.ServerRequestHandler');

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/permissions-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/permissions-checker.js
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2023 Google Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+goog.provide('GoogleSmartCard.Pcsc.PermissionsChecker');
+
+goog.require('goog.Promise');
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+/**
+ * Provides an interface for performing permission checks for the given client
+ * applications, which gates access to sending PC/SC requests to our Smart Card
+ * Connector.
+ * @abstract
+ * @constructor
+ */
+GSC.Pcsc.PermissionsChecker = class {
+  /**
+   * Starts the permission check for the given client application.
+   *
+   * The result is returned asynchronously as a promise (which will be
+   * eventually resolved if the permission is granted or rejected otherwise).
+   * @param {string|null} clientOrigin Origin of the client application, or null
+   * if the client is our own application.
+   * @return {!goog.Promise}
+   * @abstract
+   */
+  check(clientOrigin) {}
+};
+});  // goog.scope

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/policy-or-prompting-permissions-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/policy-or-prompting-permissions-checker.js
@@ -31,6 +31,7 @@ goog.provide('GoogleSmartCard.Pcsc.PolicyOrPromptingPermissionsChecker');
 goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.MessagingOrigin');
+goog.require('GoogleSmartCard.Pcsc.PermissionsChecker');
 goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.ManagedRegistry');
 goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.UserPromptingChecker');
 goog.require('goog.Promise');
@@ -61,8 +62,10 @@ const logger = GSC.Logging.getScopedLogger('Pcsc.PermissionsChecker');
  * 3. Show the dialog to the user and allow/reject the permission based on the
  *    result.
  */
-GSC.Pcsc.PolicyOrPromptingPermissionsChecker = class {
+GSC.Pcsc.PolicyOrPromptingPermissionsChecker =
+    class extends GSC.Pcsc.PermissionsChecker {
   constructor() {
+    super();
     /** @private @const */
     this.managedRegistry_ = new PermissionsChecking.ManagedRegistry;
     /** @private @const */
@@ -70,13 +73,7 @@ GSC.Pcsc.PolicyOrPromptingPermissionsChecker = class {
   }
 
   /**
-   * Starts the permission check for the given client application.
-   *
-   * The result is returned asynchronously as a promise (which will be
-   * eventually resolved if the permission is granted or rejected otherwise).
-   * @param {string|null} clientOrigin Origin of the client application, or null
-   * if the client is our own application.
-   * @return {!goog.Promise}
+   * @override
    */
   check(clientOrigin) {
     goog.log.log(


### PR DESCRIPTION
This is a pure refactoring commit. Introduce an abstract interface that allows to check whether a client (another extension) is allowed to send commands to Smart Card Connector. Change
PolicyOrPromptingPermissionsChecker to inherit from it. The abstraction will be used in follow-up changes to mock out the checker in tests.

This is preparation for implementing regression test for #824.