### PR TITLE
Fixup instead of crashing on incorrect ATR size

### DIFF
--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.cc
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.cc
@@ -37,6 +37,11 @@ std::vector<uint8_t> GetSCardReaderStateAtr(
     const SCARD_READERSTATE& s_card_reader_state) {
   if (!s_card_reader_state.cbAtr)
     return {};
+  if (s_card_reader_state.cbAtr == MAX_ATR_SIZE + 1) {
+    GOOGLE_SMART_CARD_LOG_INFO
+        << "PC/SC-Lite returned uninitialized ATR size; performing fixup...";
+    return {};
+  }
   GOOGLE_SMART_CARD_CHECK(s_card_reader_state.cbAtr <= MAX_ATR_SIZE);
   return std::vector<uint8_t>(
       s_card_reader_state.rgbAtr,


### PR DESCRIPTION
Under some circumstances PC/SC-Lite can return incorrect cbAtr, exceeding the maximum allowed MAX_ATR_SIZE. Fix this up, by treating it as zero, instead of crashing on an assertion.

The underlying root cause seems to be a race condition between the thread that handles SCardGetStatusChange() calls and the thread that manages global structures with reader information. When these read&write concurrently to the same structure, it can happen that the former reads the ATR length of the already-uninitialized reader. PC/SC-Lite's internal convention is that uninitialized reader structures have cbAtr equal to READER_NOT_INITIALIZED (which is MAX_ATR_SIZE + 1). Meanwhile we don't fix this race condition in this commit, we at least mitigate the consequences of the bug by substituting the invalid integer.

This serves as a temporary mitigation for #840; a proper fix will need to be done separately later.