### PR TITLE
[wasm] Drop support for ancient Chrome

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -95,6 +95,10 @@ EMSCRIPTEN_COMPILER_FLAGS := \
 # ENVIRONMENT: Only generate support code for running in needed Web environments
 #   and skip support for others.
 # EXPORT_NAME: Name of the JavaScript function that loads the Emscripten module.
+# MIN_CHROME_VERSION: Skip generating Emscripten support code for very old
+#   Chrome versions. (The exact boundary is chosen similarly to
+#   minimum_chrome_version in
+#   smart_card_connector_app/src/manifest.json.template.)
 # MODULARIZE: Puts Emscripten module JavaScript loading code into a factory
 #   function, in order to control its loading from other JS code and to avoid
 #   name conflicts with unrelated code.
@@ -107,6 +111,7 @@ EMSCRIPTEN_LINKER_FLAGS := \
   -s DYNAMIC_EXECUTION=0 \
   -s ENVIRONMENT=web,worker \
   -s 'EXPORT_NAME="loadEmscriptenModule_$(TARGET)"' \
+  -s MIN_CHROME_VERSION=96 \
   -s MODULARIZE=1 \
   -Wno-pthreads-mem-growth \
 


### PR DESCRIPTION
Skip generating Emscripten support code for Chrome versions <96. There are multiple technical reasons why we won't ship WebAssembly builds to such ancient client versions, so let's benefit from it by letting Emscripten prune workarounds for them.

Note: the binary size reduction is almost negligible in practice.