### PR TITLE
[JS-to-C++ test] Fix flaky USB transfer exception

### DIFF
--- a/smart_card_connector_app/src/testing_smart_card_simulation.cc
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.cc
@@ -1024,8 +1024,10 @@ void TestingSmartCardSimulation::ThreadSafeHandler::NotifySlotChange(
   // Resolve the interrupt transfer with a RDR_to_PC_NotifySlotChange message.
   std::vector<uint8_t> transfer_result = MakeNotifySlotChangeTransferReply(
       device_state.icc_status, /*slot0_changed=*/true);
-  result_callback(GenericRequestResult::CreateSuccessful(
-      Value(std::move(transfer_result))));
+  Value result_value =
+      ArrayValueBuilder().Add(std::move(transfer_result)).Get();
+  result_callback(
+      GenericRequestResult::CreateSuccessful(std::move(result_value)));
 }
 
 }  // namespace google_smart_card


### PR DESCRIPTION
One code path in TestingSmartCardSimulation - the USB interrupt transfer that's intended to notify about card insertions/removals - was returning values of incorrect format, causing assertion failures down the stack.

Presumably this never caused observable test failures, since the tests happened to coincide with the CCID driver's internal task timing (which would mean the interrupt transfers are undertested as of now).