### PR TITLE
[js style] Fix excessively long lines

### DIFF
--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -307,7 +307,8 @@ function scheduleSelfReloadIfAllowed() {
           goog.log.info(
               rootLogger,
               'Crash loop detected. The application is defunct, but the ' +
-                  'execution state is kept in order to retain the failure logs.');
+                  'execution state is kept in order to retain the failure ' +
+                  'logs.');
           return;
         }
         goog.log.info(

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
@@ -307,10 +307,10 @@ Backend.prototype.setupApiListeners_ = function() {
       goog.log.warning(
           this.logger,
           'chrome.certificateProvider API is not available. Providing ' +
-              'certificates to the Chrome browser will be impossible. This is ' +
-              'just a warning in the Debug build (in order to make some testing ' +
-              'on non-ChromeOS systems possible), but this will be a fatal ' +
-              'error in the Release build');
+              'certificates to the Chrome browser will be impossible. This ' +
+              'is just a warning in the Debug build (in order to make some ' +
+              'testing on non-ChromeOS systems possible), but this will be a ' +
+              'fatal error in the Release build');
     } else {
       goog.log.error(
           this.logger,
@@ -537,8 +537,8 @@ Backend.prototype.processSignDigestRequest_ = function(
         const signature = results[0];
         goog.log.info(
             this.logger,
-            'Responding to the digest sign request with the created signature: ' +
-                GSC.DebugDump.debugDump(signature));
+            'Responding to the digest sign request with the created ' +
+                'signature: ' + GSC.DebugDump.debugDump(signature));
         reportCallback(signature);
       },
       function() {

--- a/third_party/pcsc-lite/naclport/js_client/src/reader-tracker-through-pcsc-api.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/reader-tracker-through-pcsc-api.js
@@ -277,8 +277,8 @@ ReaderTrackerThroughPcscApi.prototype.makeReaderNamesPromise_ = function(
                     promiseResolver.resolve([]);
                   } else {
                     promiseResolver.reject(new Error(
-                        'Failed to get the list of readers from PC/SC with error ' +
-                        'code ' + GSC.DebugDump.dump(errorCode)));
+                        'Failed to get the list of readers from PC/SC with ' +
+                        'error code ' + GSC.DebugDump.dump(errorCode)));
                   }
                 });
           },
@@ -319,14 +319,15 @@ ReaderTrackerThroughPcscApi.prototype.makeReaderStatesPromise_ = function(
                   if (errorCode == API.SCARD_E_UNKNOWN_READER) {
                     goog.log.info(
                         this.logger_,
-                        'Getting the statuses of the readers from PC/SC finished ' +
-                            'unsuccessfully due to removal of the tracked reader. A ' +
-                            'retry will be attempted after some delay');
+                        'Getting the statuses of the readers from PC/SC ' +
+                            'finished unsuccessfully due to removal of the ' +
+                            'tracked reader. A retry will be attempted after ' +
+                            'some delay');
                     promiseResolver.resolve(null);
                   } else {
                     promiseResolver.reject(new Error(
-                        'Failed to get the reader statuses from PC/SC with error ' +
-                        'code ' + GSC.DebugDump.dump(errorCode)));
+                        'Failed to get the reader statuses from PC/SC with ' +
+                        'error code ' + GSC.DebugDump.dump(errorCode)));
                   }
                 },
                 this);
@@ -416,13 +417,15 @@ ReaderTrackerThroughPcscApi.prototype.makeReaderStatesChangePromise_ = function(
                   } else if (errorCode == API.SCARD_E_UNKNOWN_READER) {
                     goog.log.info(
                         this.logger_,
-                        'Waiting for the reader statuses changes from PC/SC finished ' +
-                            'unsuccessfully due to removal of the tracked reader');
+                        'Waiting for the reader statuses changes from PC/SC ' +
+                            'finished unsuccessfully due to removal of the ' +
+                            'tracked reader');
                     promiseResolver.resolve();
                   } else {
                     promiseResolver.reject(new Error(
-                        'Failed to wait for the reader statuses change from PC/SC with ' +
-                        'error code ' + GSC.DebugDump.dump(errorCode)));
+                        'Failed to wait for the reader statuses change from ' +
+                        'PC/SC with error code ' +
+                        GSC.DebugDump.dump(errorCode)));
                   }
                 },
                 this);

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
@@ -292,7 +292,8 @@ ClientHandler.prototype.getPermissionsCheckPromise_ = function() {
           function(error) {
             goog.log.warning(
                 this.logger,
-                'Client permission denied. All PC/SC requests will be rejected');
+                'Client permission denied. All PC/SC requests will be ' +
+                    'rejected');
             throw error;
           },
           this);

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
@@ -117,7 +117,8 @@ TrustedClientsRegistry.prototype.tryGetByOrigins = function(originList) {};
  */
 GSC.PcscLiteServer.TrustedClientsRegistryImpl = function() {
   /**
-   * @type {!goog.promise.Resolver.<!Map.<string,!TrustedClientInfo>>} @private @const
+   * @type {!goog.promise.Resolver.<!Map.<string,!TrustedClientInfo>>} @private
+   *     @const
    */
   this.promiseResolver_ = goog.Promise.withResolver();
 
@@ -214,9 +215,9 @@ TrustedClientsRegistryImpl.prototype.jsonLoadedCallback_ = function(e) {
                 new Error('Failed to load the trusted clients registry'));
             GSC.Logging.failWithLogger(
                 this.logger,
-                'Failed to load the trusted clients registry from JSON file (URL: "' +
-                    JSON_CONFIG_URL + '"): parsing failed with the ' +
-                    'following error: ' + exc);
+                'Failed to load the trusted clients registry from JSON file ' +
+                    '(URL: "' + JSON_CONFIG_URL +
+                    '"): parsing failed with the following error: ' + exc);
           },
           this);
 };
@@ -236,8 +237,8 @@ TrustedClientsRegistryImpl.prototype.parseJsonAndApply_ = function(json) {
     } else {
       goog.log.warning(
           this.logger,
-          'Failed to parse the following trusted clients registry JSON item: key="' +
-              key + '", value=' + GSC.DebugDump.dump(value));
+          'Failed to parse the following trusted clients registry JSON item: ' +
+              'key="' + key + '", value=' + GSC.DebugDump.dump(value));
       success = false;
     }
   }, this);
@@ -254,8 +255,8 @@ TrustedClientsRegistryImpl.prototype.parseJsonAndApply_ = function(json) {
     GSC.Logging.failWithLogger(
         this.logger,
         'Failed to load the trusted clients registry from JSON file (URL: "' +
-            JSON_CONFIG_URL + '"): parsing of some of the items ' +
-            'finished with errors');
+            JSON_CONFIG_URL + '"): parsing of some of the items finished ' +
+            'with errors');
   }
 };
 


### PR DESCRIPTION
Reformat JS code to fit into 80-column limit whenever possible (e.g., we leave long URLs as-is).

This is found via ESLint. This refactoring is part of the effort tracked by #937.