### PR TITLE
[headers] Include by abs path from pcsc-lite/

### DIFF
--- a/smart_card_connector_app/src/application.cc
+++ b/smart_card_connector_app/src/application.cc
@@ -25,11 +25,10 @@
 #include "common/cpp/src/public/unique_ptr_utils.h"
 #include "common/cpp/src/public/value.h"
 #include "common/cpp/src/public/value_conversion.h"
-#include <google_smart_card_pcsc_lite_server_clients_management/backend.h>
-#include <google_smart_card_pcsc_lite_server_clients_management/ready_message.h>
-
 #include "third_party/libusb/webport/src/public/libusb_web_port_service.h"
 #include "third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.h"
+#include "third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.h"
+#include "third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/ready_message.h"
 
 namespace google_smart_card {
 

--- a/smart_card_connector_app/src/application.h
+++ b/smart_card_connector_app/src/application.h
@@ -20,7 +20,7 @@
 
 #include "common/cpp/src/public/global_context.h"
 #include "common/cpp/src/public/messaging/typed_message_router.h"
-#include <google_smart_card_pcsc_lite_server_clients_management/backend.h>
+#include "third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.h"
 
 #include "third_party/libusb/webport/src/public/libusb_web_port_service.h"
 #include "third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.h"

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.cc
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.cc
@@ -23,13 +23,13 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.h>
+#include "third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.h"
 
 #include <reader.h>
 
 #include "common/cpp/src/public/logging/function_call_tracer.h"
 #include "common/cpp/src/public/logging/hex_dumping.h"
-#include <google_smart_card_pcsc_lite_common/scard_debug_dump.h>
+#include "third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_debug_dump.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.h
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.h
@@ -34,7 +34,7 @@
 #include <wintypes.h>
 
 #include "common/cpp/src/public/logging/logging.h"
-#include <google_smart_card_pcsc_lite_common/pcsc_lite.h>
+#include "third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_debug_dump.cc
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_debug_dump.cc
@@ -23,7 +23,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <google_smart_card_pcsc_lite_common/scard_debug_dump.h>
+#include "third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_debug_dump.h"
 
 #include <reader.h>
 

--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.cc
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.cc
@@ -23,7 +23,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <google_smart_card_pcsc_lite_common/scard_structs_serialization.h>
+#include "third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.h"
 
 #include <cstring>
 

--- a/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.cc
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.cc
@@ -37,10 +37,9 @@
 #include "common/cpp/src/public/requesting/js_requester.h"
 #include "common/cpp/src/public/requesting/requester.h"
 #include "common/cpp/src/public/unique_ptr_utils.h"
-#include <google_smart_card_pcsc_lite_common/pcsc_lite.h>
-#include <google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.h>
-
-#include "pcsc_lite_over_requester.h"
+#include "third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite.h"
+#include "third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite_tracing_wrapper.h"
+#include "third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.h"
 
 namespace {
 

--- a/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.cc
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.cc
@@ -23,7 +23,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "pcsc_lite_over_requester.h"
+#include "third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.h"
 
 #include <stdint.h>
 
@@ -38,7 +38,7 @@
 #include "common/cpp/src/public/logging/logging.h"
 #include "common/cpp/src/public/multi_string.h"
 #include "common/cpp/src/public/requesting/remote_call_arguments_conversion.h"
-#include <google_smart_card_pcsc_lite_common/scard_structs_serialization.h>
+#include "third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.h
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/pcsc_lite_over_requester.h
@@ -35,7 +35,7 @@
 #include "common/cpp/src/public/requesting/remote_call_adaptor.h"
 #include "common/cpp/src/public/requesting/request_result.h"
 #include "common/cpp/src/public/requesting/requester.h"
-#include <google_smart_card_pcsc_lite_common/pcsc_lite.h>
+#include "third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/pcsc_lite.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/cpp_demo/src/google_smart_card_pcsc_lite_cpp_demo/demo.cc
+++ b/third_party/pcsc-lite/naclport/cpp_demo/src/google_smart_card_pcsc_lite_cpp_demo/demo.cc
@@ -42,7 +42,7 @@
 #include "common/cpp/src/public/logging/hex_dumping.h"
 #include "common/cpp/src/public/logging/logging.h"
 #include "common/cpp/src/public/multi_string.h"
-#include <google_smart_card_pcsc_lite_common/scard_debug_dump.h>
+#include "third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_debug_dump.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
+++ b/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
@@ -39,8 +39,7 @@
 #include "common/cpp/src/public/optional.h"
 #include "common/cpp/src/public/value.h"
 #include "common/cpp/src/public/value_conversion.h"
-
-#include "server_sockets_manager.h"
+#include "third_party/pcsc-lite/naclport/server/src/server_sockets_manager.h"
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/version.h>

--- a/third_party/pcsc-lite/naclport/server/src/server_sockets_manager.cc
+++ b/third_party/pcsc-lite/naclport/server/src/server_sockets_manager.cc
@@ -23,7 +23,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "server_sockets_manager.h"
+#include "third_party/pcsc-lite/naclport/server/src/server_sockets_manager.h"
 
 #include "common/cpp/src/public/logging/logging.h"
 #include "common/cpp/src/public/optional.h"

--- a/third_party/pcsc-lite/naclport/server/src/winscard_msg_nacl.cc
+++ b/third_party/pcsc-lite/naclport/server/src/winscard_msg_nacl.cc
@@ -60,8 +60,7 @@ extern "C" {
 
 #include "common/cpp/src/public/ipc_emulation.h"
 #include "common/cpp/src/public/logging/logging.h"
-
-#include "server_sockets_manager.h"
+#include "third_party/pcsc-lite/naclport/server/src/server_sockets_manager.h"
 
 using google_smart_card::IpcEmulation;
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/admin_policy_getter.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/admin_policy_getter.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "admin_policy_getter.h"
+#include "third_party/pcsc-lite/naclport/server_clients_management/src/admin_policy_getter.h"
 
 #include <condition_variable>
 #include <string>

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_handles_registry.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_handles_registry.cc
@@ -23,7 +23,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "client_handles_registry.h"
+#include "third_party/pcsc-lite/naclport/server_clients_management/src/client_handles_registry.h"
 
 #include <utility>
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.cc
@@ -23,7 +23,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "client_request_processor.h"
+#include "third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h"
 
 #include <inttypes.h>
 #include <stdlib.h>
@@ -49,9 +49,8 @@
 #include "common/cpp/src/public/value.h"
 #include "common/cpp/src/public/value_conversion.h"
 #include "common/cpp/src/public/value_debug_dumping.h"
-#include <google_smart_card_pcsc_lite_common/scard_debug_dump.h>
-
-#include "admin_policy_getter.h"
+#include "third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_debug_dump.h"
+#include "third_party/pcsc-lite/naclport/server_clients_management/src/admin_policy_getter.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h
@@ -49,10 +49,9 @@
 #include "common/cpp/src/public/requesting/request_result.h"
 #include "common/cpp/src/public/tuple_unpacking.h"
 #include "common/cpp/src/public/value.h"
-#include <google_smart_card_pcsc_lite_common/scard_structs_serialization.h>
-
-#include "admin_policy_getter.h"
-#include "client_handles_registry.h"
+#include "third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_structs_serialization.h"
+#include "third_party/pcsc-lite/naclport/server_clients_management/src/admin_policy_getter.h"
+#include "third_party/pcsc-lite/naclport/server_clients_management/src/client_handles_registry.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.cc
@@ -23,7 +23,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "clients_manager.h"
+#include "third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h"
 
 #include <inttypes.h>
 
@@ -38,9 +38,8 @@
 #include "common/cpp/src/public/unique_ptr_utils.h"
 #include "common/cpp/src/public/value.h"
 #include "common/cpp/src/public/value_conversion.h"
-
-#include "admin_policy_getter.h"
-#include "client_request_processor.h"
+#include "third_party/pcsc-lite/naclport/server_clients_management/src/admin_policy_getter.h"
+#include "third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h
@@ -39,9 +39,8 @@
 #include "common/cpp/src/public/requesting/request_handler.h"
 #include "common/cpp/src/public/requesting/request_receiver.h"
 #include "common/cpp/src/public/value.h"
-
-#include "admin_policy_getter.h"
-#include "client_request_processor.h"
+#include "third_party/pcsc-lite/naclport/server_clients_management/src/admin_policy_getter.h"
+#include "third_party/pcsc-lite/naclport/server_clients_management/src/client_request_processor.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.cc
@@ -23,11 +23,10 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <google_smart_card_pcsc_lite_server_clients_management/backend.h>
-
-#include "clients_manager.h"
+#include "third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.h"
 
 #include "common/cpp/src/public/global_context.h"
+#include "third_party/pcsc-lite/naclport/server_clients_management/src/clients_manager.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.h
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/backend.h
@@ -30,8 +30,7 @@
 
 #include "common/cpp/src/public/global_context.h"
 #include "common/cpp/src/public/messaging/typed_message_router.h"
-
-#include "admin_policy_getter.h"
+#include "third_party/pcsc-lite/naclport/server_clients_management/src/admin_policy_getter.h"
 
 namespace google_smart_card {
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/ready_message.cc
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/ready_message.cc
@@ -23,7 +23,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <google_smart_card_pcsc_lite_server_clients_management/ready_message.h>
+#include "third_party/pcsc-lite/naclport/server_clients_management/src/google_smart_card_pcsc_lite_server_clients_management/ready_message.h"
 
 #include <string>
 


### PR DESCRIPTION
Change `#include <google_smart_card_pcsc_...>` and same-directory `#include "foo.h"` includes to `#include
"third_party/pcsc-lite/naclport/..."`.

This is part of the refactoring tracked by #885.