### PR TITLE
Choose latest Chromedriver per Chrome milestone

### DIFF
--- a/env/initialize.sh
+++ b/env/initialize.sh
@@ -214,7 +214,7 @@ initialize_chromedriver() {
   log_message "Installing chromedriver..."
   rm -rf ./chromedriver
   # Determine the currently installed version of Chrome, in the
-  # major-minor-build format, e.g., 72.0.3626. (# The program's output format is
+  # major-minor-build format, e.g., 72.0.3626. (The program's output format is
   # "Google Chrome 72.0.3626.0").
   local chrome_version=$(google-chrome --version | cut -f 3 -d ' ' |
     cut -d '.' -f 1-3)
@@ -236,7 +236,6 @@ initialize_chromedriver() {
     log_error_message "Failed to unpack chromedriver executable; skipping chromedriver installation..."
     return
   fi
-  rm -f latest-versions-per-milestone-with-downloads.json
   rm -f chromedriver-linux64.zip
   log_message "chromedriver ${chromedriver_version} was installed successfully."
 }

--- a/env/initialize.sh
+++ b/env/initialize.sh
@@ -213,23 +213,20 @@ initialize_chromedriver() {
   fi
   log_message "Installing chromedriver..."
   rm -rf ./chromedriver
-  # Determine the currently installed version of Chrome, e.g., "72".
-  # The program's output format is "Google Chrome 72.0.3626.0", of which we take
-  # the third space-separated token and grab its first dot-separated part.
-  local chrome_milestone=$(google-chrome --version | cut -f 3 -d ' ' |
-    cut -f 1 -d '.')
-  # Download Chromedriver's releases information.
-  local chromedriver_releases_url="https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone-with-downloads.json"
-  if ! wget "${chromedriver_releases_url}" ; then
-    log_error_message "Failed to fetch chromedriver releases at ${chromedriver_releases_url} ; skipping chromedriver installation..."
+  # Determine the currently installed version of Chrome, in the
+  # major-minor-build format, e.g., 72.0.3626. (# The program's output format is
+  # "Google Chrome 72.0.3626.0").
+  local chrome_version=$(google-chrome --version | cut -f 3 -d ' ' |
+    cut -d '.' -f 1-3)
+  # Obtain the matching Chromedriver version.
+  local chromedriver_version_url="https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_${chrome_version}"
+  local chromedriver_version
+  if ! chromedriver_version=$(curl --fail --silent "${chromedriver_version_url}") ; then
+    log_error_message "Failed to fetch chromedriver version at ${chromedriver_version_url} ; skipping chromedriver installation..."
     return
   fi
-  # Parse the JSON to get the needed milestone's Chromedriver download URL.
-  local chromedriver_url=$(jq -r ".milestones[] | \
-    select(.milestone == \"${chrome_milestone}\") | .downloads | \
-    .chromedriver[] | select(.platform == \"linux64\") | .url" \
-    latest-versions-per-milestone-with-downloads.json)
   # Download Chromedriver.
+  local chromedriver_url="https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${chromedriver_version}/linux64/chromedriver-linux64.zip"
   if ! wget "${chromedriver_url}" ; then
     log_error_message "Failed to fetch chromedriver at ${chromedriver_url} ; skipping chromedriver installation..."
     return
@@ -241,7 +238,7 @@ initialize_chromedriver() {
   fi
   rm -f latest-versions-per-milestone-with-downloads.json
   rm -f chromedriver-linux64.zip
-  log_message "chromedriver ${chrome_milestone} was installed successfully."
+  log_message "chromedriver ${chromedriver_version} was installed successfully."
 }
 
 create_activate_script() {

--- a/env/initialize.sh
+++ b/env/initialize.sh
@@ -213,12 +213,23 @@ initialize_chromedriver() {
   fi
   log_message "Installing chromedriver..."
   rm -rf ./chromedriver
-  # Determine the currently installed version of Chrome. Leave only the numbers,
-  # e.g., 72.0.3626.0.
-  local chrome_version=$(google-chrome --version | cut -f 3 -d ' ')
-  # Download Chromedriver. As of now, the maintainers guarantee that there's a
-  # matching Chromedriver artifact for every publicly released Chrome version.
-  local chromedriver_url="https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${chrome_version}/linux64/chromedriver-linux64.zip"
+  # Determine the currently installed version of Chrome, e.g., "72".
+  # The program's output format is "Google Chrome 72.0.3626.0", of which we take
+  # the third space-separated token and grab its first dot-separated part.
+  local chrome_milestone=$(google-chrome --version | cut -f 3 -d ' ' |
+    cut -f 1 -d '.')
+  # Download Chromedriver's releases information.
+  local chromedriver_releases_url="https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone-with-downloads.json"
+  if ! wget "${chromedriver_releases_url}" ; then
+    log_error_message "Failed to fetch chromedriver releases at ${chromedriver_releases_url} ; skipping chromedriver installation..."
+    return
+  fi
+  # Parse the JSON to get the needed milestone's Chromedriver download URL.
+  local chromedriver_url=$(jq -r ".milestones[] | \
+    select(.milestone == \"${chrome_milestone}\") | .downloads | \
+    .chromedriver[] | select(.platform == \"linux64\") | .url" \
+    latest-versions-per-milestone-with-downloads.json)
+  # Download Chromedriver.
   if ! wget "${chromedriver_url}" ; then
     log_error_message "Failed to fetch chromedriver at ${chromedriver_url} ; skipping chromedriver installation..."
     return
@@ -228,8 +239,9 @@ initialize_chromedriver() {
     log_error_message "Failed to unpack chromedriver executable; skipping chromedriver installation..."
     return
   fi
-  rm -rf chromedriver-linux64.zip
-  log_message "chromedriver ${chrome_version} was installed successfully."
+  rm -f latest-versions-per-milestone-with-downloads.json
+  rm -f chromedriver-linux64.zip
+  log_message "chromedriver ${chrome_milestone} was installed successfully."
 }
 
 create_activate_script() {


### PR DESCRIPTION
As in practice it's not guaranteed that every public Chrome release gets a corresponding Chromedriver release with the exact same version, we change env/initialize.sh to fetch using just milestone instead.

This is a different attempt to fix #1009. It's also a partial revert of #834 (as Chromedriver maintainers seem to have revived the convenient LATEST_RELEASE_ URLs).