### PR TITLE
[ui] Refactor OS warning UI into separate file

### DIFF
--- a/smart_card_connector_app/src/window-main.js
+++ b/smart_card_connector_app/src/window-main.js
@@ -26,12 +26,12 @@ goog.require('GoogleSmartCard.ConnectorApp.Window.AppsDisplaying');
 goog.require('GoogleSmartCard.ConnectorApp.Window.DevicesDisplaying');
 goog.require('GoogleSmartCard.ConnectorApp.Window.HelpShowing');
 goog.require('GoogleSmartCard.ConnectorApp.Window.LogsExporting');
+goog.require('GoogleSmartCard.ConnectorApp.Window.StatusDisplaying');
 goog.require('GoogleSmartCard.I18n');
 goog.require('GoogleSmartCard.InPopupMainScript');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.Packaging');
 goog.require('goog.dom');
-goog.require('goog.dom.classlist');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
 goog.require('goog.log');
@@ -55,30 +55,14 @@ GSC.ConnectorApp.Window.AppsDisplaying.initialize();
 GSC.ConnectorApp.Window.DevicesDisplaying.initialize();
 GSC.ConnectorApp.Window.HelpShowing.initialize();
 GSC.ConnectorApp.Window.LogsExporting.initialize();
+GSC.ConnectorApp.Window.StatusDisplaying.initialize();
 
 GSC.I18n.adjustAllElementsTranslation();
 
 if (GSC.Packaging.MODE === GSC.Packaging.Mode.APP)
   GSC.InPopupMainScript.showWindow();
 
-displayNonChromeOsWarningIfNeeded();
-
 function closeWindowClickListener() {
   window.close();
-}
-
-function displayNonChromeOsWarningIfNeeded() {
-  chrome.runtime.getPlatformInfo(function(platformInfo) {
-    /** @type {string} */
-    const os = platformInfo['os'];
-    if (os != 'cros') {
-      goog.log.info(
-          logger,
-          'Displaying the warning regarding non-ChromeOS system ' +
-              '(the current OS is "' + os + '")');
-      goog.dom.classlist.remove(
-          goog.dom.getElement('non-chrome-os-warning'), 'hidden');
-    }
-  });
 }
 });  // goog.scope

--- a/smart_card_connector_app/src/window-status-displaying.js
+++ b/smart_card_connector_app/src/window-status-displaying.js
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2023 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview This script implements displaying the application's overall
+ * status in the Smart Card Connector App window.
+ */
+
+goog.provide('GoogleSmartCard.ConnectorApp.Window.StatusDisplaying');
+
+goog.require('GoogleSmartCard.Logging');
+goog.require('goog.dom');
+goog.require('goog.dom.classlist');
+goog.require('goog.log');
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+/** @type {!goog.log.Logger} */
+const logger = GSC.Logging.getScopedLogger('ConnectorApp.MainWindow');
+
+function displayNonChromeOsWarningIfNeeded() {
+  chrome.runtime.getPlatformInfo(function(platformInfo) {
+    /** @type {string} */
+    const os = platformInfo['os'];
+    if (os != 'cros') {
+      goog.log.info(
+          logger,
+          'Displaying the warning regarding non-ChromeOS system ' +
+              '(the current OS is "' + os + '")');
+      goog.dom.classlist.remove(
+          goog.dom.getElement('non-chrome-os-warning'), 'hidden');
+    }
+  });
+}
+
+GSC.ConnectorApp.Window.StatusDisplaying.initialize = function() {
+  displayNonChromeOsWarningIfNeeded();
+};
+});


### PR DESCRIPTION
Create a new window-status-displaying.js and move the logic that displays the "ChromeOS only" warning into it.

This is a pure refactoring change. It's a preparation for implementing crash warning UI as tracked by #926.