### PR TITLE
[js style] Enable ESLint camelcase

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -14,6 +14,11 @@ rules:
     - ignoreComments: true
       ignoreUrls: true
       ignorePattern: ^(goog\.require|goog\.provide)\(.*\);$
+  camelcase:
+    - error
+    - allow:
+      - ^opt_
+      properties: never
   new-parens: error
   no-constant-binary-expression: error
   no-constructor-return: error


### PR DESCRIPTION
The check should prevent non-camel-case variable names which are against Google Style Guide. The exceptions are optional arguments ("opt_..."), constant names and property names.

This commit contributes to #937.