### PR TITLE
Update Emscripten to 3.1.45

### DIFF
--- a/env/constants.sh
+++ b/env/constants.sh
@@ -18,7 +18,7 @@
 DEPOT_TOOLS_REPOSITORY_URL="https://chromium.googlesource.com/chromium/tools/depot_tools.git"
 
 EMSCRIPTEN_SDK_REPOSITORY_URL="https://github.com/emscripten-core/emsdk.git"
-EMSCRIPTEN_VERSION="3.1.42"
+EMSCRIPTEN_VERSION="3.1.45"
 
 NACL_SDK_VERSION="47"
 


### PR DESCRIPTION
We don't require any particular improvements, however it's good to keep up with upstream to learn about possible issues earlier.