### PR TITLE
[headers] Include by abs path from pcsc-lite cpp_demo

### DIFF
--- a/third_party/pcsc-lite/naclport/cpp_demo/src/google_smart_card_pcsc_lite_cpp_demo/demo.cc
+++ b/third_party/pcsc-lite/naclport/cpp_demo/src/google_smart_card_pcsc_lite_cpp_demo/demo.cc
@@ -23,7 +23,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <google_smart_card_pcsc_lite_cpp_demo/demo.h>
+#include "third_party/pcsc-lite/naclport/cpp_demo/src/google_smart_card_pcsc_lite_cpp_demo/demo.h"
 
 #include <stdint.h>
 


### PR DESCRIPTION
Change `#include <google_smart_card_pcsc_lite_cpp_demo...>` to `#include "third_party/pcsc-lite/..."`.

This is part of the refactoring tracked by #885.