### PR TITLE
[js style] Add eslint-plugin-no-floating-promise

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,6 +2,8 @@ env:
   browser: true
   es2020: true
 extends: eslint:recommended
+plugins:
+  - no-floating-promise
 rules:
   # Disabled as the linter doesn't understand Closure Compiler style imports
   # ("goog.require") and Closure Library's global symbols.
@@ -55,6 +57,7 @@ rules:
   semi-spacing: error
   semi-style: error
   semi: error
+  no-floating-promise/no-floating-promise: error
 overrides:
   # Parse specific files as ES Modules (the standard parser would fail).
   - files:

--- a/env/initialize.sh
+++ b/env/initialize.sh
@@ -202,7 +202,7 @@ initialize_eslint() {
     log_message "eslint already present, skipping."
     return
   fi
-  npm install eslint
+  npm install eslint eslint-plugin-no-floating-promise
   log_message "eslint was installed successfully."
 }
 

--- a/scripts/eslint.py
+++ b/scripts/eslint.py
@@ -39,9 +39,9 @@ def get_file_paths(args):
           in subprocess.check_output(command).splitlines()]
 
 def run_linter(path, args):
-  command = ['npm', 'exec', '--prefix',
-             os.path.join(os.path.dirname(__file__), '../env/'), 'eslint', '--',
-             path]
+  env_path = os.path.join(os.path.dirname(__file__), '../env/')
+  command = ['npm', 'exec', '--prefix', env_path, 'eslint', '--', path,
+             '--resolve-plugins-relative-to', env_path]
   if args.fix:
     command += ['--fix']
   return subprocess.call(command) == 0

--- a/smart_card_connector_app/src/chrome-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/chrome-api-jstocxxtest.js
@@ -280,13 +280,13 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
   },
 
   'testSmoke': async function() {
-    launchPcscServer(/*initialDevices=*/[]);
+    await launchPcscServer(/*initialDevices=*/[]);
     await pcscReadinessTracker.promise;
   },
 
   // Test a single `onEstablishContextRequested` event.
   'testEstablishContext': async function() {
-    launchPcscServer(/*initialDevices=*/[]);
+    await launchPcscServer(/*initialDevices=*/[]);
     await establishContext(/*requestId=*/ 123);
   },
 
@@ -294,7 +294,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
   'testReleaseContext': async function() {
     expectReportReleaseContext(/*requestId=*/ 124, 'SUCCESS');
 
-    launchPcscServer(/*initialDevices=*/[]);
+    await launchPcscServer(/*initialDevices=*/[]);
     const sCardContext = await establishContext(/*requestId=*/ 123);
     await mockChromeApi
         .dispatchEvent(
@@ -307,7 +307,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
     const BAD_CONTEXT = 123;
     expectReportReleaseContext(/*requestId=*/ 42, 'INVALID_HANDLE');
 
-    launchPcscServer(/*initialDevices=*/[]);
+    await launchPcscServer(/*initialDevices=*/[]);
     await mockChromeApi
         .dispatchEvent(
             'onReleaseContextRequested', /*requestId=*/ 42, BAD_CONTEXT)
@@ -318,7 +318,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
   'testListReaders_none': async function() {
     expectReportListReaders(/*requestId=*/ 124, [], 'NO_READERS_AVAILABLE');
 
-    launchPcscServer(/*initialDevices=*/[]);
+    await launchPcscServer(/*initialDevices=*/[]);
     const sCardContext = await establishContext(/*requestId=*/ 123);
     await mockChromeApi
         .dispatchEvent(
@@ -332,7 +332,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
     expectReportReleaseContext(/*requestId=*/ 124, 'SUCCESS');
     expectReportListReaders(/*requestId=*/ 125, [], 'INVALID_HANDLE');
 
-    launchPcscServer(/*initialDevices=*/[]);
+    await launchPcscServer(/*initialDevices=*/[]);
     const sCardContext = await establishContext(/*requestId=*/ 123);
     await mockChromeApi
         .dispatchEvent(
@@ -350,7 +350,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
     expectReportListReaders(
         /*requestId=*/ 124, ['Gemalto PC Twin Reader 00 00'], 'SUCCESS');
 
-    launchPcscServer(
+    await launchPcscServer(
         /*initialDevices=*/[
           {'id': 123, 'type': SimulationConstants.GEMALTO_DEVICE_TYPE}
         ]);
@@ -372,7 +372,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
         ],
         'SUCCESS');
 
-    launchPcscServer(
+    await launchPcscServer(
         /*initialDevices=*/[
           {'id': 101, 'type': SimulationConstants.GEMALTO_DEVICE_TYPE},
           {'id': 102, 'type': SimulationConstants.DELL_DEVICE_TYPE}
@@ -396,7 +396,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
         }],
         'SUCCESS');
 
-    launchPcscServer(/*initialDevices=*/[]);
+    await launchPcscServer(/*initialDevices=*/[]);
     const sCardContext = await establishContext(/*requestId=*/ 123);
     const verifyResult =
         mockChromeApi
@@ -408,7 +408,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
                   'currentCount': 0
                 }])
             .$waitAndVerify();
-    setSimulatedDevices(
+    await setSimulatedDevices(
         [{'id': 123, 'type': SimulationConstants.GEMALTO_DEVICE_TYPE}]);
     await verifyResult;
   },
@@ -424,7 +424,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
         }],
         'SUCCESS');
 
-    launchPcscServer(/*initialDevices=*/[{
+    await launchPcscServer(/*initialDevices=*/[{
       'id': 123,
       'type': SimulationConstants.GEMALTO_DEVICE_TYPE,
       'cardType': SimulationConstants.COSMO_CARD_TYPE
@@ -453,7 +453,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
         }],
         'SUCCESS');
 
-    launchPcscServer(/*initialDevices=*/[{
+    await launchPcscServer(/*initialDevices=*/[{
       'id': 123,
       'type': SimulationConstants.GEMALTO_DEVICE_TYPE,
       'cardType': SimulationConstants.COSMO_CARD_TYPE
@@ -471,7 +471,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
                 }])
             .$waitAndVerify();
     // Simulate the card removal.
-    setSimulatedDevices(
+    await setSimulatedDevices(
         [{'id': 123, 'type': SimulationConstants.GEMALTO_DEVICE_TYPE}]);
     await verifyResult;
   },
@@ -482,7 +482,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
     expectReportGetStatusChange(
         /*requestId=*/ 124, [], 'TIMEOUT');
 
-    launchPcscServer(/*initialDevices=*/[{
+    await launchPcscServer(/*initialDevices=*/[{
       'id': 123,
       'type': SimulationConstants.GEMALTO_DEVICE_TYPE,
       'cardType': SimulationConstants.COSMO_CARD_TYPE
@@ -504,7 +504,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
     expectReportGetStatusChange(/*requestId=*/ 124, [], 'CANCELLED');
     expectReportPlainResult(/*requestId=*/ 125, 'SUCCESS');
 
-    launchPcscServer(/*initialDevices=*/[
+    await launchPcscServer(/*initialDevices=*/[
       {'id': 123, 'type': SimulationConstants.GEMALTO_DEVICE_TYPE}
     ]);
     const sCardContext = await establishContext(/*requestId=*/ 123);
@@ -538,7 +538,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
         /*requestId=*/ 124, chrome.smartCardProviderPrivate.Protocol.UNDEFINED,
         'NO_SMARTCARD');
 
-    launchPcscServer(/*initialDevices=*/[
+    await launchPcscServer(/*initialDevices=*/[
       {'id': 123, 'type': SimulationConstants.GEMALTO_DEVICE_TYPE}
     ]);
     const sCardContext = await establishContext(/*requestId=*/ 123);
@@ -554,7 +554,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
   // Test Connect succeeds with `ShareMode.DIRECT` even when there's no card
   // inserted.
   'testConnect_direct': async function() {
-    launchPcscServer(/*initialDevices=*/[
+    await launchPcscServer(/*initialDevices=*/[
       {'id': 123, 'type': SimulationConstants.GEMALTO_DEVICE_TYPE}
     ]);
     const sCardContext = await establishContext(/*requestId=*/ 123);
@@ -572,7 +572,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
 
   // Test Connect successfully connects to a card using the "T1" protocol.
   'testConnect_t1': async function() {
-    launchPcscServer(/*initialDevices=*/[{
+    await launchPcscServer(/*initialDevices=*/[{
       'id': 123,
       'type': SimulationConstants.GEMALTO_DEVICE_TYPE,
       'cardType': SimulationConstants.COSMO_CARD_TYPE
@@ -592,7 +592,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
 
   // Test Disconnect succeeds with correct handle.
   'testDisconnect_simple': async function() {
-    launchPcscServer(/*initialDevices=*/[{
+    await launchPcscServer(/*initialDevices=*/[{
       'id': 123,
       'type': SimulationConstants.GEMALTO_DEVICE_TYPE,
       'cardType': SimulationConstants.COSMO_CARD_TYPE
@@ -614,7 +614,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
 
   // Test Disconnect fails with invalid handle.
   'testDisconnect_invalid': async function() {
-    launchPcscServer(/*initialDevices=*/[{
+    await launchPcscServer(/*initialDevices=*/[{
       'id': 123,
       'type': SimulationConstants.GEMALTO_DEVICE_TYPE,
       'cardType': SimulationConstants.COSMO_CARD_TYPE

--- a/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
@@ -248,7 +248,7 @@ goog.exportSymbol('testPcscApi', {
 
   // Test that the PC/SC server can successfully start up.
   'testStartup': async function() {
-    launchPcscServer(/*initialDevices=*/[]);
+    await launchPcscServer(/*initialDevices=*/[]);
     await pcscReadinessTracker.promise;
   },
 
@@ -500,7 +500,7 @@ goog.exportSymbol('testPcscApi', {
           context, API.INFINITE,
           [new API.SCARD_READERSTATE_IN(
               PNP_NOTIFICATION, API.SCARD_STATE_UNAWARE)]);
-      setSimulatedDevices(
+      await setSimulatedDevices(
           [{'id': 123, 'type': SimulationConstants.GEMALTO_DEVICE_TYPE}]);
       const result = await resultPromise;
 
@@ -536,7 +536,7 @@ goog.exportSymbol('testPcscApi', {
           [new API.SCARD_READERSTATE_IN(
               SimulationConstants.GEMALTO_PC_TWIN_READER_PCSC_NAME0,
               API.SCARD_STATE_EMPTY)]);
-      setSimulatedDevices([]);
+      await setSimulatedDevices([]);
       const result = await resultPromise;
 
       let readerStates = null;
@@ -622,7 +622,7 @@ goog.exportSymbol('testPcscApi', {
               SimulationConstants.GEMALTO_PC_TWIN_READER_PCSC_NAME0,
               API.SCARD_STATE_EMPTY)]);
       // Simulate card insertion.
-      setSimulatedDevices([{
+      await setSimulatedDevices([{
         'id': 123,
         'type': SimulationConstants.GEMALTO_DEVICE_TYPE,
         'cardType': SimulationConstants.COSMO_CARD_TYPE
@@ -668,7 +668,7 @@ goog.exportSymbol('testPcscApi', {
               SimulationConstants.GEMALTO_PC_TWIN_READER_PCSC_NAME0,
               API.SCARD_STATE_PRESENT)]);
       // Simulate the card removal.
-      setSimulatedDevices(
+      await setSimulatedDevices(
           [{'id': 123, 'type': SimulationConstants.GEMALTO_DEVICE_TYPE}]);
       const result = await resultPromise;
 
@@ -1039,7 +1039,7 @@ goog.exportSymbol('testPcscApi', {
   // Test that the PC/SC server can shut down successfully when there's an
   // active client.
   'testShutdownWithActiveClient': async function() {
-    launchPcscServer(/*initialDevices=*/[]);
+    await launchPcscServer(/*initialDevices=*/[]);
     createFakeClient();
     await pcscReadinessTracker.promise;
     // Intentionally don't dispose the client.
@@ -1049,7 +1049,7 @@ goog.exportSymbol('testPcscApi', {
   // This verifies any lazily created internal state doesn't cause problems.
   'testShutdownWithActiveClientAfterApiCall': async function() {
     const BAD_CONTEXT = 123;
-    launchPcscServer(/*initialDevices=*/[]);
+    await launchPcscServer(/*initialDevices=*/[]);
     const localClient = createFakeClient();
     await localClient.api.SCardIsValidContext(BAD_CONTEXT);
     // Intentionally don't dispose the client.


### PR DESCRIPTION
Install and enable ESLint's "no-floating-promise" plugin, to prevent future bugs when an async function is forgotten to be awaited.

Also add a few awaits to silence the warnings, although in these places "await" wasn't strictly necessary.