### PR TITLE
[JS-to-C++ test] Shut down request receiver

### DIFF
--- a/common/integration_testing/src/public/integration_test_service.cc
+++ b/common/integration_testing/src/public/integration_test_service.cc
@@ -88,6 +88,7 @@ void IntegrationTestService::Deactivate() {
   GOOGLE_SMART_CARD_CHECK(js_request_receiver_);
   // It's expected that all helpers have been torn down.
   GOOGLE_SMART_CARD_CHECK(set_up_helpers_.empty());
+  js_request_receiver_->ShutDown();
   js_request_receiver_.reset();
   typed_message_router_ = nullptr;
 }


### PR DESCRIPTION
Make sure to shut down the IntegrationTestService's request receiver before dropping a reference on it, so that use-after-free isn't possible in case there's a background thread still using it.

This is part of the test flakiness fixes tracked by #951.