### PR TITLE
[wasm] Force-kill threads and workers on disposal

### DIFF
--- a/common/js/src/executable-module/emscripten-module-js-epilog.js.inc
+++ b/common/js/src/executable-module/emscripten-module-js-epilog.js.inc
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2023 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview This file contains code that gets injected into Emscripten's
+ * output (via --post-js).
+ */
+
+// Alias `Module.PThread.terminateAllThreads()` to
+// `pthread_terminateAllThreads()`, as the former gets renamed in Release
+// builds.
+Module['pthread_terminateAllThreads'] = Module['PThread'].terminateAllThreads;

--- a/common/js/src/executable-module/emscripten-module.js
+++ b/common/js/src/executable-module/emscripten-module.js
@@ -117,9 +117,12 @@ GSC.EmscriptenModule = class extends GSC.ExecutableModule {
       delete this.googleSmartCardModule_;
     }
     if (this.emscriptenApiModule_) {
-      // Force-shutdown threads and worker pools that Emscripten may have
-      // reserved.
-      this.emscriptenApiModule_['PThread']['terminateAllThreads']();
+      // Terminate threads and worker pools that Emscripten may have reserved.
+      // Note that the "pthread_terminateAllThreads" property is created by the
+      // code injected from emscripten-module-js-epilog.js.inc and is just an
+      // alias to `Module.PThread.terminateAllThreads()`. The alias is needed to
+      // work around renamings that happen in the Release mode.
+      this.emscriptenApiModule_['pthread_terminateAllThreads']();
       delete this.emscriptenApiModule_;
     }
     this.messageChannel_.dispose();

--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -113,6 +113,7 @@ EMSCRIPTEN_COMPILER_FLAGS := \
 #   the "Pthreads + ALLOW_MEMORY_GROWTH" combination.
 EMSCRIPTEN_LINKER_FLAGS := \
   --bind \
+  --post-js=$(ROOT_PATH)/common/js/src/executable-module/emscripten-module-js-epilog.js.inc \
   -s ABORTING_MALLOC=1 \
   -s ALLOW_MEMORY_GROWTH=1 \
   -s DYNAMIC_EXECUTION=0 \


### PR DESCRIPTION
Disposing of EmscriptenModule forcibly terminates all Emscripten threads and workers.

This is to avoid resource usage beyond the point when the module should've been logically disposed of. In particular, this should fix flaky OOM failures in the js_to_cxx tests that we run in succession now.