### PR TITLE
[js style] Fix excessive return tag

### DIFF
--- a/common/js/src/promise-helpers.js
+++ b/common/js/src/promise-helpers.js
@@ -32,7 +32,6 @@ const GSC = GoogleSmartCard;
  * Disables for the specified promise throwing of an error when it's rejected
  * with no rejection callback attached to it.
  * @param {!goog.Promise} promise
- * @return {?}
  */
 GSC.PromiseHelpers.suppressUnhandledRejectionError = function(promise) {
   promise.thenCatch(function() {});


### PR DESCRIPTION
Remove @return from the function that doesn't return anything.

This was found by ESLint. This is part of the cleanup tracked by #937.