### PR TITLE
[pcsc] Fix crash on shutdown with active client

### DIFF
--- a/smart_card_connector_app/src/application.cc
+++ b/smart_card_connector_app/src/application.cc
@@ -48,6 +48,7 @@ Application::Application(
 }
 
 void Application::ShutDownAndWait() {
+  pcsc_lite_server_clients_management_backend_.reset();
   pcsc_lite_server_web_port_service_->ShutDownAndWait();
   libusb_web_port_service_->ShutDown();
 }

--- a/smart_card_connector_app/src/application_unittest.cc
+++ b/smart_card_connector_app/src/application_unittest.cc
@@ -801,6 +801,24 @@ TEST_F(SmartCardConnectorApplicationTest, AutoCleanupContext) {
   });
 }
 
+// Regression test for the shutdown crashes in case there's an active JS client.
+TEST_F(SmartCardConnectorApplicationTest, ShutdownWithActiveClient) {
+  constexpr int kHandlerId = 1234;
+
+  // Arrange:
+  StartApplication();
+  SimulateJsClientAdded(kHandlerId, /*client_name_for_log=*/"foo");
+  SCARDCONTEXT scard_context = 0;
+  EXPECT_EQ(SimulateEstablishContextCallFromJsClient(
+                kHandlerId, SCARD_SCOPE_SYSTEM,
+                /*reserved1=*/Value(),
+                /*reserved2=*/Value(), scard_context),
+            SCARD_S_SUCCESS);
+
+  // No act/assert sections, since we just want to check the teardown doesn't
+  // crash.
+}
+
 // Test fixture that simplifies simulating commands from a single client
 // application.
 class SmartCardConnectorApplicationSingleClientTest


### PR DESCRIPTION
Fix the crash during the PC/SC server shutdown in case there's at least one connected JS client.

The underlying problem was that we didn't tear down the C++ client handling subsystem, and hence kept open pipes beyond the shutdown of all other systems. It was a test-only issue since the extensions never shut down in production (unless killed by the browser).