### PR TITLE
[ci] Skip JS targets in sanitizer/coverage builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,16 +71,6 @@ third_party/libusb/webport/build/tests: third_party/libusb/webport/build
 
 TOOLCHAIN ?= emscripten
 
-# Applications are only built in non-sanitizer builds.
-ifneq ($(TOOLCHAIN),asan_testing)
-
-APPLICATION_TARGETS += \
-	example_cpp_smart_card_client_app/build \
-	example_js_smart_card_client_app/build \
-	smart_card_connector_app/build \
-
-endif
-
 # Use our checkout of Googletest for tests in all toolchains except NaCl (whose
 # SDK provides its own version).
 ifneq ($(TOOLCHAIN),pnacl)
@@ -94,8 +84,13 @@ third_party/libusb/webport/build/tests: third_party/googletest/webport/build
 
 endif
 
-# Enable JS targets in relevant configurations.
+# Enable JS and application targets in relevant configurations.
 ifneq (,$(findstring $(TOOLCHAIN),pnacl emscripten))
+
+APPLICATION_TARGETS += \
+	example_cpp_smart_card_client_app/build \
+	example_js_smart_card_client_app/build \
+	smart_card_connector_app/build \
 
 LIBRARY_TARGETS += \
 	common/integration_testing/build \

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,17 @@ third_party/libusb/webport/build/tests: third_party/libusb/webport/build
 
 TOOLCHAIN ?= emscripten
 
+# Applications with C/C++ code are built in all non-sanitizer build modes
+# ("emscripten"/"pnacl" are production-suitable; "coverage" needs the built
+# binaries to catch parts of the code that aren't unit-tested but still linked
+# into production programs).
+ifneq ($(TOOLCHAIN),asan_testing)
+
+	example_cpp_smart_card_client_app/build \
+	smart_card_connector_app/build \
+
+endif
+
 # Use our checkout of Googletest for tests in all toolchains except NaCl (whose
 # SDK provides its own version).
 ifneq ($(TOOLCHAIN),pnacl)
@@ -84,13 +95,11 @@ third_party/libusb/webport/build/tests: third_party/googletest/webport/build
 
 endif
 
-# Enable JS and application targets in relevant configurations.
+# Enable JS targets in relevant configurations.
 ifneq (,$(findstring $(TOOLCHAIN),pnacl emscripten))
 
 APPLICATION_TARGETS += \
-	example_cpp_smart_card_client_app/build \
 	example_js_smart_card_client_app/build \
-	smart_card_connector_app/build \
 
 LIBRARY_TARGETS += \
 	common/integration_testing/build \

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ APPLICATION_TARGETS :=
 
 LIBRARY_TARGETS := \
 	common/cpp/build \
-	example_js_standalone_smart_card_client_library \
 	third_party/ccid/webport/build \
 	third_party/libusb/webport/build \
 	third_party/pcsc-lite/naclport/build_configuration \
@@ -60,12 +59,8 @@ third_party/pcsc-lite/naclport/server_clients_management/build: third_party/pcsc
 
 TEST_TARGETS := \
 	common/cpp/build/tests \
-	common/js/build/unittests \
 	smart_card_connector_app/build/executable_module/cpp_unittests \
-	smart_card_connector_app/build/js_unittests \
-	third_party/libusb/webport/build/js_unittests \
 	third_party/libusb/webport/build/tests \
-	third_party/pcsc-lite/naclport/server_clients_management/build/js_unittests \
 
 common/cpp/build/tests: common/cpp/build
 smart_card_connector_app/build/executable_module/cpp_unittests: smart_card_connector_app/build
@@ -99,15 +94,20 @@ third_party/libusb/webport/build/tests: third_party/googletest/webport/build
 
 endif
 
-# Enable JS-to-C++ tests in relevant configurations.
+# Enable JS targets in relevant configurations.
 ifneq (,$(findstring $(TOOLCHAIN),pnacl emscripten))
 
 LIBRARY_TARGETS += \
 	common/integration_testing/build \
+	example_js_standalone_smart_card_client_library \
 
 TEST_TARGETS += \
+	common/js/build/unittests \
 	example_cpp_smart_card_client_app/build/js_to_cxx_tests \
 	smart_card_connector_app/build/js_to_cxx_tests \
+	smart_card_connector_app/build/js_unittests \
+	third_party/libusb/webport/build/js_unittests \
+	third_party/pcsc-lite/naclport/server_clients_management/build/js_unittests \
 
 example_cpp_smart_card_client_app/build/js_to_cxx_tests: common/cpp/build
 example_cpp_smart_card_client_app/build/js_to_cxx_tests: common/integration_testing/build

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ TOOLCHAIN ?= emscripten
 # into production programs).
 ifneq ($(TOOLCHAIN),asan_testing)
 
+APPLICATION_TARGETS += \
 	example_cpp_smart_card_client_app/build \
 	smart_card_connector_app/build \
 


### PR DESCRIPTION
JavaScript code building and testing is only useful in relevant toolchains (currently emscripten and pnacl). It should be skipped in analysis builds that are currently focused on C/C++ code (asan_testing and coverage).

This would improve CI speed a bit by shaving off unnecessary operations in those jobs.