### PR TITLE
[JS-to-C++ test] Pull CCID config file

### DIFF
--- a/smart_card_connector_app/build/js_to_cxx_tests/Makefile
+++ b/smart_card_connector_app/build/js_to_cxx_tests/Makefile
@@ -72,9 +72,16 @@ JS_SOURCES_PATHS := \
 $(foreach src,$(CXX_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
 
 # Package resource files that the C/C++ code needs at runtime:
+# * fake_socket_file: it's needed to trick the PC/SC daemon code into thinking
+#   it can open a socket IPC communication.
 $(eval $(call ADD_RESOURCE_RULE, \
   $(ROOT_PATH)/third_party/pcsc-lite/naclport/server/src/fake_socket_file, \
   executable-module-filesystem/pcsc/fake_socket_file))
+# * Info.plist: it's a driver config for the CCID driver; at runtime, the PC/SC
+#   daemon code reads parameters from this config to call into CCID.
+$(eval $(call ADD_RESOURCE_RULE, \
+  $(ROOT_PATH)/third_party/ccid/webport/build/Info.plist, \
+  executable-module-filesystem/pcsc/drivers/ifd-ccid.bundle/Contents/Info.plist))
 
 # Targets that build the resulting executable module and JS tests.
 $(eval $(call BUILD_JS_TO_CXX_TEST,$(CXX_SOURCES),$(LIBS),$(JS_SOURCES_PATHS)))


### PR DESCRIPTION
Add the CCID driver's Info.plist config file into the output directory for smart_card_connector's js_to_cxx tests.

This is needed so that the PC/SC daemon can load the CCID driver at runtime and do anything useful. This is preparation for enabling USB simulation in tests as tracked by #869.