### PR TITLE
[JS-to-C++ test] Toolchain-agnostic build interface

### DIFF
--- a/common/integration_testing/build/Makefile
+++ b/common/integration_testing/build/Makefile
@@ -28,17 +28,6 @@ SOURCES_PATH := $(ROOT_SOURCES_PATH)/$(ROOT_SOURCES_SUBDIR)
 SOURCES := \
 	$(SOURCES_PATH)/integration_test_service.cc \
 
-ifeq ($(TOOLCHAIN),pnacl)
-
-SOURCES += \
-	$(SOURCES_PATH)/integration_test_pp_module.cc \
-
-else
-
-$(error Unexpected TOOLCHAIN "$(TOOLCHAIN)".)
-
-endif
-
 CXXFLAGS := \
 	-I$(ROOT_SOURCES_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \

--- a/common/integration_testing/include.mk
+++ b/common/integration_testing/include.mk
@@ -12,14 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-#
-# This file contains helper definitions for using this library.
+# This file provides helper definitions for building and running C++ unit tests,
+# written using the GoogleTest framework.
 #
 # /common/make/common.mk and /common/make/executable_building.mk must be
 # included before including this file.
-#
 
+# Common documentation for definitions provided by this file (they are
+# implemented in toolchain-specific .mk files, but share the same interface):
+#
+# * BUILD_JS_TO_CXX_TEST macro:
+#   Compiles the JavaScript test files and links the C/C++ counterpart.
+#   Arguments:
+#   $1 ("CXX_SOURCES"): Paths to C/C++ sources (containing helpers needed for
+#     the test) to link against.
+#   $2 ("LIBS"): C/C++ static libraries to link against.
+#   $3 ("JS_SOURCES"): Paths to JS sources (containing the tests).
+#
+# * run_test target:
+#   A target that executes the tests.
+
+.PHONY: run_test
+
+
+# TODO(emaxx): Drop the constants below.
 
 INTEGRATION_TESTING_LIB := google_smart_card_integration_testing
 
@@ -29,3 +45,11 @@ INTEGRATION_TESTING_DIR_PATH := $(COMMON_DIR_PATH)/integration_testing
 # compiling the code using this library.
 INTEGRATION_TESTING_JS_COMPILER_INPUT_DIR_PATHS := \
 	$(INTEGRATION_TESTING_DIR_PATH) \
+
+
+# Load the toolchain-specific file.
+ifeq ($(TOOLCHAIN),pnacl)
+include $(ROOT_PATH)/common/integration_testing/src/build_nacl.mk
+else
+$(error Unexpected TOOLCHAIN "$(TOOLCHAIN)".)
+endif

--- a/common/integration_testing/include.mk
+++ b/common/integration_testing/include.mk
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file provides helper definitions for building and running C++ unit tests,
-# written using the GoogleTest framework.
+# This file provides helper definitions for building and running JS-to-C++
+# integration-like tests. The JS side orchestrates and contains the actual test
+# cases, meanwhile the C++ side provides neccessary helpers and/or exercised
+# code.
 #
 # /common/make/common.mk and /common/make/executable_building.mk must be
 # included before including this file.

--- a/common/integration_testing/src/build_nacl.mk
+++ b/common/integration_testing/src/build_nacl.mk
@@ -18,15 +18,25 @@
 # Internal constant containing the list of additional C/C++ static libraries to
 # link against.
 #
-# Note: INTEGRATION_TESTING_LIB has to come before CPP_COMMON_LIB, since the
-# former uses symbols from the latter. And DEFAULT_NACL_LIBS is specified twice,
-# because there's a circular dependency between it and INTEGRATION_TESTING_LIB.
+# Notes:
+# * INTEGRATION_TESTING_LIB has to come before CPP_COMMON_LIB, since the
+#   former uses symbols from the latter.
+# * DEFAULT_NACL_LIBS is specified twice, because there's a circular dependency
+#   between it and INTEGRATION_TESTING_LIB:
+#   + ppapi_cpp depends on pp::CreateModule() that's defined by us in
+#     google_smart_card_integration_testing,
+#   + the rest of the code in google_smart_card_integration_testing uses NaCl
+#     symbols and hence depends on ppapi_cpp.
+#   Meanwhile the proper solution would be "-Wl,--start-group"/"end-group", this
+#   is not supported by the NaCl toolchain helpers.
 JS_TO_CXX_TEST_NACL_LIBS := \
 	$(DEFAULT_NACL_LIBS) \
 	$(INTEGRATION_TESTING_LIB) \
 	$(CPP_COMMON_LIB) \
 	$(DEFAULT_NACL_LIBS) \
 
+# Internal constant containing the list of additional JS sources to be passed to
+# Closure Compiler.
 JS_TO_CXX_TEST_JS_COMPILER_INPUTS := \
 	$(INTEGRATION_TESTING_JS_COMPILER_INPUT_DIR_PATHS) \
 	$(JS_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \

--- a/common/integration_testing/src/build_nacl.mk
+++ b/common/integration_testing/src/build_nacl.mk
@@ -1,0 +1,68 @@
+# Copyright 2023 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains the implementation of the ../include.mk interface that
+# builds the JS-to-C++ test runner using the Native Client toolchain.
+
+# Internal constant containing the list of additional C/C++ static libraries to
+# link against.
+#
+# Note: INTEGRATION_TESTING_LIB has to come before CPP_COMMON_LIB, since the
+# former uses symbols from the latter. And DEFAULT_NACL_LIBS is specified twice,
+# because there's a circular dependency between it and INTEGRATION_TESTING_LIB.
+JS_TO_CXX_TEST_NACL_LIBS := \
+	$(DEFAULT_NACL_LIBS) \
+	$(INTEGRATION_TESTING_LIB) \
+	$(CPP_COMMON_LIB) \
+	$(DEFAULT_NACL_LIBS) \
+
+JS_TO_CXX_TEST_JS_COMPILER_INPUTS := \
+	$(INTEGRATION_TESTING_JS_COMPILER_INPUT_DIR_PATHS) \
+	$(JS_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \
+
+# Documented in ../include.mk.
+define BUILD_JS_TO_CXX_TEST
+
+# Target that generates the NaCl executable module containing compiled C/C++
+# helpers.
+$(eval $(call LINK_EXECUTABLE_RULE,$(1),$(JS_TO_CXX_TEST_NACL_LIBS) $(2)))
+
+# Target that generates tests.js containing compiled JS tests and helpers.
+$(eval $(call BUILD_TESTING_JS_SCRIPT,tests.js,$(JS_TO_CXX_TEST_JS_COMPILER_INPUTS) $(3)))
+
+endef
+
+# Target that generates index.html.
+#
+# It's essentially a simple wrapper that executes the contents of tests.js.
+$(OUT_DIR_PATH)/index.html: $(OUT_DIR_PATH)
+	@echo "<script src='tests.js'></script>" > $(OUT_DIR_PATH)/index.html
+all: $(OUT_DIR_PATH)/index.html
+
+# Target that executes the tests by starting a Chrome instance with the test
+# runner's HTML page. A web server is additionally started that serves the page
+# and the NaCl module's files. The user-data-dir, which is passed to Chrome for
+# storing data, is cleared before each run to prevent state leakage.
+#
+# Note: The recipe uses variables that are defined by NaCl's makefiles.
+run_test: all
+	rm -rf user-data-dir
+	$(RUN_PY) \
+		-C $(OUT_DIR_PATH) \
+		-P "index.html?tc=$(TOOLCHAIN)&config=$(CONFIG)" \
+		$(addprefix -E ,$(CHROME_ENV)) \
+		-- \
+		"$(CHROME_PATH)" \
+		$(CHROME_ARGS) \
+		--register-pepper-plugins="$(PPAPI_DEBUG),$(PPAPI_RELEASE)" \

--- a/common/integration_testing/src/build_nacl.mk
+++ b/common/integration_testing/src/build_nacl.mk
@@ -57,7 +57,7 @@ define BUILD_JS_TO_CXX_TEST
 # Target that generates the NaCl executable module containing compiled C/C++
 # helpers.
 $(eval $(call LINK_EXECUTABLE_RULE,$(1) $(JS_TO_CXX_TEST_ENTRY_POINT_SOURCE),\
-	$(JS_TO_CXX_TEST_NACL_LIBS) $(2)))
+	$(2) $(JS_TO_CXX_TEST_NACL_LIBS)))
 
 # Target that generates tests.js containing compiled JS tests and helpers.
 $(eval $(call BUILD_TESTING_JS_SCRIPT,tests.js,\

--- a/example_cpp_smart_card_client_app/build/integration_tests/Makefile
+++ b/example_cpp_smart_card_client_app/build/integration_tests/Makefile
@@ -30,28 +30,12 @@ include $(COMMON_DIR_PATH)/integration_testing/include.mk
 
 SOURCE_DIR := ../../src/
 
-CPP_SOURCES := \
+CXX_SOURCES := \
 	$(SOURCE_DIR)/chrome_certificate_provider/api_bridge.cc \
 	$(SOURCE_DIR)/chrome_certificate_provider/api_bridge_integration_test_helper.cc \
 	$(SOURCE_DIR)/chrome_certificate_provider/types.cc \
 
-JS_COMPILER_INPUT_PATHS := \
-	$(INTEGRATION_TESTING_JS_COMPILER_INPUT_DIR_PATHS) \
-	$(JS_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \
-	$(SOURCE_DIR) \
-
-# Note: INTEGRATION_TESTING_LIB has to come before CPP_COMMON_LIB, since the
-# former uses symbols from the latter. And DEFAULT_NACL_LIBS is specified twice,
-# because there's a circular dependency between it and INTEGRATION_TESTING_LIB.
-LIBS := \
-	$(DEFAULT_NACL_LIBS) \
-	$(INTEGRATION_TESTING_LIB) \
-	$(CPP_COMMON_LIB) \
-	$(DEFAULT_NACL_LIBS) \
-
-DEPS := \
-
-CPPFLAGS := \
+CXXFLAGS := \
 	-I$(SOURCE_DIR) \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-I$(ROOT_PATH)/common/integration_testing/src \
@@ -62,28 +46,12 @@ CPPFLAGS := \
 	-Wextra \
 	-Wno-zero-length-array \
 
-$(foreach src,$(CPP_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CPPFLAGS))))
-$(eval $(call LINK_EXECUTABLE_RULE,$(CPP_SOURCES),$(LIBS),$(DEPS)))
+LIBS := \
 
-$(eval $(call BUILD_TESTING_JS_SCRIPT,tests.js,$(JS_COMPILER_INPUT_PATHS)))
+JS_SOURCES_PATH := $(SOURCE_DIR)
 
-$(OUT_DIR_PATH)/index.html: $(OUT_DIR_PATH)
-	@echo "<script src='tests.js'></script>" > $(OUT_DIR_PATH)/index.html
-all: $(OUT_DIR_PATH)/index.html
+# Target that compiles C++ files.
+$(foreach src,$(CXX_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
 
-# Target that executes the tests by starting a Chrome instance with the test
-# runner's HTML page. A web server is additionally started that serves the page
-# and the NaCl module's files. The user-data-dir, which is passed to Chrome for
-# storing data, is cleared before each run to prevent state leakage.
-#
-# Note: The recipe uses variables that are defined by NaCl's makefiles.
-run_test: all
-	rm -rf user-data-dir
-	$(RUN_PY) \
-		-C $(OUT_DIR_PATH) \
-		-P "index.html?tc=$(TOOLCHAIN)&config=$(CONFIG)" \
-		$(addprefix -E ,$(CHROME_ENV)) \
-		-- \
-		"$(CHROME_PATH)" \
-		$(CHROME_ARGS) \
-		--register-pepper-plugins="$(PPAPI_DEBUG),$(PPAPI_RELEASE)" \
+# Targets that build the resulting executable module and JS tests.
+$(eval $(call BUILD_JS_TO_CXX_TEST,$(CXX_SOURCES),$(LIBS),$(JS_SOURCES_PATH)))


### PR DESCRIPTION
Move the existing NaCl build rules into a common location, and refactor them to be an implementation of a toolchain-agnostic makefile rule.

This is preparation for introducing Emscripten build support for the same tests, and also for new JS-to-C++ integration tests (tracked by #816).