### PR TITLE
[wasm] Improve handling of crashes

### DIFF
--- a/common/js/src/executable-module/emscripten-module.js
+++ b/common/js/src/executable-module/emscripten-module.js
@@ -190,6 +190,11 @@ GSC.EmscriptenModule = class extends GSC.ExecutableModule {
    */
   onModuleCrashed_() {
     goog.log.error(this.logger_, 'The Emscripten module crashed');
+
+    // Drop the "module" object reference, because trying to call its destructor
+    // in `disposeInternal()` would likely cause new exceptions.
+    this.googleSmartCardModule_ = null;
+
     this.dispose();
   }
 
@@ -271,6 +276,9 @@ class EmscriptenModuleMessageChannel extends goog.messaging.AbstractChannel {
    * @package
    */
   onMessageFromModule(message) {
+    if (this.isDisposed()) {
+      return;
+    }
     const typedMessage = GSC.TypedMessage.parseTypedMessage(message);
     if (!typedMessage) {
       GSC.Logging.fail(


### PR DESCRIPTION
If the Emscripten module crashed, we should avoid making new operations with it that can trigger new exceptions (which would be confusing and useless). Hence we do two improvements in this commit:

1. Don't try calling the C++ object destructor after the crash.
2. Discard messages that the module tries to send to the JS side after the module's disposal.