### PR TITLE
[ci] Reduce apt/git log spam, uprev github actions

### DIFF
--- a/.github/actions/build-dependencies-installation/action.yml
+++ b/.github/actions/build-dependencies-installation/action.yml
@@ -11,10 +11,14 @@ runs:
   # stalled, causing 404 errors when trying to install packages later.
   - name: Apt update
     shell: bash
+    env:
+      DEBIAN_FRONTEND: noninteractive
     run: sudo apt-get update
 
   - name: Install dependencies
     shell: bash
+    env:
+      DEBIAN_FRONTEND: noninteractive
     run: >
       sudo apt-get install -y
       autoconf
@@ -25,7 +29,7 @@ runs:
       pkg-config
 
   - name: Set up Python 3
-    uses: actions/setup-python@v3.1.2
+    uses: actions/setup-python@v4
     with:
       python-version: 3.9
 
@@ -39,6 +43,8 @@ runs:
   - name: Install LLVM toolchain
     if: ${{ inputs.toolchain == 'asan_testing' || inputs.toolchain == 'coverage' }}
     shell: bash
+    env:
+      DEBIAN_FRONTEND: noninteractive
     run: >
       sudo apt-get install -y
       build-essential

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -27,7 +27,9 @@ jobs:
 
     steps:
     - name: Check out sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+        show-progress: false
 
     - name: Install build dependencies
       uses: ./.github/actions/build-dependencies-installation
@@ -78,7 +80,9 @@ jobs:
 
     steps:
     - name: Check out sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+        show-progress: false
 
     - name: Install build dependencies
       uses: ./.github/actions/build-dependencies-installation
@@ -110,7 +114,9 @@ jobs:
 
     steps:
     - name: Check out sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+        show-progress: false
 
     - name: Install build dependencies
       uses: ./.github/actions/build-dependencies-installation
@@ -144,8 +150,9 @@ jobs:
     # Check out with additionally pulling the parent commit. (In case of Pull
     # Requests, it's pointing to the base branch's head.)
     - name: Check out sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
+        show-progress: false
         fetch-depth: 2
 
     - name: Install dependencies
@@ -176,7 +183,9 @@ jobs:
     timeout-minutes: 60
     steps:
     - name: Check out sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+        show-progress: false
 
     - name: Install build dependencies
       uses: ./.github/actions/build-dependencies-installation
@@ -218,7 +227,7 @@ jobs:
     steps:
     - name: Comment on pull request
       if: github.event.pull_request
-      uses: peter-evans/create-or-update-comment@v2
+      uses: peter-evans/create-or-update-comment@v3
       with:
         issue-number: ${{ github.event.pull_request.number }}
         body: |


### PR DESCRIPTION
* Specify DEBIAN_FRONTEND=noninteractive to suppress spammy progress updates with percents.
* Use actions/checkout v4's "show-progress: false" to suppress spammy git progress updates.
* Bump actions/setup-python to v4, which fixes the "The `set-output` command is deprecated" warning.
* Bump peter-evans/create-or-update-comment to v3 just because.