### PR TITLE
[chrome-api-jstocxxtest] Add method to switch mocks back to recording

### DIFF
--- a/smart_card_connector_app/src/chrome-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/chrome-api-jstocxxtest.js
@@ -127,13 +127,14 @@ async function assertRemainsPending(promise, timeoutMillis) {
  * @param {!EstablishContextResult} outResult
  */
 function expectReportEstablishContext(requestId, resultCode, outResult) {
-  chrome
-      .smartCardProviderPrivate['reportEstablishContextResult'](
+  mockChromeApi
+      .record('reportEstablishContextResult')(
           requestId, goog.testing.mockmatchers.isNumber, resultCode)
       .$once()
       .$does((requestId, context, resultCode) => {
         outResult.sCardContext = context;
-      });
+      })
+      .$replay();
 }
 
 /**
@@ -143,10 +144,9 @@ function expectReportEstablishContext(requestId, resultCode, outResult) {
  * @param {string} resultCode
  */
 function expectReportReleaseContext(requestId, resultCode) {
-  chrome
-      .smartCardProviderPrivate['reportReleaseContextResult'](
-          requestId, resultCode)
-      .$once();
+  mockChromeApi.record('reportReleaseContextResult')(requestId, resultCode)
+      .$once()
+      .$replay();
 }
 
 /**
@@ -157,10 +157,10 @@ function expectReportReleaseContext(requestId, resultCode) {
  * @param {string} resultCode
  */
 function expectReportListReaders(requestId, readers, resultCode) {
-  chrome
-      .smartCardProviderPrivate['reportListReadersResult'](
-          requestId, readers, resultCode)
-      .$once();
+  mockChromeApi
+      .record('reportListReadersResult')(requestId, readers, resultCode)
+      .$once()
+      .$replay();
 }
 
 /**
@@ -171,10 +171,11 @@ function expectReportListReaders(requestId, readers, resultCode) {
  * @param {string} resultCode
  */
 function expectReportGetStatusChange(requestId, readerStates, resultCode) {
-  chrome
-      .smartCardProviderPrivate['reportGetStatusChangeResult'](
+  mockChromeApi
+      .record('reportGetStatusChangeResult')(
           requestId, readerStates, resultCode)
-      .$once();
+      .$once()
+      .$replay();
 }
 
 /**
@@ -184,8 +185,9 @@ function expectReportGetStatusChange(requestId, readerStates, resultCode) {
  * @param {string} resultCode
  */
 function expectReportPlainResult(requestId, resultCode) {
-  chrome.smartCardProviderPrivate['reportPlainResult'](requestId, resultCode)
-      .$once();
+  mockChromeApi.record('reportPlainResult')(requestId, resultCode)
+      .$once()
+      .$replay();
 }
 
 /**
@@ -196,12 +198,13 @@ function expectReportPlainResult(requestId, resultCode) {
  * @param {string} resultCode
  */
 function expectReportConnectResult(requestId, activeProtocol, resultCode) {
-  chrome
-      .smartCardProviderPrivate['reportConnectResult'](
+  mockChromeApi
+      .record('reportConnectResult')(
           requestId,
           /*scardHandle=*/ goog.testing.mockmatchers.isNumber, activeProtocol,
           resultCode)
-      .$once();
+      .$once()
+      .$replay();
 }
 
 goog.exportSymbol('testChromeApiProviderToCpp', {
@@ -221,6 +224,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
     mockControl = new goog.testing.MockControl();
     mockChromeApi =
         new MockChromeApi(mockControl, testController.propertyReplacer);
+    mockControl.$replayAll();
   },
 
   'tearDown': async function() {
@@ -238,7 +242,6 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
   },
 
   'testSmoke': async function() {
-    mockControl.$replayAll();
     launchPcscServer(/*initialDevices=*/[]);
     createChromeApiProvider();
     await pcscReadinessTracker.promise;
@@ -249,7 +252,6 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
     const establishContextResult = EMPTY_CONTEXT_RESULT;
     expectReportEstablishContext(
         /*requestId=*/ 123, 'SUCCESS', establishContextResult);
-    mockControl.$replayAll();
 
     launchPcscServer(/*initialDevices=*/[]);
     createChromeApiProvider();
@@ -264,7 +266,6 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
     expectReportEstablishContext(
         /*requestId=*/ 123, 'SUCCESS', establishContextResult);
     expectReportReleaseContext(/*requestId=*/ 124, 'SUCCESS');
-    mockControl.$replayAll();
 
     launchPcscServer(/*initialDevices=*/[]);
     createChromeApiProvider();
@@ -282,7 +283,6 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
   'testReleaseContext_none': async function() {
     const BAD_CONTEXT = 123;
     expectReportReleaseContext(/*requestId=*/ 42, 'INVALID_HANDLE');
-    mockControl.$replayAll();
 
     launchPcscServer(/*initialDevices=*/[]);
     createChromeApiProvider();
@@ -298,7 +298,6 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
     expectReportEstablishContext(
         /*requestId=*/ 123, 'SUCCESS', establishContextResult);
     expectReportListReaders(/*requestId=*/ 124, [], 'NO_READERS_AVAILABLE');
-    mockControl.$replayAll();
 
     launchPcscServer(/*initialDevices=*/[]);
     createChromeApiProvider();
@@ -320,7 +319,6 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
         /*requestId=*/ 123, 'SUCCESS', establishContextResult);
     expectReportReleaseContext(/*requestId=*/ 124, 'SUCCESS');
     expectReportListReaders(/*requestId=*/ 125, [], 'INVALID_HANDLE');
-    mockControl.$replayAll();
 
     launchPcscServer(/*initialDevices=*/[]);
     createChromeApiProvider();
@@ -347,7 +345,6 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
         /*requestId=*/ 123, 'SUCCESS', establishContextResult);
     expectReportListReaders(
         /*requestId=*/ 124, ['Gemalto PC Twin Reader 00 00'], 'SUCCESS');
-    mockControl.$replayAll();
 
     launchPcscServer(
         /*initialDevices=*/[
@@ -377,7 +374,6 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
           'Dell Dell Smart Card Reader Keyboard 01 00'
         ],
         'SUCCESS');
-    mockControl.$replayAll();
 
     launchPcscServer(
         /*initialDevices=*/[
@@ -409,7 +405,6 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
           'atr': new ArrayBuffer(0)
         }],
         'SUCCESS');
-    mockControl.$replayAll();
 
     launchPcscServer(/*initialDevices=*/[]);
     createChromeApiProvider();
@@ -444,7 +439,6 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
           'atr': SimulationConstants.COSMO_ID_70_ATR
         }],
         'SUCCESS');
-    mockControl.$replayAll();
 
     launchPcscServer(/*initialDevices=*/[{
       'id': 123,
@@ -480,7 +474,6 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
           'atr': new ArrayBuffer(0)
         }],
         'SUCCESS');
-    mockControl.$replayAll();
 
     launchPcscServer(/*initialDevices=*/[{
       'id': 123,
@@ -516,7 +509,6 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
         /*requestId=*/ 123, 'SUCCESS', establishContextResult);
     expectReportGetStatusChange(
         /*requestId=*/ 124, [], 'TIMEOUT');
-    mockControl.$replayAll();
 
     launchPcscServer(/*initialDevices=*/[{
       'id': 123,
@@ -546,7 +538,6 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
         /*requestId=*/ 123, 'SUCCESS', establishContextResult);
     expectReportGetStatusChange(/*requestId=*/ 124, [], 'CANCELLED');
     expectReportPlainResult(/*requestId=*/ 125, 'SUCCESS');
-    mockControl.$replayAll();
 
     launchPcscServer(/*initialDevices=*/[
       {'id': 123, 'type': SimulationConstants.GEMALTO_DEVICE_TYPE}
@@ -590,7 +581,6 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
     expectReportConnectResult(
         /*requestId=*/ 124, chrome.smartCardProviderPrivate.Protocol.UNDEFINED,
         'NO_SMARTCARD');
-    mockControl.$replayAll();
 
     launchPcscServer(/*initialDevices=*/[
       {'id': 123, 'type': SimulationConstants.GEMALTO_DEVICE_TYPE}

--- a/smart_card_connector_app/src/chrome-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/chrome-api-jstocxxtest.js
@@ -128,7 +128,7 @@ async function assertRemainsPending(promise, timeoutMillis) {
  */
 function expectReportEstablishContext(requestId, resultCode, outResult) {
   mockChromeApi
-      .record('reportEstablishContextResult')(
+      .getFreshMock('reportEstablishContextResult')(
           requestId, goog.testing.mockmatchers.isNumber, resultCode)
       .$once()
       .$does((requestId, context, resultCode) => {
@@ -144,7 +144,8 @@ function expectReportEstablishContext(requestId, resultCode, outResult) {
  * @param {string} resultCode
  */
 function expectReportReleaseContext(requestId, resultCode) {
-  mockChromeApi.record('reportReleaseContextResult')(requestId, resultCode)
+  mockChromeApi
+      .getFreshMock('reportReleaseContextResult')(requestId, resultCode)
       .$once()
       .$replay();
 }
@@ -158,7 +159,7 @@ function expectReportReleaseContext(requestId, resultCode) {
  */
 function expectReportListReaders(requestId, readers, resultCode) {
   mockChromeApi
-      .record('reportListReadersResult')(requestId, readers, resultCode)
+      .getFreshMock('reportListReadersResult')(requestId, readers, resultCode)
       .$once()
       .$replay();
 }
@@ -172,7 +173,7 @@ function expectReportListReaders(requestId, readers, resultCode) {
  */
 function expectReportGetStatusChange(requestId, readerStates, resultCode) {
   mockChromeApi
-      .record('reportGetStatusChangeResult')(
+      .getFreshMock('reportGetStatusChangeResult')(
           requestId, readerStates, resultCode)
       .$once()
       .$replay();
@@ -185,7 +186,7 @@ function expectReportGetStatusChange(requestId, readerStates, resultCode) {
  * @param {string} resultCode
  */
 function expectReportPlainResult(requestId, resultCode) {
-  mockChromeApi.record('reportPlainResult')(requestId, resultCode)
+  mockChromeApi.getFreshMock('reportPlainResult')(requestId, resultCode)
       .$once()
       .$replay();
 }
@@ -199,7 +200,7 @@ function expectReportPlainResult(requestId, resultCode) {
  */
 function expectReportConnectResult(requestId, activeProtocol, resultCode) {
   mockChromeApi
-      .record('reportConnectResult')(
+      .getFreshMock('reportConnectResult')(
           requestId,
           /*scardHandle=*/ goog.testing.mockmatchers.isNumber, activeProtocol,
           resultCode)

--- a/smart_card_connector_app/src/chrome-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/chrome-api-jstocxxtest.js
@@ -119,6 +119,22 @@ async function assertRemainsPending(promise, timeoutMillis) {
 }
 
 /**
+ * Switches the mocked chrome.smartCardProviderPrivate function back
+ * to record mode.
+ * Verifies that there were no unmet expectations before switching.
+ * @param {string} functionName
+ * @returns {Function} Mocked function object.
+ */
+function getFreshMock(functionName) {
+  const mock = chrome.smartCardProviderPrivate[functionName];
+  assertEquals(
+      `No mocked function ${functionName} found`, 'function', typeof mock);
+  mock.$verify();
+  mock.$reset();
+  return mock;
+}
+
+/**
  * Sets expectation that reportEstablishContextResult will be called for given
  * `requestId` with result code equal to `resultCode`. Sets the received result
  * to `outResult`.
@@ -127,8 +143,7 @@ async function assertRemainsPending(promise, timeoutMillis) {
  * @param {!EstablishContextResult} outResult
  */
 function expectReportEstablishContext(requestId, resultCode, outResult) {
-  mockChromeApi
-      .getFreshMock('reportEstablishContextResult')(
+  getFreshMock('reportEstablishContextResult')(
           requestId, goog.testing.mockmatchers.isNumber, resultCode)
       .$once()
       .$does((requestId, context, resultCode) => {
@@ -144,8 +159,7 @@ function expectReportEstablishContext(requestId, resultCode, outResult) {
  * @param {string} resultCode
  */
 function expectReportReleaseContext(requestId, resultCode) {
-  mockChromeApi
-      .getFreshMock('reportReleaseContextResult')(requestId, resultCode)
+  getFreshMock('reportReleaseContextResult')(requestId, resultCode)
       .$once()
       .$replay();
 }
@@ -158,8 +172,7 @@ function expectReportReleaseContext(requestId, resultCode) {
  * @param {string} resultCode
  */
 function expectReportListReaders(requestId, readers, resultCode) {
-  mockChromeApi
-      .getFreshMock('reportListReadersResult')(requestId, readers, resultCode)
+  getFreshMock('reportListReadersResult')(requestId, readers, resultCode)
       .$once()
       .$replay();
 }
@@ -172,8 +185,7 @@ function expectReportListReaders(requestId, readers, resultCode) {
  * @param {string} resultCode
  */
 function expectReportGetStatusChange(requestId, readerStates, resultCode) {
-  mockChromeApi
-      .getFreshMock('reportGetStatusChangeResult')(
+  getFreshMock('reportGetStatusChangeResult')(
           requestId, readerStates, resultCode)
       .$once()
       .$replay();
@@ -186,7 +198,7 @@ function expectReportGetStatusChange(requestId, readerStates, resultCode) {
  * @param {string} resultCode
  */
 function expectReportPlainResult(requestId, resultCode) {
-  mockChromeApi.getFreshMock('reportPlainResult')(requestId, resultCode)
+  getFreshMock('reportPlainResult')(requestId, resultCode)
       .$once()
       .$replay();
 }
@@ -199,8 +211,7 @@ function expectReportPlainResult(requestId, resultCode) {
  * @param {string} resultCode
  */
 function expectReportConnectResult(requestId, activeProtocol, resultCode) {
-  mockChromeApi
-      .getFreshMock('reportConnectResult')(
+  getFreshMock('reportConnectResult')(
           requestId,
           /*scardHandle=*/ goog.testing.mockmatchers.isNumber, activeProtocol,
           resultCode)

--- a/smart_card_connector_app/src/mock-chrome-api.js
+++ b/smart_card_connector_app/src/mock-chrome-api.js
@@ -238,20 +238,5 @@ GSC.ConnectorApp.MockChromeApi = class {
         `Event to result function map does not have ${eventName}`);
     return chrome.smartCardProviderPrivate[EVENT_TO_RESULT_MAP[eventName]];
   }
-
-  /**
-   * Switches the mocked function back to record mode.
-   * Verifies that there were no unmet expectations before switching.
-   * @param {string} functionName
-   * @returns {Function} Mocked function object.
-   */
-  getFreshMock(functionName) {
-    const mock = chrome.smartCardProviderPrivate[functionName];
-    assertEquals(
-        `No mocked function ${functionName} found`, 'function', typeof mock);
-    mock.$verify();
-    mock.$reset();
-    return mock;
-  }
 };
 });

--- a/smart_card_connector_app/src/mock-chrome-api.js
+++ b/smart_card_connector_app/src/mock-chrome-api.js
@@ -245,7 +245,7 @@ GSC.ConnectorApp.MockChromeApi = class {
    * @param {string} functionName
    * @returns {Function} Mocked function object.
    */
-  record(functionName) {
+  getFreshMock(functionName) {
     const mock = chrome.smartCardProviderPrivate[functionName];
     assertEquals(
         `No mocked function ${functionName} found`, 'function', typeof mock);

--- a/smart_card_connector_app/src/mock-chrome-api.js
+++ b/smart_card_connector_app/src/mock-chrome-api.js
@@ -238,5 +238,20 @@ GSC.ConnectorApp.MockChromeApi = class {
         `Event to result function map does not have ${eventName}`);
     return chrome.smartCardProviderPrivate[EVENT_TO_RESULT_MAP[eventName]];
   }
+
+  /**
+   * Switches the mocked function back to record mode.
+   * Verifies that there were no unmet expectations before switching.
+   * @param {string} functionName
+   * @returns {Function} Mocked function object.
+   */
+  record(functionName) {
+    const mock = chrome.smartCardProviderPrivate[functionName];
+    assertEquals(
+        `No mocked function ${functionName} found`, 'function', typeof mock);
+    mock.$verify();
+    mock.$reset();
+    return mock;
+  }
 };
 });


### PR DESCRIPTION
Currently all expectations need to be set before any testing takes place, because there's no way to switch between replaying and recording mode in goog.testing framework. Because of that we couldn't factor out repeated pieces of code, such as establishing context, to a separate function.
This CLs adds `getFreshMock` method to allow refactoring in the follow-up CLs.