### PR TITLE
Skip setup-python for toolchains that don't need python

### DIFF
--- a/.github/actions/build-dependencies-installation/action.yml
+++ b/.github/actions/build-dependencies-installation/action.yml
@@ -25,6 +25,7 @@ runs:
       pkg-config
 
   - name: Set up Python 3
+    if: ${{ inputs.toolchain == 'emscripten' || inputs.toolchain == 'pnacl' }}
     uses: actions/setup-python@v3.1.2
     with:
       python-version: 3.9


### PR DESCRIPTION
This fixes #1014.