### PR TITLE
[JS-to-C++ test] Tear down BridgeBackend

### DIFF
--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-integrationtest.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-integrationtest.js
@@ -80,8 +80,8 @@ goog.exportSymbol('testChromeCertificateProviderApiBridge', {
   'setUp': async function() {
     testController = new GSC.IntegrationTestController();
     await testController.initAsync();
-    bridgeBackend = new CertificateProviderBridge.Backend(
-        testController.executableModule);
+    bridgeBackend =
+        new CertificateProviderBridge.Backend(testController.executableModule);
     await testController.setUpCppHelper(
         'ChromeCertificateProviderApiBridge', /*helperArgument=*/ {});
   },
@@ -89,7 +89,9 @@ goog.exportSymbol('testChromeCertificateProviderApiBridge', {
   'tearDown': async function() {
     try {
       await testController.disposeAsync();
+      bridgeBackend.dispose();
     } finally {
+      bridgeBackend = null;
       testController = null;
     }
   },

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-integrationtest.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-integrationtest.js
@@ -88,8 +88,8 @@ goog.exportSymbol('testChromeCertificateProviderApiBridge', {
 
   'tearDown': async function() {
     try {
-      await testController.disposeAsync();
       bridgeBackend.dispose();
+      await testController.disposeAsync();
     } finally {
       bridgeBackend = null;
       testController = null;


### PR DESCRIPTION
Make sure to dispose of BridgeBackend in the bridge-integrationtest's teardown.

This was spotted while looking through the ESLint reports per #937.