### PR TITLE
[headers] Add root dir to include search path

### DIFF
--- a/common/integration_testing/build/Makefile
+++ b/common/integration_testing/build/Makefile
@@ -34,6 +34,7 @@ SOURCES := \
 
 CXXFLAGS := \
 	-I$(ROOT_SOURCES_PATH) \
+	-I$(ROOT_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-pedantic \
 	-Wall \

--- a/common/integration_testing/src/build_emscripten.mk
+++ b/common/integration_testing/src/build_emscripten.mk
@@ -24,6 +24,7 @@ JS_TO_CXX_TEST_ENTRY_POINT_SOURCE := \
 	$(ROOT_PATH)/common/integration_testing/src/entry_point_emscripten.cc
 
 JS_TO_CXX_TEST_ENTRY_POINT_FLAGS := \
+	-I$(ROOT_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-I$(ROOT_PATH)/common/integration_testing/src \
 	-pedantic \

--- a/common/integration_testing/src/build_nacl.mk
+++ b/common/integration_testing/src/build_nacl.mk
@@ -24,6 +24,7 @@ JS_TO_CXX_TEST_ENTRY_POINT_SOURCE := \
 	$(ROOT_PATH)/common/integration_testing/src/entry_point_nacl.cc
 
 JS_TO_CXX_TEST_ENTRY_POINT_FLAGS := \
+	-I$(ROOT_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-I$(ROOT_PATH)/common/integration_testing/src \
 	-pedantic \

--- a/example_cpp_smart_card_client_app/build/executable_module/Makefile
+++ b/example_cpp_smart_card_client_app/build/executable_module/Makefile
@@ -69,6 +69,7 @@ LIBS := \
 
 CPPFLAGS := \
 	-I$(SOURCES_DIR) \
+	-I$(ROOT_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-I$(ROOT_PATH)/third_party/pcsc-lite/naclport/cpp_client/src \
 	-I$(ROOT_PATH)/third_party/pcsc-lite/naclport/cpp_demo/src \

--- a/example_cpp_smart_card_client_app/build/integration_tests/Makefile
+++ b/example_cpp_smart_card_client_app/build/integration_tests/Makefile
@@ -37,6 +37,7 @@ CXX_SOURCES := \
 
 CXXFLAGS := \
 	-I$(SOURCE_DIR) \
+	-I$(ROOT_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-I$(ROOT_PATH)/common/integration_testing/src \
 	-pedantic \

--- a/third_party/libusb/webport/build/Makefile
+++ b/third_party/libusb/webport/build/Makefile
@@ -53,6 +53,7 @@ SOURCES := \
 CPPFLAGS := \
 	-I$(LIBUSB_NACL_SOURCES_PATH) \
 	-I$(LIBUSB_SOURCES_PATH)/libusb \
+	-I$(ROOT_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-Wall \
 	-Werror \

--- a/third_party/pcsc-lite/naclport/common/build/Makefile
+++ b/third_party/pcsc-lite/naclport/common/build/Makefile
@@ -45,6 +45,7 @@ SOURCES := \
 CXXFLAGS := \
 	-I$(PCSC_LITE_ORIGINAL_HEADERS_DIR_PATH) \
 	-I$(SOURCES_PATH) \
+	-I$(ROOT_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-pedantic \
 	-Wall \

--- a/third_party/pcsc-lite/naclport/cpp_client/build/Makefile
+++ b/third_party/pcsc-lite/naclport/cpp_client/build/Makefile
@@ -42,6 +42,7 @@ SOURCES_PATH := ../src
 COMMON_CPPFLAGS := \
 	-I$(PCSC_LITE_ORIGINAL_HEADERS_DIR_PATH) \
 	-I$(SOURCES_PATH) \
+	-I$(ROOT_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-I$(ROOT_PATH)/third_party/pcsc-lite/naclport/common/src \
 

--- a/third_party/pcsc-lite/naclport/cpp_demo/build/Makefile
+++ b/third_party/pcsc-lite/naclport/cpp_demo/build/Makefile
@@ -44,6 +44,7 @@ SOURCES := \
 
 CXXFLAGS := \
 	-I$(PCSC_LITE_ORIGINAL_HEADERS_DIR_PATH) \
+	-I$(ROOT_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-I$(ROOT_PATH)/third_party/pcsc-lite/naclport/common/src \
 	-I$(SOURCES_PATH) \

--- a/third_party/pcsc-lite/naclport/server_clients_management/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server_clients_management/build/Makefile
@@ -54,6 +54,7 @@ SOURCES := \
 
 CXXFLAGS := \
 	-I$(SOURCES_PATH) \
+	-I$(ROOT_PATH) \
 	-I$(ROOT_PATH)/common/cpp/src \
 	-I$(ROOT_PATH)/third_party/pcsc-lite/naclport/common/src \
 	-I$(ROOT_PATH)/third_party/pcsc-lite/src/src/PCSC \


### PR DESCRIPTION
Add the repository's root directory into the C/C++ search path.

This is preparation for the refactoring to use absolute include paths consistently, as tracked by #885.