### PR TITLE
[js style] Add basic ESLint config

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,16 @@
+env:
+  browser: true
+  es2020: true
+extends: eslint:recommended
+rules:
+  # Disabled as the linter doesn't understand Closure Compiler style imports
+  # ("goog.require") and Closure Library's global symbols.
+  no-undef: off
+  # Disabled as causes spurious errors on Closure Compiler typedefs and casts.
+  no-unused-vars: off
+overrides:
+  # Parse specific files as ES Modules (the standard parser would fail).
+  - files:
+      example_js_standalone_smart_card_client_library/src/es-module-exports.js
+    parserOptions:
+      sourceType: module


### PR DESCRIPTION
Add the initial config for ESLint - the JavaScript linter tool.

The config enables most of the standard rules, except those that cause major incompatibility with our Closure-based source code.

Follow-ups will add scripts and CI actions that use this config.

This commit is part of the effort tracked by #937.