### PR TITLE
Update ServerReadinessTracker type to a promise in ChromeApiProvider

### DIFF
--- a/smart_card_connector_app/src/chrome-api-provider.js
+++ b/smart_card_connector_app/src/chrome-api-provider.js
@@ -20,6 +20,7 @@ goog.provide('GoogleSmartCard.ConnectorApp.ChromeApiProvider');
 goog.require('GoogleSmartCard.PcscLiteClient.API');
 goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.ServerRequestHandler');
 goog.require('goog.Disposable');
+goog.require('goog.Promise');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
@@ -384,7 +385,7 @@ class ChromeEventListener extends goog.Disposable {
 GSC.ConnectorApp.ChromeApiProvider = class extends goog.Disposable {
   /**
    * @param {!goog.messaging.AbstractChannel} serverMessageChannel
-   * @param {!Pcsc.ReadinessTracker} serverReadinessTracker
+   * @param {!goog.Promise} serverReadinessTracker
    */
   constructor(serverMessageChannel, serverReadinessTracker) {
     super();


### PR DESCRIPTION
This CL updates the typing in `smart_card_connector_app/src/chrome-api-provider.js`, since `ClientHandler` now accepts promise as a serverReadinessTracker. See  #830 for details.