### PR TITLE
[js] Fix forgotten arg inside LogBufferForwarder

### DIFF
--- a/common/js/src/logging/log-buffer-forwarder.js
+++ b/common/js/src/logging/log-buffer-forwarder.js
@@ -73,7 +73,8 @@ GSC.LogBufferForwarder = class {
      */
     this.logCapturingEnabled_ = true;
     /** @type {!goog.structs.CircularBuffer<string>} @private @const */
-    this.postponedLogRecords_ = new goog.structs.CircularBuffer();
+    this.postponedLogRecords_ =
+        new goog.structs.CircularBuffer(POSTPONING_BUFFER_CAPACITY);
 
     logBuffer.addObserver(this.onLogRecordObserved_.bind(this));
   }


### PR DESCRIPTION
We forgot to pass POSTPONING_BUFFER_CAPACITY to the underlying CircularBuffer. Luckily, this has been a no-op bug since the constant happened to equal the buffer's default size.

This is found via ESLint. It's part of the effort tracked by #937.