### PR TITLE
[wasm] Prune unneeded ENVIRONMENT support code

### DIFF
--- a/common/cpp_unit_test_runner/src/build_emscripten.mk
+++ b/common/cpp_unit_test_runner/src/build_emscripten.mk
@@ -29,6 +29,8 @@ TEST_ADDITIONAL_CXXFLAGS := \
 # Documented in ../include.mk.
 #
 # Explanation:
+# ENVIRONMENT: Generate support code for running in the Node.js environment.
+#   (This overrides the default setting in executable_building_emscripten.mk.)
 # EXIT_RUNTIME: Quit the program when the main() exits - otherwise the execution
 #   will hang.
 # EXPORT_NAME: Restore the standard value "Module" for this flag, overriding the
@@ -42,14 +44,12 @@ TEST_ADDITIONAL_CXXFLAGS := \
 # PROXY_TO_PTHREAD: Run the main() function, and hence all test bodies, in a
 #   separate thread. Otherwise, multi-threaded tests will hang as background
 #   tests aren't created until the main thread yields.
-# ENVIRONMENT: Generate support code for running in the Node.js environment.
-#   (This overrides the default setting in executable_building_emscripten.mk.)
 TEST_ADDITIONAL_LDFLAGS := \
+	-s ENVIRONMENT=node \
 	-s EXIT_RUNTIME \
 	-s EXPORT_NAME=Module \
 	-s MODULARIZE=0 \
 	-s PROXY_TO_PTHREAD \
-	-s ENVIRONMENT=node \
 
 # Documented in ../include.mk.
 TEST_RUNNER_SOURCES :=

--- a/common/cpp_unit_test_runner/src/build_emscripten.mk
+++ b/common/cpp_unit_test_runner/src/build_emscripten.mk
@@ -49,7 +49,7 @@ TEST_ADDITIONAL_LDFLAGS := \
 	-s EXPORT_NAME=Module \
 	-s MODULARIZE=0 \
 	-s PROXY_TO_PTHREAD \
-  -s ENVIRONMENT=node \
+	-s ENVIRONMENT=node \
 
 # Documented in ../include.mk.
 TEST_RUNNER_SOURCES :=

--- a/common/cpp_unit_test_runner/src/build_emscripten.mk
+++ b/common/cpp_unit_test_runner/src/build_emscripten.mk
@@ -42,11 +42,14 @@ TEST_ADDITIONAL_CXXFLAGS := \
 # PROXY_TO_PTHREAD: Run the main() function, and hence all test bodies, in a
 #   separate thread. Otherwise, multi-threaded tests will hang as background
 #   tests aren't created until the main thread yields.
+# ENVIRONMENT: Generate support code for running in the Node.js environment.
+#   (This overrides the default setting in executable_building_emscripten.mk.)
 TEST_ADDITIONAL_LDFLAGS := \
 	-s EXIT_RUNTIME \
 	-s EXPORT_NAME=Module \
 	-s MODULARIZE=0 \
 	-s PROXY_TO_PTHREAD \
+  -s ENVIRONMENT=node \
 
 # Documented in ../include.mk.
 TEST_RUNNER_SOURCES :=

--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -105,7 +105,7 @@ EMSCRIPTEN_LINKER_FLAGS := \
   -s ABORTING_MALLOC=1 \
   -s ALLOW_MEMORY_GROWTH=1 \
   -s DYNAMIC_EXECUTION=0 \
-	-s ENVIRONMENT=web,worker \
+  -s ENVIRONMENT=web,worker \
   -s 'EXPORT_NAME="loadEmscriptenModule_$(TARGET)"' \
   -s MODULARIZE=1 \
   -Wno-pthreads-mem-growth \

--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -92,6 +92,8 @@ EMSCRIPTEN_COMPILER_FLAGS := \
 # DYNAMIC_EXECUTION: Disable dynamic code execution in Emscripten JavaScript
 #   code (not doing this will cause "unsafe-eval" Content Security Policy
 #   violations when running this code inside Chrome Apps/Extensions).
+# ENVIRONMENT: Only generate support code for running in needed Web environments
+#   and skip support for others.
 # EXPORT_NAME: Name of the JavaScript function that loads the Emscripten module.
 # MODULARIZE: Puts Emscripten module JavaScript loading code into a factory
 #   function, in order to control its loading from other JS code and to avoid
@@ -103,6 +105,7 @@ EMSCRIPTEN_LINKER_FLAGS := \
   -s ABORTING_MALLOC=1 \
   -s ALLOW_MEMORY_GROWTH=1 \
   -s DYNAMIC_EXECUTION=0 \
+  -s ENVIRONMENT=web,worker \
   -s 'EXPORT_NAME="loadEmscriptenModule_$(TARGET)"' \
   -s MODULARIZE=1 \
   -Wno-pthreads-mem-growth \

--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -105,7 +105,7 @@ EMSCRIPTEN_LINKER_FLAGS := \
   -s ABORTING_MALLOC=1 \
   -s ALLOW_MEMORY_GROWTH=1 \
   -s DYNAMIC_EXECUTION=0 \
-  -s ENVIRONMENT=web,worker \
+	-s ENVIRONMENT=web,worker \
   -s 'EXPORT_NAME="loadEmscriptenModule_$(TARGET)"' \
   -s MODULARIZE=1 \
   -Wno-pthreads-mem-growth \


### PR DESCRIPTION
Tell Emscripten to only generate code for supporting "web"/"worker" environment by default, and only "node" when building C++ unit test runner.

This commit optimizes away unneeded support code from the resulting artifacts. The exact improvement is around a couple kilobytes, still there's no reason to avoid doing this.

For reference, the default value of the "ENVIRONMENT" Emscripten setting is "web,webview,worker,node".