### PR TITLE
[js style] Use brackets when calling constructors

### DIFF
--- a/common/integration_testing/src/public/integration-test-controller.js
+++ b/common/integration_testing/src/public/integration-test-controller.js
@@ -57,7 +57,7 @@ GSC.IntegrationTestController = class {
         TIMEOUT_MILLISECONDS;
 
     /** @type {!goog.testing.PropertyReplacer} @const */
-    this.propertyReplacer = new goog.testing.PropertyReplacer;
+    this.propertyReplacer = new goog.testing.PropertyReplacer();
     /** @type {!GSC.ExecutableModule} @const */
     this.executableModule = createExecutableModule();
     /** @type {!GSC.Requester} @private @const */

--- a/common/js/src/container-helpers-unittest.js
+++ b/common/js/src/container-helpers-unittest.js
@@ -28,7 +28,7 @@ const substituteArrayBuffersRecursively =
     GSC.ContainerHelpers.substituteArrayBuffersRecursively;
 
 goog.exportSymbol('testBuildObjectFromMap', function() {
-  assertObjectEquals(buildObjectFromMap(new Map), {});
+  assertObjectEquals(buildObjectFromMap(new Map()), {});
   assertObjectEquals(
       buildObjectFromMap(new Map([['key', 'value']])), {'key': 'value'});
   assertObjectEquals(

--- a/common/js/src/deferred-processor.js
+++ b/common/js/src/deferred-processor.js
@@ -102,7 +102,7 @@ constructor(awaitedPromise) {
   this.isCurrentlyFlushingJobs_ = false;
 
   /** @type {!goog.structs.Queue.<!Job>} @private @const */
-  this.jobsQueue_ = new goog.structs.Queue;
+  this.jobsQueue_ = new goog.structs.Queue();
 
   awaitedPromise.then(
       this.promiseResolvedListener_.bind(this),

--- a/common/js/src/executable-module/emscripten-module.js
+++ b/common/js/src/executable-module/emscripten-module.js
@@ -64,7 +64,7 @@ GSC.EmscriptenModule = class extends GSC.ExecutableModule {
     GSC.PromiseHelpers.suppressUnhandledRejectionError(
         this.loadPromiseResolver_.promise);
     /** @type {!EmscriptenModuleMessageChannel} @const @private */
-    this.messageChannel_ = new EmscriptenModuleMessageChannel;
+    this.messageChannel_ = new EmscriptenModuleMessageChannel();
     // Object that is an entry point on the C++ side and is used for exchanging
     // messages with it. Untyped, since the class "GoogleSmartCardModule" is
     // defined within the Emscripten module (using Embind) and therefore isn't

--- a/common/js/src/i18n-unittest.js
+++ b/common/js/src/i18n-unittest.js
@@ -27,7 +27,7 @@ goog.scope(function() {
 
 const GSC = GoogleSmartCard;
 
-const propertyReplacer = new goog.testing.PropertyReplacer;
+const propertyReplacer = new goog.testing.PropertyReplacer();
 /** @type {Element?} */
 let pNode1;
 /** @type {Element?} */

--- a/common/js/src/json.js
+++ b/common/js/src/json.js
@@ -35,7 +35,7 @@ const GSC = GoogleSmartCard;
  * @return {!goog.Promise.<*>}
  */
 GSC.Json.parse = function(jsonString) {
-  const processor = new goog.json.NativeJsonProcessor;
+  const processor = new goog.json.NativeJsonProcessor();
   /** @preserveTry */
   try {
     return goog.Promise.resolve(processor.parse(jsonString));

--- a/common/js/src/logging/crash-loop-detection-unittest.js
+++ b/common/js/src/logging/crash-loop-detection-unittest.js
@@ -30,7 +30,7 @@ const SOME_DATE = new Date(
     /*year=*/ 2001, /*monthIndex=*/ 2, /*day=*/ 3, /*hours=*/ 4, /*minutes=*/ 5,
     /*seconds=*/ 6, /*milliseconds=*/ 7);
 
-const propertyReplacer = new goog.testing.PropertyReplacer;
+const propertyReplacer = new goog.testing.PropertyReplacer();
 
 /** @type {!Date} */
 let currentDate = SOME_DATE;

--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -350,7 +350,7 @@ function setupSystemLogLogging() {
 }
 
 function setupConsoleLogging() {
-  const console = new goog.debug.Console;
+  const console = new goog.debug.Console();
   const formatter = console.getFormatter();
   formatter.showAbsoluteTime = true;
   formatter.showRelativeTime = false;

--- a/common/js/src/messaging/message-channel-pool.js
+++ b/common/js/src/messaging/message-channel-pool.js
@@ -52,7 +52,7 @@ GSC.MessageChannelPool = class {
      * @type {!goog.labs.structs.Multimap}
      * @private @const
      */
-    this.channels_ = new goog.labs.structs.Multimap;
+    this.channels_ = new goog.labs.structs.Multimap();
 
     /** @type {!Array.<function(!Array.<string>)>} @private @const */
     this.onUpdateListeners_ = [];

--- a/common/js/src/requesting/requester-unittest.js
+++ b/common/js/src/requesting/requester-unittest.js
@@ -69,7 +69,7 @@ goog.exportSymbol('testRequester', function() {
   const REQUEST_1_ERROR_MESSAGE = 'test error';
   const REQUEST_2_RESPONSE_PAYLOAD = {some_result: 123};
 
-  const mockControl = new goog.testing.MockControl;
+  const mockControl = new goog.testing.MockControl();
   const mockMessageChannel =
       new goog.testing.messaging.MockMessageChannel(mockControl);
   /** @type {?} */ mockMessageChannel.send;
@@ -149,7 +149,7 @@ goog.exportSymbol('testRequester', function() {
 goog.exportSymbol('testRequester_disposed', function() {
   const REQUESTER_NAME = 'test-requester';
 
-  const mockControl = new goog.testing.MockControl;
+  const mockControl = new goog.testing.MockControl();
   const mockMessageChannel =
       new goog.testing.messaging.MockMessageChannel(mockControl);
   /** @type {?} */ mockMessageChannel.send;

--- a/common/js/src/requesting/requester.js
+++ b/common/js/src/requesting/requester.js
@@ -82,7 +82,7 @@ GSC.Requester = class extends goog.Disposable {
      * @type {Map.<number, !goog.promise.Resolver>?}
      * @private
      */
-    this.requestIdToPromiseResolverMap_ = new Map;
+    this.requestIdToPromiseResolverMap_ = new Map();
 
     this.registerResponseMessagesService_();
     this.addChannelDisposedListener_();

--- a/smart_card_connector_app/src/chrome-login-state-hook-unittest.js
+++ b/smart_card_connector_app/src/chrome-login-state-hook-unittest.js
@@ -97,7 +97,7 @@ function setUpChromeLoginStateMock(
  */
 function makeTest(fakeProfileType, fakeSessionState, testCallback) {
   return function() {
-    const propertyReplacer = new goog.testing.PropertyReplacer;
+    const propertyReplacer = new goog.testing.PropertyReplacer();
 
     function cleanup() {
       propertyReplacer.reset();

--- a/third_party/pcsc-lite/naclport/cpp_client/src/nacl-client-backend.js
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/nacl-client-backend.js
@@ -115,7 +115,7 @@ GSC.PcscLiteClient.NaclClientBackend = class {
     this.api_ = null;
 
     /** @type {!goog.structs.Queue.<!BufferedRequest>} @private @const */
-    this.bufferedRequestsQueue_ = new goog.structs.Queue;
+    this.bufferedRequestsQueue_ = new goog.structs.Queue();
 
     /**
      * @type {number|null}

--- a/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
+++ b/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
@@ -220,7 +220,7 @@ function TrackerThroughPcscServerHook(
    * @type {!Map.<number, !ReaderInfo>}
    * @private @const
    */
-  this.portToReaderInfoMap_ = new Map;
+  this.portToReaderInfoMap_ = new Map();
 
   serverMessageChannel.registerService(
       'reader_init_add', this.readerInitAddListener_.bind(this), true);

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
@@ -208,7 +208,7 @@ function getPermissionsChecker() {
     return permissionsCheckerOverrideForTesting;
   if (!defaultPermissionsChecker) {
     defaultPermissionsChecker =
-        new GSC.Pcsc.PolicyOrPromptingPermissionsChecker;
+        new GSC.Pcsc.PolicyOrPromptingPermissionsChecker();
   }
   return defaultPermissionsChecker;
 }

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
@@ -58,7 +58,7 @@ PermissionsChecking.ManagedRegistry = function() {
    * @type {!Set.<string>}
    * @private
    */
-  this.allowedClientOrigins_ = new Set;
+  this.allowedClientOrigins_ = new Set();
 
   this.loadManagedStorage_();
   this.listenForStorageChanging_();
@@ -185,7 +185,7 @@ ManagedRegistry.prototype.setAllowedClientOriginsFromStorageData_ = function(
     return false;
   }
 
-  const newAllowedClientOrigins = new Set;
+  const newAllowedClientOrigins = new Set();
   let success = true;
   goog.array.forEach(/** @type {!Array} */ (storageData), function(item) {
     if (typeof item !== 'string') {

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/policy-or-prompting-permissions-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/policy-or-prompting-permissions-checker.js
@@ -67,9 +67,9 @@ GSC.Pcsc.PolicyOrPromptingPermissionsChecker =
   constructor() {
     super();
     /** @private @const */
-    this.managedRegistry_ = new PermissionsChecking.ManagedRegistry;
+    this.managedRegistry_ = new PermissionsChecking.ManagedRegistry();
     /** @private @const */
-    this.userPromptingChecker_ = new PermissionsChecking.UserPromptingChecker;
+    this.userPromptingChecker_ = new PermissionsChecking.UserPromptingChecker();
   }
 
   /**

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
@@ -227,7 +227,7 @@ TrustedClientsRegistryImpl.prototype.jsonLoadedCallback_ = function(e) {
  */
 TrustedClientsRegistryImpl.prototype.parseJsonAndApply_ = function(json) {
   /** @type {!Map.<string, !TrustedClientInfo>} */
-  const originToInfoMap = new Map;
+  const originToInfoMap = new Map();
   let success = true;
   goog.object.forEach(json, function(value, key) {
     const info = this.tryParseTrustedClientInfo_(key, value);

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittest.js
@@ -196,8 +196,8 @@ function makeTest(
     fakeInitialStorageData, expectedStorageDataToBeWritten,
     mockedDialogBehavior, testCallback) {
   return function() {
-    const mockControl = new goog.testing.MockControl;
-    const propertyReplacer = new goog.testing.PropertyReplacer;
+    const mockControl = new goog.testing.MockControl();
+    const propertyReplacer = new goog.testing.PropertyReplacer();
 
     function cleanup() {
       mockControl.$tearDown();
@@ -230,7 +230,7 @@ function makeTest(
     let testPromise;
     /** @preserveTry */
     try {
-      testPromise = testCallback(new UserPromptingChecker);
+      testPromise = testCallback(new UserPromptingChecker());
     } catch (exc) {
       // Cleanup after the test fatally failed synchronously.
       cleanup();

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
@@ -83,7 +83,7 @@ PermissionsChecking.UserPromptingChecker = function() {
   this.localStoragePromise_ = this.loadLocalStorage_();
 
   /** @type {!Map.<string, !Promise<void>>} @private @const */
-  this.checkPromiseMap_ = new Map;
+  this.checkPromiseMap_ = new Map();
 };
 
 const UserPromptingChecker = PermissionsChecking.UserPromptingChecker;
@@ -276,7 +276,7 @@ function fixupLegacyStoredIdentifier(identifier) {
 UserPromptingChecker.prototype.parseLocalStorageUserSelections_ = function(
     rawData) {
   /** @type {!Map.<string, boolean>} */
-  const storedUserSelections = new Map;
+  const storedUserSelections = new Map();
   if (!rawData[LOCAL_STORAGE_KEY])
     return storedUserSelections;
   const contents = rawData[LOCAL_STORAGE_KEY];


### PR DESCRIPTION
Fix the "new-parens" ESLint error.

This is part of the cleanup tracked by #937.