### PR TITLE
[js] Fix forgotten arg inside getChildLogger

### DIFF
--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -213,7 +213,8 @@ GSC.Logging.getScopedLogger = function(name, opt_level) {
  * @return {!goog.log.Logger}
  */
 GSC.Logging.getChildLogger = function(parentLogger, relativeName, opt_level) {
-  return GSC.Logging.getLogger(parentLogger.getName() + '.' + relativeName);
+  return GSC.Logging.getLogger(
+      parentLogger.getName() + '.' + relativeName, opt_level);
 };
 
 /**


### PR DESCRIPTION
Fix Logging.getChildLogger to correctly pass through the opt_level parameter.

This is found via ESLint. It's part of the effort tracked by #937.