### PR TITLE
[js style] Fix extra semicolons

### DIFF
--- a/common/js/src/logging/log-buffer.js
+++ b/common/js/src/logging/log-buffer.js
@@ -73,7 +73,7 @@ class State {
     result += suffix;
     return result;
   }
-};
+}
 
 goog.exportProperty(State.prototype, 'getAsText', State.prototype.getAsText);
 

--- a/common/js/src/messaging/message-channel-pair.js
+++ b/common/js/src/messaging/message-channel-pair.js
@@ -154,5 +154,5 @@ class MessageChannelPairItem extends goog.messaging.AbstractChannel {
     GSC.Logging.checkWithLogger(logger, !this.isDisposed());
     this.deliver(serviceName, payload);
   }
-};
+}
 });  // goog.scope

--- a/common/js/src/requesting/requester-unittest.js
+++ b/common/js/src/requesting/requester-unittest.js
@@ -57,7 +57,7 @@ class PromiseTracker {
     this.isResolved = true;
     this.isRejected = true;
   }
-};
+}
 
 goog.exportSymbol('testRequester', function() {
   const REQUESTER_NAME = 'test-requester';

--- a/smart_card_connector_app/src/chrome-api-provider.js
+++ b/smart_card_connector_app/src/chrome-api-provider.js
@@ -416,7 +416,7 @@ class ChromeEventListener extends goog.Disposable {
     this.chromeEvent_.removeListener(this.callback_);
     this.callback_ = null;
   }
-};
+}
 
 /**
  * This class provides chrome.smartCardProviderPrivate API with PCSC responses.

--- a/smart_card_connector_app/src/chrome-login-state-hook-unittest.js
+++ b/smart_card_connector_app/src/chrome-login-state-hook-unittest.js
@@ -170,7 +170,7 @@ class FakeLibusbProxyHookDelegate extends GSC.LibusbToJsApiAdaptor {
     fail('Unexpected call');
     goog.asserts.fail();
   }
-};
+}
 
 /**
  * Simulates Chrome changing the session state.

--- a/smart_card_connector_app/src/smart-card-filter-libusb-hook-unittest.js
+++ b/smart_card_connector_app/src/smart-card-filter-libusb-hook-unittest.js
@@ -96,7 +96,7 @@ class FakeLibusbProxyHookDelegate extends GSC.LibusbToJsApiAdaptor {
     fail('Unexpected call');
     goog.asserts.fail();
   }
-};
+}
 
 /** @type {!FakeLibusbProxyHookDelegate|undefined} */
 let fakeDelegate;


### PR DESCRIPTION
Fix a few occurrences of extra semicolons in JS code. This is found via ESLint.

This is a pure refactoring commit.