### PR TITLE
[wasm] Prune code for unneeded Module attributes

### DIFF
--- a/common/js/src/executable-module/emscripten-module.js
+++ b/common/js/src/executable-module/emscripten-module.js
@@ -168,6 +168,9 @@ GSC.EmscriptenModule = class extends GSC.ExecutableModule {
    * @private
    */
   getEmscriptenApiModuleSettings_() {
+    // Note: If you add a new key here don't forget to include it into the
+    // "INCOMING_MODULE_JS_API" build-time setting in
+    // executable_building_emscripten.mk.
     return {
       'onAbort': () => {
         this.onModuleCrashed_();

--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -95,6 +95,8 @@ EMSCRIPTEN_COMPILER_FLAGS := \
 # ENVIRONMENT: Only generate support code for running in needed Web environments
 #   and skip support for others.
 # EXPORT_NAME: Name of the JavaScript function that loads the Emscripten module.
+# INCOMING_MODULE_JS_API: Names of Emscripten Module attributes that we need at
+#   runtime (code for other attributes is optimized away).
 # MODULARIZE: Puts Emscripten module JavaScript loading code into a factory
 #   function, in order to control its loading from other JS code and to avoid
 #   name conflicts with unrelated code.
@@ -107,6 +109,7 @@ EMSCRIPTEN_LINKER_FLAGS := \
   -s DYNAMIC_EXECUTION=0 \
   -s ENVIRONMENT=web,worker \
   -s 'EXPORT_NAME="loadEmscriptenModule_$(TARGET)"' \
+  -s INCOMING_MODULE_JS_API=[buffer,instantiateWasm,onAbort,preRun,print,printErr,wasmMemory] \
   -s MODULARIZE=1 \
   -Wno-pthreads-mem-growth \
 


### PR DESCRIPTION
Tell Emscripten to only generate code for the attributes of the Module class that we're actually using at runtime. This allows to optimize away code for unneeded ones.

In practice, this reduces the resulting files by a couple kilobytes.