### PR TITLE
[headers] Include by abs path from common/integration_testing/

### DIFF
--- a/common/integration_testing/src/entry_point_emscripten.cc
+++ b/common/integration_testing/src/entry_point_emscripten.cc
@@ -32,7 +32,7 @@
 #include "common/cpp/src/public/messaging/typed_message_router.h"
 #include "common/cpp/src/public/value.h"
 #include "common/cpp/src/public/value_emscripten_val_conversion.h"
-#include <google_smart_card_integration_testing/integration_test_service.h>
+#include "common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h"
 
 namespace google_smart_card {
 

--- a/common/integration_testing/src/entry_point_nacl.cc
+++ b/common/integration_testing/src/entry_point_nacl.cc
@@ -29,7 +29,7 @@
 #include "common/cpp/src/public/value.h"
 #include "common/cpp/src/public/value_debug_dumping.h"
 #include "common/cpp/src/public/value_nacl_pp_var_conversion.h"
-#include <google_smart_card_integration_testing/integration_test_service.h>
+#include "common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h"
 
 namespace google_smart_card {
 

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.cc
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_integration_testing/integration_test_helper.h>
+#include "common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h"
 
 #include <functional>
 

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.cc
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google_smart_card_integration_testing/integration_test_service.h>
+#include "common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h"
 
 #include <atomic>
 #include <functional>
@@ -32,7 +32,7 @@
 #include "common/cpp/src/public/unique_ptr_utils.h"
 #include "common/cpp/src/public/value.h"
 #include "common/cpp/src/public/value_conversion.h"
-#include <google_smart_card_integration_testing/integration_test_helper.h>
+#include "common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h"
 
 namespace google_smart_card {
 

--- a/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
+++ b/common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h
@@ -24,7 +24,7 @@
 #include "common/cpp/src/public/messaging/typed_message_listener.h"
 #include "common/cpp/src/public/requesting/js_request_receiver.h"
 #include "common/cpp/src/public/value.h"
-#include <google_smart_card_integration_testing/integration_test_helper.h>
+#include "common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h"
 
 namespace google_smart_card {
 

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge_integration_test_helper.cc
@@ -29,8 +29,8 @@
 #include "common/cpp/src/public/unique_ptr_utils.h"
 #include "common/cpp/src/public/value.h"
 #include "common/cpp/src/public/value_conversion.h"
-#include <google_smart_card_integration_testing/integration_test_helper.h>
-#include <google_smart_card_integration_testing/integration_test_service.h>
+#include "common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h"
+#include "common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h"
 
 #include "chrome_certificate_provider/api_bridge.h"
 #include "chrome_certificate_provider/types.h"

--- a/smart_card_connector_app/src/application_integration_test_helper.cc
+++ b/smart_card_connector_app/src/application_integration_test_helper.cc
@@ -24,8 +24,8 @@
 #include "common/cpp/src/public/requesting/request_receiver.h"
 #include "common/cpp/src/public/unique_ptr_utils.h"
 #include "common/cpp/src/public/value.h"
-#include <google_smart_card_integration_testing/integration_test_helper.h>
-#include <google_smart_card_integration_testing/integration_test_service.h>
+#include "common/integration_testing/src/google_smart_card_integration_testing/integration_test_helper.h"
+#include "common/integration_testing/src/google_smart_card_integration_testing/integration_test_service.h"
 
 #include "smart_card_connector_app/src/testing_smart_card_simulation.h"
 


### PR DESCRIPTION
Change `#include <google_smart_card_integration_testing/...>` includes to `#include "common/integration_testing/src/..."`.

This is part of the refactoring tracked by #885.