### PR TITLE
[js style] Use const when possible

### DIFF
--- a/common/js/src/container-helpers.js
+++ b/common/js/src/container-helpers.js
@@ -33,8 +33,8 @@ const GSC = GoogleSmartCard;
  * @return {!Object}
  */
 GSC.ContainerHelpers.buildObjectFromMap = function(map) {
-  let obj = {};
-  for (let [key, value] of map) {
+  const obj = {};
+  for (const [key, value] of map) {
     GSC.Logging.check(
         typeof key === 'string' || typeof key === 'number',
         'Invalid type for object key');

--- a/common/js/src/i18n.js
+++ b/common/js/src/i18n.js
@@ -63,7 +63,7 @@ function transformElement(element, attribute, transformFunction) {
  */
 function transformAllElements(attribute, transformFunction) {
   const selector = '[' + attribute + ']';
-  for (let element of document.querySelectorAll(selector)) {
+  for (const element of document.querySelectorAll(selector)) {
     transformElement(element, attribute, transformFunction);
   }
 }

--- a/common/js/src/messaging/message-channel-pair.js
+++ b/common/js/src/messaging/message-channel-pair.js
@@ -87,7 +87,7 @@ GSC.MessageChannelPair = class extends goog.Disposable {
 
   /** @override */
   disposeInternal() {
-    for (let item of this.items_)
+    for (const item of this.items_)
       item.dispose();
     this.items_ = [];
     super.disposeInternal();

--- a/common/js/src/messaging/message-channel-pool.js
+++ b/common/js/src/messaging/message-channel-pool.js
@@ -129,7 +129,7 @@ GSC.MessageChannelPool = class {
    */
   fireOnUpdateListeners_() {
     goog.log.fine(this.logger, 'Firing channel update listeners');
-    for (let listener of this.onUpdateListeners_) {
+    for (const listener of this.onUpdateListeners_) {
       try {
         listener(this.getMessagingOrigins());
       } catch (exc) {

--- a/common/js/src/messaging/mock-port.js
+++ b/common/js/src/messaging/mock-port.js
@@ -74,7 +74,7 @@ GSC.MockPort = class extends goog.Disposable {
     GSC.Logging.checkWithLogger(
         logger, !this.isDisposed() && this.isConnected_,
         'Trying to fire onMessage for closed mock port');
-    for (let listener of this.getListeners_('onMessage'))
+    for (const listener of this.getListeners_('onMessage'))
       listener(message);
   }
 
@@ -125,7 +125,7 @@ GSC.MockPort = class extends goog.Disposable {
     if (!this.isConnected_)
       return;
     this.isConnected_ = false;
-    for (let listener of this.getListeners_('onDisconnect'))
+    for (const listener of this.getListeners_('onDisconnect'))
       listener();
   }
 
@@ -154,7 +154,7 @@ GSC.MockPort = class extends goog.Disposable {
    */
   getListeners_(type) {
     const result = [];
-    for (let listenerKey of this.listenerMap_.getListeners(type, false)) {
+    for (const listenerKey of this.listenerMap_.getListeners(type, false)) {
       if (goog.functions.isFunction(listenerKey.listener))
         result.push(listenerKey.listener);
     }

--- a/common/js/src/messaging/port-message-channel-unittest.js
+++ b/common/js/src/messaging/port-message-channel-unittest.js
@@ -150,7 +150,7 @@ goog.exportSymbol('testPortMessageChannelMessageSending', function() {
 
   const mockPort = new GSC.MockPort('mock port');
   setUpPingRespondingForMockPort(mockPort);
-  for (let testMessage of TEST_MESSAGES) {
+  for (const testMessage of TEST_MESSAGES) {
     mockPort
         .postMessage(new goog.testing.mockmatchers.ObjectEquals(
             testMessage.makeMessage()))
@@ -159,7 +159,7 @@ goog.exportSymbol('testPortMessageChannelMessageSending', function() {
   mockPort.postMessage.$replay();
 
   function onPortMessageChannelEstablished() {
-    for (let testMessage of TEST_MESSAGES)
+    for (const testMessage of TEST_MESSAGES)
       portMessageChannel.send(testMessage.type, testMessage.data);
 
     mockPort.postMessage.$verify();
@@ -218,7 +218,7 @@ goog.exportSymbol('testPortMessageChannelMessageReceiving', function() {
   function onPortMessageChannelEstablished() {
     const receivedMessages = [];
 
-    for (let testMessage of TEST_MESSAGES) {
+    for (const testMessage of TEST_MESSAGES) {
       portMessageChannel.registerService(
           testMessage.type, function(messageData) {
             GSC.Logging.check(goog.isObject(messageData));
@@ -228,7 +228,7 @@ goog.exportSymbol('testPortMessageChannelMessageReceiving', function() {
           }, true);
     }
 
-    for (let testMessage of TEST_MESSAGES)
+    for (const testMessage of TEST_MESSAGES)
       mockPort.fireOnMessage(testMessage.makeMessage());
 
     assertObjectEquals(TEST_MESSAGES, receivedMessages);

--- a/common/js/src/messaging/single-message-based-channel-unittest.js
+++ b/common/js/src/messaging/single-message-based-channel-unittest.js
@@ -194,7 +194,7 @@ goog.exportSymbol('testSingleMessageBasedChannel', {
         EXTENSION_ID, /* opt_onEstablished= */ waiter.callback);
     await waiter.promise;
     // Send test messages through the channel.
-    for (let testMessage of TEST_MESSAGES)
+    for (const testMessage of TEST_MESSAGES)
       testChannel.send(testMessage.type, testMessage.data);
 
     // Assert.
@@ -248,14 +248,14 @@ goog.exportSymbol('testSingleMessageBasedChannel', {
     await waiter.promise;
     // Set up an observer for incoming messages.
     const receivedMessages = [];
-    for (let testMessage of TEST_MESSAGES) {
+    for (const testMessage of TEST_MESSAGES) {
       testChannel.registerService(testMessage.type, function(messageData) {
         goog.asserts.assert(goog.isObject(messageData));
         receivedMessages.push(new TypedMessage(testMessage.type, messageData));
       }, /* opt_objectPayload= */ true);
     }
     // Simulate incoming test messages.
-    for (let testMessage of TEST_MESSAGES)
+    for (const testMessage of TEST_MESSAGES)
       testChannel.deliverMessage(testMessage.makeMessage());
 
     // Assert: check all messages were received and in the correct order.

--- a/smart_card_connector_app/src/chrome-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/chrome-api-jstocxxtest.js
@@ -160,7 +160,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
 
   // Test a single `onEstablishContextRequested` event.
   'testEstablishContext': async function() {
-    let establishContextResult = EMPTY_CONTEXT_RESULT;
+    const establishContextResult = EMPTY_CONTEXT_RESULT;
     expectReportEstablishContext(
         /*requestId=*/ 123, 'SUCCESS', establishContextResult);
     mockControl.$replayAll();
@@ -175,7 +175,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
 
   // Test releasing the established context.
   'testReleaseContext': async function() {
-    let establishContextResult = EMPTY_CONTEXT_RESULT;
+    const establishContextResult = EMPTY_CONTEXT_RESULT;
     expectReportEstablishContext(
         /*requestId=*/ 123, 'SUCCESS', establishContextResult);
     expectReportReleaseContext(/*requestId=*/ 124, 'SUCCESS');
@@ -210,7 +210,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
 
   // Test ListReaders with no readers attached.
   'testListReaders_none': async function() {
-    let establishContextResult = EMPTY_CONTEXT_RESULT;
+    const establishContextResult = EMPTY_CONTEXT_RESULT;
     expectReportEstablishContext(
         /*requestId=*/ 123, 'SUCCESS', establishContextResult);
     expectReportListReaders(/*requestId=*/ 124, [], 'NO_READERS_AVAILABLE');
@@ -232,7 +232,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
   // Test that ListReaders requested with already released context returns
   // INVALID_HANDLE error.
   'testListReaders_releasedContext': async function() {
-    let establishContextResult = EMPTY_CONTEXT_RESULT;
+    const establishContextResult = EMPTY_CONTEXT_RESULT;
     expectReportEstablishContext(
         /*requestId=*/ 123, 'SUCCESS', establishContextResult);
     expectReportReleaseContext(/*requestId=*/ 124, 'SUCCESS');
@@ -260,7 +260,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
   // Test ListReaders returns a one-item list when there's a single attached
   // device.
   'testListReaders_singleDevice': async function() {
-    let establishContextResult = EMPTY_CONTEXT_RESULT;
+    const establishContextResult = EMPTY_CONTEXT_RESULT;
     expectReportEstablishContext(
         /*requestId=*/ 123, 'SUCCESS', establishContextResult);
     expectReportListReaders(
@@ -284,7 +284,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
 
   // Test ListReaders returns a two-item list when there're two attached device.
   'testListReaders_twoDevices': async function() {
-    let establishContextResult = EMPTY_CONTEXT_RESULT;
+    const establishContextResult = EMPTY_CONTEXT_RESULT;
     expectReportEstablishContext(
         /*requestId=*/ 123, 'SUCCESS', establishContextResult);
     expectReportListReaders(

--- a/smart_card_connector_app/src/chrome-api-provider.js
+++ b/smart_card_connector_app/src/chrome-api-provider.js
@@ -122,7 +122,7 @@ function convertErrorCodeToEnum(errorCode) {
 function convertReaderStateIn(readerState) {
   let currentState = 0;
   /** @type {!chrome.smartCardProviderPrivate.ReaderStateFlags} */
-  let currentStateFlags = readerState.currentState;
+  const currentStateFlags = readerState.currentState;
   if (currentStateFlags.unaware)
     currentState |= PcscApi.SCARD_STATE_UNAWARE;
   if (currentStateFlags.ignore)
@@ -162,10 +162,10 @@ function convertReaderStateIn(readerState) {
  */
 function convertReaderStateOut(readerState) {
   /** @type {!chrome.smartCardProviderPrivate.ReaderStateFlags} */
-  let readerStateFlags = {};
+  const readerStateFlags = {};
   // Reader state flags are stored in the lower 16 bits of the event state.
   /** @type {number} */
-  let eventState = readerState['event_state'] & STATE_FLAGS_MASK;
+  const eventState = readerState['event_state'] & STATE_FLAGS_MASK;
   if (eventState == PcscApi.SCARD_STATE_UNAWARE)
     readerStateFlags.unaware = true;
   if (eventState & PcscApi.SCARD_STATE_IGNORE)
@@ -190,7 +190,7 @@ function convertReaderStateOut(readerState) {
     readerStateFlags.unpowered = true;
   // The number of events is stored in the upper 16 bits of the event state.
   /** @type {number} */
-  let eventCount = readerState['event_state'] >> 16;
+  const eventCount = readerState['event_state'] >> 16;
   return {
     reader: readerState['reader_name'],
     eventState: readerStateFlags,

--- a/smart_card_connector_app/src/window-devices-displaying.js
+++ b/smart_card_connector_app/src/window-devices-displaying.js
@@ -122,7 +122,7 @@ function displayReaderList(readers) {
           ' card reader(s): ' + GSC.DebugDump.dump(readers));
   goog.dom.removeChildren(readersListElement);
 
-  for (let reader of readers) {
+  for (const reader of readers) {
     GSC.Logging.checkWithLogger(logger, readersListElement !== null);
     goog.asserts.assert(readersListElement);
 
@@ -150,7 +150,7 @@ function displayReaderList(readers) {
 }
 
 function makeReaderNameForDisplaying(readerName) {
-  for (let suffixToRemove of READER_NAME_SUFFIXES_TO_REMOVE) {
+  for (const suffixToRemove of READER_NAME_SUFFIXES_TO_REMOVE) {
     if (goog.string.endsWith(readerName, suffixToRemove)) {
       const newReaderName =
           readerName.substr(0, readerName.length - suffixToRemove.length);

--- a/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
+++ b/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
@@ -185,7 +185,7 @@ ReaderTracker.prototype.fireOnUpdateListeners_ = function() {
       this.logger_,
       'Firing readers updated listeners with data ' +
           GSC.DebugDump.dump(readers));
-  for (let listener of this.updateListeners_) {
+  for (const listener of this.updateListeners_) {
     try {
       listener(readers);
     } catch (exc) {


### PR DESCRIPTION
Use const instead of let whenever possible.

This is found and fixed via ESLint. This refactoring is part of the effort tracked by #937.