### PR TITLE
[JS-to-C++ test] Guard NaCl-specific sources build

### DIFF
--- a/common/integration_testing/build/Makefile
+++ b/common/integration_testing/build/Makefile
@@ -26,8 +26,18 @@ ROOT_SOURCES_SUBDIR := google_smart_card_integration_testing
 SOURCES_PATH := $(ROOT_SOURCES_PATH)/$(ROOT_SOURCES_SUBDIR)
 
 SOURCES := \
-	$(SOURCES_PATH)/integration_test_pp_module.cc \
 	$(SOURCES_PATH)/integration_test_service.cc \
+
+ifeq ($(TOOLCHAIN),pnacl)
+
+SOURCES += \
+	$(SOURCES_PATH)/integration_test_pp_module.cc \
+
+else
+
+$(error Unexpected TOOLCHAIN "$(TOOLCHAIN)".)
+
+endif
 
 CXXFLAGS := \
 	-I$(ROOT_SOURCES_PATH) \


### PR DESCRIPTION
Only build the NaCl-specific integration_test source file (integration_test_pp_module.cc) when the TOOLCHAIN=pnacl is specified.

This is preparation commit for enabling these tests on TOOLCHAIN=emscripten (tracked by #816).