### PR TITLE
[JS-to-C++ test] Make helper TearDown async

### DIFF
--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.cc
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.cc
@@ -14,6 +14,8 @@
 
 #include <google_smart_card_integration_testing/integration_test_helper.h>
 
+#include <functional>
+
 #include <google_smart_card_common/global_context.h>
 #include <google_smart_card_common/messaging/typed_message_router.h>
 #include <google_smart_card_common/requesting/request_receiver.h>
@@ -30,6 +32,11 @@ void IntegrationTestHelper::SetUp(
     Value /*data*/,
     RequestReceiver::ResultCallback result_callback) {
   result_callback(GenericRequestResult::CreateSuccessful(Value()));
+}
+
+void IntegrationTestHelper::TearDown(
+    std::function<void()> completion_callback) {
+  completion_callback();
 }
 
 }  // namespace google_smart_card

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_SMART_CARD_INTEGRATION_TESTING_INTEGRATION_TEST_HELPER_H_
 #define GOOGLE_SMART_CARD_INTEGRATION_TESTING_INTEGRATION_TEST_HELPER_H_
 
+#include <functional>
 #include <string>
 
 #include <google_smart_card_common/global_context.h>
@@ -50,7 +51,7 @@ class IntegrationTestHelper {
                      TypedMessageRouter* typed_message_router,
                      Value data,
                      RequestReceiver::ResultCallback result_callback);
-  virtual void TearDown() {}
+  virtual void TearDown(std::function<void()> completion_callback);
   virtual void OnMessageFromJs(
       Value data,
       RequestReceiver::ResultCallback result_callback) = 0;

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
@@ -62,7 +62,7 @@ class IntegrationTestService final : public RequestHandler {
   void SetUpHelper(const std::string& helper_name,
                    Value data_for_helper,
                    RequestReceiver::ResultCallback result_callback);
-  void TearDownAllHelpers();
+  void TearDownAllHelpers(RequestReceiver::ResultCallback result_callback);
   void SendMessageToHelper(const std::string& helper_name,
                            Value message_for_helper,
                            RequestReceiver::ResultCallback result_callback);

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
@@ -14,6 +14,7 @@
 
 #include <stdint.h>
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <thread>
@@ -84,7 +85,7 @@ class ApiBridgeIntegrationTestHelper final : public gsc::IntegrationTestHelper {
              gsc::TypedMessageRouter* typed_message_router,
              gsc::Value data,
              gsc::RequestReceiver::ResultCallback result_callback) override;
-  void TearDown() override;
+  void TearDown(std::function<void()> completion_callback) override;
   void OnMessageFromJs(
       gsc::Value data,
       gsc::RequestReceiver::ResultCallback result_callback) override;
@@ -116,9 +117,11 @@ void ApiBridgeIntegrationTestHelper::SetUp(
   result_callback(gsc::GenericRequestResult::CreateSuccessful(gsc::Value()));
 }
 
-void ApiBridgeIntegrationTestHelper::TearDown() {
+void ApiBridgeIntegrationTestHelper::TearDown(
+    std::function<void()> completion_callback) {
   api_bridge_->ShutDown();
   api_bridge_.reset();
+  completion_callback();
 }
 
 void ApiBridgeIntegrationTestHelper::OnMessageFromJs(


### PR DESCRIPTION
Change IntegrationTestHelper::TearDown() to report its completion asynchronously via a callback.

This change is similar to the previous change for SetUp(), except that teardown doesn't need to return any value, and that we have to properly account for callbacks in the bulk "tear down all helpers" operation.

This commit contributes to #869.