### PR TITLE
Expose errorCode in JS API

### DIFF
--- a/third_party/pcsc-lite/naclport/js_client/src/api.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/api.js
@@ -2148,6 +2148,17 @@ goog.exportProperty(
     API.ResultOrErrorCode.prototype.getBase);
 
 /**
+ * @return {!API.ERROR_CODE}
+ */
+API.ResultOrErrorCode.prototype.getErrorCode = function() {
+  return this.errorCode;
+};
+
+goog.exportProperty(
+    API.ResultOrErrorCode.prototype, 'getErrorCode',
+    API.ResultOrErrorCode.prototype.getErrorCode);
+
+/**
  * @return {boolean}
  */
 API.ResultOrErrorCode.prototype.isSuccessful = function() {


### PR DESCRIPTION
JavaScript API library didn't expose the ResultOrErrorCode's error code value. The "errorCode" property wasn't marked as exported, hence it was unaccessible after minification.

This commit fixes this by exporting a new "getErrorCode" method instead. This fixes #793.