### PR TITLE
Implement smoke test for ClientHandler

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/build/js_unittests/Makefile
+++ b/third_party/pcsc-lite/naclport/server_clients_management/build/js_unittests/Makefile
@@ -23,10 +23,10 @@ TARGET := js_pcsc_lite_server_clients_management_unittests
 
 include ../../../../../../common/make/common.mk
 
-include $(COMMON_DIR_PATH)/make/js_building_common.mk
-
-include $(COMMON_DIR_PATH)/js/include.mk
-include ../../include.mk
+include $(ROOT_PATH)/common/make/js_building_common.mk
+include $(ROOT_PATH)/common/js/include.mk
+include $(ROOT_PATH)/third_party/pcsc-lite/naclport/common/include.mk
+include $(ROOT_PATH)/third_party/pcsc-lite/naclport/server_clients_management/include.mk
 
 
 # Compile all JavaScript files rooting in the tested component's directory
@@ -36,6 +36,7 @@ include ../../include.mk
 # The path constants used below come from the include.mk files.
 JS_COMPILER_INPUT_PATHS := \
 	$(PCSC_LITE_SERVER_CLIENTS_MANAGEMENT_SOURCES_PATH) \
+	$(PCSC_LITE_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \
 	$(JS_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \
 
 $(eval $(call BUILD_JS_UNITTESTS,$(JS_COMPILER_INPUT_PATHS)))

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler-unittest.js
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2023 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.ClientHandler');
+goog.require('goog.Promise');
+goog.require('goog.testing');
+goog.require('goog.testing.MockControl');
+goog.require('goog.testing.jsunit');
+goog.require('goog.testing.messaging.MockMessageChannel');
+
+goog.setTestOnly();
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+const ClientHandler = GSC.PcscLiteServerClientsManagement.ClientHandler;
+
+const EXTENSION_ID_A = 'chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+class StubPermissionsChecker extends GSC.Pcsc.PermissionsChecker {
+  /** @override */
+  check(clientOrigin) {
+    return goog.Promise.resolve();
+  }
+}
+
+/** @type {!goog.testing.MockControl|undefined} */
+let mockControl;
+let mockServerMessageChannel;
+let mockClientMessageChannel;
+const stubPermissionsChecker = new StubPermissionsChecker();
+
+goog.exportSymbol('testClientHandler', {
+  'setUp': function() {
+    mockControl = new goog.testing.MockControl();
+    mockServerMessageChannel =
+        new goog.testing.messaging.MockMessageChannel(mockControl);
+    mockClientMessageChannel =
+        new goog.testing.messaging.MockMessageChannel(mockControl);
+
+    ClientHandler.overridePermissionsCheckerForTesting(stubPermissionsChecker);
+  },
+
+  'tearDown': function() {
+    // Check all mock expectations are satisfied.
+    mockControl.$verifyAll();
+
+    ClientHandler.overridePermissionsCheckerForTesting(null);
+  },
+
+  'testSmoke': function() {
+    const handler = new ClientHandler(
+        mockServerMessageChannel, goog.Promise.resolve(),
+        mockClientMessageChannel, EXTENSION_ID_A);
+
+    handler.dispose();
+  },
+});
+});  // goog.scope


### PR DESCRIPTION
This unit test verifies that the ClientHandler object can be successfully created and disposed of.

This is preparation for implementing regression test for #824.