### PR TITLE
[js style] Fix no-prototype-builtins

### DIFF
--- a/common/js/src/logging/crash-loop-detection-unittest.js
+++ b/common/js/src/logging/crash-loop-detection-unittest.js
@@ -64,7 +64,7 @@ function stubChromeStorageLocalGet(key, callback) {
     return;
   }
   const resultItems = {};
-  if (currentStorage.hasOwnProperty(key))
+  if (Object.prototype.hasOwnProperty.call(currentStorage, key))
     resultItems[key] = currentStorage[key];
   callback(resultItems);
 }

--- a/common/js/src/logging/crash-loop-detection.js
+++ b/common/js/src/logging/crash-loop-detection.js
@@ -110,7 +110,7 @@ function loadRecentCrashTimestamps() {
   return new Promise(resolve => {
     chrome.storage.local.get(STORAGE_KEY, function(loadedStorage) {
       if (chrome.runtime.lastError ||
-          !loadedStorage.hasOwnProperty(STORAGE_KEY) ||
+          !Object.prototype.hasOwnProperty.call(loadedStorage, STORAGE_KEY) ||
           !Array.isArray(loadedStorage[STORAGE_KEY])) {
         resolve([]);
         return;

--- a/common/js/src/nacl-module/nacl-module.js
+++ b/common/js/src/nacl-module/nacl-module.js
@@ -277,7 +277,7 @@ GSC.NaclModule = class extends GSC.ExecutableModule {
     // If the browser doesn't have NaCl plugin installed, it'll silently fall
     // back to creating the <embed> without any functionality. Detect this case
     // by checking for an arbitrary NaCl-specific property.
-    return this.element_.hasOwnProperty('postMessage');
+    return Object.prototype.hasOwnProperty.call(this.element_, 'postMessage');
   }
 };
 


### PR DESCRIPTION
Instead of calling hasOwnProperty() on the target object, use the Object.prototype.hasOwnProperty.call() notation instead. This makes sure there's no shadowing possible.

This is found via ESLint. It's part of the effort tracked by #937.