### PR TITLE
[policy] Fix crash if policy loaded after disposal

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/admin-policy-service.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/admin-policy-service.js
@@ -131,6 +131,9 @@ AdminPolicyService.prototype.loadManagedStorage_ = function() {
  * @private
  */
 AdminPolicyService.prototype.managedStorageLoadedCallback_ = function(items) {
+  if (this.isDisposed()) {
+    return;
+  }
   goog.log.info(
       this.logger,
       'Loaded the following data from the managed storage: ' +


### PR DESCRIPTION
Fix exception thrown in AdminPolicyService in case the managed storage gets loaded after the object is already disposed of.

This doesn't happen normally, but in case the executable module crashed due to some issue this AdminPolicyService exception would be a red herring that confuses the developer.