### PR TITLE
Connector requires ChromeOS >=81

### DIFF
--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -67,7 +67,7 @@ ${endif}
   # WebUSB and WebAssembly are required in this mode and are only stable and
   # reliable on new versions.
 ${if PACKAGING=app}
-  "minimum_chrome_version": "48",
+  "minimum_chrome_version": "81",
 ${endif}
 ${if PACKAGING=extension}
   "minimum_chrome_version": "96",


### PR DESCRIPTION
Bump the Smart Card Connector's minimum_chrome_version to "81", to reflect the fact that it cannot be installed onto older ChromeOS versions (due to the "invalid manifest" error).

The underlying root cause is the "chrome-untrusted://" URL that we've been using in the manifest.json since 1.3.9.3 (see #838). Unfortunately we didn't realize the backwards incompatibility issue back then, which means the current commit won't fix the issue for users on ChromeOS < 81. Still, it's better to fix the manifest to tell the real requirement now.