### PR TITLE
[JS-to-C++ test] Exclude Connector unit tests

### DIFF
--- a/smart_card_connector_app/build/js_to_cxx_tests/Makefile
+++ b/smart_card_connector_app/build/js_to_cxx_tests/Makefile
@@ -64,10 +64,10 @@ LIBS := \
   $(CPP_COMMON_LIB) \
   $(DEFAULT_NACL_LIBS) \
 
+# Include *-jstocxxtest.js and non-test files needed for them.
 JS_SOURCES_PATHS := \
   $(SOURCE_DIR) \
   !$(SOURCE_DIR)/**-unittest.js \
-  $(SOURCE_DIR)/**-jstocxxtest.js \
   $(ROOT_PATH)/third_party/libusb/webport/src \
   !$(ROOT_PATH)/third_party/libusb/webport/src/**test.js \
   $(PCSC_LITE_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \


### PR DESCRIPTION
Exclude JS unit tests ("...-unittest.js") from the js_to_cxx test target. These unit tests are executed by their dedicated targets anyway, so it was duplicate execution.