### PR TITLE
[JS-to-C++ test] Fix in NaCl builds

### DIFF
--- a/smart_card_connector_app/build/js_to_cxx_tests/Makefile
+++ b/smart_card_connector_app/build/js_to_cxx_tests/Makefile
@@ -60,6 +60,14 @@ LIBS := \
   $(CPP_COMMON_LIB) \
   $(DEFAULT_NACL_LIBS) \
 
+# In NaCl builds, extra libraries are needed.
+ifeq ($(TOOLCHAIN),pnacl)
+
+LIBS += nacl_io
+$(eval $(call DEPEND_RULE,nacl_io))
+
+endif
+
 # Include *-jstocxxtest.js and non-test files needed for them.
 JS_SOURCES_PATHS := \
   $(SOURCE_DIR) \


### PR DESCRIPTION
Make JS-to-C++ tests also work in NaCl builds, by initializing the nacl_io library (and hence allowing to perform file operations).

This contributes to effort tracked by #869.