### PR TITLE
[headers] Include by abs path from common/cpp/

### DIFF
--- a/common/cpp/src/google_smart_card_common/external_logs_printer.cc
+++ b/common/cpp/src/google_smart_card_common/external_logs_printer.cc
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/external_logs_printer.h>
+#include "common/cpp/src/google_smart_card_common/external_logs_printer.h"
 
 #include <iostream>
 #include <string>
 
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/messaging/typed_message_listener.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_listener.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/external_logs_printer.h
+++ b/common/cpp/src/google_smart_card_common/external_logs_printer.h
@@ -20,8 +20,8 @@
 
 #include <string>
 
-#include <google_smart_card_common/messaging/typed_message_listener.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_listener.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/formatting.cc
+++ b/common/cpp/src/google_smart_card_common/formatting.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/formatting.h>
+#include "common/cpp/src/google_smart_card_common/formatting.h"
 
 #include <cstdio>
 #include <utility>

--- a/common/cpp/src/google_smart_card_common/formatting_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/formatting_unittest.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/formatting.h>
+#include "common/cpp/src/google_smart_card_common/formatting.h"
 
 #include <string>
 

--- a/common/cpp/src/google_smart_card_common/global_context.h
+++ b/common/cpp/src/google_smart_card_common/global_context.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_SMART_CARD_COMMON_GLOBAL_CONTEXT_H_
 #define GOOGLE_SMART_CARD_COMMON_GLOBAL_CONTEXT_H_
 
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.cc
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/global_context_impl_emscripten.h>
+#include "common/cpp/src/google_smart_card_common/global_context_impl_emscripten.h"
 
 #include <memory>
 #include <thread>
@@ -20,9 +20,9 @@
 #include <emscripten/threading.h>
 #include <emscripten/val.h>
 
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_emscripten_val_conversion.h>
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.h
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_emscripten.h
@@ -24,8 +24,8 @@
 
 #include <emscripten/val.h>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/global_context_impl_nacl.cc
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_nacl.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/global_context_impl_nacl.h>
+#include "common/cpp/src/google_smart_card_common/global_context_impl_nacl.h"
 
 #include <mutex>
 
@@ -20,8 +20,8 @@
 #include <ppapi/cpp/instance.h>
 #include <ppapi/cpp/var.h>
 
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/global_context_impl_nacl.h
+++ b/common/cpp/src/google_smart_card_common/global_context_impl_nacl.h
@@ -24,8 +24,8 @@
 #include <ppapi/cpp/core.h>
 #include <ppapi/cpp/instance.h>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/ipc_emulation.cc
+++ b/common/cpp/src/google_smart_card_common/ipc_emulation.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/ipc_emulation.h>
+#include "common/cpp/src/google_smart_card_common/ipc_emulation.h"
 
 #include <errno.h>
 
@@ -22,9 +22,9 @@
 #include <deque>
 #include <limits>
 
-#include <google_smart_card_common/cpp_attributes.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/optional.h>
+#include "common/cpp/src/google_smart_card_common/cpp_attributes.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/ipc_emulation.h
+++ b/common/cpp/src/google_smart_card_common/ipc_emulation.h
@@ -28,8 +28,8 @@
 #include <mutex>
 #include <unordered_map>
 
-#include <google_smart_card_common/cpp_attributes.h>
-#include <google_smart_card_common/optional.h>
+#include "common/cpp/src/google_smart_card_common/cpp_attributes.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/ipc_emulation_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/ipc_emulation_unittest.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/ipc_emulation.h>
+#include "common/cpp/src/google_smart_card_common/ipc_emulation.h"
 
 #include <stdint.h>
 

--- a/common/cpp/src/google_smart_card_common/join_string_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/join_string_unittest.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/join_string.h>
+#include "common/cpp/src/google_smart_card_common/join_string.h"
 
 #include <set>
 #include <string>

--- a/common/cpp/src/google_smart_card_common/logging/function_call_tracer.cc
+++ b/common/cpp/src/google_smart_card_common/logging/function_call_tracer.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/logging/function_call_tracer.h>
+#include "common/cpp/src/google_smart_card_common/logging/function_call_tracer.h"
 
 #include <stdint.h>
 

--- a/common/cpp/src/google_smart_card_common/logging/function_call_tracer.h
+++ b/common/cpp/src/google_smart_card_common/logging/function_call_tracer.h
@@ -20,8 +20,8 @@
 #include <string>
 #include <vector>
 
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/optional.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/logging/hex_dumping.cc
+++ b/common/cpp/src/google_smart_card_common/logging/hex_dumping.cc
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/logging/hex_dumping.h>
+#include "common/cpp/src/google_smart_card_common/logging/hex_dumping.h"
 
 #include <limits>
 #include <sstream>
 
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/numeric_conversions.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/numeric_conversions.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/logging/hex_dumping_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/logging/hex_dumping_unittest.cc
@@ -18,7 +18,7 @@
 
 #include <gtest/gtest.h>
 
-#include <google_smart_card_common/logging/hex_dumping.h>
+#include "common/cpp/src/google_smart_card_common/logging/hex_dumping.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/logging/logging.cc
+++ b/common/cpp/src/google_smart_card_common/logging/logging.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/logging/logging.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
 
 #include <algorithm>
 #include <cctype>

--- a/common/cpp/src/google_smart_card_common/logging/logging_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/logging/logging_unittest.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/logging/logging.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
 
 #include <gtest/gtest.h>
 

--- a/common/cpp/src/google_smart_card_common/logging/mask_dumping.h
+++ b/common/cpp/src/google_smart_card_common/logging/mask_dumping.h
@@ -20,7 +20,7 @@
 #include <string>
 #include <vector>
 
-#include <google_smart_card_common/logging/hex_dumping.h>
+#include "common/cpp/src/google_smart_card_common/logging/hex_dumping.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/logging/syslog/syslog.cc
+++ b/common/cpp/src/google_smart_card_common/logging/syslog/syslog.cc
@@ -28,13 +28,13 @@
  * SUCH DAMAGE.
  */
 
-#include <google_smart_card_common/logging/syslog/syslog.h>
+#include "common/cpp/src/google_smart_card_common/logging/syslog/syslog.h"
 
 #include <cstdarg>
 #include <string>
 
-#include <google_smart_card_common/formatting.h>
-#include <google_smart_card_common/logging/logging.h>
+#include "common/cpp/src/google_smart_card_common/formatting.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
 
 void syslog(int priority, const char* format, ...) {
   va_list var_args;

--- a/common/cpp/src/google_smart_card_common/messaging/message_listener.h
+++ b/common/cpp/src/google_smart_card_common/messaging/message_listener.h
@@ -17,7 +17,7 @@
 
 #include <string>
 
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/messaging/typed_message.h>
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message.h"
 
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message.h
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message.h
@@ -26,7 +26,7 @@
 
 #include <string>
 
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_listener.h
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_listener.h
@@ -17,7 +17,7 @@
 
 #include <string>
 
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_router.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_router.cc
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/messaging/typed_message_router.h>
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
 
 #include <algorithm>
 #include <string>
 
-#include <google_smart_card_common/formatting.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/messaging/typed_message.h>
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/formatting.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_router.h
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_router.h
@@ -19,9 +19,9 @@
 #include <string>
 #include <unordered_map>
 
-#include <google_smart_card_common/messaging/message_listener.h>
-#include <google_smart_card_common/messaging/typed_message_listener.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/messaging/message_listener.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_listener.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/messaging/typed_message_router_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/messaging/typed_message_router_unittest.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/messaging/typed_message_router.h>
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
 
 #include <string>
 #include <thread>
@@ -21,11 +21,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <google_smart_card_common/formatting.h>
-#include <google_smart_card_common/messaging/typed_message.h>
-#include <google_smart_card_common/messaging/typed_message_listener.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/formatting.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_listener.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 // Google Mock doesn't provide the C++11 "override" specifier for the mock
 // method definitions

--- a/common/cpp/src/google_smart_card_common/multi_string.cc
+++ b/common/cpp/src/google_smart_card_common/multi_string.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/multi_string.h>
+#include "common/cpp/src/google_smart_card_common/multi_string.h"
 
-#include <google_smart_card_common/logging/logging.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/multi_string_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/multi_string_unittest.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/multi_string.h>
+#include "common/cpp/src/google_smart_card_common/multi_string.h"
 
 #include <string>
 

--- a/common/cpp/src/google_smart_card_common/nacl_io_utils.cc
+++ b/common/cpp/src/google_smart_card_common/nacl_io_utils.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/nacl_io_utils.h>
+#include "common/cpp/src/google_smart_card_common/nacl_io_utils.h"
 
 #include <sys/mount.h>
 
@@ -20,7 +20,7 @@
 #include <ppapi/cpp/core.h>
 #include <ppapi/cpp/module.h>
 
-#include <google_smart_card_common/logging/logging.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/numeric_conversions.cc
+++ b/common/cpp/src/google_smart_card_common/numeric_conversions.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/numeric_conversions.h>
+#include "common/cpp/src/google_smart_card_common/numeric_conversions.h"
 
-#include <google_smart_card_common/logging/logging.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/numeric_conversions.h
+++ b/common/cpp/src/google_smart_card_common/numeric_conversions.h
@@ -25,9 +25,9 @@
 #include <string>
 #include <type_traits>
 
-#include <google_smart_card_common/formatting.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/optional.h>
+#include "common/cpp/src/google_smart_card_common/formatting.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/numeric_conversions_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/numeric_conversions_unittest.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/numeric_conversions.h>
+#include "common/cpp/src/google_smart_card_common/numeric_conversions.h"
 
 #include <stdint.h>
 

--- a/common/cpp/src/google_smart_card_common/optional.h
+++ b/common/cpp/src/google_smart_card_common/optional.h
@@ -19,7 +19,7 @@
 #include <type_traits>
 #include <utility>
 
-#include <google_smart_card_common/logging/logging.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/optional_test_utils.h
+++ b/common/cpp/src/google_smart_card_common/optional_test_utils.h
@@ -20,7 +20,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <google_smart_card_common/optional.h>
+#include "common/cpp/src/google_smart_card_common/optional.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/async_request.h
+++ b/common/cpp/src/google_smart_card_common/requesting/async_request.h
@@ -24,9 +24,9 @@
 #include <string>
 #include <utility>
 
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/requesting/request_result.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/async_request_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/async_request_unittest.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/requesting/async_request.h>
+#include "common/cpp/src/google_smart_card_common/requesting/async_request.h"
 
 #include <chrono>
 #include <functional>
@@ -22,8 +22,8 @@
 
 #include <gtest/gtest.h>
 
-#include <google_smart_card_common/requesting/request_result.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/async_requests_storage.h
+++ b/common/cpp/src/google_smart_card_common/requesting/async_requests_storage.h
@@ -20,10 +20,10 @@
 #include <unordered_map>
 #include <vector>
 
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/requesting/async_request.h>
-#include <google_smart_card_common/requesting/request_id.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/requesting/async_request.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_id.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/async_requests_storage_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/async_requests_storage_unittest.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/requesting/async_requests_storage.h>
+#include "common/cpp/src/google_smart_card_common/requesting/async_requests_storage.h"
 
 #include <memory>
 #include <thread>
@@ -20,9 +20,9 @@
 
 #include <gtest/gtest.h>
 
-#include <google_smart_card_common/requesting/async_request.h>
-#include <google_smart_card_common/requesting/request_id.h>
-#include <google_smart_card_common/requesting/request_result.h>
+#include "common/cpp/src/google_smart_card_common/requesting/async_request.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_id.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.cc
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/requesting/js_request_receiver.h>
+#include "common/cpp/src/google_smart_card_common/requesting/js_request_receiver.h"
 
 #include <utility>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/messaging/typed_message.h>
-#include <google_smart_card_common/requesting/requester_message.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message.h"
+#include "common/cpp/src/google_smart_card_common/requesting/requester_message.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.h
+++ b/common/cpp/src/google_smart_card_common/requesting/js_request_receiver.h
@@ -19,14 +19,14 @@
 #include <memory>
 #include <string>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/messaging/typed_message_listener.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/requesting/request_handler.h>
-#include <google_smart_card_common/requesting/request_id.h>
-#include <google_smart_card_common/requesting/request_receiver.h>
-#include <google_smart_card_common/requesting/request_result.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_listener.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_handler.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_id.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_receiver.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/js_requester.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/js_requester.cc
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/requesting/js_requester.h>
+#include "common/cpp/src/google_smart_card_common/requesting/js_requester.h"
 
 #include <utility>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/messaging/typed_message.h>
-#include <google_smart_card_common/requesting/request_id.h>
-#include <google_smart_card_common/requesting/request_result.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_id.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/js_requester.h
+++ b/common/cpp/src/google_smart_card_common/requesting/js_requester.h
@@ -19,12 +19,12 @@
 #include <memory>
 #include <string>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/messaging/typed_message_listener.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/requesting/requester.h>
-#include <google_smart_card_common/requesting/requester_message.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_listener.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/requesting/requester.h"
+#include "common/cpp/src/google_smart_card_common/requesting/requester_message.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/requesting/remote_call_adaptor.h>
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.h"
 
 #include <utility>
 
-#include <google_smart_card_common/requesting/remote_call_message.h>
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_message.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.h
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.h
@@ -18,12 +18,12 @@
 #include <string>
 #include <utility>
 
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/requesting/async_request.h>
-#include <google_smart_card_common/requesting/remote_call_arguments_conversion.h>
-#include <google_smart_card_common/requesting/remote_call_message.h>
-#include <google_smart_card_common/requesting/request_result.h>
-#include <google_smart_card_common/requesting/requester.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/requesting/async_request.h"
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.h"
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_message.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
+#include "common/cpp/src/google_smart_card_common/requesting/requester.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.cc
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/requesting/remote_call_arguments_conversion.h>
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.h"
 
 #include <string>
 #include <utility>
 #include <vector>
 
-#include <google_smart_card_common/formatting.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
-#include <google_smart_card_common/value_debug_dumping.h>
+#include "common/cpp/src/google_smart_card_common/formatting.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
+#include "common/cpp/src/google_smart_card_common/value_debug_dumping.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.h
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.h
@@ -19,11 +19,11 @@
 #include <utility>
 #include <vector>
 
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/requesting/remote_call_message.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_message.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion_unittest.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/requesting/remote_call_arguments_conversion.h>
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.h"
 
 #include <string>
 #include <vector>
@@ -20,12 +20,12 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/requesting/remote_call_message.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
-#include <google_smart_card_common/value_test_utils.h>
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_message.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
+#include "common/cpp/src/google_smart_card_common/value_test_utils.h"
 
 using testing::ElementsAre;
 using testing::IsEmpty;

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_message.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_message.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/requesting/remote_call_message.h>
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_message.h"
 
 #include <string>
 
-#include <google_smart_card_common/value_conversion.h>
-#include <google_smart_card_common/value_debug_dumping.h>
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
+#include "common/cpp/src/google_smart_card_common/value_debug_dumping.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/remote_call_message.h
+++ b/common/cpp/src/google_smart_card_common/requesting/remote_call_message.h
@@ -18,7 +18,7 @@
 #include <string>
 #include <vector>
 
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/request_handler.h
+++ b/common/cpp/src/google_smart_card_common/requesting/request_handler.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_SMART_CARD_COMMON_REQUESTING_REQUEST_HANDLER_H_
 #define GOOGLE_SMART_CARD_COMMON_REQUESTING_REQUEST_HANDLER_H_
 
-#include <google_smart_card_common/requesting/request_receiver.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/requesting/request_receiver.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/request_receiver.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/request_receiver.cc
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/requesting/request_receiver.h>
+#include "common/cpp/src/google_smart_card_common/requesting/request_receiver.h"
 
 #include <utility>
 
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/requesting/request_handler.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_handler.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/request_receiver.h
+++ b/common/cpp/src/google_smart_card_common/requesting/request_receiver.h
@@ -19,9 +19,9 @@
 #include <memory>
 #include <string>
 
-#include <google_smart_card_common/requesting/request_id.h>
-#include <google_smart_card_common/requesting/request_result.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/requesting/request_id.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/request_result.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/request_result.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/requesting/request_result.h>
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/request_result.h
+++ b/common/cpp/src/google_smart_card_common/requesting/request_result.h
@@ -20,9 +20,9 @@
 #include <string>
 #include <utility>
 
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/requester.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/requester.cc
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/requesting/requester.h>
+#include "common/cpp/src/google_smart_card_common/requesting/requester.h"
 
 #include <condition_variable>
 #include <mutex>
 #include <utility>
 
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/requester.h
+++ b/common/cpp/src/google_smart_card_common/requesting/requester.h
@@ -17,11 +17,11 @@
 
 #include <string>
 
-#include <google_smart_card_common/requesting/async_request.h>
-#include <google_smart_card_common/requesting/async_requests_storage.h>
-#include <google_smart_card_common/requesting/request_id.h>
-#include <google_smart_card_common/requesting/request_result.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/requesting/async_request.h"
+#include "common/cpp/src/google_smart_card_common/requesting/async_requests_storage.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_id.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/requester_message.cc
+++ b/common/cpp/src/google_smart_card_common/requesting/requester_message.cc
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/requesting/requester_message.h>
+#include "common/cpp/src/google_smart_card_common/requesting/requester_message.h"
 
 #include <string>
 #include <utility>
 
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/requesting/requester_message.h
+++ b/common/cpp/src/google_smart_card_common/requesting/requester_message.h
@@ -27,9 +27,9 @@
 
 #include <string>
 
-#include <google_smart_card_common/requesting/request_id.h>
-#include <google_smart_card_common/requesting/request_result.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/requesting/request_id.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/thread_safe_unique_ptr.h
+++ b/common/cpp/src/google_smart_card_common/thread_safe_unique_ptr.h
@@ -19,7 +19,7 @@
 #include <mutex>
 #include <utility>
 
-#include <google_smart_card_common/logging/logging.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/value.cc
+++ b/common/cpp/src/google_smart_card_common/value.cc
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 #include <string>
 #include <utility>
 #include <vector>
 
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/value_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 #include <inttypes.h>
 #include <stdint.h>
@@ -22,11 +22,11 @@
 #include <string>
 #include <utility>
 
-#include <google_smart_card_common/formatting.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/numeric_conversions.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_debug_dumping.h>
+#include "common/cpp/src/google_smart_card_common/formatting.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/numeric_conversions.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_debug_dumping.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/value_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_conversion.h
@@ -49,12 +49,12 @@
 #include <utility>
 #include <vector>
 
-#include <google_smart_card_common/formatting.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_debug_dumping.h>
+#include "common/cpp/src/google_smart_card_common/formatting.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_debug_dumping.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_conversion_unittest.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 #include <stdint.h>
 
@@ -25,8 +25,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 using testing::MatchesRegex;
 using testing::StartsWith;

--- a/common/cpp/src/google_smart_card_common/value_debug_dumping.cc
+++ b/common/cpp/src/google_smart_card_common/value_debug_dumping.cc
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/value_debug_dumping.h>
+#include "common/cpp/src/google_smart_card_common/value_debug_dumping.h"
 
 #include <string>
 
-#include <google_smart_card_common/logging/hex_dumping.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/logging/hex_dumping.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/value_debug_dumping.h
+++ b/common/cpp/src/google_smart_card_common/value_debug_dumping.h
@@ -17,7 +17,7 @@
 
 #include <string>
 
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/value_debug_dumping_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_debug_dumping_unittest.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/value_debug_dumping.h>
+#include "common/cpp/src/google_smart_card_common/value_debug_dumping.h"
 
 #include <stdint.h>
 
@@ -23,8 +23,8 @@
 
 #include <gtest/gtest.h>
 
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/value_emscripten_val_conversion.h>
+#include "common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.h"
 
 #include <stdint.h>
 
@@ -25,12 +25,12 @@
 #include <emscripten/val.h>
 #include <emscripten/wire.h>
 
-#include <google_smart_card_common/formatting.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/numeric_conversions.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/formatting.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/numeric_conversions.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.h
@@ -26,8 +26,8 @@
 
 #include <emscripten/val.h>
 
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_emscripten_val_conversion_unittest.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/value_emscripten_val_conversion.h>
+#include "common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.h"
 
 #include <stdint.h>
 
@@ -27,8 +27,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 using testing::MatchesRegex;
 

--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.cc
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
+#include "common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h"
 
 #include <stdint.h>
 
@@ -27,11 +27,11 @@
 #include <ppapi/cpp/var_array_buffer.h>
 #include <ppapi/cpp/var_dictionary.h>
 
-#include <google_smart_card_common/formatting.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/formatting.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h
@@ -26,8 +26,8 @@
 
 #include <ppapi/cpp/var.h>
 
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion_unittest.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
+#include "common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h"
 
 #include <stdint.h>
 
@@ -32,9 +32,9 @@
 #include <ppapi/cpp/var_array_buffer.h>
 #include <ppapi/cpp/var_dictionary.h>
 
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/value_test_utils.h
+++ b/common/cpp/src/google_smart_card_common/value_test_utils.h
@@ -18,9 +18,9 @@
 
 #include <gmock/gmock.h>
 
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
-#include <google_smart_card_common/value_debug_dumping.h>
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
+#include "common/cpp/src/google_smart_card_common/value_debug_dumping.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/google_smart_card_common/value_unittest.cc
+++ b/common/cpp/src/google_smart_card_common/value_unittest.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 #include <stdint.h>
 
@@ -23,7 +23,7 @@
 
 #include <gtest/gtest.h>
 
-#include <google_smart_card_common/unique_ptr_utils.h>
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/public/testing_global_context.cc
+++ b/common/cpp/src/public/testing_global_context.cc
@@ -22,17 +22,17 @@
 #include <utility>
 #include <vector>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/messaging/typed_message.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/requesting/remote_call_message.h>
-#include <google_smart_card_common/requesting/requester_message.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
-#include <google_smart_card_common/value_debug_dumping.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_message.h"
+#include "common/cpp/src/google_smart_card_common/requesting/requester_message.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
+#include "common/cpp/src/google_smart_card_common/value_debug_dumping.h"
 
 #include "common/cpp/src/public/value_builder.h"
 

--- a/common/cpp/src/public/testing_global_context.h
+++ b/common/cpp/src/public/testing_global_context.h
@@ -23,13 +23,13 @@
 #include <string>
 #include <thread>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/messaging/typed_message.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/requesting/request_id.h>
-#include <google_smart_card_common/requesting/requester_message.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_id.h"
+#include "common/cpp/src/google_smart_card_common/requesting/requester_message.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/public/value_builder.cc
+++ b/common/cpp/src/public/value_builder.cc
@@ -17,10 +17,10 @@
 #include <string>
 #include <utility>
 
-#include <google_smart_card_common/formatting.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/formatting.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/public/value_builder.h
+++ b/common/cpp/src/public/value_builder.h
@@ -21,8 +21,8 @@
 #include <utility>
 #include <vector>
 
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 namespace google_smart_card {
 

--- a/common/cpp/src/public/value_builder_unittest.cc
+++ b/common/cpp/src/public/value_builder_unittest.cc
@@ -21,7 +21,7 @@
 
 #include <gtest/gtest.h>
 
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/integration_testing/src/entry_point_emscripten.cc
+++ b/common/integration_testing/src/entry_point_emscripten.cc
@@ -27,11 +27,11 @@
 #include <emscripten/bind.h>
 #include <emscripten/val.h>
 
-#include <google_smart_card_common/global_context_impl_emscripten.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_emscripten_val_conversion.h>
+#include "common/cpp/src/google_smart_card_common/global_context_impl_emscripten.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.h"
 #include <google_smart_card_integration_testing/integration_test_service.h>
 
 namespace google_smart_card {

--- a/common/integration_testing/src/entry_point_nacl.cc
+++ b/common/integration_testing/src/entry_point_nacl.cc
@@ -22,13 +22,13 @@
 #include <ppapi/cpp/module.h>
 #include <ppapi/cpp/var.h>
 
-#include <google_smart_card_common/global_context_impl_nacl.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_debug_dumping.h>
-#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
+#include "common/cpp/src/google_smart_card_common/global_context_impl_nacl.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_debug_dumping.h"
+#include "common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h"
 #include <google_smart_card_integration_testing/integration_test_service.h>
 
 namespace google_smart_card {

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.cc
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.cc
@@ -16,11 +16,11 @@
 
 #include <functional>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/requesting/request_receiver.h>
-#include <google_smart_card_common/requesting/request_result.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_receiver.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h
@@ -18,10 +18,10 @@
 #include <functional>
 #include <string>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/requesting/request_receiver.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_receiver.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.cc
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.cc
@@ -22,16 +22,16 @@
 #include <utility>
 #include <vector>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/requesting/js_request_receiver.h>
-#include <google_smart_card_common/requesting/remote_call_arguments_conversion.h>
-#include <google_smart_card_common/requesting/remote_call_message.h>
-#include <google_smart_card_common/requesting/request_result.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/requesting/js_request_receiver.h"
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.h"
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_message.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 #include <google_smart_card_integration_testing/integration_test_helper.h>
 
 namespace google_smart_card {

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
@@ -20,10 +20,10 @@
 #include <string>
 #include <vector>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/messaging/typed_message_listener.h>
-#include <google_smart_card_common/requesting/js_request_receiver.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_listener.h"
+#include "common/cpp/src/google_smart_card_common/requesting/js_request_receiver.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 #include <google_smart_card_integration_testing/integration_test_helper.h>
 
 namespace google_smart_card {

--- a/example_cpp_smart_card_client_app/src/application.cc
+++ b/example_cpp_smart_card_client_app/src/application.cc
@@ -23,11 +23,11 @@
 #include <utility>
 #include <vector>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_debug_dumping.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_debug_dumping.h"
 #include <google_smart_card_pcsc_lite_client/global.h>
 #include <google_smart_card_pcsc_lite_cpp_demo/demo.h>
 

--- a/example_cpp_smart_card_client_app/src/application.h
+++ b/example_cpp_smart_card_client_app/src/application.h
@@ -18,8 +18,8 @@
 #include <memory>
 #include <mutex>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
 #include <google_smart_card_pcsc_lite_client/global.h>
 
 #include "built_in_pin_dialog/built_in_pin_dialog_server.h"

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.cc
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.cc
@@ -17,10 +17,10 @@
 #include <string>
 #include <utility>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/requesting/request_result.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 namespace gsc = google_smart_card;
 namespace scc = smart_card_client;

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.h
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built_in_pin_dialog_server.h
@@ -17,9 +17,9 @@
 
 #include <string>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/requesting/js_requester.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/requesting/js_requester.h"
 
 namespace smart_card_client {
 

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
@@ -17,15 +17,15 @@
 #include <thread>
 #include <utility>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/logging/function_call_tracer.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/requesting/remote_call_arguments_conversion.h>
-#include <google_smart_card_common/requesting/remote_call_message.h>
-#include <google_smart_card_common/requesting/request_result.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/logging/function_call_tracer.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.h"
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_message.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 namespace scc = smart_card_client;
 namespace gsc = google_smart_card;

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
@@ -26,14 +26,14 @@
 #include <string>
 #include <vector>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/requesting/js_request_receiver.h>
-#include <google_smart_card_common/requesting/js_requester.h>
-#include <google_smart_card_common/requesting/remote_call_adaptor.h>
-#include <google_smart_card_common/requesting/request_handler.h>
-#include <google_smart_card_common/requesting/request_receiver.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/requesting/js_request_receiver.h"
+#include "common/cpp/src/google_smart_card_common/requesting/js_requester.h"
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_handler.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_receiver.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 #include "chrome_certificate_provider/types.h"
 

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
@@ -21,14 +21,14 @@
 #include <utility>
 #include <vector>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/requesting/request_receiver.h>
-#include <google_smart_card_common/requesting/request_result.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_receiver.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 #include <google_smart_card_integration_testing/integration_test_helper.h>
 #include <google_smart_card_integration_testing/integration_test_service.h>
 

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.cc
@@ -14,7 +14,7 @@
 
 #include "chrome_certificate_provider/types.h"
 
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 namespace ccp = smart_card_client::chrome_certificate_provider;
 

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.h
@@ -29,7 +29,7 @@
 #include <string>
 #include <vector>
 
-#include <google_smart_card_common/optional.h>
+#include "common/cpp/src/google_smart_card_common/optional.h"
 
 namespace smart_card_client {
 

--- a/example_cpp_smart_card_client_app/src/entry_point_emscripten.cc
+++ b/example_cpp_smart_card_client_app/src/entry_point_emscripten.cc
@@ -28,12 +28,12 @@
 #include <emscripten/bind.h>
 #include <emscripten/val.h>
 
-#include <google_smart_card_common/global_context_impl_emscripten.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_debug_dumping.h>
-#include <google_smart_card_common/value_emscripten_val_conversion.h>
+#include "common/cpp/src/google_smart_card_common/global_context_impl_emscripten.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_debug_dumping.h"
+#include "common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.h"
 
 #include "application.h"
 

--- a/example_cpp_smart_card_client_app/src/entry_point_nacl.cc
+++ b/example_cpp_smart_card_client_app/src/entry_point_nacl.cc
@@ -31,12 +31,12 @@
 #include <ppapi/cpp/module.h>
 #include <ppapi/cpp/var.h>
 
-#include <google_smart_card_common/global_context_impl_nacl.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
+#include "common/cpp/src/google_smart_card_common/global_context_impl_nacl.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h"
 
 #include "application.h"
 

--- a/example_cpp_smart_card_client_app/src/ui_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/ui_bridge.cc
@@ -18,14 +18,14 @@
 #include <thread>
 #include <utility>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/messaging/typed_message.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
-#include <google_smart_card_common/value_debug_dumping.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
+#include "common/cpp/src/google_smart_card_common/value_debug_dumping.h"
 
 namespace gsc = google_smart_card;
 

--- a/example_cpp_smart_card_client_app/src/ui_bridge.h
+++ b/example_cpp_smart_card_client_app/src/ui_bridge.h
@@ -20,10 +20,10 @@
 
 #include <atomic>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/messaging/typed_message_listener.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_listener.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace smart_card_client {
 

--- a/smart_card_connector_app/src/application.cc
+++ b/smart_card_connector_app/src/application.cc
@@ -18,13 +18,13 @@
 #include <thread>
 #include <utility>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/messaging/typed_message.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 #include <google_smart_card_pcsc_lite_server_clients_management/backend.h>
 #include <google_smart_card_pcsc_lite_server_clients_management/ready_message.h>
 

--- a/smart_card_connector_app/src/application.h
+++ b/smart_card_connector_app/src/application.h
@@ -18,8 +18,8 @@
 #include <functional>
 #include <memory>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
 #include <google_smart_card_pcsc_lite_server_clients_management/backend.h>
 
 #include "third_party/libusb/webport/src/public/libusb_web_port_service.h"

--- a/smart_card_connector_app/src/application_integration_test_helper.cc
+++ b/smart_card_connector_app/src/application_integration_test_helper.cc
@@ -19,11 +19,11 @@
 #include <string>
 #include <thread>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/requesting/request_receiver.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_receiver.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 #include <google_smart_card_integration_testing/integration_test_helper.h>
 #include <google_smart_card_integration_testing/integration_test_service.h>
 

--- a/smart_card_connector_app/src/application_unittest.cc
+++ b/smart_card_connector_app/src/application_unittest.cc
@@ -35,18 +35,18 @@
 #include <reader.h>
 #include <winscard.h>
 
-#include <google_smart_card_common/formatting.h>
-#include <google_smart_card_common/messaging/typed_message.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/multi_string.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/optional_test_utils.h>
-#include <google_smart_card_common/requesting/remote_call_message.h>
-#include <google_smart_card_common/requesting/requester_message.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
-#include <google_smart_card_common/value_test_utils.h>
+#include "common/cpp/src/google_smart_card_common/formatting.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/multi_string.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/optional_test_utils.h"
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_message.h"
+#include "common/cpp/src/google_smart_card_common/requesting/requester_message.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
+#include "common/cpp/src/google_smart_card_common/value_test_utils.h"
 
 #include "common/cpp/src/public/testing_global_context.h"
 #include "common/cpp/src/public/value_builder.h"
@@ -54,7 +54,7 @@
 #include "third_party/libusb/webport/src/libusb_js_proxy_constants.h"
 
 #ifdef __native_client__
-#include <google_smart_card_common/nacl_io_utils.h>
+#include "common/cpp/src/google_smart_card_common/nacl_io_utils.h"
 #endif  // __native_client__
 
 #ifdef __native_client__

--- a/smart_card_connector_app/src/entry_point_emscripten.cc
+++ b/smart_card_connector_app/src/entry_point_emscripten.cc
@@ -30,12 +30,12 @@
 #include <emscripten/bind.h>
 #include <emscripten/val.h>
 
-#include <google_smart_card_common/global_context_impl_emscripten.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_emscripten_val_conversion.h>
+#include "common/cpp/src/google_smart_card_common/global_context_impl_emscripten.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_emscripten_val_conversion.h"
 
 #include "application.h"
 

--- a/smart_card_connector_app/src/entry_point_nacl.cc
+++ b/smart_card_connector_app/src/entry_point_nacl.cc
@@ -31,15 +31,15 @@
 #include <ppapi/cpp/module.h>
 #include <ppapi/cpp/var.h>
 
-#include <google_smart_card_common/external_logs_printer.h>
-#include <google_smart_card_common/global_context_impl_nacl.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/nacl_io_utils.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_nacl_pp_var_conversion.h>
+#include "common/cpp/src/google_smart_card_common/external_logs_printer.h"
+#include "common/cpp/src/google_smart_card_common/global_context_impl_nacl.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/nacl_io_utils.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_nacl_pp_var_conversion.h"
 
 #include "application.h"
 

--- a/smart_card_connector_app/src/testing_smart_card_simulation.cc
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.cc
@@ -22,17 +22,16 @@
 #include <utility>
 #include <vector>
 
-#include <google_smart_card_common/logging/hex_dumping.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/requesting/remote_call_message.h>
-#include <google_smart_card_common/requesting/request_receiver.h>
-#include <google_smart_card_common/requesting/request_result.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
-#include <google_smart_card_common/value_debug_dumping.h>
-
+#include "common/cpp/src/google_smart_card_common/logging/hex_dumping.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_message.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_receiver.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
+#include "common/cpp/src/google_smart_card_common/value_debug_dumping.h"
 #include "common/cpp/src/public/value_builder.h"
 #include "third_party/libusb/webport/src/libusb_js_proxy_data_model.h"
 

--- a/smart_card_connector_app/src/testing_smart_card_simulation.h
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.h
@@ -24,14 +24,13 @@
 #include <string>
 #include <vector>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/requesting/js_request_receiver.h>
-#include <google_smart_card_common/requesting/request_receiver.h>
-#include <google_smart_card_common/requesting/request_result.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/value.h>
-
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/requesting/js_request_receiver.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_receiver.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 #include "third_party/libusb/webport/src/libusb_js_proxy_data_model.h"
 
 namespace google_smart_card {

--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -26,9 +26,9 @@
 #include <utility>
 #include <vector>
 
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/numeric_conversions.h>
-#include <google_smart_card_common/requesting/request_result.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/numeric_conversions.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
 
 #include "libusb_js_proxy_data_model.h"
 #include "third_party/libusb/webport/src/libusb_js_proxy_constants.h"

--- a/third_party/libusb/webport/src/libusb_js_proxy.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy.h
@@ -24,11 +24,11 @@
 
 #include <libusb.h>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/requesting/js_requester.h>
-#include <google_smart_card_common/requesting/remote_call_adaptor.h>
-#include <google_smart_card_common/requesting/request_result.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/requesting/js_requester.h"
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
 
 #include "libusb_contexts_storage.h"
 #include "libusb_interface.h"

--- a/third_party/libusb/webport/src/libusb_js_proxy_data_model.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_data_model.cc
@@ -16,7 +16,7 @@
 
 #include "libusb_js_proxy_data_model.h"
 
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 namespace google_smart_card {
 

--- a/third_party/libusb/webport/src/libusb_js_proxy_data_model.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy_data_model.h
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-#include <google_smart_card_common/optional.h>
+#include "common/cpp/src/google_smart_card_common/optional.h"
 
 namespace google_smart_card {
 

--- a/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
@@ -33,8 +33,8 @@
 #include <gtest/gtest.h>
 #include <libusb.h>
 
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 #include "common/cpp/src/public/testing_global_context.h"
 #include "common/cpp/src/public/value_builder.h"

--- a/third_party/libusb/webport/src/libusb_opaque_types.cc
+++ b/third_party/libusb/webport/src/libusb_opaque_types.cc
@@ -19,7 +19,7 @@
 #include <chrono>
 #include <utility>
 
-#include <google_smart_card_common/logging/logging.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
 
 void libusb_context::AddAsyncTransferInFlight(
     TransferAsyncRequestStatePtr async_request_state,

--- a/third_party/libusb/webport/src/libusb_opaque_types.h
+++ b/third_party/libusb/webport/src/libusb_opaque_types.h
@@ -37,8 +37,8 @@
 
 #include <libusb.h>
 
-#include <google_smart_card_common/requesting/async_request.h>
-#include <google_smart_card_common/requesting/request_result.h>
+#include "common/cpp/src/google_smart_card_common/requesting/async_request.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
 
 #include "libusb_js_proxy_data_model.h"
 #include "usb_transfer_destination.h"

--- a/third_party/libusb/webport/src/libusb_tracing_wrapper.cc
+++ b/third_party/libusb/webport/src/libusb_tracing_wrapper.cc
@@ -19,10 +19,10 @@
 #include <cstring>
 #include <string>
 
-#include <google_smart_card_common/logging/function_call_tracer.h>
-#include <google_smart_card_common/logging/hex_dumping.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/logging/mask_dumping.h>
+#include "common/cpp/src/google_smart_card_common/logging/function_call_tracer.h"
+#include "common/cpp/src/google_smart_card_common/logging/hex_dumping.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/logging/mask_dumping.h"
 
 namespace google_smart_card {
 

--- a/third_party/libusb/webport/src/public/libusb_web_port_service.cc
+++ b/third_party/libusb/webport/src/public/libusb_web_port_service.cc
@@ -18,10 +18,10 @@
 
 #include <utility>
 
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/requesting/js_requester.h>
-#include <google_smart_card_common/requesting/requester.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/requesting/js_requester.h"
+#include "common/cpp/src/google_smart_card_common/requesting/requester.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
 
 #include "libusb_interface.h"
 #include "libusb_js_proxy.h"

--- a/third_party/libusb/webport/src/public/libusb_web_port_service.h
+++ b/third_party/libusb/webport/src/public/libusb_web_port_service.h
@@ -19,8 +19,8 @@
 
 #include <memory>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
 
 namespace google_smart_card {
 

--- a/third_party/libusb/webport/src/usb_transfer_destination.h
+++ b/third_party/libusb/webport/src/usb_transfer_destination.h
@@ -21,7 +21,7 @@
 
 #include <libusb.h>
 
-#include <google_smart_card_common/optional.h>
+#include "common/cpp/src/google_smart_card_common/optional.h"
 
 namespace google_smart_card {
 

--- a/third_party/libusb/webport/src/usb_transfers_parameters_storage.cc
+++ b/third_party/libusb/webport/src/usb_transfers_parameters_storage.cc
@@ -16,7 +16,7 @@
 
 #include "usb_transfers_parameters_storage.h"
 
-#include <google_smart_card_common/logging/logging.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
 
 namespace google_smart_card {
 

--- a/third_party/libusb/webport/src/usb_transfers_parameters_storage.h
+++ b/third_party/libusb/webport/src/usb_transfers_parameters_storage.h
@@ -24,7 +24,7 @@
 
 #include <libusb.h>
 
-#include <google_smart_card_common/requesting/async_request.h>
+#include "common/cpp/src/google_smart_card_common/requesting/async_request.h"
 
 #include "libusb_js_proxy_data_model.h"
 #include "usb_transfer_destination.h"

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.cc
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.cc
@@ -27,8 +27,8 @@
 
 #include <reader.h>
 
-#include <google_smart_card_common/logging/function_call_tracer.h>
-#include <google_smart_card_common/logging/hex_dumping.h>
+#include "common/cpp/src/google_smart_card_common/logging/function_call_tracer.h"
+#include "common/cpp/src/google_smart_card_common/logging/hex_dumping.h"
 #include <google_smart_card_pcsc_lite_common/scard_debug_dump.h>
 
 namespace google_smart_card {

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.h
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.h
@@ -33,7 +33,7 @@
 #include <winscard.h>
 #include <wintypes.h>
 
-#include <google_smart_card_common/logging/logging.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
 #include <google_smart_card_pcsc_lite_common/pcsc_lite.h>
 
 namespace google_smart_card {

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_debug_dump.cc
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_debug_dump.cc
@@ -27,10 +27,10 @@
 
 #include <reader.h>
 
-#include <google_smart_card_common/logging/hex_dumping.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/logging/mask_dumping.h>
-#include <google_smart_card_common/multi_string.h>
+#include "common/cpp/src/google_smart_card_common/logging/hex_dumping.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/logging/mask_dumping.h"
+#include "common/cpp/src/google_smart_card_common/multi_string.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.cc
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.cc
@@ -27,7 +27,7 @@
 
 #include <cstring>
 
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.h
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.h
@@ -46,7 +46,7 @@
 #include <winscard.h>
 #include <wintypes.h>
 
-#include <google_smart_card_common/optional.h>
+#include "common/cpp/src/google_smart_card_common/optional.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.cc
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.cc
@@ -33,10 +33,10 @@
 #include <winscard.h>
 #include <wintypes.h>
 
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/requesting/js_requester.h>
-#include <google_smart_card_common/requesting/requester.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/requesting/js_requester.h"
+#include "common/cpp/src/google_smart_card_common/requesting/requester.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
 #include <google_smart_card_pcsc_lite_common/pcsc_lite.h>
 #include <google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.h>
 

--- a/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.h
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.h
@@ -28,8 +28,8 @@
 
 #include <memory>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.cc
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.cc
@@ -35,9 +35,9 @@
 #include <utility>
 #include <vector>
 
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/multi_string.h>
-#include <google_smart_card_common/requesting/remote_call_arguments_conversion.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/multi_string.h"
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.h"
 #include <google_smart_card_pcsc_lite_common/scard_structs_serialization.h>
 
 namespace google_smart_card {

--- a/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.h
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.h
@@ -32,9 +32,9 @@
 #include <winscard.h>
 #include <wintypes.h>
 
-#include <google_smart_card_common/requesting/remote_call_adaptor.h>
-#include <google_smart_card_common/requesting/request_result.h>
-#include <google_smart_card_common/requesting/requester.h>
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_adaptor.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
+#include "common/cpp/src/google_smart_card_common/requesting/requester.h"
 #include <google_smart_card_pcsc_lite_common/pcsc_lite.h>
 
 namespace google_smart_card {

--- a/third_party/pcsc-lite/naclport/cpp_demo/src/google_smart_card_pcsc_lite_cpp_demo/demo.cc
+++ b/third_party/pcsc-lite/naclport/cpp_demo/src/google_smart_card_pcsc_lite_cpp_demo/demo.cc
@@ -39,9 +39,9 @@
 #include <winscard.h>
 #include <wintypes.h>
 
-#include <google_smart_card_common/logging/hex_dumping.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/multi_string.h>
+#include "common/cpp/src/google_smart_card_common/logging/hex_dumping.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/multi_string.h"
 #include <google_smart_card_pcsc_lite_common/scard_debug_dump.h>
 
 namespace google_smart_card {

--- a/third_party/pcsc-lite/naclport/server/src/cmath.cc
+++ b/third_party/pcsc-lite/naclport/server/src/cmath.cc
@@ -27,7 +27,7 @@
 
 #include <cmath>
 
-#include <google_smart_card_common/logging/logging.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
 
 extern "C" double nexttoward(double /*x*/, long double /*y*/) {
   // FIXME(emaxx): Investigate why does the PNaCl standard library causes the

--- a/third_party/pcsc-lite/naclport/server/src/dyn_nacl.cc
+++ b/third_party/pcsc-lite/naclport/server/src/dyn_nacl.cc
@@ -49,7 +49,7 @@ extern "C" {
 #undef min
 }
 
-#include <google_smart_card_common/logging/logging.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
 
 namespace {
 

--- a/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
+++ b/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
@@ -33,12 +33,12 @@
 #include <thread>
 #include <utility>
 
-#include <google_smart_card_common/ipc_emulation.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/messaging/typed_message.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/ipc_emulation.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 #include "server_sockets_manager.h"
 

--- a/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.h
+++ b/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.h
@@ -28,8 +28,8 @@
 
 #include <thread>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/server/src/server_sockets_manager.cc
+++ b/third_party/pcsc-lite/naclport/server/src/server_sockets_manager.cc
@@ -25,8 +25,8 @@
 
 #include "server_sockets_manager.h"
 
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/optional.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/server/src/server_sockets_manager.h
+++ b/third_party/pcsc-lite/naclport/server/src/server_sockets_manager.h
@@ -30,7 +30,7 @@
 #include <mutex>
 #include <queue>
 
-#include <google_smart_card_common/optional.h>
+#include "common/cpp/src/google_smart_card_common/optional.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/server/src/unistd_nacl.cc
+++ b/third_party/pcsc-lite/naclport/server/src/unistd_nacl.cc
@@ -21,7 +21,7 @@
 
 #include <unistd.h>
 
-#include <google_smart_card_common/logging/logging.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
 
 unsigned alarm(unsigned /*seconds*/) {
   // This is a stub implementation that should be never invoked.

--- a/third_party/pcsc-lite/naclport/server/src/winscard_msg_nacl.cc
+++ b/third_party/pcsc-lite/naclport/server/src/winscard_msg_nacl.cc
@@ -58,8 +58,8 @@ extern "C" {
 #undef min
 }
 
-#include <google_smart_card_common/ipc_emulation.h>
-#include <google_smart_card_common/logging/logging.h>
+#include "common/cpp/src/google_smart_card_common/ipc_emulation.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
 
 #include "server_sockets_manager.h"
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/admin_policy_getter.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/admin_policy_getter.cc
@@ -17,9 +17,9 @@
 #include <condition_variable>
 #include <string>
 
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/value_conversion.h>
-#include <google_smart_card_common/value_debug_dumping.h>
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
+#include "common/cpp/src/google_smart_card_common/value_debug_dumping.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/admin_policy_getter.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/admin_policy_getter.h
@@ -20,8 +20,8 @@
 #include <string>
 #include <vector>
 
-#include <google_smart_card_common/messaging/typed_message_listener.h>
-#include <google_smart_card_common/optional.h>
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_listener.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_handles_registry.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_handles_registry.cc
@@ -27,7 +27,7 @@
 
 #include <utility>
 
-#include <google_smart_card_common/logging/logging.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.cc
@@ -38,17 +38,17 @@
 #include <tuple>
 #include <vector>
 
-#include <google_smart_card_common/formatting.h>
-#include <google_smart_card_common/join_string.h>
-#include <google_smart_card_common/logging/function_call_tracer.h>
-#include <google_smart_card_common/logging/hex_dumping.h>
-#include <google_smart_card_common/multi_string.h>
-#include <google_smart_card_common/requesting/remote_call_arguments_conversion.h>
-#include <google_smart_card_common/requesting/remote_call_message.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
-#include <google_smart_card_common/value_debug_dumping.h>
+#include "common/cpp/src/google_smart_card_common/formatting.h"
+#include "common/cpp/src/google_smart_card_common/join_string.h"
+#include "common/cpp/src/google_smart_card_common/logging/function_call_tracer.h"
+#include "common/cpp/src/google_smart_card_common/logging/hex_dumping.h"
+#include "common/cpp/src/google_smart_card_common/multi_string.h"
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_arguments_conversion.h"
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_message.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
+#include "common/cpp/src/google_smart_card_common/value_debug_dumping.h"
 #include <google_smart_card_pcsc_lite_common/scard_debug_dump.h>
 
 #include "admin_policy_getter.h"

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h
@@ -42,13 +42,13 @@
 #include <winscard.h>
 #include <wintypes.h>
 
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/optional.h>
-#include <google_smart_card_common/requesting/remote_call_message.h>
-#include <google_smart_card_common/requesting/request_receiver.h>
-#include <google_smart_card_common/requesting/request_result.h>
-#include <google_smart_card_common/tuple_unpacking.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/optional.h"
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_message.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_receiver.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_result.h"
+#include "common/cpp/src/google_smart_card_common/tuple_unpacking.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 #include <google_smart_card_pcsc_lite_common/scard_structs_serialization.h>
 
 #include "admin_policy_getter.h"

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
@@ -31,13 +31,13 @@
 #include <string>
 #include <utility>
 
-#include <google_smart_card_common/formatting.h>
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/logging/logging.h>
-#include <google_smart_card_common/requesting/remote_call_message.h>
-#include <google_smart_card_common/unique_ptr_utils.h>
-#include <google_smart_card_common/value.h>
-#include <google_smart_card_common/value_conversion.h>
+#include "common/cpp/src/google_smart_card_common/formatting.h"
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/logging/logging.h"
+#include "common/cpp/src/google_smart_card_common/requesting/remote_call_message.h"
+#include "common/cpp/src/google_smart_card_common/unique_ptr_utils.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
+#include "common/cpp/src/google_smart_card_common/value_conversion.h"
 
 #include "admin_policy_getter.h"
 #include "client_request_processor.h"

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h
@@ -32,13 +32,13 @@
 #include <string>
 #include <unordered_map>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/messaging/typed_message_listener.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
-#include <google_smart_card_common/requesting/js_request_receiver.h>
-#include <google_smart_card_common/requesting/request_handler.h>
-#include <google_smart_card_common/requesting/request_receiver.h>
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_listener.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
+#include "common/cpp/src/google_smart_card_common/requesting/js_request_receiver.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_handler.h"
+#include "common/cpp/src/google_smart_card_common/requesting/request_receiver.h"
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 #include "admin_policy_getter.h"
 #include "client_request_processor.h"

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.cc
@@ -27,7 +27,7 @@
 
 #include "clients_manager.h"
 
-#include <google_smart_card_common/global_context.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.h
@@ -28,8 +28,8 @@
 
 #include <memory>
 
-#include <google_smart_card_common/global_context.h>
-#include <google_smart_card_common/messaging/typed_message_router.h>
+#include "common/cpp/src/google_smart_card_common/global_context.h"
+#include "common/cpp/src/google_smart_card_common/messaging/typed_message_router.h"
 
 #include "admin_policy_getter.h"
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/ready_message.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/ready_message.cc
@@ -27,7 +27,7 @@
 
 #include <string>
 
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/ready_message.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/ready_message.h
@@ -34,7 +34,7 @@
 
 #include <string>
 
-#include <google_smart_card_common/value.h>
+#include "common/cpp/src/google_smart_card_common/value.h"
 
 namespace google_smart_card {
 


### PR DESCRIPTION
Change "#include <google_smart_card_common/...>" to "#include "common/cpp/src/...".

This is part of the refactoring tracked by #885.