### PR TITLE
[JS-to-C++ test] Test PC/SC server startup

### DIFF
--- a/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
@@ -24,6 +24,7 @@
  */
 
 goog.require('GoogleSmartCard.IntegrationTestController');
+goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.ReadinessTracker');
 goog.require('goog.testing');
 goog.require('goog.testing.jsunit');
 
@@ -32,27 +33,36 @@ goog.setTestOnly();
 goog.scope(function() {
 
 const GSC = GoogleSmartCard;
+const ReadinessTracker = GSC.PcscLiteServerClientsManagement.ReadinessTracker;
 
 /** @type {GSC.IntegrationTestController?} */
 let testController;
+/** @type {ReadinessTracker?} */
+let pcscReadinessTracker;
 
 goog.exportSymbol('testPcscApi', {
   'setUp': async function() {
     testController = new GSC.IntegrationTestController();
     await testController.initAsync();
+    pcscReadinessTracker = new ReadinessTracker(
+        testController.executableModule.getMessageChannel());
   },
 
   'tearDown': async function() {
     try {
       await testController.disposeAsync();
+      pcscReadinessTracker.dispose();
     } finally {
+      pcscReadinessTracker = null;
       testController = null;
     }
   },
 
-  'testSmoke': async function() {
-    // TODO(emaxx): The test currently does nothing. Add functional tests after
-    // implementing needed C++ helpers.
+  // Test that the PC/SC server can successfully start up.
+  'testStartup': async function() {
+    await testController.setUpCppHelper(
+        'SmartCardConnectorApplicationTestHelper', {});
+    await pcscReadinessTracker.promise;
   },
 });
 });  // goog.scope


### PR DESCRIPTION
Add a test that verifies the PC/SC server successfully started up.

Technically, the JS side does this by asking the C++ side to set up the "SmartCardConnectorApplicationTestHelper", and then waiting until the C++ side sends the "ready" message to the JS.

Follow-ups will use this approach for testing actual PC/SC functionality, as tracked by #869.