### PR TITLE
Switch to new Chromedriver download URLs

### DIFF
--- a/env/initialize.sh
+++ b/env/initialize.sh
@@ -188,25 +188,23 @@ initialize_chromedriver() {
   fi
   log_message "Installing chromedriver..."
   rm -rf ./chromedriver
-  # Determine the currently installed version of Chrome. Leave only the
-  # major-minor-build triple, e.g., 72.0.3626.
-  local chrome_version=$(google-chrome --version | cut -f 3 -d ' ' | cut -d '.' -f 1-3)
-  # Obtain the matching Chromedriver version.
-  local chromedriver_version_url="http://chromedriver.storage.googleapis.com/LATEST_RELEASE_${chrome_version}"
-  local chromedriver_version
-  if ! chromedriver_version=$(curl --fail --silent "${chromedriver_version_url}") ; then
-    log_error_message "Failed to fetch chromedriver version at ${chromedriver_version_url} ; skipping chromedriver installation..."
-    return
-  fi
-  # Download Chromedriver.
-  local chromedriver_url="https://chromedriver.storage.googleapis.com/${chromedriver_version}/chromedriver_linux64.zip"
+  # Determine the currently installed version of Chrome. Leave only the numbers,
+  # e.g., 72.0.3626.0.
+  local chrome_version=$(google-chrome --version | cut -f 3 -d ' ')
+  # Download Chromedriver. As of now, the maintainers guarantee that there's a
+  # matching Chromedriver artifact for every publicly released Chrome version.
+  local chromedriver_url="https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${chrome_version}/linux64/chromedriver-linux64.zip"
   if ! wget "${chromedriver_url}" ; then
     log_error_message "Failed to fetch chromedriver at ${chromedriver_url} ; skipping chromedriver installation..."
     return
   fi
-  unzip -q chromedriver_linux64.zip
-  rm -rf chromedriver_linux64.zip
-  log_message "chromedriver ${chromedriver_version} was installed successfully."
+  # Unpack a single file with the executable.
+  if ! unzip -q -j chromedriver-linux64.zip chromedriver-linux64/chromedriver ; then
+    log_error_message "Failed to unpack chromedriver executable; skipping chromedriver installation..."
+    return
+  fi
+  rm -rf chromedriver-linux64.zip
+  log_message "chromedriver ${chrome_version} was installed successfully."
 }
 
 create_activate_script() {


### PR DESCRIPTION
Per [1], Chromedriver shouldn't be downloaded anymore by a two-stage process, which was first obtaining the closest Chromedriver version to the installed Chrome version, and then actually downloading the latter's package. Now, starting from Chrome 115, it's guaranteed that every official release of Chrome has a corresponding version of Chromedriver available.

[1] https://groups.google.com/g/chromedriver-users/c/clpipqvOGjE

This also fixes #832, since the old way of downloading stopped working for Chrome >=115.