### PR TITLE
[wasm] Suppress warning logs about worker pool

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -100,6 +100,9 @@ EMSCRIPTEN_COMPILER_FLAGS := \
 # MODULARIZE: Puts Emscripten module JavaScript loading code into a factory
 #   function, in order to control its loading from other JS code and to avoid
 #   name conflicts with unrelated code.
+# PTHREAD_POOL_SIZE_STRICT: Suppress runtime warnings when a new worker has to
+#   start for a new thread (this warning is confusing and is mostly useful in
+#   early days of development).
 # no-pthreads-mem-growth: Suppress the linker warning about the performance of
 #   the "Pthreads + ALLOW_MEMORY_GROWTH" combination.
 EMSCRIPTEN_LINKER_FLAGS := \
@@ -114,6 +117,7 @@ EMSCRIPTEN_LINKER_FLAGS := \
   -s MIN_IE_VERSION=-1 \
   -s MIN_SAFARI_VERSION=-1 \
   -s MODULARIZE=1 \
+  -s PTHREAD_POOL_SIZE_STRICT=0 \
   -Wno-pthreads-mem-growth \
 
 ifeq ($(CONFIG),Release)


### PR DESCRIPTION
Disable Emscripten logs every time a new thread is started and there's no free worker.

These warnings are useful when the web porting works just started, because they hint the developer about potential deadlocks caused by deviations of Emscripten semantics from POSIX (namely, that a thread spawned from the main thread won't actually start until the main thread returns to the event loop). Now that we did the basic migration work for Emscripten, these warnings are mostly red herring.