### PR TITLE
Refactor logic for finding sources-to-be-linted

### DIFF
--- a/format-code.sh
+++ b/format-code.sh
@@ -28,10 +28,8 @@ set -eu
 # Go to the root directory of the repository.
 cd $(dirname $(realpath ${0}))
 
-# Find all relevant touched files. Bail out if nothing is found.
-# Note: "d" in --diff-filter means excluding deleted files - otherwise
-# clang-format fails on these non-existing files.
-FILES=$(git diff --name-only --diff-filter=d main -- "*.cc" "*.h" "*.js")
+# Find all relevant files to be checked. Bail out if nothing is found.
+FILES=$(scripts/internal/find-files-for-linting.sh "*.cc" "*.h" "*.js")
 [ "${FILES}" ] || exit 0
 
 # Run clang-format on every found file.

--- a/scripts/internal/find-files-for-linting.sh
+++ b/scripts/internal/find-files-for-linting.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This scripts returns paths to files that are manually edited by this
+# repository's maintainers and hence need to undergo linting/reformatting/etc.
+#
+# Parameters: `find-files-for-linting.sh [glob-pattern]*`.
+
+# Find all touched files tracked by Git. Bail out if nothing is found.
+# Note: "d" in --diff-filter means excluding deleted files - they don't need to
+# be linted.
+git diff --name-only --diff-filter=d main -- "$@"


### PR DESCRIPTION
Create a separate helper script for finding manually maintained source files. Currently it's only used for running clang-format from format-code.sh, but we're planning to add a similar script for JS linting.

This contributes to the effort tracked by #937.