### PR TITLE
[js style] Enable ESLint guard-for-in

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -14,6 +14,7 @@ rules:
     - ignoreComments: true
       ignoreUrls: true
       ignorePattern: ^(goog\.require|goog\.provide)\(.*\);$
+  guard-for-in: error
   new-parens: error
   no-constant-binary-expression: error
   no-constructor-return: error

--- a/common/js/src/logging/crash-loop-detection-unittest.js
+++ b/common/js/src/logging/crash-loop-detection-unittest.js
@@ -82,8 +82,11 @@ function stubChromeStorageLocalSet(items, callback) {
     propertyReplacer.set(chrome, 'runtime', {'lastError': undefined});
     return;
   }
-  for (const key in items)
-    currentStorage[key] = items[key];
+  for (const key in items) {
+    if (Object.prototype.hasOwnProperty.call(items, key)) {
+      currentStorage[key] = items[key];
+    }
+  }
   callback();
 }
 


### PR DESCRIPTION
And fix the existing violation of this rule (in tests).

This commit contributes to #937.