### PR TITLE
[JS-to-C++ test] run-js-tests custom Chrome args

### DIFF
--- a/common/js_test_runner/run-js-tests.py
+++ b/common/js_test_runner/run-js-tests.py
@@ -147,7 +147,7 @@ def parse_command_line_args():
   parser.add_argument('--serve-via-web-server', action='store_true',
                       help='host the whole directory via localhost webserver '
                            'and navigate to it instead of a file:// URL')
-  parser.add_argument('--chrome-arg', nargs='*', dest='chrome_args',
+  parser.add_argument('--chrome-arg', nargs='*', default=[], dest='chrome_args',
                       help='additional command-line arguments to be passed to '
                            'Chrome')
   parser.add_argument('--timeout', type=int, default=60,


### PR DESCRIPTION
Add the "--chrome-arg" parameter to the "run-js-tests.py" script, allowing a build script to specify additional command-line parameters to be specified when launching Chrome[driver].

This commit contributes to #816, because by default Chrome doesn't allow multithreaded Emscripten programs: technically, SharedArrayBuffer isn't allowed unless the website specifies CORS headers, which would be too tedious to set up for our simple localhost server. Instead, we're going to force-allow the needed Chrome features via command line.