### PR TITLE
[JS-to-C++ test] Print full JS logs on failure

### DIFF
--- a/common/js_test_runner/run-js-tests.py
+++ b/common/js_test_runner/run-js-tests.py
@@ -185,9 +185,10 @@ def main():
         sys.stderr.write('Waiting for the test completion...\n')
         wait_for_test_completion(driver, args.timeout)
         print(get_js_test_report(driver))
-        if args.print_js_logs:
+        success = is_js_test_successful(driver)
+        if args.print_js_logs or not success:
           print(get_js_logs(driver))
-        if not is_js_test_successful(driver):
+        if not success:
           if args.pause_after_failure:
             wait_for_ui_closed(driver)
           return 1


### PR DESCRIPTION
Collect and dump all logs from the JS console in case the test fails, for easier investigation for the developer.