### PR TITLE
Refactor TestingGlobalContext callbacks

### DIFF
--- a/smart_card_connector_app/src/application_unittest.cc
+++ b/smart_card_connector_app/src/application_unittest.cc
@@ -92,8 +92,7 @@ class ReaderNotificationObserver final {
       global_context.RegisterMessageHandler(
           event_name,
           std::bind(&ReaderNotificationObserver::OnMessageToJs, this,
-                    event_name, /*request_payload=*/std::placeholders::_1,
-                    /*request_id=*/std::placeholders::_2));
+                    event_name, /*message_data=*/std::placeholders::_1));
     }
   }
 
@@ -123,13 +122,10 @@ class ReaderNotificationObserver final {
   }
 
  private:
-  void OnMessageToJs(const std::string& event_name,
-                     optional<Value> message_data,
-                     optional<RequestId> /*request_id*/) {
-    ASSERT_TRUE(message_data);
+  void OnMessageToJs(const std::string& event_name, Value message_data) {
     std::string notification =
         event_name + ":" +
-        message_data->GetDictionaryItem("readerName")->GetString();
+        message_data.GetDictionaryItem("readerName")->GetString();
 
     std::unique_lock<std::mutex> lock(mutex_);
     recorded_notifications_.push(notification);
@@ -561,8 +557,8 @@ class SmartCardConnectorApplicationTest : public ::testing::Test {
         TestingSmartCardSimulation::kRequesterName,
         std::bind(&TestingSmartCardSimulation::OnRequestToJs,
                   &smart_card_simulation_,
-                  /*request_payload=*/std::placeholders::_1,
-                  /*request_id=*/std::placeholders::_2));
+                  /*request_id=*/std::placeholders::_1,
+                  /*request_payload=*/std::placeholders::_2));
   }
 
   TypedMessageRouter typed_message_router_;

--- a/smart_card_connector_app/src/testing_smart_card_simulation.h
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.h
@@ -83,8 +83,7 @@ class TestingSmartCardSimulation final {
   ~TestingSmartCardSimulation();
 
   // Subscribe this to the C++-to-JS message channel.
-  void OnRequestToJs(optional<Value> request_payload,
-                     optional<RequestId> request_id);
+  void OnRequestToJs(RequestId request_id, Value request_payload);
 
   void SetDevices(const std::vector<Device>& devices);
 


### PR DESCRIPTION
Make a separate callback for each type of the observation: (a) just message, (b) request message, (c) response message. Previously all three types were using the same callback type, but the arguments were omitted or had different meaning depending on the case.

The refactoring should make the code clearer and simplify passing use-case-specific arguments. This is preparation for USB simulation in JS-to-C++ tests as tracked by #869.