### PR TITLE
[js style] Use aliases where already defined

### DIFF
--- a/common/js/src/messaging/port-message-channel-unittest.js
+++ b/common/js/src/messaging/port-message-channel-unittest.js
@@ -88,7 +88,7 @@ goog.exportSymbol('testPortMessageChannelEstablishing', function() {
     testCasePromiseResolver.reject();
   }
 
-  const portMessageChannel = new GSC.PortMessageChannel(
+  const portMessageChannel = new PortMessageChannel(
       mockPort.getFakePort(), onPortMessageChannelEstablished);
   portMessageChannel.addOnDisposeCallback(onPortMessageChannelDisposed);
 
@@ -129,7 +129,7 @@ goog.exportSymbol('testPortMessageChannelFailureToEstablish', {
       mockPort.dispose();
     }
 
-    const portMessageChannel = new GSC.PortMessageChannel(
+    const portMessageChannel = new PortMessageChannel(
         mockPort.getFakePort(), onPortMessageChannelEstablished);
     portMessageChannel.addOnDisposeCallback(onPortMessageChannelDisposed);
 
@@ -171,7 +171,7 @@ goog.exportSymbol('testPortMessageChannelMessageSending', function() {
     testCasePromiseResolver.reject();
   }
 
-  const portMessageChannel = new GSC.PortMessageChannel(
+  const portMessageChannel = new PortMessageChannel(
       mockPort.getFakePort(), onPortMessageChannelEstablished);
   portMessageChannel.addOnDisposeCallback(onPortMessageChannelDisposed);
 
@@ -193,7 +193,7 @@ goog.exportSymbol('testPortMessageChannelArrayBufferSending', function() {
       .$once();
   mockPort.postMessage.$replay();
 
-  const portMessageChannel = new GSC.PortMessageChannel(mockPort.getFakePort());
+  const portMessageChannel = new PortMessageChannel(mockPort.getFakePort());
   portMessageChannel.send(MESSAGE_TYPE, MESSAGE_DATA);
   mockPort.postMessage.$verify();
 
@@ -242,7 +242,7 @@ goog.exportSymbol('testPortMessageChannelMessageReceiving', function() {
     testCasePromiseResolver.reject();
   }
 
-  const portMessageChannel = new GSC.PortMessageChannel(
+  const portMessageChannel = new PortMessageChannel(
       mockPort.getFakePort(), onPortMessageChannelEstablished);
   portMessageChannel.addOnDisposeCallback(onPortMessageChannelDisposed);
 
@@ -271,7 +271,7 @@ goog.exportSymbol('testPortMessageChannelDisconnection', function() {
     mockPort.dispose();
   }
 
-  const portMessageChannel = new GSC.PortMessageChannel(
+  const portMessageChannel = new PortMessageChannel(
       mockPort.getFakePort(), onPortMessageChannelEstablished);
 
   return testCasePromiseResolver.promise;

--- a/common/js/src/messaging/single-message-based-channel-unittest.js
+++ b/common/js/src/messaging/single-message-based-channel-unittest.js
@@ -74,7 +74,7 @@ const isPingMessageMatcher =
 const propertyReplacer = new goog.testing.PropertyReplacer();
 /** @type {!goog.testing.MockControl|undefined} */
 let mockControl;
-/** @type {!GSC.SingleMessageBasedChannel|undefined} */
+/** @type {!SingleMessageBasedChannel|undefined} */
 let testChannel;
 /** @type {!goog.testing.StrictMock|undefined} */
 let mockedSendMessage;
@@ -141,7 +141,7 @@ goog.exportSymbol('testSingleMessageBasedChannel', {
     // Act: instantiate a channel and wait till it switches into the
     // "established" state.
     const waiter = new Waiter();
-    testChannel = new GSC.SingleMessageBasedChannel(
+    testChannel = new SingleMessageBasedChannel(
         EXTENSION_ID, /* opt_onEstablished= */ waiter.callback);
     await waiter.promise;
 
@@ -162,7 +162,7 @@ goog.exportSymbol('testSingleMessageBasedChannel', {
     // Act: create a channel and wait until it switches into the "disposed"
     // state.
     const waiter = new Waiter();
-    testChannel = new GSC.SingleMessageBasedChannel(
+    testChannel = new SingleMessageBasedChannel(
         EXTENSION_ID, /* opt_onEstablished= */
         () => {
           fail('Unexpectedly established');
@@ -190,7 +190,7 @@ goog.exportSymbol('testSingleMessageBasedChannel', {
     // Act: create a channel, and wait until it switches into the "established"
     // state.
     const waiter = new Waiter();
-    testChannel = new GSC.SingleMessageBasedChannel(
+    testChannel = new SingleMessageBasedChannel(
         EXTENSION_ID, /* opt_onEstablished= */ waiter.callback);
     await waiter.promise;
     // Send test messages through the channel.
@@ -222,7 +222,7 @@ goog.exportSymbol('testSingleMessageBasedChannel', {
     // Act: create a channel, and wait until it switches into the "established"
     // state.
     const waiter = new Waiter();
-    testChannel = new GSC.SingleMessageBasedChannel(
+    testChannel = new SingleMessageBasedChannel(
         EXTENSION_ID, /* opt_onEstablished= */ waiter.callback);
     await waiter.promise;
     // Send a test message with an array buffer through the channel.
@@ -243,7 +243,7 @@ goog.exportSymbol('testSingleMessageBasedChannel', {
     // Act: create a channel, and wait until it switches into the "established"
     // state.
     const waiter = new Waiter();
-    testChannel = new GSC.SingleMessageBasedChannel(
+    testChannel = new SingleMessageBasedChannel(
         EXTENSION_ID, /* opt_onEstablished= */ waiter.callback);
     await waiter.promise;
     // Set up an observer for incoming messages.
@@ -286,7 +286,7 @@ goog.exportSymbol('testSingleMessageBasedChannel', {
     // Act: create a channel, and wait until it switches into the "established"
     // state.
     const waiter = new Waiter();
-    testChannel = new GSC.SingleMessageBasedChannel(
+    testChannel = new SingleMessageBasedChannel(
         EXTENSION_ID, /* opt_onEstablished= */ waiter.callback);
     await waiter.promise;
     // Wait until the channel switches into the "disposed" state.

--- a/common/js/src/requesting/requester-unittest.js
+++ b/common/js/src/requesting/requester-unittest.js
@@ -74,7 +74,7 @@ goog.exportSymbol('testRequester', function() {
       new goog.testing.messaging.MockMessageChannel(mockControl);
   /** @type {?} */ mockMessageChannel.send;
 
-  const requester = new GSC.Requester(REQUESTER_NAME, mockMessageChannel);
+  const requester = new Requester(REQUESTER_NAME, mockMessageChannel);
 
   // Set up expectation for three request messages.
   mockMessageChannel.send(
@@ -154,7 +154,7 @@ goog.exportSymbol('testRequester_disposed', function() {
       new goog.testing.messaging.MockMessageChannel(mockControl);
   /** @type {?} */ mockMessageChannel.send;
 
-  const requester = new GSC.Requester(REQUESTER_NAME, mockMessageChannel);
+  const requester = new Requester(REQUESTER_NAME, mockMessageChannel);
   requester.dispose();
 
   const requestPromise = requester.postRequest({});


### PR DESCRIPTION
Whenever we already have a shorter alias defined in the file, prefer to use it in favor of the long name. This is a pure refactoring commit.

This is found via ESLint. It's part of the effort tracked by #937.