### PR TITLE
Build scripts use Emscripten by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ third_party/libusb/webport/build/tests: third_party/libusb/webport/build
 
 # Toolchain related definitions #################
 
-TOOLCHAIN ?= pnacl
+TOOLCHAIN ?= emscripten
 
 # Applications are only built in non-sanitizer builds.
 ifneq ($(TOOLCHAIN),asan_testing)


### PR DESCRIPTION
Change default toolchain in ./Makefile as well. This is a follow-up for #836.