### PR TITLE
[JS-to-C++ test] Boilerplate for testing Connector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,10 +106,14 @@ LIBRARY_TARGETS += \
 
 TEST_TARGETS += \
 	example_cpp_smart_card_client_app/build/integration_tests \
+	smart_card_connector_app/build/js_to_cxx_tests \
 
 example_cpp_smart_card_client_app/build/integration_tests: common/cpp/build
 example_cpp_smart_card_client_app/build/integration_tests: common/integration_testing/build
 example_cpp_smart_card_client_app/build/integration_tests: example_cpp_smart_card_client_app/build
+smart_card_connector_app/build/js_to_cxx_tests: common/cpp/build
+smart_card_connector_app/build/js_to_cxx_tests: common/integration_testing/build
+smart_card_connector_app/build/js_to_cxx_tests: smart_card_connector_app/build
 
 endif
 

--- a/smart_card_connector_app/build/js_to_cxx_tests/.gitignore
+++ b/smart_card_connector_app/build/js_to_cxx_tests/.gitignore
@@ -1,0 +1,5 @@
+/js_build/
+/out/
+/out-artifacts-emscripten/
+/pnacl/
+/user-data-dir/

--- a/smart_card_connector_app/build/js_to_cxx_tests/Makefile
+++ b/smart_card_connector_app/build/js_to_cxx_tests/Makefile
@@ -1,0 +1,43 @@
+# Copyright 2023 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Makefile for JavaScript-to-C++ integration tests.
+
+TARGET := integration_tests
+
+include ../../../common/make/common.mk
+
+include $(ROOT_PATH)/common/make/js_building_common.mk
+include $(ROOT_PATH)/common/make/executable_building.mk
+include $(ROOT_PATH)/common/cpp/include.mk
+include $(ROOT_PATH)/common/js/include.mk
+include $(ROOT_PATH)/common/integration_testing/include.mk
+
+
+SOURCE_DIR := $(ROOT_PATH)/smart_card_connector_app/src/
+
+# TODO(emaxx): Add C++ helpers for controlling the PC/SC-Lite server.
+CXX_SOURCES := \
+
+CXXFLAGS := \
+
+LIBS := \
+
+JS_SOURCES_PATH := $(SOURCE_DIR)/**-jstocxxtest.js
+
+# Target that compiles C++ files.
+$(foreach src,$(CXX_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
+
+# Targets that build the resulting executable module and JS tests.
+$(eval $(call BUILD_JS_TO_CXX_TEST,$(CXX_SOURCES),$(LIBS),$(JS_SOURCES_PATH)))

--- a/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
@@ -15,6 +15,14 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview This file contains tests for the PC/SC API exposed by Smart
+ * Card Connector.
+ *
+ * TODO(emaxx): This is currently just a boilerplate. Real tests will be added
+ * after needed helpers are implemented.
+ */
+
 goog.require('GoogleSmartCard.IntegrationTestController');
 goog.require('goog.testing');
 goog.require('goog.testing.jsunit');

--- a/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2023 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.require('GoogleSmartCard.IntegrationTestController');
+goog.require('goog.testing');
+goog.require('goog.testing.jsunit');
+
+goog.setTestOnly();
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+/** @type {GSC.IntegrationTestController?} */
+let testController;
+
+goog.exportSymbol('testPcscApi', {
+  'setUp': async function() {
+    testController = new GSC.IntegrationTestController();
+    await testController.initAsync();
+  },
+
+  'tearDown': async function() {
+    try {
+      await testController.disposeAsync();
+    } finally {
+      testController = null;
+    }
+  },
+
+  'testSmoke': async function() {},
+});
+});  // goog.scope

--- a/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
@@ -42,6 +42,9 @@ goog.exportSymbol('testPcscApi', {
     }
   },
 
-  'testSmoke': async function() {},
+  'testSmoke': async function() {
+    // TODO(emaxx): The test currently does nothing. Add functional tests after
+    // implementing needed C++ helpers.
+  },
 });
 });  // goog.scope


### PR DESCRIPTION
Add build scripts and an empty test for testing Smart Card Connector. This boilerplate can be used for adding functional tests in follow-ups as tracked by #869.