### PR TITLE
[JS-to-C++ test] Test args of SCardEstablishContext

### DIFF
--- a/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
@@ -105,7 +105,23 @@ goog.exportSymbol('testPcscApi', {
     },
 
     // Test `SCardEstablishContext()`.
-    'testScardEstablishContext': async function() {
+    '1testScardEstablishContext': async function() {
+      const result = await api.SCardEstablishContext(
+          GSC.PcscLiteClient.API.SCARD_SCOPE_SYSTEM, null, null);
+      let sCardContext;
+      result.get(
+          (context) => {
+            sCardContext = context;
+          },
+          (errorCode) => {
+            fail(`Unexpected error ${errorCode}`);
+          });
+      assert(Number.isInteger(sCardContext));
+    },
+
+    // Test `SCardEstablishContext()` when it's called without providing
+    // optional arguments.
+    '1testScardEstablishContext_omittedOptionalArgs': async function() {
       const result = await api.SCardEstablishContext(
           GSC.PcscLiteClient.API.SCARD_SCOPE_SYSTEM);
       let sCardContext;

--- a/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
@@ -18,9 +18,6 @@
 /**
  * @fileoverview This file contains tests for the PC/SC API exposed by Smart
  * Card Connector.
- *
- * TODO(emaxx): This is currently just a boilerplate. Real tests will be added
- * after needed helpers are implemented.
  */
 
 goog.require('GoogleSmartCard.IntegrationTestController');
@@ -105,7 +102,7 @@ goog.exportSymbol('testPcscApi', {
     },
 
     // Test `SCardEstablishContext()`.
-    '1testScardEstablishContext': async function() {
+    'testScardEstablishContext': async function() {
       const result = await api.SCardEstablishContext(
           GSC.PcscLiteClient.API.SCARD_SCOPE_SYSTEM, null, null);
       let sCardContext;
@@ -121,7 +118,7 @@ goog.exportSymbol('testPcscApi', {
 
     // Test `SCardEstablishContext()` when it's called without providing
     // optional arguments.
-    '1testScardEstablishContext_omittedOptionalArgs': async function() {
+    'testScardEstablishContext_omittedOptionalArgs': async function() {
       const result = await api.SCardEstablishContext(
           GSC.PcscLiteClient.API.SCARD_SCOPE_SYSTEM);
       let sCardContext;


### PR DESCRIPTION
Extend the C++-to-JS test of the SCardEstablishContext() a little bit,
by checking the variant with explicitly passed optional arguments.

This commit contributes to #869.