### PR TITLE
[js style] Fix invalid typeof comparison

### DIFF
--- a/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
@@ -255,8 +255,8 @@ function convertChromeUsbDeviceToLibusb(chromeUsbDevice) {
     'manufacturerName': chromeUsbDevice.manufacturerName,
     'serialNumber': chromeUsbDevice.serialNumber,
   };
-  if (typeof chromeUsbDevice.version !== undefined &&
-      typeof chromeUsbDevice.version !== null) {
+  if (chromeUsbDevice.version !== undefined &&
+      chromeUsbDevice.version !== null) {
     // The "version" field was only added in Chrome 51.
     libusbJsDevice['version'] = chromeUsbDevice.version;
   }


### PR DESCRIPTION
Compare values using just "!==" as opposed to "typeof ... !==", since the latter uses a string and hence would never pass.

This seems like a real bug, although it's probably unlikely to hit any user since it requires ChromeOS <=50.

This was found by ESLint. This is part of the cleanup tracked by #937.