### PR TITLE
[JS-to-C++ test] Make helper SetUp async

### DIFF
--- a/common/integration_testing/build/Makefile
+++ b/common/integration_testing/build/Makefile
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This makefile builds the "google_smart_card_integration_testing" static
+# library, which is contains common code for JS-to-C++ tests.
+
 TARGET := google_smart_card_integration_testing
 
 include ../../make/common.mk
@@ -26,6 +29,7 @@ ROOT_SOURCES_SUBDIR := google_smart_card_integration_testing
 SOURCES_PATH := $(ROOT_SOURCES_PATH)/$(ROOT_SOURCES_SUBDIR)
 
 SOURCES := \
+	$(SOURCES_PATH)/integration_test_helper.cc \
 	$(SOURCES_PATH)/integration_test_service.cc \
 
 CXXFLAGS := \

--- a/common/integration_testing/build/Makefile
+++ b/common/integration_testing/build/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This makefile builds the "google_smart_card_integration_testing" static
-# library, which is contains common code for JS-to-C++ tests.
+# library, which contains common code for JS-to-C++ tests.
 
 TARGET := google_smart_card_integration_testing
 

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.cc
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.cc
@@ -1,0 +1,35 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google_smart_card_integration_testing/integration_test_helper.h>
+
+#include <google_smart_card_common/global_context.h>
+#include <google_smart_card_common/messaging/typed_message_router.h>
+#include <google_smart_card_common/requesting/request_receiver.h>
+#include <google_smart_card_common/requesting/request_result.h>
+#include <google_smart_card_common/value.h>
+
+namespace google_smart_card {
+
+IntegrationTestHelper::~IntegrationTestHelper() = default;
+
+void IntegrationTestHelper::SetUp(
+    GlobalContext* /*global_context*/,
+    TypedMessageRouter* /*typed_message_router*/,
+    Value /*data*/,
+    RequestReceiver::ResultCallback result_callback) {
+  result_callback(GenericRequestResult::CreateSuccessful(Value()));
+}
+
+}  // namespace google_smart_card

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h
@@ -43,12 +43,13 @@ namespace google_smart_card {
 // trick is actually used by Googletest internally.
 class IntegrationTestHelper {
  public:
-  virtual ~IntegrationTestHelper() = default;
+  virtual ~IntegrationTestHelper();
 
   virtual std::string GetName() const = 0;
-  virtual void SetUp(GlobalContext* /*global_context*/,
-                     TypedMessageRouter* /*typed_message_router*/,
-                     Value /*data*/) {}
+  virtual void SetUp(GlobalContext* global_context,
+                     TypedMessageRouter* typed_message_router,
+                     Value data,
+                     RequestReceiver::ResultCallback result_callback);
   virtual void TearDown() {}
   virtual void OnMessageFromJs(
       Value data,

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.cc
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.cc
@@ -87,8 +87,7 @@ void IntegrationTestService::HandleRequest(
     ExtractRemoteCallArgumentsOrDie(std::move(request.function_name),
                                     std::move(request.arguments), &helper_name,
                                     &data_for_helper);
-    SetUpHelper(helper_name, std::move(data_for_helper));
-    result_callback(GenericRequestResult::CreateSuccessful(Value()));
+    SetUpHelper(helper_name, std::move(data_for_helper), result_callback);
     return;
   }
   if (request.function_name == "TearDownAll") {
@@ -124,15 +123,17 @@ IntegrationTestHelper* IntegrationTestService::FindHelperByName(
   return nullptr;
 }
 
-void IntegrationTestService::SetUpHelper(const std::string& helper_name,
-                                         Value data_for_helper) {
+void IntegrationTestService::SetUpHelper(
+    const std::string& helper_name,
+    Value data_for_helper,
+    RequestReceiver::ResultCallback result_callback) {
   IntegrationTestHelper* helper = FindHelperByName(helper_name);
   if (!helper)
     GOOGLE_SMART_CARD_LOG_FATAL << "Unknown helper " << helper_name;
   GOOGLE_SMART_CARD_CHECK(!set_up_helpers_.count(helper));
   set_up_helpers_.insert(helper);
   helper->SetUp(global_context_, typed_message_router_,
-                std::move(data_for_helper));
+                std::move(data_for_helper), result_callback);
 }
 
 void IntegrationTestService::TearDownAllHelpers() {

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
@@ -58,7 +58,9 @@ class IntegrationTestService final : public RequestHandler {
   ~IntegrationTestService() override;
 
   IntegrationTestHelper* FindHelperByName(const std::string& name);
-  void SetUpHelper(const std::string& helper_name, Value data_for_helper);
+  void SetUpHelper(const std::string& helper_name,
+                   Value data_for_helper,
+                   RequestReceiver::ResultCallback result_callback);
   void TearDownAllHelpers();
   void SendMessageToHelper(const std::string& helper_name,
                            Value message_for_helper,

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
@@ -82,7 +82,8 @@ class ApiBridgeIntegrationTestHelper final : public gsc::IntegrationTestHelper {
   std::string GetName() const override;
   void SetUp(gsc::GlobalContext* global_context,
              gsc::TypedMessageRouter* typed_message_router,
-             gsc::Value data) override;
+             gsc::Value data,
+             gsc::RequestReceiver::ResultCallback result_callback) override;
   void TearDown() override;
   void OnMessageFromJs(
       gsc::Value data,
@@ -107,10 +108,12 @@ std::string ApiBridgeIntegrationTestHelper::GetName() const {
 void ApiBridgeIntegrationTestHelper::SetUp(
     gsc::GlobalContext* global_context,
     gsc::TypedMessageRouter* typed_message_router,
-    gsc::Value /*data*/) {
+    gsc::Value /*data*/,
+    gsc::RequestReceiver::ResultCallback result_callback) {
   api_bridge_ =
       std::make_shared<ApiBridge>(global_context, typed_message_router,
                                   /*request_handling_mutex=*/nullptr);
+  result_callback(gsc::GenericRequestResult::CreateSuccessful(gsc::Value()));
 }
 
 void ApiBridgeIntegrationTestHelper::TearDown() {


### PR DESCRIPTION
Change IntegrationTestHelper::SetUp() to return its result asynchronously via a callback.

These asynchronous helpers will be used in follow-up PRs for doing startup/shutdown of the PC/SC server in JS-to-C++ tests of Smart Card Connector, tracked by #869.