### PR TITLE
Update set-output to GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -194,9 +194,9 @@ jobs:
       run: >
         set -o pipefail &&
         (./coverage-report.sh | tee coverage-output.txt) &&
-        echo "::set-output name=LINE_COVERAGE_PERCENT::$(
+        echo "LINE_COVERAGE_PERCENT=$(
           scripts/parse-coverage-output.py < coverage-output.txt
-        )"
+        )" >> $GITHUB_OUTPUT
 
     - name: Upload coverage report
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
`set-output` is [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).