### PR TITLE
[JS-to-C++ test] Enable SharedArrayBuffer for Emscripten

### DIFF
--- a/common/integration_testing/src/build_emscripten.mk
+++ b/common/integration_testing/src/build_emscripten.mk
@@ -73,9 +73,15 @@ all: $(OUT_DIR_PATH)/index.html
 # --serve-via-web-server: Run the tests as "localhost:<random_port>/index.html"
 #   instead of just navigating to "file://.../index.html", because Chrome
 #   doesn't allow loading additional JavaScript code on file:// URLs.
+# --chrome-arg:
+#   --enable-features=SharedArrayBuffer: Force-enable SharedArrayBuffer that's
+#     normally disallowed when the page has no CORS headers (which our test
+#     server doesn't). SharedArrayBuffer is needed for multi-threaded
+#     Emscripten modules.
 run_test: all
 	. $(ROOT_PATH)/env/python3_venv/bin/activate && \
 		$(ROOT_PATH)/common/js_test_runner/run-js-tests.py \
 			$(OUT_DIR_PATH)/index.html \
 			--chromedriver-path=$(ROOT_PATH)/env/chromedriver \
-			--serve-via-web-server
+			--serve-via-web-server \
+			--chrome-arg="--enable-features=SharedArrayBuffer"


### PR DESCRIPTION
Force-enable Chrome's SharedArrayBuffer feature when running integration tests in the TOOLCHAIN=emscripten mode, because otherwise multi-threading wouldn't work, which is required by the tests.

The underlying reason is that by default Chrome only allows the SharedArrayBuffer on pages that have CORS headers set up properly: see https://developer.chrome.com/blog/enabling-shared-array-buffer/ . Our tests are run a simple local web server which doesn't have them. As setting these up would be too tedious, the workaround here is to tweak Chrome when running the tests instead.

This commit contributes to #816 and is one of the last blockers before actually enabling integration tests in Emscripten mode and in CI.