### PR TITLE
[JS-to-C++ test] Boilerplate for //common/js tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ LIBRARY_TARGETS += \
 	example_js_standalone_smart_card_client_library \
 
 TEST_TARGETS += \
+	common/js/build/js_to_cxx_tests \
 	common/js/build/unittests \
 	example_cpp_smart_card_client_app/build/js_to_cxx_tests \
 	smart_card_connector_app/build/js_to_cxx_tests \
@@ -122,6 +123,8 @@ TEST_TARGETS += \
 	third_party/libusb/webport/build/js_unittests \
 	third_party/pcsc-lite/naclport/server_clients_management/build/js_unittests \
 
+common/js/build/js_to_cxx_tests: common/cpp/build
+common/js/build/js_to_cxx_tests: common/integration_testing/build
 example_cpp_smart_card_client_app/build/js_to_cxx_tests: common/cpp/build
 example_cpp_smart_card_client_app/build/js_to_cxx_tests: common/integration_testing/build
 example_cpp_smart_card_client_app/build/js_to_cxx_tests: example_cpp_smart_card_client_app/build

--- a/common/integration_testing/include.mk
+++ b/common/integration_testing/include.mk
@@ -17,8 +17,9 @@
 # cases, meanwhile the C++ side provides neccessary helpers and/or exercised
 # code.
 #
-# /common/make/common.mk and /common/make/executable_building.mk must be
-# included before including this file.
+# /common/make/common.mk, common/make/js_building_common.mk and
+# /common/make/executable_building.mk must be included before including this
+# file.
 
 # Common documentation for definitions provided by this file (they are
 # implemented in toolchain-specific .mk files, but share the same interface):

--- a/common/js/build/js_to_cxx_tests/.gitignore
+++ b/common/js/build/js_to_cxx_tests/.gitignore
@@ -1,0 +1,5 @@
+/js_build/
+/out/
+/out-artifacts-emscripten/
+/pnacl/
+/user-data-dir/

--- a/common/js/build/js_to_cxx_tests/Makefile
+++ b/common/js/build/js_to_cxx_tests/Makefile
@@ -17,11 +17,8 @@
 TARGET := integration_tests
 
 include ../../../../common/make/common.mk
-
-include $(ROOT_PATH)/common/make/js_building_common.mk
 include $(ROOT_PATH)/common/make/executable_building.mk
 include $(ROOT_PATH)/common/cpp/include.mk
-include $(ROOT_PATH)/common/js/include.mk
 include $(ROOT_PATH)/common/integration_testing/include.mk
 
 

--- a/common/js/build/js_to_cxx_tests/Makefile
+++ b/common/js/build/js_to_cxx_tests/Makefile
@@ -19,6 +19,7 @@ TARGET := integration_tests
 include ../../../../common/make/common.mk
 include $(ROOT_PATH)/common/make/executable_building.mk
 include $(ROOT_PATH)/common/cpp/include.mk
+include $(ROOT_PATH)/common/make/js_building_common.mk
 include $(ROOT_PATH)/common/integration_testing/include.mk
 
 

--- a/common/js/build/js_to_cxx_tests/Makefile
+++ b/common/js/build/js_to_cxx_tests/Makefile
@@ -1,0 +1,53 @@
+# Copyright 2023 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Makefile for JavaScript-to-C++ integration tests for the //common/js/ code.
+
+TARGET := integration_tests
+
+include ../../../../common/make/common.mk
+
+include $(ROOT_PATH)/common/make/js_building_common.mk
+include $(ROOT_PATH)/common/make/executable_building.mk
+include $(ROOT_PATH)/common/cpp/include.mk
+include $(ROOT_PATH)/common/js/include.mk
+include $(ROOT_PATH)/common/integration_testing/include.mk
+
+
+CXX_SOURCES := \
+
+CXXFLAGS := \
+  -I$(ROOT_PATH) \
+  -Wall \
+  -Werror \
+  -Wextra \
+  -pedantic \
+  -std=$(CXX_DIALECT) \
+
+LIBS := \
+  google_smart_card_common \
+
+# Include *-jstocxxtest.js and non-test files needed for them.
+#
+# Note: unit test files are compiled and executed differently, via
+# //common/js/build/unittests/.
+JS_SOURCES_PATHS := \
+  $(ROOT_PATH)/common/js/src \
+  !$(ROOT_PATH)/common/js/src/**-unittest.js \
+
+# Target that compiles C++ files.
+$(foreach src,$(CXX_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
+
+# Targets that build the resulting executable module and JS tests.
+$(eval $(call BUILD_JS_TO_CXX_TEST,$(CXX_SOURCES),$(LIBS),$(JS_SOURCES_PATHS)))

--- a/common/js/build/unittests/Makefile
+++ b/common/js/build/unittests/Makefile
@@ -22,7 +22,12 @@ include $(COMMON_DIR_PATH)/make/js_building_common.mk
 include $(COMMON_DIR_PATH)/js/include.mk
 
 
+# Include *-unittest.js and non-test files needed for them.
+#
+# Note: "jstocxxtest" files are compiled and executed differently, via
+# //common/js/build/js_to_cxx_tests/.
 JS_COMPILER_INPUT_PATHS := \
-	$(JS_COMMON_SOURCES_PATH)
+	$(ROOT_PATH)/common/js/src \
+	!$(ROOT_PATH)/common/js/src/**-jstocxxtest.js \
 
 $(eval $(call BUILD_JS_UNITTESTS,$(JS_COMPILER_INPUT_PATHS)))

--- a/common/js/include.mk
+++ b/common/js/include.mk
@@ -30,7 +30,7 @@ JS_COMMON_SOURCES_PATH := $(JS_COMMON_DIR_PATH)/src
 # compiling the code using this library.
 JS_COMMON_JS_COMPILER_INPUT_DIR_PATHS := \
 	$(JS_COMMON_SOURCES_PATH) \
-	!$(JS_COMMON_SOURCES_PATH)/**-unittest.js \
+	!$(JS_COMMON_SOURCES_PATH)/**test.js \
 
 
 

--- a/common/js/src/executable-module/executable-module-jstocxxtest.js
+++ b/common/js/src/executable-module/executable-module-jstocxxtest.js
@@ -48,8 +48,6 @@ goog.exportSymbol('testExecutableModule', {
     }
   },
 
-  'testSmoke': function() {
-  },
+  'testSmoke': function() {},
 });
-
 });

--- a/common/js/src/executable-module/executable-module-jstocxxtest.js
+++ b/common/js/src/executable-module/executable-module-jstocxxtest.js
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2023 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview This file contains tests for the executable module wrapper.
+ */
+
+goog.require('GoogleSmartCard.ExecutableModule');
+goog.require('GoogleSmartCard.IntegrationTestController');
+goog.require('goog.testing.jsunit');
+
+goog.setTestOnly();
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+/** @type {GSC.IntegrationTestController?} */
+let testController;
+
+// TODO(emaxx): This test currently does nothing. Add real assertions.
+goog.exportSymbol('testExecutableModule', {
+  'setUp': async function() {
+    // Set up the controller and load the C/C++ executable module.
+    testController = new GSC.IntegrationTestController();
+    await testController.initAsync();
+  },
+
+  'tearDown': async function() {
+    try {
+      await testController.disposeAsync();
+    } finally {
+      testController = null;
+    }
+  },
+
+  'testSmoke': function() {
+  },
+});
+
+});


### PR DESCRIPTION
Add build target for //common/js/build/js_to_cxx_tests/, so that we can write tests for this common JS and C++ code.

This is preparation for implementing a regression test for #823.