### PR TITLE
[headers] Include by abs path from pcsc-lite cpp_client

### DIFF
--- a/example_cpp_smart_card_client_app/src/application.cc
+++ b/example_cpp_smart_card_client_app/src/application.cc
@@ -28,7 +28,7 @@
 #include "common/cpp/src/public/messaging/typed_message_router.h"
 #include "common/cpp/src/public/value.h"
 #include "common/cpp/src/public/value_debug_dumping.h"
-#include <google_smart_card_pcsc_lite_client/global.h>
+#include "third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.h"
 #include <google_smart_card_pcsc_lite_cpp_demo/demo.h>
 
 #include "built_in_pin_dialog/built_in_pin_dialog_server.h"

--- a/example_cpp_smart_card_client_app/src/application.h
+++ b/example_cpp_smart_card_client_app/src/application.h
@@ -20,7 +20,7 @@
 
 #include "common/cpp/src/public/global_context.h"
 #include "common/cpp/src/public/messaging/typed_message_router.h"
-#include <google_smart_card_pcsc_lite_client/global.h>
+#include "third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.h"
 
 #include "built_in_pin_dialog/built_in_pin_dialog_server.h"
 #include "chrome_certificate_provider/api_bridge.h"

--- a/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.cc
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.cc
@@ -23,7 +23,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <google_smart_card_pcsc_lite_client/global.h>
+#include "third_party/pcsc-lite/naclport/cpp_client/src/google_smart_card_pcsc_lite_client/global.h"
 
 #include <string>
 #include <utility>


### PR DESCRIPTION
Change `#include <google_smart_card_pcsc_lite_client...>` to `#include "third_party/pcsc-lite/..."`.

This is part of the refactoring tracked by #885.