### PR TITLE
[ui] Show warning in UI if application crashed

### DIFF
--- a/smart_card_connector_app/src/_locales/en/messages.json
+++ b/smart_card_connector_app/src/_locales/en/messages.json
@@ -19,6 +19,10 @@
     "message": "Smart Card Connector",
     "description": "The header displayed in the main window"
   },
+  "crashWarning": {
+    "message": "Error: The application crashed. Please submit a feedback report (press Alt+Shift+i).",
+    "description": "The text that is displayed as a warning when the app entered a crash loop"
+  },
   "nonChromeOsWarning": {
     "message": "Warning: The app is intended to be run on ChromeOS only!",
     "description": "The text that is displayed as a warning when the app is executed on non-ChromeOS systems"

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -177,6 +177,19 @@ function executableModuleDisposedListener() {
 }
 
 /**
+ * Schedules the listener to be called when the executable module gets disposed
+ * of (e.g., because of a crash).
+ *
+ * The listener is called immediately if this already happened.
+ * @param {!function()} listener
+ */
+function addOnExecutableModuleDisposedListener(listener) {
+  executableModule.addOnDisposeCallback(() => {
+    listener();
+  });
+}
+
+/**
  * Called when the onLaunched event is received (that is, when the user clicks
  * on the app in the ChromeOS app launcher).
  */
@@ -346,6 +359,8 @@ function createClientHandler(clientMessageChannel, clientOrigin) {
  * Sets global variables to be used by the main window (once it's opened).
  */
 function exposeGlobalsForMainWindow() {
+  goog.global['googleSmartCard_executableModuleDisposalSubscriber'] =
+      addOnExecutableModuleDisposedListener;
   goog.global['googleSmartCard_clientAppListUpdateSubscriber'] =
       messageChannelPool.addOnUpdateListener.bind(messageChannelPool);
   goog.global['googleSmartCard_clientAppListUpdateUnsubscriber'] =

--- a/smart_card_connector_app/src/window.css
+++ b/smart_card_connector_app/src/window.css
@@ -68,6 +68,13 @@ body {
   -webkit-user-select: none;
 }
 
+#crash-warning {
+  color: red;
+  font-size: 15px;
+  font-weight: 600;
+  margin-top: 15px;
+}
+
 #non-chrome-os-warning {
   color: red;
   font-size: 15px;

--- a/smart_card_connector_app/src/window.html
+++ b/smart_card_connector_app/src/window.html
@@ -25,6 +25,7 @@ limitations under the License.
     <h1 id="header" data-i18n="mainWindowHeader"></h1>
   </div>
 
+  <div id="crash-warning" class="hidden" data-i18n="crashWarning"></div>
   <div id="non-chrome-os-warning" class="hidden" data-i18n="nonChromeOsWarning"></div>
 
   <button id="close-window" data-i18n-aria-label="windowClose">×</button>


### PR DESCRIPTION
If the executable module crashes (and cannot recover by self-reloading), notify the user by displaying a warning in the Smart Card Connector's main window UI.

This fixes #926.