### PR TITLE
Refactor LibusbJsProxy constant into a header

### DIFF
--- a/third_party/libusb/webport/build/Makefile
+++ b/third_party/libusb/webport/build/Makefile
@@ -39,6 +39,7 @@ C_SOURCES := \
 CXX_SOURCES := \
 	$(LIBUSB_NACL_SOURCES_PATH)/libusb_contexts_storage.cc \
 	$(LIBUSB_NACL_SOURCES_PATH)/libusb_js_proxy.cc \
+	$(LIBUSB_NACL_SOURCES_PATH)/libusb_js_proxy_constants.cc \
 	$(LIBUSB_NACL_SOURCES_PATH)/libusb_js_proxy_data_model.cc \
 	$(LIBUSB_NACL_SOURCES_PATH)/libusb_opaque_types.cc \
 	$(LIBUSB_NACL_SOURCES_PATH)/libusb_tracing_wrapper.cc \
@@ -53,6 +54,7 @@ SOURCES := \
 CPPFLAGS := \
 	-I$(LIBUSB_NACL_SOURCES_PATH) \
 	-I$(LIBUSB_SOURCES_PATH)/libusb \
+	-I$(ROOT_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-Wall \
 	-Werror \

--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -31,13 +31,13 @@
 #include <google_smart_card_common/requesting/request_result.h>
 
 #include "libusb_js_proxy_data_model.h"
+#include "third_party/libusb/webport/src/libusb_js_proxy_constants.h"
 
 namespace google_smart_card {
 
 namespace {
 
 // These constants must match the strings in libusb-proxy-receiver.js.
-constexpr char kJsRequesterName[] = "libusb";
 constexpr char kJsRequestListDevices[] = "listDevices";
 constexpr char kJsRequestGetConfigurations[] = "getConfigurations";
 constexpr char kJsRequestOpenDeviceHandle[] = "openDeviceHandle";
@@ -131,7 +131,9 @@ libusb_context* GetLibusbTransferContextChecked(
 
 LibusbJsProxy::LibusbJsProxy(GlobalContext* global_context,
                              TypedMessageRouter* typed_message_router)
-    : js_requester_(kJsRequesterName, global_context, typed_message_router),
+    : js_requester_(kLibusbJsProxyRequesterName,
+                    global_context,
+                    typed_message_router),
       js_call_adaptor_(&js_requester_),
       default_context_(contexts_storage_.CreateContext()) {}
 

--- a/third_party/libusb/webport/src/libusb_js_proxy_constants.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_constants.cc
@@ -1,0 +1,23 @@
+// Copyright 2023 Google Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include "third_party/libusb/webport/src/libusb_js_proxy_constants.h"
+
+namespace google_smart_card {
+
+const char kLibusbJsProxyRequesterName[] = "libusb";
+
+}  // namespace google_smart_card

--- a/third_party/libusb/webport/src/libusb_js_proxy_constants.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy_constants.h
@@ -1,0 +1,31 @@
+// Copyright 2023 Google Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef GOOGLE_SMART_CARD_THIRD_PARTY_LIBUSB_LIBUSB_JS_PROXY_CONSTANTS_H_
+#define GOOGLE_SMART_CARD_THIRD_PARTY_LIBUSB_LIBUSB_JS_PROXY_CONSTANTS_H_
+
+namespace google_smart_card {
+
+// The requester name that's used by the C++ libusb_js_proxy code.
+//
+// The JavaScript side has a "request receiver" that receives and handles the
+// calls by triggering the corresponding JavaScript USB API functionality (see
+// libusb-to-js-api-adaptor.js).
+extern const char kLibusbJsProxyRequesterName[];
+
+}  // namespace google_smart_card
+
+#endif  // GOOGLE_SMART_CARD_THIRD_PARTY_LIBUSB_LIBUSB_JS_PROXY_CONSTANTS_H_


### PR DESCRIPTION
Create a new header for the string constant in libusb_js_proxy, so that it can be included without pulling the bunch of libusb-specific includes.

This refactoring is preparation for the USB simulation in JS-to-C++ tests, as tracked by #869.