### PR TITLE
Ignore non-smart-card USB interfaces

### DIFF
--- a/smart_card_connector_app/src/smart-card-filter-libusb-hook-unittest.js
+++ b/smart_card_connector_app/src/smart-card-filter-libusb-hook-unittest.js
@@ -1,0 +1,330 @@
+/**
+ * @license
+ * Copyright 2023 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.require('GoogleSmartCard.LibusbProxyDataModel');
+goog.require('GoogleSmartCard.LibusbToJsApiAdaptor');
+goog.require('GoogleSmartCard.SmartCardFilterLibusbHook');
+goog.require('goog.asserts');
+goog.require('goog.testing');
+goog.require('goog.testing.asserts');
+goog.require('goog.testing.jsunit');
+
+goog.setTestOnly();
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+const LibusbJsConfigurationDescriptor =
+    GSC.LibusbProxyDataModel.LibusbJsConfigurationDescriptor;
+
+const FAKE_DEVICE_ID = 123;
+
+class FakeLibusbProxyHookDelegate extends GSC.LibusbToJsApiAdaptor {
+  constructor() {
+    super();
+    /** @type {!Array<!LibusbJsConfigurationDescriptor>} */
+    this.fakeConfigurations_ = [];
+  }
+
+  /**
+   * @param {!Array<!LibusbJsConfigurationDescriptor>} fakeConfigurations
+   */
+  setFakeConfigurations(fakeConfigurations) {
+    this.fakeConfigurations_ = fakeConfigurations;
+  }
+
+  /** @override */
+  async listDevices() {
+    fail('Unexpected call');
+    goog.asserts.fail();
+  }
+  /** @override */
+  async getConfigurations(deviceId) {
+    return this.fakeConfigurations_;
+  }
+  /** @override */
+  async openDeviceHandle(deviceId) {
+    fail('Unexpected call');
+    goog.asserts.fail();
+  }
+  /** @override */
+  async closeDeviceHandle(deviceId, deviceHandle) {
+    fail('Unexpected call');
+    goog.asserts.fail();
+  }
+  /** @override */
+  async claimInterface(deviceId, deviceHandle, interfaceNumber) {
+    fail('Unexpected call');
+    goog.asserts.fail();
+  }
+  /** @override */
+  async releaseInterface(deviceId, deviceHandle, interfaceNumber) {
+    fail('Unexpected call');
+    goog.asserts.fail();
+  }
+  /** @override */
+  async resetDevice(deviceId, deviceHandle) {
+    fail('Unexpected call');
+    goog.asserts.fail();
+  }
+  /** @override */
+  async controlTransfer(deviceId, deviceHandle, parameters) {
+    fail('Unexpected call');
+    goog.asserts.fail();
+  }
+  /** @override */
+  async bulkTransfer(deviceId, deviceHandle, parameters) {
+    fail('Unexpected call');
+    goog.asserts.fail();
+  }
+  /** @override */
+  async interruptTransfer(deviceId, deviceHandle, parameters) {
+    fail('Unexpected call');
+    goog.asserts.fail();
+  }
+};
+
+/** @type {!FakeLibusbProxyHookDelegate|undefined} */
+let fakeDelegate;
+/** @type {!GSC.SmartCardFilterLibusbHook|undefined} */
+let hook;
+
+goog.exportSymbol('test_SmartCardFilterLibusbHook', {
+  'setUp': function() {
+    fakeDelegate = new FakeLibusbProxyHookDelegate();
+    hook = new GSC.SmartCardFilterLibusbHook();
+    hook.setDelegate(fakeDelegate);
+  },
+
+  'tearDown': function() {
+    hook = undefined;
+    fakeDelegate = undefined;
+  },
+
+  'testEmpty': async function() {
+    const got = await hook.getConfigurations(FAKE_DEVICE_ID);
+
+    assertObjectEquals([], got);
+  },
+
+  // A simple device with the Smart Card USB interface class is passed as-is.
+  'testSingleInterface_SmartCardClass': async function() {
+    const CONFIGS = [{
+      'active': true,
+      'configurationValue': 1,
+      'interfaces': [{
+        'interfaceNumber': 123,
+        'interfaceClass': 0xB,
+        'interfaceSubclass': 0,
+        'interfaceProtocol': 0,
+        'endpoints': [
+          {
+            'endpointNumber': 1,
+            'direction': 'out',
+            'type': 'bulk',
+            'packetSize': 64,
+          },
+        ],
+      }],
+    }];
+    fakeDelegate.setFakeConfigurations(CONFIGS);
+
+    const got = await hook.getConfigurations(FAKE_DEVICE_ID);
+
+    assertObjectEquals(CONFIGS, got);
+  },
+
+  // A simple device with an unexpected USB interface class is filtered out.
+  'testSingleInterface_OtherClass': async function() {
+    const CONFIGS = [{
+      'active': true,
+      'configurationValue': 1,
+      'interfaces': [{
+        'interfaceNumber': 123,
+        'interfaceClass': 0x3,
+        'interfaceSubclass': 0,
+        'interfaceProtocol': 0,
+        'endpoints': [
+          {
+            'endpointNumber': 1,
+            'direction': 'out',
+            'type': 'bulk',
+            'packetSize': 64,
+          },
+        ],
+      }],
+    }];
+    fakeDelegate.setFakeConfigurations(CONFIGS);
+
+    const got = await hook.getConfigurations(FAKE_DEVICE_ID);
+
+    const EXPECTED_RESULT = [{
+      'active': true,
+      'configurationValue': 1,
+      'interfaces': [],
+    }];
+    assertObjectEquals(EXPECTED_RESULT, got);
+  },
+
+  // A simple device with the Vendor Specific USB interface class and the
+  // specific "extra data" (54-byte long, conforming to the CCID specs) is
+  // passed as-is.
+  'testSingleInterface_VendorClassLikeSmartCard': async function() {
+    const CONFIGS = [{
+      'active': true,
+      'configurationValue': 1,
+      'interfaces': [{
+        'interfaceNumber': 123,
+        'interfaceClass': 0xFF,
+        'interfaceSubclass': 0,
+        'interfaceProtocol': 0,
+        'extraData': new ArrayBuffer(54),
+        'endpoints': [
+          {
+            'endpointNumber': 1,
+            'direction': 'out',
+            'type': 'bulk',
+            'packetSize': 64,
+          },
+        ],
+      }],
+    }];
+    fakeDelegate.setFakeConfigurations(CONFIGS);
+
+    const got = await hook.getConfigurations(FAKE_DEVICE_ID);
+
+    assertObjectEquals(CONFIGS, got);
+  },
+
+  // A simple device with the Vendor Specific USB interface class and without
+  // "extra data" is filtered out.
+  'testSingleInterface_VendorClassWithoutExtraData': async function() {
+    // Unlike the test above, the "extraData" key is missing.
+    const CONFIGS = [{
+      'active': true,
+      'configurationValue': 1,
+      'interfaces': [{
+        'interfaceNumber': 123,
+        'interfaceClass': 0xFF,
+        'interfaceSubclass': 0,
+        'interfaceProtocol': 0,
+        'endpoints': [
+          {
+            'endpointNumber': 1,
+            'direction': 'out',
+            'type': 'bulk',
+            'packetSize': 64,
+          },
+        ],
+      }],
+    }];
+    fakeDelegate.setFakeConfigurations(CONFIGS);
+
+    const got = await hook.getConfigurations(FAKE_DEVICE_ID);
+
+    const EXPECTED_RESULT = [{
+      'active': true,
+      'configurationValue': 1,
+      'interfaces': [],
+    }];
+    assertObjectEquals(EXPECTED_RESULT, got);
+  },
+
+  // A simple device with the Vendor Specific USB interface class and with
+  // "extra data" of unexpected length is filtered out.
+  'testSingleInterface_VendorClassDifferentExtraDataLength': async function() {
+    // Unlike the successful test above, the "extraData" key is missing.
+    const CONFIGS = [{
+      'active': true,
+      'configurationValue': 1,
+      'interfaces': [{
+        'interfaceNumber': 123,
+        'interfaceClass': 0xFF,
+        'interfaceSubclass': 0,
+        'interfaceProtocol': 0,
+        'extraData': new ArrayBuffer(10),
+        'endpoints': [
+          {
+            'endpointNumber': 1,
+            'direction': 'out',
+            'type': 'bulk',
+            'packetSize': 64,
+          },
+        ],
+      }],
+    }];
+    fakeDelegate.setFakeConfigurations(CONFIGS);
+
+    const got = await hook.getConfigurations(FAKE_DEVICE_ID);
+
+    const EXPECTED_RESULT = [{
+      'active': true,
+      'configurationValue': 1,
+      'interfaces': [],
+    }];
+    assertObjectEquals(EXPECTED_RESULT, got);
+  },
+
+  // A composite device with both interfaces (one having the Smart Card class
+  // and another having a different class) is passed only in half.
+  'testSingleInterface_Composite_SmartCardAndOtherClass': async function() {
+    const SMART_CARD_INTERFACE = {
+      'interfaceNumber': 123,
+      'interfaceClass': 0xB,
+      'interfaceSubclass': 0,
+      'interfaceProtocol': 0,
+      'endpoints': [
+        {
+          'endpointNumber': 1,
+          'direction': 'out',
+          'type': 'bulk',
+          'packetSize': 64,
+        },
+      ],
+    };
+    const HUMAN_INTERFACE_DEVICE_INTERFACE = {
+      'interfaceNumber': 234,
+      'interfaceClass': 0x3,
+      'interfaceSubclass': 0,
+      'interfaceProtocol': 0,
+      'endpoints': [
+        {
+          'endpointNumber': 1,
+          'direction': 'out',
+          'type': 'bulk',
+          'packetSize': 64,
+        },
+      ],
+    };
+    const CONFIGS = [{
+      'active': true,
+      'configurationValue': 1,
+      'interfaces': [SMART_CARD_INTERFACE, HUMAN_INTERFACE_DEVICE_INTERFACE],
+    }];
+    fakeDelegate.setFakeConfigurations(CONFIGS);
+
+    const got = await hook.getConfigurations(FAKE_DEVICE_ID);
+
+    const EXPECTED_RESULT = [{
+      'active': true,
+      'configurationValue': 1,
+      'interfaces': [SMART_CARD_INTERFACE],
+    }];
+    assertObjectEquals(EXPECTED_RESULT, got);
+  },
+});
+});

--- a/smart_card_connector_app/src/smart-card-filter-libusb-hook.js
+++ b/smart_card_connector_app/src/smart-card-filter-libusb-hook.js
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2023 Google Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+goog.provide('GoogleSmartCard.SmartCardFilterLibusbHook');
+
+goog.require('GoogleSmartCard.LibusbProxyDataModel');
+goog.require('GoogleSmartCard.LibusbProxyHook');
+goog.require('goog.object');
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+const LibusbJsConfigurationDescriptor =
+    GSC.LibusbProxyDataModel.LibusbJsConfigurationDescriptor;
+const LibusbJsInterfaceDescriptor =
+    GSC.LibusbProxyDataModel.LibusbJsInterfaceDescriptor;
+
+/**
+ * A hook that hides non-smart-card USB interfaces.
+ */
+GSC.SmartCardFilterLibusbHook = class extends GSC.LibusbProxyHook {
+  /** @override */
+  async getConfigurations(deviceId) {
+    const originalConfigurations =
+        await this.getDelegateOrThrow().getConfigurations(deviceId);
+    return originalConfigurations.map(convertConfiguration);
+  }
+};
+
+/**
+ * @param {!LibusbJsConfigurationDescriptor} usbConfiguration
+ * @return {!LibusbJsConfigurationDescriptor}
+ */
+function convertConfiguration(usbConfiguration) {
+  const copy = /** @type {!LibusbJsConfigurationDescriptor} */ (
+      goog.object.clone(usbConfiguration));
+  copy['interfaces'] = copy['interfaces'].filter(isSmartCardInterface);
+  return copy;
+}
+
+/**
+ * @param {!LibusbJsInterfaceDescriptor} usbInterface
+ * @return {boolean}
+ */
+function isSmartCardInterface(usbInterface) {
+  // The implementation follows the checks in
+  // third_party/ccid/src/src/ccid_usb.c. Note that these checks also allow for
+  // vendor-specific class code, which is designed to support the (rare) smart
+  // card readers that don't use the proper class code.
+  const SMART_CARD_USB_INTERFACE_CLASS = 0x0B;
+  const VENDOR_SPECIFIC_USB_INTERFACE_CLASS = 0xFF;
+  const CCID_USB_DESCRIPTOR_LENGTH = 54;
+  if (usbInterface['interfaceClass'] == SMART_CARD_USB_INTERFACE_CLASS) {
+    return true;
+  }
+  if (usbInterface['interfaceClass'] == VENDOR_SPECIFIC_USB_INTERFACE_CLASS &&
+      usbInterface['extraData'] &&
+      usbInterface['extraData'].byteLength == CCID_USB_DESCRIPTOR_LENGTH) {
+    return true;
+  }
+  return false;
+}
+});  // goog.scope

--- a/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
@@ -593,15 +593,16 @@ TEST_P(LibusbJsProxyTest, LibusbGetActiveConfigDescriptorScmScr3310) {
 }
 
 // Test the behavior of `LibusbGetActiveConfigDescriptor()` on the parameters
-// taken from the real Rocketek device. In this case some (non-smart-card) USB
-// interfaces are skipped, hence the result contains sentinel records.
-TEST_P(LibusbJsProxyTest, LibusbGetActiveConfigDescriptorRocketek) {
+// taken from the real Dell Smart Card Reader Keyboard. In this case some
+// (non-smart-card) USB interfaces are skipped, hence the result contains
+// sentinel records.
+TEST_P(LibusbJsProxyTest, LibusbGetActiveConfigDescriptorDellKeyboard) {
   const std::vector<uint8_t> kInterfaceExtraData{
-      0x36, 0x21, 0x00, 0x01, 0x00, 0x01, 0x03, 0x00, 0x00, 0x00, 0xa0,
-      0x0f, 0x00, 0x00, 0xe0, 0x2e, 0x00, 0x00, 0x00, 0x80, 0x25, 0x00,
-      0x00, 0x00, 0xb0, 0x04, 0x00, 0x00, 0xfc, 0x00, 0x00, 0x00, 0x00,
-      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xba, 0x00, 0x01, 0x00,
-      0x07, 0x01, 0x00, 0x00, 0xff, 0xff, 0x00, 0x00, 0x00, 0x01};
+      0x36, 0x21, 0x01, 0x01, 0x00, 0x07, 0x03, 0x00, 0x00, 0x00, 0xc0,
+      0x12, 0x00, 0x00, 0xc0, 0x12, 0x00, 0x00, 0x00, 0x67, 0x32, 0x00,
+      0x00, 0xce, 0x99, 0x0c, 0x00, 0x35, 0xfe, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x02, 0x01, 0x00,
+      0x0f, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x01};
 
   // Arrange.
   global_context()->WillReplyToRequestWith(
@@ -654,7 +655,7 @@ TEST_P(LibusbJsProxyTest, LibusbGetActiveConfigDescriptorRocketek) {
                                                     .Add("endpointAddress", 131)
                                                     .Add("direction", "in")
                                                     .Add("type", "interrupt")
-                                                    .Add("maxPacketSize", 16)
+                                                    .Add("maxPacketSize", 8)
                                                     .Get())
                                            .Get())
                                   .Get())
@@ -673,9 +674,9 @@ TEST_P(LibusbJsProxyTest, LibusbGetActiveConfigDescriptorRocketek) {
   EXPECT_EQ(descriptor->bDescriptorType, LIBUSB_DT_CONFIG);
   EXPECT_EQ(descriptor->wTotalLength, sizeof(libusb_config_descriptor));
   EXPECT_EQ(descriptor->bConfigurationValue, 1);
-  ASSERT_EQ(descriptor->bNumInterfaces, 2);
   EXPECT_EQ(descriptor->extra, nullptr);
   EXPECT_EQ(descriptor->extra_length, 0);
+  ASSERT_EQ(descriptor->bNumInterfaces, 2);
   const auto& interface0 = descriptor->interface[0];
   const auto& interface1 = descriptor->interface[1];
   EXPECT_EQ(interface1.num_altsetting, 0);
@@ -685,7 +686,6 @@ TEST_P(LibusbJsProxyTest, LibusbGetActiveConfigDescriptorRocketek) {
   EXPECT_EQ(interface_descriptor.bLength, sizeof(libusb_interface_descriptor));
   EXPECT_EQ(interface_descriptor.bDescriptorType, LIBUSB_DT_INTERFACE);
   EXPECT_EQ(interface_descriptor.bInterfaceNumber, 1);
-  ASSERT_EQ(interface_descriptor.bNumEndpoints, 3);
   EXPECT_EQ(interface_descriptor.bInterfaceClass, 11);
   EXPECT_EQ(interface_descriptor.bInterfaceSubClass, 0);
   EXPECT_EQ(interface_descriptor.bInterfaceProtocol, 0);
@@ -695,6 +695,7 @@ TEST_P(LibusbJsProxyTest, LibusbGetActiveConfigDescriptorRocketek) {
                 interface_descriptor.extra,
                 interface_descriptor.extra + interface_descriptor.extra_length),
             kInterfaceExtraData);
+  ASSERT_EQ(interface_descriptor.bNumEndpoints, 3);
   const auto* endpoint = interface_descriptor.endpoint;
   ASSERT_TRUE(endpoint);
   EXPECT_EQ(endpoint[0].bLength, sizeof(libusb_endpoint_descriptor));
@@ -715,7 +716,7 @@ TEST_P(LibusbJsProxyTest, LibusbGetActiveConfigDescriptorRocketek) {
   EXPECT_EQ(endpoint[2].bDescriptorType, LIBUSB_DT_ENDPOINT);
   EXPECT_EQ(endpoint[2].bEndpointAddress, 131);
   EXPECT_EQ(endpoint[2].bmAttributes, LIBUSB_TRANSFER_TYPE_INTERRUPT);
-  EXPECT_EQ(endpoint[2].wMaxPacketSize, 16);
+  EXPECT_EQ(endpoint[2].wMaxPacketSize, 8);
   EXPECT_EQ(endpoint[2].extra, nullptr);
   EXPECT_EQ(endpoint[2].extra_length, 0);
 

--- a/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
@@ -592,6 +592,138 @@ TEST_P(LibusbJsProxyTest, LibusbGetActiveConfigDescriptorScmScr3310) {
   FreeLibusbDevices(devices);
 }
 
+// Test the behavior of `LibusbGetActiveConfigDescriptor()` on the parameters
+// taken from the real Rocketek device. In this case some (non-smart-card) USB
+// interfaces are skipped, hence the result contains sentinel records.
+TEST_P(LibusbJsProxyTest, LibusbGetActiveConfigDescriptorRocketek) {
+  const std::vector<uint8_t> kInterfaceExtraData{
+      0x36, 0x21, 0x00, 0x01, 0x00, 0x01, 0x03, 0x00, 0x00, 0x00, 0xa0,
+      0x0f, 0x00, 0x00, 0xe0, 0x2e, 0x00, 0x00, 0x00, 0x80, 0x25, 0x00,
+      0x00, 0x00, 0xb0, 0x04, 0x00, 0x00, 0xfc, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xba, 0x00, 0x01, 0x00,
+      0x07, 0x01, 0x00, 0x00, 0xff, 0xff, 0x00, 0x00, 0x00, 0x01};
+
+  // Arrange.
+  global_context()->WillReplyToRequestWith(
+      "libusb", "listDevices",
+      /*arguments=*/Value(Value::Type::kArray),
+      /*result_to_reply_with=*/
+      ArrayValueBuilder()
+          .Add(DictValueBuilder()
+                   .Add("deviceId", 123)
+                   .Add("vendorId", 1)
+                   .Add("productId", 2)
+                   .Get())
+          .Get());
+  std::vector<libusb_device*> devices = GetLibusbDevices();
+  ASSERT_THAT(devices, SizeIs(1));
+  global_context()->WillReplyToRequestWith(
+      "libusb", "getConfigurations",
+      /*arguments=*/ArrayValueBuilder().Add(123).Get(),
+      /*result_to_reply_with=*/
+      ArrayValueBuilder()
+          .Add(
+              DictValueBuilder()
+                  .Add("active", true)
+                  .Add("configurationValue", 1)
+                  .Add(
+                      "interfaces",
+                      ArrayValueBuilder()
+                          .Add(
+                              DictValueBuilder()
+                                  .Add("interfaceNumber", 1)
+                                  .Add("interfaceClass", 11)
+                                  .Add("interfaceSubclass", 0)
+                                  .Add("interfaceProtocol", 0)
+                                  .Add("extraData", kInterfaceExtraData)
+                                  .Add("endpoints",
+                                       ArrayValueBuilder()
+                                           .Add(DictValueBuilder()
+                                                    .Add("endpointAddress", 1)
+                                                    .Add("direction", "out")
+                                                    .Add("type", "bulk")
+                                                    .Add("maxPacketSize", 64)
+                                                    .Get())
+                                           .Add(DictValueBuilder()
+                                                    .Add("endpointAddress", 130)
+                                                    .Add("direction", "in")
+                                                    .Add("type", "bulk")
+                                                    .Add("maxPacketSize", 64)
+                                                    .Get())
+                                           .Add(DictValueBuilder()
+                                                    .Add("endpointAddress", 131)
+                                                    .Add("direction", "in")
+                                                    .Add("type", "interrupt")
+                                                    .Add("maxPacketSize", 16)
+                                                    .Get())
+                                           .Get())
+                                  .Get())
+                          .Get())
+                  .Get())
+          .Get());
+
+  // Act.
+  libusb_config_descriptor* descriptor = nullptr;
+  EXPECT_EQ(libusb()->LibusbGetActiveConfigDescriptor(devices[0], &descriptor),
+            LIBUSB_SUCCESS);
+
+  // Assert.
+  ASSERT_TRUE(descriptor);
+  EXPECT_EQ(descriptor->bLength, sizeof(libusb_config_descriptor));
+  EXPECT_EQ(descriptor->bDescriptorType, LIBUSB_DT_CONFIG);
+  EXPECT_EQ(descriptor->wTotalLength, sizeof(libusb_config_descriptor));
+  EXPECT_EQ(descriptor->bConfigurationValue, 1);
+  ASSERT_EQ(descriptor->bNumInterfaces, 2);
+  EXPECT_EQ(descriptor->extra, nullptr);
+  EXPECT_EQ(descriptor->extra_length, 0);
+  const auto& interface0 = descriptor->interface[0];
+  const auto& interface1 = descriptor->interface[1];
+  EXPECT_EQ(interface1.num_altsetting, 0);
+  EXPECT_EQ(interface1.altsetting, nullptr);
+  EXPECT_EQ(interface0.num_altsetting, 1);
+  const auto& interface_descriptor = interface0.altsetting[0];
+  EXPECT_EQ(interface_descriptor.bLength, sizeof(libusb_interface_descriptor));
+  EXPECT_EQ(interface_descriptor.bDescriptorType, LIBUSB_DT_INTERFACE);
+  EXPECT_EQ(interface_descriptor.bInterfaceNumber, 1);
+  ASSERT_EQ(interface_descriptor.bNumEndpoints, 3);
+  EXPECT_EQ(interface_descriptor.bInterfaceClass, 11);
+  EXPECT_EQ(interface_descriptor.bInterfaceSubClass, 0);
+  EXPECT_EQ(interface_descriptor.bInterfaceProtocol, 0);
+  ASSERT_TRUE(interface_descriptor.extra);
+  ASSERT_GT(interface_descriptor.extra_length, 0);
+  EXPECT_EQ(std::vector<uint8_t>(
+                interface_descriptor.extra,
+                interface_descriptor.extra + interface_descriptor.extra_length),
+            kInterfaceExtraData);
+  const auto* endpoint = interface_descriptor.endpoint;
+  ASSERT_TRUE(endpoint);
+  EXPECT_EQ(endpoint[0].bLength, sizeof(libusb_endpoint_descriptor));
+  EXPECT_EQ(endpoint[0].bDescriptorType, LIBUSB_DT_ENDPOINT);
+  EXPECT_EQ(endpoint[0].bEndpointAddress, 1);
+  EXPECT_EQ(endpoint[0].bmAttributes, LIBUSB_TRANSFER_TYPE_BULK);
+  EXPECT_EQ(endpoint[0].wMaxPacketSize, 64);
+  EXPECT_EQ(endpoint[0].extra, nullptr);
+  EXPECT_EQ(endpoint[0].extra_length, 0);
+  EXPECT_EQ(endpoint[1].bLength, sizeof(libusb_endpoint_descriptor));
+  EXPECT_EQ(endpoint[1].bDescriptorType, LIBUSB_DT_ENDPOINT);
+  EXPECT_EQ(endpoint[1].bEndpointAddress, 130);
+  EXPECT_EQ(endpoint[1].bmAttributes, LIBUSB_TRANSFER_TYPE_BULK);
+  EXPECT_EQ(endpoint[1].wMaxPacketSize, 64);
+  EXPECT_EQ(endpoint[1].extra, nullptr);
+  EXPECT_EQ(endpoint[1].extra_length, 0);
+  EXPECT_EQ(endpoint[2].bLength, sizeof(libusb_endpoint_descriptor));
+  EXPECT_EQ(endpoint[2].bDescriptorType, LIBUSB_DT_ENDPOINT);
+  EXPECT_EQ(endpoint[2].bEndpointAddress, 131);
+  EXPECT_EQ(endpoint[2].bmAttributes, LIBUSB_TRANSFER_TYPE_INTERRUPT);
+  EXPECT_EQ(endpoint[2].wMaxPacketSize, 16);
+  EXPECT_EQ(endpoint[2].extra, nullptr);
+  EXPECT_EQ(endpoint[2].extra_length, 0);
+
+  // Cleanup.
+  libusb()->LibusbFreeConfigDescriptor(descriptor);
+  FreeLibusbDevices(devices);
+}
+
 // Test that `LibusbGetBusNumber()` initially returns the default bus number.
 TEST_P(LibusbJsProxyTest, BusNumber) {
   // Arrange.

--- a/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
@@ -618,6 +618,9 @@ TEST_P(LibusbJsProxyTest, LibusbGetActiveConfigDescriptorDellKeyboard) {
           .Get());
   std::vector<libusb_device*> devices = GetLibusbDevices();
   ASSERT_THAT(devices, SizeIs(1));
+  // Configure mock USB configuration. Note the "interfaceNumber" value that's
+  // equal to "1", as it makes the test different from above by leaving out the
+  // interface "0".
   global_context()->WillReplyToRequestWith(
       "libusb", "getConfigurations",
       /*arguments=*/ArrayValueBuilder().Add(123).Get(),


### PR DESCRIPTION
Only let the PC/SC see those USB device interfaces that have suitable properties. The exact criteria is replicated from what the CCID driver does internally: either the interface class should be "11" ("Smart Card") or both it should be "255" ("Vendor Specific") and the extra data length should be "54" (which is the standard length of the CCID descriptor).

The primary goal is to workaround issues with specific composite devices on modern ChromeOS versions. Before this commit, PC/SC would see all interfaces and attempt to connect via each of them. This used to cause no harm, except spurious errors (which we suppressed heuristically).

However, ChromeOS version 105 introduced behavior change, not allowing to connect to such composite devices more than once. In combination with our previously built heuristic "if connection fails, simulate that the whole device reappears under a different bus number" this results in some devices not being able to initialize at all. This commit fixes such issues (we're still discussing if ChromeOS permission_broker could behave better in this case). As a bonus, we reduce log spam for all composite devices.

This fixes #849. More context in https://b.corp.google.com/issues/291810618.