### PR TITLE
[JS-to-C++ test] Create TestingSmartCardSimulation

### DIFF
--- a/smart_card_connector_app/build/js_to_cxx_tests/Makefile
+++ b/smart_card_connector_app/build/js_to_cxx_tests/Makefile
@@ -33,12 +33,14 @@ include $(ROOT_PATH)/third_party/pcsc-lite/naclport/server_clients_management/in
 
 SOURCE_DIR := $(ROOT_PATH)/smart_card_connector_app/src/
 
-# TODO(emaxx): application.cc is also compiled for other targets
-# (../executable_module/ and ../executable_module/cpp_unittests/). Get rid of
-# duplicate compilation by putting it into a static library.
+# TODO(emaxx): application.cc and testing_smart_card_simulation.cc are also
+# compiled for other targets (both for ../executable_module/ and the latter for
+# ../executable_module/cpp_unittests/). Get rid of duplicate compilation by
+# putting them into static libraries.
 CXX_SOURCES := \
   $(SOURCE_DIR)/application.cc \
   $(SOURCE_DIR)/application_integration_test_helper.cc \
+  $(SOURCE_DIR)/testing_smart_card_simulation.cc \
 
 CXXFLAGS := \
   -I$(ROOT_PATH) \

--- a/smart_card_connector_app/src/application_integration_test_helper.cc
+++ b/smart_card_connector_app/src/application_integration_test_helper.cc
@@ -27,6 +27,8 @@
 #include <google_smart_card_integration_testing/integration_test_helper.h>
 #include <google_smart_card_integration_testing/integration_test_service.h>
 
+#include "smart_card_connector_app/src/testing_smart_card_simulation.h"
+
 namespace google_smart_card {
 
 // The helper that can be used in JS-to-C++ tests to run the core functionality
@@ -46,6 +48,7 @@ class SmartCardConnectorApplicationTestHelper final
       RequestReceiver::ResultCallback result_callback) override;
 
  private:
+  std::unique_ptr<TestingSmartCardSimulation> smart_card_simulation_;
   std::unique_ptr<Application> application_;
 };
 
@@ -64,6 +67,8 @@ void SmartCardConnectorApplicationTestHelper::SetUp(
     TypedMessageRouter* typed_message_router,
     Value /*data*/,
     RequestReceiver::ResultCallback result_callback) {
+  smart_card_simulation_ = MakeUnique<TestingSmartCardSimulation>(
+      global_context, typed_message_router);
   application_ = MakeUnique<Application>(global_context, typed_message_router,
                                          std::function<void()>());
   // Note: We don't wait until the application completes its initialization on
@@ -79,6 +84,7 @@ void SmartCardConnectorApplicationTestHelper::TearDown(
   std::thread([this, completion_callback] {
     application_->ShutDownAndWait();
     application_.reset();
+    smart_card_simulation_.reset();
     completion_callback();
   }).detach();
 }


### PR DESCRIPTION
Instantiate TestingSmartCardSimulation in JS-to-C++ tests that use SmartCardConnectorApplicationTestHelper.

To note, it's still disfunctional because we need to wire it up with Libusb requests. This will be addressed in follow-ups.

This commit contributes to #869.