### PR TITLE
[js style] Fix missing semicolons

### DIFF
--- a/common/js/src/messaging/message-channel-pool.js
+++ b/common/js/src/messaging/message-channel-pool.js
@@ -137,7 +137,7 @@ GSC.MessageChannelPool = class {
         // break our caller and also to still notify the remaining listeners.
         setTimeout(() => {
           throw exc;
-        })
+        });
       }
     }
   }

--- a/common/js/src/messaging/single-message-based-channel-unittest.js
+++ b/common/js/src/messaging/single-message-based-channel-unittest.js
@@ -164,7 +164,9 @@ goog.exportSymbol('testSingleMessageBasedChannel', {
     const waiter = new Waiter();
     testChannel = new GSC.SingleMessageBasedChannel(
         EXTENSION_ID, /* opt_onEstablished= */
-        () => {fail('Unexpectedly established');});
+        () => {
+          fail('Unexpectedly established');
+        });
     testChannel.addOnDisposeCallback(waiter.callback);
     await waiter.promise;
   },

--- a/common/js/src/messaging/single-message-based-channel-unittest.js
+++ b/common/js/src/messaging/single-message-based-channel-unittest.js
@@ -164,7 +164,7 @@ goog.exportSymbol('testSingleMessageBasedChannel', {
     const waiter = new Waiter();
     testChannel = new GSC.SingleMessageBasedChannel(
         EXTENSION_ID, /* opt_onEstablished= */
-        () => {fail('Unexpectedly established')});
+        () => {fail('Unexpectedly established');});
     testChannel.addOnDisposeCallback(waiter.callback);
     await waiter.promise;
   },

--- a/smart_card_connector_app/src/chrome-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/chrome-api-jstocxxtest.js
@@ -128,7 +128,9 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
             /*requestId=*/ 123,
             /*scardContext=*/ goog.testing.mockmatchers.isNumber, 'SUCCESS')
         .$once()
-        .$does((requestId, context, resultCode) => {sCardContext = context;});
+        .$does((requestId, context, resultCode) => {
+          sCardContext = context;
+        });
     chrome
         .smartCardProviderPrivate['reportReleaseContextResult'](
             /*requestId=*/ 124, 'SUCCESS')

--- a/smart_card_connector_app/src/chrome-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/chrome-api-jstocxxtest.js
@@ -128,7 +128,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
             /*requestId=*/ 123,
             /*scardContext=*/ goog.testing.mockmatchers.isNumber, 'SUCCESS')
         .$once()
-        .$does((requestId, context, resultCode) => {sCardContext = context});
+        .$does((requestId, context, resultCode) => {sCardContext = context;});
     chrome
         .smartCardProviderPrivate['reportReleaseContextResult'](
             /*requestId=*/ 124, 'SUCCESS')

--- a/smart_card_connector_app/src/chrome-api-provider.js
+++ b/smart_card_connector_app/src/chrome-api-provider.js
@@ -305,7 +305,7 @@ function convertProtocolToPci(protocol) {
  * @param {number} state
  */
 function logUnexpectedConnectionState(state) {
-  goog.log.warning(logger, `Unexpected connection state bitmask: ${state}`)
+  goog.log.warning(logger, `Unexpected connection state bitmask: ${state}`);
 }
 
 /**

--- a/smart_card_connector_app/src/testing-smart-card-simulation-libusb-hook.js
+++ b/smart_card_connector_app/src/testing-smart-card-simulation-libusb-hook.js
@@ -110,5 +110,5 @@ GSC.TestingLibusbSmartCardSimulationHook = class extends GSC.LibusbProxyHook {
     GSC.Logging.check(outputs.length == 1);
     return outputs[0];
   }
-}
+};
 });

--- a/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
+++ b/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
@@ -193,7 +193,7 @@ ReaderTracker.prototype.fireOnUpdateListeners_ = function() {
       // our caller and also to still notify the remaining listeners.
       setTimeout(() => {
         throw exc;
-      })
+      });
     }
   }
 };


### PR DESCRIPTION
Fix a few occurrences of missing semicolons in JS code. This is found via ESLint.

This is a pure refactoring commit.