### PR TITLE
[headers] Include by abs path from libusb/webport/

### DIFF
--- a/third_party/libusb/webport/src/libusb_contexts_storage.cc
+++ b/third_party/libusb/webport/src/libusb_contexts_storage.cc
@@ -14,7 +14,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include "libusb_contexts_storage.h"
+#include "third_party/libusb/webport/src/libusb_contexts_storage.h"
 
 namespace google_smart_card {
 

--- a/third_party/libusb/webport/src/libusb_contexts_storage.h
+++ b/third_party/libusb/webport/src/libusb_contexts_storage.h
@@ -23,7 +23,7 @@
 
 #include <libusb.h>
 
-#include "libusb_opaque_types.h"
+#include "third_party/libusb/webport/src/libusb_opaque_types.h"
 
 namespace google_smart_card {
 

--- a/third_party/libusb/webport/src/libusb_error_name.c
+++ b/third_party/libusb/webport/src/libusb_error_name.c
@@ -22,7 +22,7 @@
 
 #include <libusb.h>
 
-#include "config.h"
+#include "third_party/libusb/webport/src/config.h"
 
 /**
  * This function was borrowed from libusb sources (file libusb/core.c).

--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -14,7 +14,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include "libusb_js_proxy.h"
+#include "third_party/libusb/webport/src/libusb_js_proxy.h"
 
 #include <stdlib.h>
 
@@ -30,8 +30,8 @@
 #include "common/cpp/src/public/numeric_conversions.h"
 #include "common/cpp/src/public/requesting/request_result.h"
 
-#include "libusb_js_proxy_data_model.h"
 #include "third_party/libusb/webport/src/libusb_js_proxy_constants.h"
+#include "third_party/libusb/webport/src/libusb_js_proxy_data_model.h"
 
 namespace google_smart_card {
 

--- a/third_party/libusb/webport/src/libusb_js_proxy.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy.h
@@ -29,10 +29,9 @@
 #include "common/cpp/src/public/requesting/js_requester.h"
 #include "common/cpp/src/public/requesting/remote_call_adaptor.h"
 #include "common/cpp/src/public/requesting/request_result.h"
-
-#include "libusb_contexts_storage.h"
-#include "libusb_interface.h"
-#include "libusb_opaque_types.h"
+#include "third_party/libusb/webport/src/libusb_contexts_storage.h"
+#include "third_party/libusb/webport/src/libusb_interface.h"
+#include "third_party/libusb/webport/src/libusb_opaque_types.h"
 
 namespace google_smart_card {
 

--- a/third_party/libusb/webport/src/libusb_js_proxy_data_model.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_data_model.cc
@@ -14,7 +14,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include "libusb_js_proxy_data_model.h"
+#include "third_party/libusb/webport/src/libusb_js_proxy_data_model.h"
 
 #include "common/cpp/src/public/value_conversion.h"
 

--- a/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
@@ -14,7 +14,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include "libusb_js_proxy.h"
+#include "third_party/libusb/webport/src/libusb_js_proxy.h"
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/third_party/libusb/webport/src/libusb_opaque_types.cc
+++ b/third_party/libusb/webport/src/libusb_opaque_types.cc
@@ -14,7 +14,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include "libusb_opaque_types.h"
+#include "third_party/libusb/webport/src/libusb_opaque_types.h"
 
 #include <chrono>
 #include <utility>

--- a/third_party/libusb/webport/src/libusb_opaque_types.h
+++ b/third_party/libusb/webport/src/libusb_opaque_types.h
@@ -39,10 +39,9 @@
 
 #include "common/cpp/src/public/requesting/async_request.h"
 #include "common/cpp/src/public/requesting/request_result.h"
-
-#include "libusb_js_proxy_data_model.h"
-#include "usb_transfer_destination.h"
-#include "usb_transfers_parameters_storage.h"
+#include "third_party/libusb/webport/src/libusb_js_proxy_data_model.h"
+#include "third_party/libusb/webport/src/usb_transfer_destination.h"
+#include "third_party/libusb/webport/src/usb_transfers_parameters_storage.h"
 
 // Definition of the libusb_context type declared in the libusb headers.
 //

--- a/third_party/libusb/webport/src/libusb_tracing_wrapper.cc
+++ b/third_party/libusb/webport/src/libusb_tracing_wrapper.cc
@@ -14,7 +14,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include "libusb_tracing_wrapper.h"
+#include "third_party/libusb/webport/src/libusb_tracing_wrapper.h"
 
 #include <cstring>
 #include <string>

--- a/third_party/libusb/webport/src/libusb_tracing_wrapper.h
+++ b/third_party/libusb/webport/src/libusb_tracing_wrapper.h
@@ -22,7 +22,7 @@
 
 #include <libusb.h>
 
-#include "libusb_interface.h"
+#include "third_party/libusb/webport/src/libusb_interface.h"
 
 namespace google_smart_card {
 

--- a/third_party/libusb/webport/src/public/libusb_web_port_service.cc
+++ b/third_party/libusb/webport/src/public/libusb_web_port_service.cc
@@ -14,7 +14,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include "libusb_web_port_service.h"
+#include "third_party/libusb/webport/src/public/libusb_web_port_service.h"
 
 #include <utility>
 
@@ -22,10 +22,9 @@
 #include "common/cpp/src/public/requesting/js_requester.h"
 #include "common/cpp/src/public/requesting/requester.h"
 #include "common/cpp/src/public/unique_ptr_utils.h"
-
-#include "libusb_interface.h"
-#include "libusb_js_proxy.h"
-#include "libusb_tracing_wrapper.h"
+#include "third_party/libusb/webport/src/libusb_interface.h"
+#include "third_party/libusb/webport/src/libusb_js_proxy.h"
+#include "third_party/libusb/webport/src/libusb_tracing_wrapper.h"
 
 namespace {
 

--- a/third_party/libusb/webport/src/usb_transfer_destination.cc
+++ b/third_party/libusb/webport/src/usb_transfer_destination.cc
@@ -20,7 +20,7 @@
 // This structure is used for finding matches between transfers and transfer
 // results (see the comments in the libusb_over_chrome_usb.h header).
 
-#include "usb_transfer_destination.h"
+#include "third_party/libusb/webport/src/usb_transfer_destination.h"
 
 #include <stdint.h>
 

--- a/third_party/libusb/webport/src/usb_transfers_parameters_storage.cc
+++ b/third_party/libusb/webport/src/usb_transfers_parameters_storage.cc
@@ -14,7 +14,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include "usb_transfers_parameters_storage.h"
+#include "third_party/libusb/webport/src/usb_transfers_parameters_storage.h"
 
 #include "common/cpp/src/public/logging/logging.h"
 

--- a/third_party/libusb/webport/src/usb_transfers_parameters_storage.h
+++ b/third_party/libusb/webport/src/usb_transfers_parameters_storage.h
@@ -25,9 +25,8 @@
 #include <libusb.h>
 
 #include "common/cpp/src/public/requesting/async_request.h"
-
-#include "libusb_js_proxy_data_model.h"
-#include "usb_transfer_destination.h"
+#include "third_party/libusb/webport/src/libusb_js_proxy_data_model.h"
+#include "third_party/libusb/webport/src/usb_transfer_destination.h"
 
 namespace google_smart_card {
 


### PR DESCRIPTION
Change `#include "foo.h"` (which implicitly relied on manipulated include search paths) to `#include "third_party/libusb/webport/src/"`.

This is part of the refactoring tracked by #885.