### PR TITLE
[js style] Enable no-invalid-this linter

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -18,6 +18,7 @@ rules:
   no-constant-binary-expression: error
   no-constructor-return: error
   no-duplicate-imports: error
+  no-invalid-this: error
   no-new-native-nonconstructor: error
   no-promise-executor-return: error
   no-self-compare: error

--- a/common/js/src/requesting/requester.js
+++ b/common/js/src/requesting/requester.js
@@ -135,12 +135,12 @@ GSC.Requester = class extends goog.Disposable {
     const runningRequestIds =
         Array.from(this.requestIdToPromiseResolverMap_.keys());
     goog.array.sort(runningRequestIds);
-    goog.array.forEach(runningRequestIds, function(requestId) {
+    goog.array.forEach(runningRequestIds, (requestId) => {
       // FIXME(emaxx): Probably add the disposal reason information into the
       // message?
       this.rejectRequest_(
           goog.string.parseInt(requestId), 'The requester is disposed');
-    }, this);
+    });
     this.requestIdToPromiseResolverMap_ = null;
 
     this.messageChannel_ = null;

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/policy-or-prompting-permissions-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/policy-or-prompting-permissions-checker.js
@@ -108,22 +108,21 @@ GSC.Pcsc.PolicyOrPromptingPermissionsChecker =
 
     this.managedRegistry_.getByOrigin(clientOrigin)
         .then(
-            function() {
+            () => {
               goog.log.log(
                   logger, goog.log.Level.FINER,
                   'Granted permissions for client ' + clientOrigin +
                       ' through the managed registry');
               checkPromiseResolver.resolve();
             },
-            function() {
+            () => {
               goog.log.log(
                   logger, goog.log.Level.FINER,
                   'No permissions found for client ' + clientOrigin +
                       ' through the managed registry');
               this.checkByUserPromptingChecker_(
                   clientOrigin, checkPromiseResolver);
-            },
-            this);
+            });
   }
 
   /**

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/server-request-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/server-request-handler.js
@@ -241,22 +241,21 @@ Pcsc.ServerRequestHandler = class extends goog.Disposable {
     return this.serverRequester_
         .postRequest(remoteCallMessage.makeRequestPayload())
         .then(
-            function(result) {
+            (result) => {
               const resultDump = GSC.DebugDump.debugDump(result);
               goog.log.fine(
                   this.logger,
                   `PC/SC call ${requestDump} completed: ${resultDump}`);
               return result;
             },
-            function(error) {
+            (error) => {
               goog.log.log(
                   this.logger,
                   this.isDisposed() ? goog.log.Level.FINE :
                                       goog.log.Level.WARNING,
                   `PC/SC call ${requestDump} failed: ${error}`);
               throw error;
-            },
-            this);
+            });
   }
 
   /**


### PR DESCRIPTION
Enable ESlint's no-invalid-this diagnostics, and refactor some code to avoid spurious warnings (no real bug detected though).

This contributes to the effort tracked by #937.