### PR TITLE
[pcsc] Fix flaky shutdown

### DIFF
--- a/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
+++ b/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
@@ -148,18 +148,6 @@ void PcscLiteServerDaemonThreadMain() {
   // `SVCServiceRunLoop()` function in pcsc-lite/src/src/pcscdaemon.c.
   HPStopHotPluggables();
 
-  // TODO: Upstream's approach with a magic sleep is flaky: the background
-  // thread might be still running after this point, causing crashes and memory
-  // leaks in tests. Replace this with a proper waiting mechanism.
-  int timeout_seconds = 10;
-#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
-  timeout_seconds *= 2;
-#endif
-#if !defined(NDEBUG)
-  timeout_seconds *= 2;
-#endif
-  SYS_Sleep(timeout_seconds);
-
   RFCleanupReaders();
   EHDeinitializeEventStructures();
   ContextsDeinitialize();

--- a/third_party/pcsc-lite/src/src/hotplug_libusb.c
+++ b/third_party/pcsc-lite/src/src/hotplug_libusb.c
@@ -447,30 +447,6 @@ static void HPRescanUsbBus(void)
 
 	/* free the libusb allocated list & devices */
 	libusb_free_device_list(devs, 1);
-
-	if (AraKiriHotPlug)
-	{
-		int retval;
-
-		for (i=0; i<PCSCLITE_MAX_READERS_CONTEXTS; i++)
-		{
-			if (readerTracker[i].fullName != NULL)
-				HPCleanupHotPluggable(i);
-		}
-
-		for (i=0; i<driverSize; i++)
-		{
-			/* free strings allocated by strdup() */
-			free(driverTracker[i].bundleName);
-			free(driverTracker[i].libraryPath);
-			free(driverTracker[i].readerName);
-			free(driverTracker[i].CFBundleName);
-		}
-		free(driverTracker);
-
-		Log1(PCSC_LOG_INFO, "Hotplug stopped");
-		pthread_exit(&retval);
-	}
 }
 
 static void * HPEstablishUSBNotifications(int pipefd[2])
@@ -519,6 +495,13 @@ static void * HPEstablishUSBNotifications(int pipefd[2])
 		do_polling = true;
 	}
 
+	char dummy;
+	if (pipe(rescan_pipe) == -1)
+	{
+		Log2(PCSC_LOG_ERROR, "pipe: %s", strerror(errno));
+		return NULL;
+	}
+
 	if (do_polling)
 	{
 		while (!AraKiriHotPlug)
@@ -526,17 +509,9 @@ static void * HPEstablishUSBNotifications(int pipefd[2])
 			SYS_Sleep(HPForceReaderPolling);
 			HPRescanUsbBus();
 		}
-		libusb_exit(ctx);
 	}
 	else
 	{
-		char dummy;
-
-		if (pipe(rescan_pipe) == -1)
-		{
-			Log2(PCSC_LOG_ERROR, "pipe: %s", strerror(errno));
-			return NULL;
-		}
 		while (read(rescan_pipe[0], &dummy, sizeof(dummy)) > 0)
 		{
 			Log1(PCSC_LOG_INFO, "Reload serial configuration");
@@ -546,9 +521,30 @@ static void * HPEstablishUSBNotifications(int pipefd[2])
 #endif
 			Log1(PCSC_LOG_INFO, "End reload serial configuration");
 		}
-		close(rescan_pipe[0]);
-		rescan_pipe[0] = -1;
 	}
+
+	for (int i=0; i<PCSCLITE_MAX_READERS_CONTEXTS; i++)
+	{
+		if (readerTracker[i].fullName != NULL)
+			HPCleanupHotPluggable(i);
+	}
+
+	libusb_exit(ctx);
+
+	for (int i=0; i<driverSize; i++)
+	{
+		/* free strings allocated by strdup() */
+		free(driverTracker[i].bundleName);
+		free(driverTracker[i].libraryPath);
+		free(driverTracker[i].readerName);
+		free(driverTracker[i].CFBundleName);
+	}
+	free(driverTracker);
+
+	Log1(PCSC_LOG_INFO, "Hotplug stopped");
+
+	if (write(rescan_pipe[0], &dummy, sizeof(dummy)) == -1)
+		Log2(PCSC_LOG_ERROR, "write: %s", strerror(errno));
 
 	return NULL;
 }
@@ -599,6 +595,10 @@ LONG HPStopHotPluggables(void)
 	AraKiriHotPlug = true;
 	if (rescan_pipe[1] >= 0)
 	{
+		char dummy;
+		read(rescan_pipe[1], &dummy, sizeof(dummy));
+		close(rescan_pipe[0]);
+		rescan_pipe[0] = -1;
 		close(rescan_pipe[1]);
 		rescan_pipe[1] = -1;
 	}

--- a/third_party/pcsc-lite/src/src/hotplug_libusb.c
+++ b/third_party/pcsc-lite/src/src/hotplug_libusb.c
@@ -467,6 +467,13 @@ static void * HPEstablishUSBNotifications(int pipefd[2])
 	/* scan the USB bus for devices at startup */
 	HPRescanUsbBus();
 
+	char dummy;
+	if (pipe(rescan_pipe) == -1)
+	{
+		Log2(PCSC_LOG_ERROR, "pipe: %s", strerror(errno));
+		return NULL;
+	}
+
 	/* signal that the initially connected readers are now visible */
 	if (write(pipefd[1], &c, 1) == -1)
 	{
@@ -493,13 +500,6 @@ static void * HPEstablishUSBNotifications(int pipefd[2])
 		Log2(PCSC_LOG_INFO,
 				"Polling forced every %d second(s)", HPForceReaderPolling);
 		do_polling = true;
-	}
-
-	char dummy;
-	if (pipe(rescan_pipe) == -1)
-	{
-		Log2(PCSC_LOG_ERROR, "pipe: %s", strerror(errno));
-		return NULL;
 	}
 
 	if (do_polling)


### PR DESCRIPTION
Fix flaky memory leaks and drop magic sleep in the PC/SC shutdown logic, in favor of deterministic signaling and waiting.