### PR TITLE
Downgrade warning logs for ReaderTracker removal

### DIFF
--- a/third_party/pcsc-lite/naclport/js_client/src/reader-tracker-through-pcsc-api.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/reader-tracker-through-pcsc-api.js
@@ -317,7 +317,7 @@ ReaderTrackerThroughPcscApi.prototype.makeReaderStatesPromise_ = function(
                 promiseResolver.resolve.bind(promiseResolver),
                 function(errorCode) {
                   if (errorCode == API.SCARD_E_UNKNOWN_READER) {
-                    goog.log.warning(
+                    goog.log.info(
                         this.logger_,
                         'Getting the statuses of the readers from PC/SC finished ' +
                             'unsuccessfully due to removal of the tracked reader. A ' +
@@ -414,7 +414,7 @@ ReaderTrackerThroughPcscApi.prototype.makeReaderStatesChangePromise_ = function(
                             'within the timeout');
                     promiseResolver.resolve();
                   } else if (errorCode == API.SCARD_E_UNKNOWN_READER) {
-                    goog.log.warning(
+                    goog.log.info(
                         this.logger_,
                         'Waiting for the reader statuses changes from PC/SC finished ' +
                             'unsuccessfully due to removal of the tracked reader');


### PR DESCRIPTION
When the reader suddenly becomes unknown in the ReaderTracker, we shouldn't emit a warning log, because it's happening legitimately when the reader is unplugged in the middle of the SCardGetStatusChange() call.

Hence log these messages at the "info" level instead.

This is another small improvement for #53.