### PR TITLE
[JS-to-C++ test] Exclude libusb unit tests

### DIFF
--- a/smart_card_connector_app/build/js_to_cxx_tests/Makefile
+++ b/smart_card_connector_app/build/js_to_cxx_tests/Makefile
@@ -67,7 +67,8 @@ LIBS := \
 JS_SOURCES_PATHS := \
   $(SOURCE_DIR) \
   $(SOURCE_DIR)/**-jstocxxtest.js \
-  $(LIBUSB_JS_COMPILER_INPUT_DIR_PATHS) \
+  $(ROOT_PATH)/third_party/libusb/webport/src \
+  !$(ROOT_PATH)/third_party/libusb/webport/src/**test.js \
   $(PCSC_LITE_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \
   $(PCSC_LITE_JS_CLIENT_COMPILER_INPUT_DIR_PATHS) \
   $(PCSC_LITE_SERVER_CLIENTS_MANAGEMENT_JS_COMPILER_INPUT_DIR_PATHS) \


### PR DESCRIPTION
Fix the accidental inclusion of Libusb's unit tests into the Smart Card Connector's js_to_cxx_tests test target.

The Libusb unit tests are already tested by their own target //third_party/libusb/webport/build/js_unittests/.