### PR TITLE
Yet another magic sleep tweak for ASan+Debug tests

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -19,7 +19,7 @@ jobs:
   # Build and test in WebAssembly mode.
   build-emscripten:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       matrix:
         build-config: [Release, Debug]
@@ -45,7 +45,7 @@ jobs:
       env:
         TOOLCHAIN: emscripten
         CONFIG: ${{ matrix.build-config }}
-      timeout-minutes: 15
+      timeout-minutes: 30
       run: >
         source env/activate && make test
 
@@ -102,7 +102,7 @@ jobs:
   # Run unit tests under ASan.
   test-asan:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       matrix:
         build-config: [Release, Debug]
@@ -131,7 +131,7 @@ jobs:
       env:
         TOOLCHAIN: asan_testing
         CONFIG: ${{ matrix.build-config }}
-      timeout-minutes: 30
+      timeout-minutes: 45
       run: >
         source env/activate && make test
 
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       LINE_COVERAGE_PERCENT: ${{ steps.build-coverage.outputs.LINE_COVERAGE_PERCENT }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     steps:
     - name: Check out sources
       uses: actions/checkout@v3

--- a/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
+++ b/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
@@ -148,14 +148,19 @@ void PcscLiteServerDaemonThreadMain() {
   // code. This follows the code in the "if (AraKiri)" block in the
   // `SVCServiceRunLoop()` function in pcsc-lite/src/src/pcscdaemon.c.
   HPStopHotPluggables();
+
   // TODO: Upstream's approach with a magic sleep is flaky: the background
-  // thread might be still running after this point, causing crashes. Replace
-  // this with a proper waiting mechanism.
+  // thread might be still running after this point, causing crashes and memory
+  // leaks in tests. Replace this with a proper waiting mechanism.
+  int timeout_seconds = 10;
 #if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
-  SYS_Sleep(20);
-#else
-  SYS_Sleep(10);
+  timeout_seconds *= 2;
 #endif
+#if !defined(NDEBUG)
+  timeout_seconds *= 2;
+#endif
+  SYS_Sleep(timeout_seconds);
+
   RFCleanupReaders();
   EHDeinitializeEventStructures();
   ContextsDeinitialize();


### PR DESCRIPTION
As we're still observing flaky failures from the ASan+Debug test configuration, and as upstream PC/SC still doesn't have a proper solution to avoid this kind of teardown problem, further increase the magic sleep workaround we're using in tests.

The new formula will give x2 multipler when the build is either ASan or Debug, and x4 multiplier when both hold.