### PR TITLE
Use "ChromeOS" spelling in code and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Smart Card Connector App for Chrome OS
+# Smart Card Connector App for ChromeOS
 
-This repository contains sources of the Chrome OS **Smart Card Connector App**
+This repository contains sources of the ChromeOS **Smart Card Connector App**
 (distributed at
 [https://chrome.google.com/webstore/detail/smart-card-connector/khpfeaanjngmcnplbdlpegiifgpfgdco](https://chrome.google.com/webstore/detail/smart-card-connector/khpfeaanjngmcnplbdlpegiifgpfgdco))
 and examples how programs can communicate with this app.
@@ -10,17 +10,17 @@ and examples how programs can communicate with this app.
 
 This documentation is split into several parts for different target audiences:
 
-* **Are you a Chrome OS user?**
+* **Are you a ChromeOS user?**
 
   Please refer to this Help Center article:
   [https://support.google.com/chrome/a/answer/7014689](https://support.google.com/chrome/a/answer/7014689).
 
-* **Are you a Chrome OS administrator?**
+* **Are you a ChromeOS administrator?**
 
   Please refer to this Help Center article:
   [https://support.google.com/chrome/a/answer/7014520](https://support.google.com/chrome/a/answer/7014520).
 
-* **Are you a developer of a Chrome OS extension/app that needs to access the
+* **Are you a developer of a ChromeOS extension/app that needs to access the
   PC/SC API in order to talk to smart cards?**
 
   Please refer to this README:
@@ -47,8 +47,8 @@ Yubikey devices (see
 ### Do I need the Smart Card Connector App?
 
 You only need this in case you have a smart card (or a device that emulates it)
-and need to use it on your Chrome OS device for authenticating at web pages,
-remote desktop applications, logging into Chrome OS in enterprise deployments,
+and need to use it on your ChromeOS device for authenticating at web pages,
+remote desktop applications, logging into ChromeOS in enterprise deployments,
 etc.
 
 ### Can I use it with my memory card (microSD, etc.)?

--- a/docs/building.md
+++ b/docs/building.md
@@ -33,7 +33,7 @@ Connector App and examples of how programs can communicate with the app.
 
 In order to **run** the built apps, you will need *either* of these:
 
-* a **Chromebook** with Chrome OS >= 48.
+* a **Chromebook** with ChromeOS >= 48.
 
   This will provide the closest environment to the real world's one.
 
@@ -52,8 +52,8 @@ In order to **run** the built apps, you will need *either* of these:
   interfering with the real Chrome profile.
 
   One downside of this option is that the desktop Chrome does not provide all
-  the APIs that are provided under Chrome OS. The most noticeable example is the
-  **chrome.certificateProvider** API: it's only available under Chrome OS, so
+  the APIs that are provided under ChromeOS. The most noticeable example is the
+  **chrome.certificateProvider** API: it's only available under ChromeOS, so
   its usages in the apps will have to be stubbed out when executing locally.
 
   Another downside is that the desktop OS may require additional setup in order

--- a/docs/connector-app-api.md
+++ b/docs/connector-app-api.md
@@ -1,6 +1,6 @@
 # API exposed by the Smart Card Connector App
 
-The Smart Card Connector App exposes an API that allows other Chrome OS
+The Smart Card Connector App exposes an API that allows other ChromeOS
 extensions/apps to make PC/SC calls (see the generic specification of this API
 at
 [https://pcsclite.apdu.fr/api/group__API.html](https://pcsclite.apdu.fr/api/group__API.html)).

--- a/docs/index-developer.md
+++ b/docs/index-developer.md
@@ -18,7 +18,7 @@ the original documentation of the PC/SC-Lite daemon on Linux:
 The daemon is ported using the Native Client technology for running inside the
 JavaScript-based app.
 
-Our port of the daemon exposes the PC/SC API to other Chrome OS extensions/apps:
+Our port of the daemon exposes the PC/SC API to other ChromeOS extensions/apps:
 see [docs/connector-app-api.md](connector-app-api.md).
 
 ### CCID Free Software Driver
@@ -46,7 +46,7 @@ See [docs/building.md](building.md).
 
   Currently, there's only the CCID Free Software Driver supported. We might want
   to extend this in the future, by exposing a new API that would allow separate
-  Chrome OS extensions/apps to implement drivers for other devices.
+  ChromeOS extensions/apps to implement drivers for other devices.
 
 
 ## Maintenance tasks

--- a/docs/index-third-party-application-developer.md
+++ b/docs/index-third-party-application-developer.md
@@ -1,10 +1,10 @@
-# Documentation for developers of Chrome OS extensions/apps that need the PC/SC API
+# Documentation for developers of ChromeOS extensions/apps that need the PC/SC API
 
 
 ## Background
 
 The Smart Card Connector App acts as the provider of the **PC/SC API** to other
-Chrome OS extensions or apps.
+ChromeOS extensions or apps.
 
 The Smart Card Connector App plays, basically, the same role as the **PC/SC-Lite
 Daemon** does on Linux (see
@@ -15,19 +15,19 @@ Driver** ([https://ccid.apdu.fr/](https://ccid.apdu.fr/)), which means that most
 of CCID-compatible readers are supported.
 
 
-## Providing smart card certificates and keys to Chrome OS
+## Providing smart card certificates and keys to ChromeOS
 
 The Smart Card Connector App itself has no smart card middleware and therefore
-isn't able to provide access to certificates and keys to Chrome OS.
+isn't able to provide access to certificates and keys to ChromeOS.
 
-This role is delegated to separate (first-party or third-party) Chrome OS
+This role is delegated to separate (first-party or third-party) ChromeOS
 extensions and apps that can consume the PC/SC API and use the
 **chrome.certificateProvider** API
 ([https://developer.chrome.com/extensions/certificateProvider](https://developer.chrome.com/extensions/certificateProvider))
-in order to provide them to various Chrome OS components, namely:
+in order to provide them to various ChromeOS components, namely:
 
 * TLS client authentication when visiting Web pages;
-* Chrome OS user authentication (when the SAML-based login is used and the
+* ChromeOS user authentication (when the SAML-based login is used and the
   Identity Provider is configured to use the smart card based authentication).
 
 

--- a/docs/running-on-desktop.md
+++ b/docs/running-on-desktop.md
@@ -1,7 +1,7 @@
 # Running on desktop OS'es
 
 Note: The target platform of the Smart Card Connector App and other code in this
-repository is **only Chrome OS**.
+repository is **only ChromeOS**.
 
 However, for developers there's currently a possibility to run this code on
 desktop OS'es as well (i.e., Linux, Windows, etc.).
@@ -11,7 +11,7 @@ desktop OS'es as well (i.e., Linux, Windows, etc.).
 * **chrome.certificateProvider Chrome API is unavailable**.
 
   This is working as intended. This Chrome API, along with several others, is
-  provided only on Chrome OS (see the Chrome App APIs documentation at
+  provided only on ChromeOS (see the Chrome App APIs documentation at
   [https://developer.chrome.com/apps/api_index](https://developer.chrome.com/apps/api_index)).
 
   The usages of such APIs will have to be stubbed out when running under desktop

--- a/docs/updating-ccid.md
+++ b/docs/updating-ccid.md
@@ -1,12 +1,12 @@
 # Updating the CCID free software driver
 
-Note: This page is mainly intended for the Chrome OS Smart Card Connector
+Note: This page is mainly intended for the ChromeOS Smart Card Connector
 project maintainers.
 
 
 ## Background
 
-The Chrome OS Smart Card Connector app is shipped with a specific (pinned)
+The ChromeOS Smart Card Connector app is shipped with a specific (pinned)
 version of the CCID free software driver. This is a driver for smart card
 readers (not to be confused with drivers for smart cards, also sometimes called
 middleware).
@@ -17,7 +17,7 @@ Reasons for pinning to a specific version of the driver:
   required after updating to new versions (note that we don't run the driver
   verbatim, but instead port it under the WebAssembly and Native Client
   technologies to run inside the JavaScript-based App);
-* We can test the driver version and assure its quality on Chrome OS.
+* We can test the driver version and assure its quality on ChromeOS.
 
 However, this approach also implies some amount of maintenance work to update
 the driver (say, every few months). It also means that the users typically get a

--- a/docs/updating-pcsc-lite.md
+++ b/docs/updating-pcsc-lite.md
@@ -1,12 +1,12 @@
 # Updating the PC/SC-Lite daemon
 
-Note: This page is mainly intended for the Chrome OS Smart Card Connector
+Note: This page is mainly intended for the ChromeOS Smart Card Connector
 project maintainers.
 
 
 ## Background
 
-The Chrome OS Smart Card Connector app is shipped with a specific (pinned)
+The ChromeOS Smart Card Connector app is shipped with a specific (pinned)
 version of the PC/SC-Lite daemon. This daemon exposes the PC/SC API to client
 extensions/apps, transforming this API calls into commands to the drivers
 (currently, we have only one driver - the CCID Free Software driver).
@@ -17,7 +17,7 @@ Reasons for pinning to a specific version of the daemon:
   required after updating to new versions (note that we don't run the daemon
   verbatim, but instead port it under the Native Client technology to run inside
   the JavaScript-based App);
-* We can test the daemon version and assure its quality on Chrome OS.
+* We can test the daemon version and assure its quality on ChromeOS.
 
 However, this approach also implies some amount of maintenance work to update
 the daemon (say, every few months). It also means that the users typically get a

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
@@ -68,8 +68,8 @@ const GSC = GoogleSmartCard;
  *
  * Note: The actual string values are hardcoded below, instead of references to
  * |chrome.certificateProvider|, since the latter will break when run with the
- * API version that doesn't have these (on Chrome OS <=85 or on some future
- * Chrome OS that has the legacy Hash enum deleted from the API).
+ * API version that doesn't have these (on ChromeOS <=85 or on some future
+ * ChromeOS that has the legacy Hash enum deleted from the API).
  * @type {!Map<string,string>}
  */
 const HASH_TO_ALGORITHM_MAPPING = new Map([
@@ -285,7 +285,7 @@ Backend.prototype.handleRequest_ = function(payload) {
   } else {
     promiseResolver.reject(
         'No such function in the API: ' + remoteCallMessage.functionName +
-        '. Please check that the extension is running on Chrome OS and that ' +
+        '. Please check that the extension is running on ChromeOS and that ' +
         'the Chrome version is sufficiently new.');
   }
 
@@ -309,7 +309,7 @@ Backend.prototype.setupApiListeners_ = function() {
           'chrome.certificateProvider API is not available. Providing ' +
               'certificates to the Chrome browser will be impossible. This is ' +
               'just a warning in the Debug build (in order to make some testing ' +
-              'on non-Chrome OS systems possible), but this will be a fatal ' +
+              'on non-ChromeOS systems possible), but this will be a fatal ' +
               'error in the Release build');
     } else {
       goog.log.error(
@@ -331,9 +331,9 @@ Backend.prototype.setupApiListeners_ = function() {
     chrome.certificateProvider.onSignatureRequested.addListener(
         this.signatureRequestListener_);
   } else {
-    // TODO: Remove this branch after support of Chrome OS <=85 is dropped.
+    // TODO: Remove this branch after support of ChromeOS <=85 is dropped.
     // (There's no specific timeline - a conservative approach would be to wait
-    // until all devices released with Chrome OS <=85 reach the auto-update
+    // until all devices released with ChromeOS <=85 reach the auto-update
     // expiration date, which will be roughly in year 2028.)
     goog.log.info(
         this.logger,

--- a/smart_card_connector_app/src/_locales/en/messages.json
+++ b/smart_card_connector_app/src/_locales/en/messages.json
@@ -20,8 +20,8 @@
     "description": "The header displayed in the main window"
   },
   "nonChromeOsWarning": {
-    "message": "Warning: The app is intended to be run on Chrome OS only!",
-    "description": "The text that is displayed as a warning when the app is executed on non-Chrome OS systems"
+    "message": "Warning: The app is intended to be run on ChromeOS only!",
+    "description": "The text that is displayed as a warning when the app is executed on non-ChromeOS systems"
   },
   "windowClose": {
     "message": "Close",

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -168,7 +168,7 @@ function executableModuleDisposedListener() {
 
 /**
  * Called when the onLaunched event is received (that is, when the user clicks
- * on the app in the Chrome OS app launcher).
+ * on the app in the ChromeOS app launcher).
  */
 function launchedListener() {
   goog.log.fine(logger, 'Received onLaunched event, opening window...');

--- a/smart_card_connector_app/src/chrome-api-provider.js
+++ b/smart_card_connector_app/src/chrome-api-provider.js
@@ -151,7 +151,7 @@ function convertReaderStateIn(readerState) {
  * chrome.smartCardProviderPrivate.ReaderStateOut type.
  * This function doesn't handle the API.SCARD_STATE_ATRMATCH flag,
  * since there is no corresponding flag in chrome.smartCardProviderPrivate
- * API and we don't expect it to be used on Chrome OS.
+ * API and we don't expect it to be used on ChromeOS.
  * @param {!PcscApi.SCARD_READERSTATE_OUT} readerState
  * @returns {!chrome.smartCardProviderPrivate.ReaderStateOut}
  */

--- a/smart_card_connector_app/src/window-main.js
+++ b/smart_card_connector_app/src/window-main.js
@@ -74,7 +74,7 @@ function displayNonChromeOsWarningIfNeeded() {
     if (os != 'cros') {
       goog.log.info(
           logger,
-          'Displaying the warning regarding non-Chrome OS system ' +
+          'Displaying the warning regarding non-ChromeOS system ' +
               '(the current OS is "' + os + '")');
       goog.dom.classlist.remove(
           goog.dom.getElement('non-chrome-os-warning'), 'hidden');

--- a/third_party/libusb/webport/src/chrome_usb/chrome-login-state-hook.js
+++ b/third_party/libusb/webport/src/chrome_usb/chrome-login-state-hook.js
@@ -53,7 +53,7 @@ GSC.LibusbLoginStateHook = class extends GSC.LibusbProxyHook {
     } else {
       goog.log.info(
           logger,
-          'chrome.loginState API is not available (either the Chrome OS ' +
+          'chrome.loginState API is not available (either the ChromeOS ' +
               'version is too old or a different OS is used). Will skip ' +
               'observing OS session state.');
       this.resolveInitializationPromise_();

--- a/third_party/pcsc-lite/naclport/server/README.rst
+++ b/third_party/pcsc-lite/naclport/server/README.rst
@@ -33,7 +33,7 @@ The original original PC/SC-Lite project consists of two parts:
 This is how the original PC/SC-Lite service intended to works on \*nix
 and on other platforms.
 
-In order to port PC/SC-Lite onto **Chrome OS**, different circumstances
+In order to port PC/SC-Lite onto **ChromeOS**, different circumstances
 had to be taken into account:
 
 *   Each application (both PC/SC-Lite daemon and the client
@@ -46,7 +46,7 @@ had to be taken into account:
     There is no full analogue of POSIX domain sockets for communication
     between different Apps.
 
-*   In Chrome OS environment, it makes sense to write some client
+*   In ChromeOS environment, it makes sense to write some client
     applications entirely in pure JavaScript.
 
     This implies that the binary protocol that was used by the original
@@ -54,7 +54,7 @@ had to be taken into account:
     for the server App to expose the analog of the client PC/SC-Lite
     API.
 
-As a consequence, it was decided that the server App on Chrome OS should
+As a consequence, it was decided that the server App on ChromeOS should
 consist of **both** the parts of the original PC/SC-Lite daemon and the
 parts of the original PC/SC-Lite client library. This is what the
 presented library consists of.


### PR DESCRIPTION
This is the official name that's been preferred since a while. I haven't found official announcements, but a non-official one is https://9to5google.com/2022/04/29/google-prepares-chromeos-rebrand-to-drop-the-space/