### PR TITLE
[JS-to-C++ test] Test SCardCancel success

### DIFF
--- a/smart_card_connector_app/src/application_unittest.cc
+++ b/smart_card_connector_app/src/application_unittest.cc
@@ -1355,7 +1355,7 @@ TEST_F(SmartCardConnectorApplicationSingleClientTest,
   EXPECT_THAT(reader_states, IsEmpty());
 }
 
-// `SCardCancel()` call from JS terminates a running `ScardGetStatusChange()`
+// `SCardCancel()` call from JS terminates a running `SCardGetStatusChange()`
 // call.
 TEST_F(SmartCardConnectorApplicationSingleClientTest, Cancel) {
   // Arrange:


### PR DESCRIPTION
Verify the JavaScript API's SCardCancel() behavior on canceling a blocking SCardGetStatusChange() call.

This commit contributes to #869.