### PR TITLE
[style] format-code in Python, supports --base

### DIFF
--- a/format-code.sh
+++ b/format-code.sh
@@ -14,24 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script formats the modified C++/JS files via clang-format according to
-# the Chromium Style Guides.
-# Only files that are known to Git and belong to the diff of the "main" branch
-# are considered.
-#
-# Note: Sorting of C/C++ #include's is currently disabled, since the standard
-# algorithm reorders them incorrectly (e.g., it puts includes within our project
-# into the same group as C system headers).
-
 set -eu
 
-# Go to the root directory of the repository.
-cd $(dirname $(realpath ${0}))
+>&2 echo "WARNING: The script has been moved. Use scripts/format-code.py instead."
 
-# Find all relevant files to be checked. Bail out if nothing is found.
-FILES=$(scripts/internal/find-files-for-linting.py "*.cc" "*.h" "*.js")
-[ "${FILES}" ] || exit 0
-
-# Run clang-format on every found file.
-echo "${FILES}" | \
-  xargs clang-format -i --style=Chromium --sort-includes=false
+$(dirname $(realpath ${0}))/scripts/format-code.py

--- a/scripts/format-code.py
+++ b/scripts/format-code.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+# Copyright 2023 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runs clang-format on all relevant C++/JavaScript files in the repository."""
+
+import argparse
+import os.path
+import subprocess
+import sys
+
+FILE_MASKS = ['*.cc', '*.h', '*.js']
+FORMAT_OPTIONS = [
+  '--style=Chromium',
+  # TODO(emaxx): Consider reenabling this, now that we don't use <> includes for
+  # the headers maintained in this project.
+  '--sort-includes=false',
+]
+
+def parse_command_line_args():
+  parser = argparse.ArgumentParser(
+      description='Runs clang-format on C++/JS files in the repository.')
+  parser.add_argument(
+      '--base', type=str, default='main',
+      help='Git ref to diff against, or "none" if the whole repository is to '
+           'be reformatted (default: %(default)s)')
+  return parser.parse_args()
+
+def get_file_paths(args):
+  command = [os.path.join(os.path.dirname(__file__),
+                          'internal/find-files-for-linting.py'),
+             '--base', args.base] + FILE_MASKS
+  return [line.strip().decode() for line
+          in subprocess.check_output(command).splitlines()]
+
+def run_clang_format(path, args):
+  command = ['clang-format', '-i'] + FORMAT_OPTIONS + [path]
+  return subprocess.call(command) == 0
+
+def main():
+  args = parse_command_line_args()
+  paths = get_file_paths(args)
+  return 0 if all([run_clang_format(path, args) for path in paths]) else 1
+
+if __name__ == '__main__':
+  sys.exit(main())


### PR DESCRIPTION
Rewrite the format-code Shell script into Python, and make it support "--base=..." argument.

The refactoring is for better maintainability, and the "--base" arg allows reformatting the whole repository instead of the current diff.