### PR TITLE
[headers] Include by abs path from smart_card_connector_app/

### DIFF
--- a/smart_card_connector_app/src/application.cc
+++ b/smart_card_connector_app/src/application.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "application.h"
+#include "smart_card_connector_app/src/application.h"
 
 #include <functional>
 #include <thread>

--- a/smart_card_connector_app/src/application_integration_test_helper.cc
+++ b/smart_card_connector_app/src/application_integration_test_helper.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "application.h"
+#include "smart_card_connector_app/src/application.h"
 
 #include <functional>
 #include <memory>

--- a/smart_card_connector_app/src/entry_point_emscripten.cc
+++ b/smart_card_connector_app/src/entry_point_emscripten.cc
@@ -36,8 +36,7 @@
 #include "common/cpp/src/public/unique_ptr_utils.h"
 #include "common/cpp/src/public/value.h"
 #include "common/cpp/src/public/value_emscripten_val_conversion.h"
-
-#include "application.h"
+#include "smart_card_connector_app/src/application.h"
 
 namespace google_smart_card {
 

--- a/smart_card_connector_app/src/entry_point_nacl.cc
+++ b/smart_card_connector_app/src/entry_point_nacl.cc
@@ -40,8 +40,7 @@
 #include "common/cpp/src/public/unique_ptr_utils.h"
 #include "common/cpp/src/public/value.h"
 #include "common/cpp/src/public/value_nacl_pp_var_conversion.h"
-
-#include "application.h"
+#include "smart_card_connector_app/src/application.h"
 
 namespace google_smart_card {
 


### PR DESCRIPTION
Change same-directory `#include "foo.h"` includes to `#include "smart_card_connector_app/src/..."`.

This is part of the refactoring tracked by #885.