### PR TITLE
[CI] Don't try posting comments in PRs in forks

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -177,6 +177,9 @@ jobs:
     runs-on: ubuntu-latest
     # Depend on all other jobs, so that we don't post a PR comment if any fails.
     needs: [build-emscripten, build-nacl, test-asan, collect-coverage]
+    # Skip running this in forks, because it'd fail with "Resource not
+    # accessible by integration".
+    if: github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 5
 
     steps:


### PR DESCRIPTION
Normally our continuous integration scripts post a comment on a Pull Request once all jobs successfully complete. However, this doesn't work when the PR is in a fork, as the "Resource not accessible by integration" permission error occurs
(https://github.com/peter-evans/create-or-update-comment#action-inputs).

This commit makes this job being completely skipped. That way, we avoid spurious errors for now, until we maybe figure out the right way to do it.