### PR TITLE
Pass Promise instead of ReadinessTracker

### DIFF
--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -321,7 +321,7 @@ function createClientHandler(clientMessageChannel, clientOrigin) {
   // because it manages its lifetime itself, based on the lifetimes of the
   // passed message channels.
   const clientHandler = new GSC.PcscLiteServerClientsManagement.ClientHandler(
-      executableModule.getMessageChannel(), pcscLiteReadinessTracker,
+      executableModule.getMessageChannel(), pcscLiteReadinessTracker.promise,
       clientMessageChannel, clientOrigin);
 
   const logMessage = 'Created a new PC/SC-Lite client handler for ' +

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
@@ -126,10 +126,9 @@ function getClientNameForLog(clientOrigin) {
  *    handling of the client requests impossible).
  * @param {!goog.messaging.AbstractChannel} serverMessageChannel Message channel
  * to the PC/SC server into which the PC/SC requests will be forwarded.
- * @param {!GSC.PcscLiteServerClientsManagement.ReadinessTracker}
- * serverReadinessTracker Tracker of the PC/SC server that allows to delay
- * forwarding of the PC/SC requests to the PC/SC server until it is ready to
- * receive them.
+ * @param {!goog.Promise} serverReadinessTracker Tracker of the PC/SC server
+ * that allows to delay forwarding of the PC/SC requests to the PC/SC server
+ * until it is ready to receive them.
  * @param {!goog.messaging.AbstractChannel} clientMessageChannel Message channel
  * to the client.
  * @param {string=} clientOrigin Origin of the client that's sending commands

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/server-request-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/server-request-handler.js
@@ -31,7 +31,6 @@ goog.provide('GoogleSmartCard.PcscLiteServerClientsManagement.ServerRequestHandl
 goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.DeferredProcessor');
 goog.require('GoogleSmartCard.Logging');
-goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.ReadinessTracker');
 goog.require('GoogleSmartCard.RemoteCallMessage');
 goog.require('GoogleSmartCard.Requester');
 goog.require('goog.Disposable');
@@ -132,10 +131,9 @@ Pcsc.ServerRequestHandler = class extends goog.Disposable {
    * @param {!goog.messaging.AbstractChannel} serverMessageChannel Message
    *     channel
    * to the PC/SC server into which the PC/SC requests will be forwarded.
-   * @param {!Pcsc.ReadinessTracker} serverReadinessTracker
-   * Tracker of the PC/SC server that allows to delay
-   * forwarding of the PC/SC requests to the PC/SC server until it is ready to
-   * receive them.
+   * @param {!goog.Promise} serverReadinessTracker Tracker of the PC/SC server
+   * that allows to delay forwarding of the PC/SC requests to the PC/SC server
+   * until it is ready to receive them.
    * @param {string} clientNameForLog
    */
   constructor(serverMessageChannel, serverReadinessTracker, clientNameForLog) {
@@ -175,7 +173,7 @@ Pcsc.ServerRequestHandler = class extends goog.Disposable {
     // established.
     /** @private */
     this.deferredProcessor_ =
-        new DeferredProcessor(this.serverReadinessTracker_.promise);
+        new DeferredProcessor(this.serverReadinessTracker_);
 
     this.serverMessageChannel_.addOnDisposeCallback(
         () => this.serverMessageChannelDisposedListener_());


### PR DESCRIPTION
This is a pure refactoring commit. Change the JS code to pass around a Promise instead of the whole ReadinessTracker object. This is sufficient in order to delay command processing until the server is ready, and is otherwise much simpler to mock out in tests.

This is preparation for implementing regression test for #824.