### PR TITLE
[js style] More ESLint rules

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,6 +8,27 @@ rules:
   no-undef: off
   # Disabled as causes spurious errors on Closure Compiler typedefs and casts.
   no-unused-vars: off
+  # Enforce 80-column limit, with some reasonable exceptions.
+  max-len:
+    - error
+    - ignoreComments: true
+      ignoreUrls: true
+      ignorePattern: ^(goog\.require|goog\.provide)\(.*\);$
+  new-parens: error
+  no-constant-binary-expression: error
+  no-constructor-return: error
+  no-duplicate-imports: error
+  no-new-native-nonconstructor: error
+  no-promise-executor-return: error
+  no-self-compare: error
+  no-template-curly-in-string: error
+  no-unmodified-loop-condition: error
+  no-unreachable-loop: error
+  no-unused-private-class-members: error
+  prefer-const: error
+  semi: error
+  semi-spacing: error
+  semi-style: error
 overrides:
   # Parse specific files as ES Modules (the standard parser would fail).
   - files:


### PR DESCRIPTION
Enable more of turned-off-by-default ESLint rules.

This commit is part of the effort tracked by #937.