### PR TITLE
Build scripts use Emscripten by default

### DIFF
--- a/common/make/common.mk
+++ b/common/make/common.mk
@@ -32,9 +32,9 @@ endif
 
 # Supported values: "Release" (default), "Debug".
 CONFIG ?= Release
-# Supported values: "pnacl" (Portable Native Client; default), "emscripten"
-# (Emscripten/WebAssembly).
-TOOLCHAIN ?= pnacl
+# Supported values: "emscripten" (Emscripten/WebAssembly; default), "pnacl"
+# (Portable Native Client).
+TOOLCHAIN ?= emscripten
 # Build parameter that specifies the packaging type. Supported values: "app"
 # (default), "extension".
 PACKAGING ?= app


### PR DESCRIPTION
When no TOOLCHAIN environment variable is specified, assume "emscripten" by default.

Previously "pnacl" has been used by default, however it's becoming increasingly cumbersome for developers to use it.

Note that we continue shipping Smart Card Connector's pnacl version into production - this commit doesn't change that.