### PR TITLE
Test stub passes through response error messages

### DIFF
--- a/common/cpp/src/public/testing_global_context.h
+++ b/common/cpp/src/public/testing_global_context.h
@@ -43,7 +43,8 @@ class TestingGlobalContext final : public GlobalContext {
       std::function<void(RequestId request_id, Value request_payload)>;
   using ResponseCallback =
       std::function<void(RequestId request_id,
-                         optional<Value> response_payload)>;
+                         optional<Value> response_payload,
+                         optional<std::string> response_error_message)>;
 
   // Helper returned by `Create...Waiter()` methods. Allows to wait until the
   // specified C++-to-JS message is sent.
@@ -181,7 +182,8 @@ class TestingGlobalContext final : public GlobalContext {
                              Value request_payload);
   void HandleReroutedResponse(const std::string& new_requester_name,
                               RequestId request_id,
-                              optional<Value> response_payload);
+                              optional<Value> response_payload,
+                              optional<std::string> response_error_message);
 
   TypedMessageRouter* const typed_message_router_;
   // ID of the thread on which `this` was created.


### PR DESCRIPTION
Make TestingGlobalContext, when it intercepts a request's response, pass the error message if it's populated instead of the payload.

This will be used by follow-ups to properly reroute request-response USB commands, including those that failed, in application_unittest. This commit contributes to #869.