### PR TITLE
[js style] Rename fns to debugDump{Full,Sanitized}

### DIFF
--- a/common/js/src/executable-module/emscripten-module.js
+++ b/common/js/src/executable-module/emscripten-module.js
@@ -283,7 +283,7 @@ class EmscriptenModuleMessageChannel extends goog.messaging.AbstractChannel {
     if (!typedMessage) {
       GSC.Logging.fail(
           'Failed to parse message received from Emscripten module: ' +
-          GSC.DebugDump.debugDump(message));
+          GSC.DebugDump.debugDumpSanitized(message));
     }
     this.deliver(typedMessage.type, typedMessage.data);
   }

--- a/common/js/src/executable-module/nacl-module-messaging-channel.js
+++ b/common/js/src/executable-module/nacl-module-messaging-channel.js
@@ -81,7 +81,8 @@ GSC.NaclModuleMessageChannel = class extends goog.messaging.AbstractChannel {
       return;
     goog.log.log(
         this.logger_, goog.log.Level.FINEST,
-        'Sending message to NaCl module: ' + GSC.DebugDump.debugDump(message));
+        'Sending message to NaCl module: ' +
+            GSC.DebugDump.debugDumpSanitized(message));
     this.naclModuleElement_['postMessage'](message);
   }
 
@@ -105,13 +106,13 @@ GSC.NaclModuleMessageChannel = class extends goog.messaging.AbstractChannel {
       GSC.Logging.failWithLogger(
           this.logger_,
           'Failed to parse message received from NaCl module: ' +
-              GSC.DebugDump.debugDump(messageData));
+              GSC.DebugDump.debugDumpSanitized(messageData));
     }
 
     goog.log.log(
         this.logger_, goog.log.Level.FINEST,
         'Received a message from NaCl module: ' +
-            GSC.DebugDump.debugDump(messageData));
+            GSC.DebugDump.debugDumpSanitized(messageData));
     this.deliver(typedMessage.type, typedMessage.data);
   }
 
@@ -120,7 +121,8 @@ GSC.NaclModuleMessageChannel = class extends goog.messaging.AbstractChannel {
     GSC.Logging.failWithLogger(
         this.logger_,
         'Unhandled message received from NaCl module: serviceName="' +
-            serviceName + '", payload=' + GSC.DebugDump.debugDump(payload));
+            serviceName +
+            '", payload=' + GSC.DebugDump.debugDumpSanitized(payload));
   }
 };
 });  // goog.scope

--- a/common/js/src/logging/debug-dump-unittest.js
+++ b/common/js/src/logging/debug-dump-unittest.js
@@ -25,129 +25,138 @@ goog.scope(function() {
 
 const GSC = GoogleSmartCard;
 
-const dump = GSC.DebugDump.dump;
+const debugDumpFull = GSC.DebugDump.debugDumpFull;
 
 goog.exportSymbol('testDebugDump', function() {
-  assertEquals('undefined', dump(undefined));
+  assertEquals('undefined', debugDumpFull(undefined));
 
-  assertEquals('null', dump(null));
+  assertEquals('null', debugDumpFull(null));
 
-  assertEquals('false', dump(false));
-  assertEquals('true', dump(true));
+  assertEquals('false', debugDumpFull(false));
+  assertEquals('true', debugDumpFull(true));
 
-  assertEquals('0x00', dump(0));
-  assertEquals('0xFE', dump(254));
-  assertEquals('0x00000100', dump(256));
-  assertEquals('0xFFFFFFFF', dump(Math.pow(2, 32) - 1));
-  assertEquals('0x0000000100000000', dump(Math.pow(2, 32)));
-  assertEquals('0x4000000000000000', dump(Math.pow(2, 62)));
-  assertEquals('0xFF', dump(-1));
-  assertEquals('0x80000000', dump(-Math.pow(2, 31)));
-  assertEquals('1.5', dump(1.5));
+  assertEquals('0x00', debugDumpFull(0));
+  assertEquals('0xFE', debugDumpFull(254));
+  assertEquals('0x00000100', debugDumpFull(256));
+  assertEquals('0xFFFFFFFF', debugDumpFull(Math.pow(2, 32) - 1));
+  assertEquals('0x0000000100000000', debugDumpFull(Math.pow(2, 32)));
+  assertEquals('0x4000000000000000', debugDumpFull(Math.pow(2, 62)));
+  assertEquals('0xFF', debugDumpFull(-1));
+  assertEquals('0x80000000', debugDumpFull(-Math.pow(2, 31)));
+  assertEquals('1.5', debugDumpFull(1.5));
 
-  assertEquals('"foo bar"', dump('foo bar'));
+  assertEquals('"foo bar"', debugDumpFull('foo bar'));
 
-  assertEquals('[0x01, "foo", [0x02, 0x03], []]', dump([1, 'foo', [2, 3], []]));
+  assertEquals(
+      '[0x01, "foo", [0x02, 0x03], []]', debugDumpFull([1, 'foo', [2, 3], []]));
 
-  assertEquals('ArrayBuffer[]', dump(new ArrayBuffer(0)));
-  assertEquals('ArrayBuffer[0x01FF]', dump(new Uint8Array([1, 255]).buffer));
+  assertEquals('ArrayBuffer[]', debugDumpFull(new ArrayBuffer(0)));
+  assertEquals(
+      'ArrayBuffer[0x01FF]', debugDumpFull(new Uint8Array([1, 255]).buffer));
 
   assertEquals(
       'Map{0x01: 0x02, 0x03: "foo", "bar": {}, {}: 0x04}',
-      dump(new Map([[1, 2], [3, 'foo'], ['bar', {}], [{}, 4]])));
+      debugDumpFull(new Map([[1, 2], [3, 'foo'], ['bar', {}], [{}, 4]])));
 
-  assertEquals('Set{0x01, 0x02}', dump(new Set([1, 2])));
+  assertEquals('Set{0x01, 0x02}', debugDumpFull(new Set([1, 2])));
 
-  assertEquals('{}', dump({}));
-  assertEquals('{"a": "b", "c": [0x01, "d"]}', dump({'a': 'b', 'c': [1, 'd']}));
+  assertEquals('{}', debugDumpFull({}));
+  assertEquals(
+      '{"a": "b", "c": [0x01, "d"]}', debugDumpFull({'a': 'b', 'c': [1, 'd']}));
 
-  assertEquals('<Function>', dump(function() {}));
+  assertEquals('<Function>', debugDumpFull(function() {}));
 
-  assertEquals('<Document>', dump(document));
-  assertEquals('<Window>', dump(window));
-  assertEquals('<Node>', dump(document.body));
-  assertEquals('<NodeList>', dump(document.body.childNodes));
-  assertEquals('<HTMLCollection>', dump(document.body.children));
+  assertEquals('<Document>', debugDumpFull(document));
+  assertEquals('<Window>', debugDumpFull(window));
+  assertEquals('<Node>', debugDumpFull(document.body));
+  assertEquals('<NodeList>', debugDumpFull(document.body.childNodes));
+  assertEquals('<HTMLCollection>', debugDumpFull(document.body.children));
 });
 
 goog.exportSymbol('testDebugDumpTypedArray', function() {
-  assertEquals('Uint8Array[]', dump(new Uint8Array(0)));
-  assertEquals('Uint8Array[0x01FF]', dump(new Uint8Array([1, 255])));
-  assertEquals('Uint16Array[]', dump(new Uint16Array(0)));
+  assertEquals('Uint8Array[]', debugDumpFull(new Uint8Array(0)));
+  assertEquals('Uint8Array[0x01FF]', debugDumpFull(new Uint8Array([1, 255])));
+  assertEquals('Uint16Array[]', debugDumpFull(new Uint16Array(0)));
   assertEquals(
-      'Uint16Array[0x01, 0x0000FFFF]', dump(new Uint16Array([1, 65535])));
-  assertEquals('Float32Array[]', dump(new Float32Array([])));
-  assertEquals('Float32Array[0.5, 2.5]', dump(new Float32Array([0.5, 2.5])));
+      'Uint16Array[0x01, 0x0000FFFF]',
+      debugDumpFull(new Uint16Array([1, 65535])));
+  assertEquals('Float32Array[]', debugDumpFull(new Float32Array([])));
+  assertEquals(
+      'Float32Array[0.5, 2.5]', debugDumpFull(new Float32Array([0.5, 2.5])));
 });
 
 goog.exportSymbol('testDebugDumpDataView', function() {
   const emptyBuffer = new ArrayBuffer(0);
-  assertEquals('DataView[]', dump(new DataView(emptyBuffer)));
+  assertEquals('DataView[]', debugDumpFull(new DataView(emptyBuffer)));
 
   const buffer = (new Uint8Array([1, 16, 255])).buffer;
-  assertEquals('DataView[0x0110FF]', dump(new DataView(buffer)));
+  assertEquals('DataView[0x0110FF]', debugDumpFull(new DataView(buffer)));
   assertEquals(
-      'DataView[0x10FF]', dump(new DataView(buffer, /*byteOffset=*/ 1)));
+      'DataView[0x10FF]',
+      debugDumpFull(new DataView(buffer, /*byteOffset=*/ 1)));
   assertEquals(
       'DataView[0x10]',
-      dump(new DataView(buffer, /*byteOffset=*/ 1, /*byteLength=*/ 1)));
+      debugDumpFull(
+          new DataView(buffer, /*byteOffset=*/ 1, /*byteLength=*/ 1)));
   assertEquals(
       'DataView[]',
-      dump(new DataView(buffer, /*byteOffset=*/ 1, /*byteLength=*/ 0)));
+      debugDumpFull(
+          new DataView(buffer, /*byteOffset=*/ 1, /*byteLength=*/ 0)));
 });
 
-// Test the `dump()` method against container types with circular references: it
-// should detect the loops and avoid infinite recursion.
+// Test the `debugDumpFull()` method against container types with circular
+// references: it should detect the loops and avoid infinite recursion.
 goog.exportSymbol('testDebugDumpWithCircularRefs', function() {
   const circularInsideArray = [];
   circularInsideArray.push(circularInsideArray);
-  assertEquals('[<circular>]', dump(circularInsideArray));
+  assertEquals('[<circular>]', debugDumpFull(circularInsideArray));
 
   const circularInObject = {'a': 'b'};
   circularInObject['c'] = circularInObject;
-  assertEquals('{"a": "b", "c": <circular>}', dump(circularInObject));
+  assertEquals('{"a": "b", "c": <circular>}', debugDumpFull(circularInObject));
 
   const circularInMap = new Map();
   circularInMap.set('a', 'b');
   circularInMap.set('c', circularInMap);
-  assertEquals('Map{"a": "b", "c": <circular>}', dump(circularInMap));
+  assertEquals('Map{"a": "b", "c": <circular>}', debugDumpFull(circularInMap));
 
   const circularInSet = new Set();
   circularInSet.add('foo');
   circularInSet.add(circularInSet);
-  assertEquals('Set{"foo", <circular>}', dump(circularInSet));
+  assertEquals('Set{"foo", <circular>}', debugDumpFull(circularInSet));
 
   const nestedCircular = {};
   nestedCircular['foo'] = {'bar': nestedCircular};
-  assertEquals('{"foo": {"bar": <circular>}}', dump(nestedCircular));
+  assertEquals('{"foo": {"bar": <circular>}}', debugDumpFull(nestedCircular));
 });
 
-// Test that the `dump()` method correctly handles the case when an object is
-// linked from two different places: it shouldn't be confused with a circular
-// reference.
+// Test that the `debugDumpFull()` method correctly handles the case when an
+// object is linked from two different places: it shouldn't be confused with a
+// circular reference.
 goog.exportSymbol('testDebugDumpWithDuplicateRefs', function() {
   const object = {'a': 'b'};
   const arrayWithDuplicates = [object, object];
-  assertEquals('[{"a": "b"}, {"a": "b"}]', dump(arrayWithDuplicates));
+  assertEquals('[{"a": "b"}, {"a": "b"}]', debugDumpFull(arrayWithDuplicates));
 
   const array = [];
   const objectWithDuplicates = {'foo': array, 'foobar': array};
-  assertEquals('{"foo": [], "foobar": []}', dump(objectWithDuplicates));
+  assertEquals(
+      '{"foo": [], "foobar": []}', debugDumpFull(objectWithDuplicates));
 
   const diamond = {'x': {'a': array}, 'y': {'b': array}};
-  assertEquals('{"x": {"a": []}, "y": {"b": []}}', dump(diamond));
+  assertEquals('{"x": {"a": []}, "y": {"b": []}}', debugDumpFull(diamond));
 });
 
-// Test that calling `dump()` with the `chrome` object (the object that holds
-// all Apps/Extensions APIs) returns a short string instead of recursively
+// Test that calling `debugDumpFull()` with the `chrome` object (the object that
+// holds all Apps/Extensions APIs) returns a short string instead of recursively
 // dumping all its properties.
 // Skip this test when not running inside Chrome (otherwise we'd need to mock
 // global objects, which isn't reliable due to Closure Compiler optimizations).
 if (goog.global['chrome']) {
   goog.exportSymbol('testDebugDumpChrome', function() {
     const chrome = goog.global['chrome'];
-    assertEquals('<chrome>', dump(chrome));
-    assertEquals('[0x01, <chrome>]', dump([1, chrome]));
+    assertEquals('<chrome>', debugDumpFull(chrome));
+    assertEquals('[0x01, <chrome>]', debugDumpFull([1, chrome]));
   });
 }
 });  // goog.scope

--- a/common/js/src/logging/debug-dump.js
+++ b/common/js/src/logging/debug-dump.js
@@ -349,11 +349,12 @@ function dump(value, recursionParentObjects) {
  * Generates a debug textual representation of the passed value.
  *
  * Note that in the cases when the passed value may contain privacy-sensitive
- * data, the GoogleSmartCard.DebugDump.debugDump method should be used instead.
+ * data, the GoogleSmartCard.DebugDump.debugDumpSanitized method should be used
+ * instead.
  * @param {?} value
  * @return {string}
  */
-GSC.DebugDump.dump = function(value) {
+GSC.DebugDump.debugDumpFull = function(value) {
   const recursionParentObjects = new WeakSet();
   if (goog.DEBUG) {
     return dump(value, recursionParentObjects);
@@ -375,9 +376,9 @@ GSC.DebugDump.dump = function(value) {
  * @param {*} value
  * @return {string}
  */
-GSC.DebugDump.debugDump = function(value) {
+GSC.DebugDump.debugDumpSanitized = function(value) {
   if (goog.DEBUG)
-    return GSC.DebugDump.dump(value);
+    return GSC.DebugDump.debugDumpFull(value);
   else
     return '<stripped value>';
 };

--- a/common/js/src/messaging/common.js
+++ b/common/js/src/messaging/common.js
@@ -53,7 +53,7 @@ function nonFatalDefaultServiceCallback(channel, serviceName, payload) {
   goog.log.warning(
       LOGGER,
       'Unhandled message received: serviceName="' + serviceName +
-          '", payload=' + GSC.DebugDump.debugDump(payload));
+          '", payload=' + GSC.DebugDump.debugDumpSanitized(payload));
   channel.dispose();
 }
 

--- a/common/js/src/messaging/port-message-channel.js
+++ b/common/js/src/messaging/port-message-channel.js
@@ -114,7 +114,7 @@ GSC.PortMessageChannel = class extends goog.messaging.AbstractChannel {
     const message = typedMessage.makeMessage();
     goog.log.log(
         this.logger, goog.log.Level.FINEST,
-        'Posting a message: ' + GSC.DebugDump.debugDump(message));
+        'Posting a message: ' + GSC.DebugDump.debugDumpSanitized(message));
 
     if (this.isDisposed()) {
       GSC.Logging.failWithLogger(
@@ -172,14 +172,14 @@ GSC.PortMessageChannel = class extends goog.messaging.AbstractChannel {
   messageEventHandler_(message) {
     goog.log.log(
         this.logger, goog.log.Level.FINEST,
-        'Received a message: ' + GSC.DebugDump.debugDump(message));
+        'Received a message: ' + GSC.DebugDump.debugDumpSanitized(message));
 
     const typedMessage = GSC.TypedMessage.parseTypedMessage(message);
     if (!typedMessage) {
       GSC.Logging.failWithLogger(
           this.logger,
           'Failed to parse the received message: ' +
-              GSC.DebugDump.debugDump(message));
+              GSC.DebugDump.debugDumpSanitized(message));
     }
 
     this.deliver(typedMessage.type, typedMessage.data);
@@ -194,7 +194,7 @@ GSC.PortMessageChannel = class extends goog.messaging.AbstractChannel {
     GSC.Logging.failWithLogger(
         this.logger,
         'Unhandled message received: serviceName="' + serviceName +
-            '", payload=' + GSC.DebugDump.debugDump(payload));
+            '", payload=' + GSC.DebugDump.debugDumpSanitized(payload));
   }
 };
 });  // goog.scope

--- a/common/js/src/messaging/single-message-based-channel.js
+++ b/common/js/src/messaging/single-message-based-channel.js
@@ -103,7 +103,7 @@ GSC.SingleMessageBasedChannel = class extends goog.messaging.AbstractChannel {
     const message = typedMessage.makeMessage();
     goog.log.log(
         this.logger, goog.log.Level.FINEST,
-        'Posting a message: ' + GSC.DebugDump.debugDump(message));
+        'Posting a message: ' + GSC.DebugDump.debugDumpSanitized(message));
 
     if (this.isDisposed()) {
       GSC.Logging.failWithLogger(
@@ -121,14 +121,14 @@ GSC.SingleMessageBasedChannel = class extends goog.messaging.AbstractChannel {
   deliverMessage(message) {
     goog.log.log(
         this.logger, goog.log.Level.FINEST,
-        'Received a message: ' + GSC.DebugDump.debugDump(message));
+        'Received a message: ' + GSC.DebugDump.debugDumpSanitized(message));
 
     const typedMessage = GSC.TypedMessage.parseTypedMessage(message);
     if (!typedMessage) {
       GSC.Logging.failWithLogger(
           this.logger,
           'Failed to parse the received message: ' +
-              GSC.DebugDump.debugDump(message));
+              GSC.DebugDump.debugDumpSanitized(message));
     }
 
     this.deliver(typedMessage.type, typedMessage.data);
@@ -158,7 +158,7 @@ GSC.SingleMessageBasedChannel = class extends goog.messaging.AbstractChannel {
     GSC.Logging.failWithLogger(
         this.logger,
         'Unhandled message received: serviceName="' + serviceName +
-            '", payload=' + GSC.DebugDump.debugDump(payload));
+            '", payload=' + GSC.DebugDump.debugDumpSanitized(payload));
   }
 
   /** @private */

--- a/common/js/src/object-helpers.js
+++ b/common/js/src/object-helpers.js
@@ -45,7 +45,7 @@ GSC.ObjectHelpers.extractKey = function(object, key) {
     GSC.Logging.failWithLogger(
         LOGGER,
         'Key "' + key + '" not present in object ' +
-            GSC.DebugDump.debugDump(object));
+            GSC.DebugDump.debugDumpSanitized(object));
   }
 
   return object[key];

--- a/common/js/src/popup-window/in-popup-main-script.js
+++ b/common/js/src/popup-window/in-popup-main-script.js
@@ -79,7 +79,7 @@ GSC.InPopupMainScript.resolveModalDialog = function(result) {
   goog.log.fine(
       logger,
       'The modal dialog is resolved with the following result: ' +
-          GSC.DebugDump.debugDump(result));
+          GSC.DebugDump.debugDumpSanitized(result));
 
   if (GSC.Packaging.MODE === GSC.Packaging.Mode.APP) {
     const callback = popUpData['resolveModalDialog'];

--- a/common/js/src/popup-window/popup-opener.js
+++ b/common/js/src/popup-window/popup-opener.js
@@ -86,8 +86,8 @@ GSC.PopupOpener.createWindow = function(url, windowOptions, opt_data) {
   goog.log.fine(
       logger,
       'Creating a popup window with url="' + url +
-          '", options=' + GSC.DebugDump.debugDump(windowOptions) +
-          ', data=' + GSC.DebugDump.debugDump(opt_data));
+          '", options=' + GSC.DebugDump.debugDumpSanitized(windowOptions) +
+          ', data=' + GSC.DebugDump.debugDumpSanitized(opt_data));
 
   /** @preserveTry */
   try {
@@ -118,7 +118,8 @@ GSC.PopupOpener.createWindow = function(url, windowOptions, opt_data) {
     GSC.Logging.failWithLogger(
         logger,
         'Failed to create the popup window with URL "' + url + '" and ' +
-            'options ' + GSC.DebugDump.debugDump(windowOptions) + ': ' + exc);
+            'options ' + GSC.DebugDump.debugDumpSanitized(windowOptions) +
+            ': ' + exc);
   }
 };
 
@@ -187,7 +188,7 @@ function createWindowCallback(createdWindowExtends, createdWindow) {
       logger, goog.log.Level.FINER,
       'The popup window callback is executed, injecting the following data ' +
           'into the created window: ' +
-          GSC.DebugDump.debugDump(createdWindowExtends));
+          GSC.DebugDump.debugDumpSanitized(createdWindowExtends));
   Object.assign(createdWindowScope, createdWindowExtends);
 }
 });  // goog.scope

--- a/common/js/src/requesting/remote-call-message.js
+++ b/common/js/src/requesting/remote-call-message.js
@@ -76,7 +76,8 @@ GSC.RemoteCallMessage = class {
     return goog.string.subs(
         '%s(%s)', this.functionName,
         goog.iter.join(
-            goog.iter.map(this.functionArguments, GSC.DebugDump.debugDump),
+            goog.iter.map(
+                this.functionArguments, GSC.DebugDump.debugDumpSanitized),
             ', '));
   }
 };

--- a/common/js/src/requesting/request-receiver.js
+++ b/common/js/src/requesting/request-receiver.js
@@ -109,7 +109,7 @@ GSC.RequestReceiver = class {
     GSC.Logging.checkWithLogger(this.logger, goog.isObject(messageData));
     goog.asserts.assertObject(messageData);
 
-    const debugDump = GSC.DebugDump.debugDump(messageData);
+    const debugDump = GSC.DebugDump.debugDumpSanitized(messageData);
 
     const requestMessageData = RequestMessageData.parseMessageData(messageData);
     if (requestMessageData === null) {
@@ -152,7 +152,7 @@ GSC.RequestReceiver = class {
       return;
     }
 
-    const debugDump = GSC.DebugDump.debugDump(payload);
+    const debugDump = GSC.DebugDump.debugDumpSanitized(payload);
     goog.log.fine(
         this.logger,
         `Sending result for requestId ${requestMessageData.requestId}: ` +

--- a/common/js/src/requesting/requester.js
+++ b/common/js/src/requesting/requester.js
@@ -107,7 +107,7 @@ GSC.Requester = class extends goog.Disposable {
     goog.log.fine(
         this.logger,
         'Starting a request with identifier ' + requestId +
-            ', the payload is: ' + GSC.DebugDump.debugDump(payload));
+            ', the payload is: ' + GSC.DebugDump.debugDumpSanitized(payload));
 
     const promiseResolver = goog.Promise.withResolver();
 
@@ -190,7 +190,7 @@ GSC.Requester = class extends goog.Disposable {
       GSC.Logging.failWithLogger(
           this.logger,
           'Failed to parse the received response message: ' +
-              GSC.DebugDump.debugDump(messageData));
+              GSC.DebugDump.debugDumpSanitized(messageData));
     }
     const requestId = responseMessageData.requestId;
 
@@ -216,7 +216,7 @@ GSC.Requester = class extends goog.Disposable {
     goog.log.fine(
         this.logger,
         'The request with identifier ' + requestId + ' succeeded with the ' +
-            'following result: ' + GSC.DebugDump.debugDump(payload));
+            'following result: ' + GSC.DebugDump.debugDumpSanitized(payload));
     this.popRequestPromiseResolver_(requestId).resolve(payload);
   }
 

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
@@ -251,7 +251,7 @@ Backend.prototype.handleRequest_ = function(payload) {
     GSC.Logging.failWithLogger(
         this.logger,
         'Failed to parse the remote call message: ' +
-            GSC.DebugDump.debugDump(payload));
+            GSC.DebugDump.debugDumpSanitized(payload));
   }
 
   const debugRepresentation = 'chrome.certificateProvider.' +
@@ -410,7 +410,8 @@ Backend.prototype.processCertificatesUpdateRequest_ = function(request) {
         goog.log.info(
             this.logger,
             'Setting the certificate list with ' + certificates.length +
-                ' certificates: ' + GSC.DebugDump.debugDump(certificates));
+                ' certificates: ' +
+                GSC.DebugDump.debugDumpSanitized(certificates));
         chrome.certificateProvider.setCertificates({
           certificatesRequestId: request.certificatesRequestId,
           clientCertificates: certificates
@@ -437,8 +438,9 @@ Backend.prototype.processSignatureRequest_ = function(request) {
       this.logger,
       'Started handling signature request. The request contents are: ' +
           'algorithm is "' + request.algorithm + '", input is ' +
-          GSC.DebugDump.debugDump(request.input) + ', certificate is ' +
-          GSC.DebugDump.debugDump(request.certificate));
+          GSC.DebugDump.debugDumpSanitized(request.input) +
+          ', certificate is ' +
+          GSC.DebugDump.debugDumpSanitized(request.certificate));
   /** @type {!ExecutableModuleSignatureRequest} */
   const executableRequest = {
     signRequestId: request.signRequestId,
@@ -458,7 +460,7 @@ Backend.prototype.processSignatureRequest_ = function(request) {
         goog.log.info(
             this.logger,
             'Responding to the signature request with the created signature: ' +
-                GSC.DebugDump.debugDump(signature));
+                GSC.DebugDump.debugDumpSanitized(signature));
         chrome.certificateProvider.reportSignature(
             {signRequestId: request.signRequestId, signature: signature});
       },
@@ -492,8 +494,8 @@ Backend.prototype.processCertificatesRequest_ = function(reportCallback) {
         goog.log.info(
             this.logger,
             'Responding to the certificates request with ' +
-                certificates.length +
-                ' certificates: ' + GSC.DebugDump.debugDump(certificates));
+                certificates.length + ' certificates: ' +
+                GSC.DebugDump.debugDumpSanitized(certificates));
         reportCallback(
             certificates, this.rejectedCertificatesCallback_.bind(this));
       },
@@ -517,8 +519,9 @@ Backend.prototype.processSignDigestRequest_ = function(
       this.logger,
       'Started handling digest signing request. The request contents are: ' +
           'hash is "' + request.hash + '", digest is ' +
-          GSC.DebugDump.debugDump(request.digest) + ', certificate is ' +
-          GSC.DebugDump.debugDump(request.certificate));
+          GSC.DebugDump.debugDumpSanitized(request.digest) +
+          ', certificate is ' +
+          GSC.DebugDump.debugDumpSanitized(request.certificate));
   /** @type {!ExecutableModuleSignatureRequest} */
   const executableRequest = {
     signRequestId: request.signRequestId,
@@ -538,7 +541,7 @@ Backend.prototype.processSignDigestRequest_ = function(
         goog.log.info(
             this.logger,
             'Responding to the digest sign request with the created ' +
-                'signature: ' + GSC.DebugDump.debugDump(signature));
+                'signature: ' + GSC.DebugDump.debugDumpSanitized(signature));
         reportCallback(signature);
       },
       function() {
@@ -561,7 +564,8 @@ Backend.prototype.rejectedCertificatesCallback_ = function(
   goog.log.warning(
       this.logger,
       'chrome.certificateProvider API rejected ' + rejectedCertificates.length +
-          ' certificates: ' + GSC.DebugDump.debugDump(rejectedCertificates));
+          ' certificates: ' +
+          GSC.DebugDump.debugDumpSanitized(rejectedCertificates));
 };
 
 /**

--- a/smart_card_connector_app/src/chrome-api-provider.js
+++ b/smart_card_connector_app/src/chrome-api-provider.js
@@ -374,7 +374,7 @@ function getArrayDebugRepresentation(arr) {
     if ((!goog.DEBUG) && (value instanceof ArrayBuffer)) {
       return '<stripped value>';
     }
-    return GSC.DebugDump.dump(value);
+    return GSC.DebugDump.debugDumpFull(value);
   }), ', ');
 }
 

--- a/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
@@ -49,7 +49,7 @@ const ClientHandler = GSC.PcscLiteServerClientsManagement.ClientHandler;
 const ReadinessTracker = GSC.PcscLiteServerClientsManagement.ReadinessTracker;
 const API = GSC.PcscLiteClient.API;
 const SimulationConstants = GSC.TestingLibusbSmartCardSimulationConstants;
-const dump = GSC.DebugDump.dump;
+const debugDumpFull = GSC.DebugDump.debugDumpFull;
 
 const PCSC_REQUEST_MESSAGE_TYPE = GSC.RequesterMessage.getRequestMessageType(
     GSC.PcscLiteCommon.Constants.REQUESTER_TITLE);
@@ -216,7 +216,8 @@ function readerStateEquals(a, b) {
  * @param {!API.SCARD_READERSTATE_OUT} b
  */
 function assertReaderStateEquals(a, b) {
-  assertTrue(`${dump(a)} != ${dump(b)}`, readerStateEquals(a, b));
+  assertTrue(
+      `${debugDumpFull(a)} != ${debugDumpFull(b)}`, readerStateEquals(a, b));
 }
 
 goog.exportSymbol('testPcscApi', {
@@ -565,8 +566,8 @@ goog.exportSymbol('testPcscApi', {
           /*eventState=*/ API.SCARD_STATE_CHANGED | API.SCARD_STATE_UNAVAILABLE,
           /*atr=*/ new ArrayBuffer(0));
       assertTrue(
-          `${dump(readerState)} equals neither ${dump(expected1)} nor ${
-              dump(expected2)}`,
+          `${debugDumpFull(readerState)} equals neither ${
+              debugDumpFull(expected1)} nor ${debugDumpFull(expected2)}`,
           readerStateEquals(readerState, expected1) ||
               readerStateEquals(readerState, expected2));
 

--- a/smart_card_connector_app/src/window-apps-displaying.js
+++ b/smart_card_connector_app/src/window-apps-displaying.js
@@ -92,7 +92,8 @@ function onUpdateListener(clientOriginList) {
   goog.log.fine(
       logger,
       'Application list updated, refreshing the view. ' +
-          'New list of origins: ' + GSC.DebugDump.dump(sortedClientOriginList));
+          'New list of origins: ' +
+          GSC.DebugDump.debugDumpFull(sortedClientOriginList));
 
   const trustedClientInfosPromise =
       trustedClientsRegistry.tryGetByOrigins(sortedClientOriginList);

--- a/smart_card_connector_app/src/window-devices-displaying.js
+++ b/smart_card_connector_app/src/window-devices-displaying.js
@@ -119,7 +119,7 @@ function displayReaderList(readers) {
   goog.log.info(
       logger,
       'Displaying ' + readers.length +
-          ' card reader(s): ' + GSC.DebugDump.dump(readers));
+          ' card reader(s): ' + GSC.DebugDump.debugDumpFull(readers));
   goog.dom.removeChildren(readersListElement);
 
   for (const reader of readers) {

--- a/third_party/libusb/webport/src/libusb-proxy-receiver.js
+++ b/third_party/libusb/webport/src/libusb-proxy-receiver.js
@@ -37,7 +37,7 @@ goog.scope(function() {
 const EXECUTABLE_MODULE_REQUESTER_NAME = 'libusb';
 
 const GSC = GoogleSmartCard;
-const debugDump = GSC.DebugDump.debugDump;
+const debugDumpSanitized = GSC.DebugDump.debugDumpSanitized;
 
 const logger = GSC.Logging.getScopedLogger('LibusbProxyReceiver');
 
@@ -96,7 +96,8 @@ GSC.LibusbProxyReceiver = class {
     if (!remoteCallMessage) {
       GSC.Logging.failWithLogger(
           logger,
-          'Failed to parse the remote call message: ' + debugDump(payload));
+          'Failed to parse the remote call message: ' +
+              debugDumpSanitized(payload));
     }
     goog.log.fine(
         logger,

--- a/third_party/libusb/webport/src/libusb-to-webusb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-webusb-adaptor.js
@@ -45,8 +45,8 @@ const LibusbJsTransferRecipient =
 const LibusbJsTransferRequestType =
     GSC.LibusbProxyDataModel.LibusbJsTransferRequestType;
 const LibusbJsTransferResult = GSC.LibusbProxyDataModel.LibusbJsTransferResult;
-const debugDump = GSC.DebugDump.debugDump;
-const dump = GSC.DebugDump.dump;
+const debugDumpSanitized = GSC.DebugDump.debugDumpSanitized;
+const debugDumpFull = GSC.DebugDump.debugDumpFull;
 
 const logger = GSC.Logging.getScopedLogger('LibusbToWebusbAdaptor');
 /**
@@ -402,7 +402,7 @@ async function callWebusbGetDevices() {
   goog.log.fine(logger, 'getDevices(): called');
   try {
     const devices = await navigator['usb']['getDevices']();
-    goog.log.fine(logger, `getDevices(): returned ${dump(devices)}`);
+    goog.log.fine(logger, `getDevices(): returned ${debugDumpFull(devices)}`);
     return devices;
   } catch (exc) {
     // This is the only WebUSB function whose failure we're logging at warning
@@ -418,8 +418,8 @@ async function callWebusbGetDevices() {
  * @return {string}
  */
 function dumpWebusbDeviceForLog(webusbDevice) {
-  const vendorString = dump(webusbDevice['vendorId']);
-  const productString = dump(webusbDevice['productId']);
+  const vendorString = debugDumpFull(webusbDevice['vendorId']);
+  const productString = debugDumpFull(webusbDevice['productId']);
   return `<vendor=${vendorString} product=${productString}>`;
 }
 
@@ -471,7 +471,7 @@ async function callWebusbDeviceClaimInterface(webusbDevice, interfaceNumber) {
   const functionLogTitle =
       `${dumpWebusbDeviceForLog(webusbDevice)}.claimInterface`;
   goog.log.info(
-      logger, `${functionLogTitle}(${dump(interfaceNumber)}): called`);
+      logger, `${functionLogTitle}(${debugDumpFull(interfaceNumber)}): called`);
   try {
     await webusbDevice['claimInterface'](interfaceNumber);
     goog.log.info(logger, `${functionLogTitle}(): succeeded`);
@@ -490,7 +490,7 @@ async function callWebusbDeviceReleaseInterface(webusbDevice, interfaceNumber) {
   const functionLogTitle =
       `${dumpWebusbDeviceForLog(webusbDevice)}.releaseInterface`;
   goog.log.info(
-      logger, `${functionLogTitle}(${dump(interfaceNumber)}): called`);
+      logger, `${functionLogTitle}(${debugDumpFull(interfaceNumber)}): called`);
   try {
     await webusbDevice['releaseInterface'](interfaceNumber);
     goog.log.info(logger, `${functionLogTitle}(): succeeded`);
@@ -521,10 +521,10 @@ async function callWebusbDeviceReset(webusbDevice) {
  * @return {string}
  */
 function dumpWebusbInTransferResultForLog(inTransferResult) {
-  // The data is passed through `debugDump()`, since we shouldn't log
+  // The data is passed through `debugDumpSanitized()`, since we shouldn't log
   // (potentially) security/privacy sensitive data in Release mode.
   return `status=${inTransferResult['status']} data=${
-      debugDump(inTransferResult['data'])}`;
+      debugDumpSanitized(inTransferResult['data'])}`;
 }
 
 /**
@@ -551,7 +551,8 @@ async function callWebusbDeviceControlTransferIn(webusbDevice, setup, length) {
       `${dumpWebusbDeviceForLog(webusbDevice)}.controlTransferIn#${
           transferLogNumber}`;
   goog.log.info(
-      logger, `${functionLogTitle}(${dump(setup)}, ${length}): called`);
+      logger,
+      `${functionLogTitle}(${debugDumpFull(setup)}, ${length}): called`);
   try {
     const transferResult =
         await webusbDevice['controlTransferIn'](setup, length);
@@ -578,11 +579,12 @@ async function callWebusbDeviceControlTransferOut(webusbDevice, setup, data) {
   const functionLogTitle =
       `${dumpWebusbDeviceForLog(webusbDevice)}.controlTransferOut#${
           transferLogNumber}`;
-  // Pass the data through `debugDump()`, so that this potentially
+  // Pass the data through `debugDumpSanitized()`, so that this potentially
   // security/privacy sensitive information isn't logged in Release mode.
   goog.log.info(
       logger,
-      `${functionLogTitle}(${dump(setup)}, ${debugDump(data)}): called`);
+      `${functionLogTitle}(${debugDumpFull(setup)}, ${
+          debugDumpSanitized(data)}): called`);
   try {
     const transferResult =
         await webusbDevice['controlTransferOut'](setup, data);
@@ -611,7 +613,8 @@ async function callWebusbDeviceTransferIn(
       `${dumpWebusbDeviceForLog(webusbDevice)}.transferIn#${transferLogNumber}`;
   goog.log.info(
       logger,
-      `${functionLogTitle}(${dump(endpointNumber)}, ${length}): called`);
+      `${functionLogTitle}(${debugDumpFull(endpointNumber)}, ${
+          length}): called`);
   try {
     const transferResult =
         await webusbDevice['transferIn'](endpointNumber, length);
@@ -637,12 +640,12 @@ async function callWebusbDeviceTransferOut(webusbDevice, endpointNumber, data) {
   ++transferLogCounter;
   const functionLogTitle = `${
       dumpWebusbDeviceForLog(webusbDevice)}.transferOut#${transferLogNumber}`;
-  // Pass the data through `debugDump()`, so that this potentially
+  // Pass the data through `debugDumpSanitized()`, so that this potentially
   // security/privacy sensitive information isn't logged in Release mode.
   goog.log.info(
       logger,
-      `${functionLogTitle}(${dump(endpointNumber)}, ${
-          debugDump(data)}): called`);
+      `${functionLogTitle}(${debugDumpFull(endpointNumber)}, ${
+          debugDumpSanitized(data)}): called`);
   try {
     const transferResult =
         await webusbDevice['transferOut'](endpointNumber, data);

--- a/third_party/pcsc-lite/naclport/cpp_client/src/nacl-client-backend.js
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/nacl-client-backend.js
@@ -144,7 +144,7 @@ GSC.PcscLiteClient.NaclClientBackend = class {
       GSC.Logging.failWithLogger(
           logger,
           'Failed to parse the remote call message: ' +
-              GSC.DebugDump.debugDump(payload));
+              GSC.DebugDump.debugDumpSanitized(payload));
     }
 
     goog.log.fine(

--- a/third_party/pcsc-lite/naclport/js_client/src/api.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/api.js
@@ -2194,18 +2194,19 @@ goog.exportProperty(
  */
 API.ResultOrErrorCode.prototype.getDebugRepresentation = function() {
   if (this.errorCode == API.SCARD_S_SUCCESS) {
-    // Apply debugDump() to all result values except the error code, since they
-    // can contain sensitive information in them (like the contents of the
-    // digital signature). The debugDump() function dumps the values only when
-    // goog.DEBUG is true, and otherwise shows only the number of values.
+    // Apply debugDumpSanitized() to all result values except the error code,
+    // since they can contain sensitive information in them (like the contents
+    // of the digital signature). The debugDumpSanitized() function dumps the
+    // values only when goog.DEBUG is true, and otherwise shows only the number
+    // of values.
     const dumpedItems = this.resultItems && this.resultItems.length ?
-        ' ' + GSC.DebugDump.debugDump(this.resultItems) :
+        ' ' + GSC.DebugDump.debugDumpSanitized(this.resultItems) :
         '';
     return 'SCARD_S_SUCCESS' + dumpedItems;
   }
   // Dump the error code regardless of whether the mode is Debug or Release,
   // since there's no sensitive information in it.
-  return 'error ' + GSC.DebugDump.dump(this.errorCode);
+  return 'error ' + GSC.DebugDump.debugDumpFull(this.errorCode);
 };
 
 goog.exportProperty(

--- a/third_party/pcsc-lite/naclport/js_client/src/reader-tracker-through-pcsc-api.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/reader-tracker-through-pcsc-api.js
@@ -174,7 +174,7 @@ ReaderTrackerThroughPcscApi.prototype.makeSCardContextPromise_ = function(api) {
                 function(errorCode) {
                   promiseResolver.reject(new Error(
                       'Failed to establish a PC/SC context with error code ' +
-                      GSC.DebugDump.dump(errorCode)));
+                      GSC.DebugDump.debugDumpFull(errorCode)));
                 });
           },
           function(error) {
@@ -278,7 +278,8 @@ ReaderTrackerThroughPcscApi.prototype.makeReaderNamesPromise_ = function(
                   } else {
                     promiseResolver.reject(new Error(
                         'Failed to get the list of readers from PC/SC with ' +
-                        'error code ' + GSC.DebugDump.dump(errorCode)));
+                        'error code ' +
+                        GSC.DebugDump.debugDumpFull(errorCode)));
                   }
                 });
           },
@@ -327,7 +328,8 @@ ReaderTrackerThroughPcscApi.prototype.makeReaderStatesPromise_ = function(
                   } else {
                     promiseResolver.reject(new Error(
                         'Failed to get the reader statuses from PC/SC with ' +
-                        'error code ' + GSC.DebugDump.dump(errorCode)));
+                        'error code ' +
+                        GSC.DebugDump.debugDumpFull(errorCode)));
                   }
                 },
                 this);
@@ -393,7 +395,7 @@ ReaderTrackerThroughPcscApi.prototype.makeReaderStatesChangePromise_ = function(
   goog.log.fine(
       this.logger_,
       'Waiting for the reader statuses change from PC/SC with the following ' +
-          'data: ' + GSC.DebugDump.dump(readerStatesIn) + '...');
+          'data: ' + GSC.DebugDump.debugDumpFull(readerStatesIn) + '...');
 
   api.SCardGetStatusChange(
          sCardContext, READER_STATUS_QUERY_TIMEOUT_MILLISECONDS, readerStatesIn)
@@ -404,7 +406,7 @@ ReaderTrackerThroughPcscApi.prototype.makeReaderStatesChangePromise_ = function(
                   goog.log.fine(
                       this.logger_,
                       'Received a reader statuses change event from PC/SC: ' +
-                          GSC.DebugDump.dump(readerStatesOut));
+                          GSC.DebugDump.debugDumpFull(readerStatesOut));
                   promiseResolver.resolve();
                 },
                 function(errorCode) {
@@ -425,7 +427,7 @@ ReaderTrackerThroughPcscApi.prototype.makeReaderStatesChangePromise_ = function(
                     promiseResolver.reject(new Error(
                         'Failed to wait for the reader statuses change from ' +
                         'PC/SC with error code ' +
-                        GSC.DebugDump.dump(errorCode)));
+                        GSC.DebugDump.debugDumpFull(errorCode)));
                   }
                 },
                 this);

--- a/third_party/pcsc-lite/naclport/js_demo/src/demo.js
+++ b/third_party/pcsc-lite/naclport/js_demo/src/demo.js
@@ -50,7 +50,7 @@ const SPECIAL_READER_NAME = '\\\\?PnP?\\Notification';
 const GSC = GoogleSmartCard;
 const Demo = GSC.PcscLiteClient.Demo;
 const API = GoogleSmartCard.PcscLiteClient.API;
-const dump = GSC.DebugDump.dump;
+const debugDumpFull = GSC.DebugDump.debugDumpFull;
 
 /**
  * @type {!goog.log.Logger}
@@ -84,7 +84,8 @@ function establishContext(api, onDemoSucceeded, onDemoFailed) {
 
 function onContextEstablished(
     api, onDemoSucceeded, onDemoFailed, sCardContext) {
-  goog.log.info(logger, 'Established a new context: ' + dump(sCardContext));
+  goog.log.info(
+      logger, 'Established a new context: ' + debugDumpFull(sCardContext));
   validateContext(api, onDemoSucceeded, onDemoFailed, sCardContext);
 }
 
@@ -169,7 +170,8 @@ function onReadersChanged(
     onDemoFailed();
     return;
   }
-  goog.log.info(logger, 'Caught readers change: ' + dump(readerStates));
+  goog.log.info(
+      logger, 'Caught readers change: ' + debugDumpFull(readerStates));
   listReaderGroups(api, onDemoSucceeded, onDemoFailed, sCardContext);
 }
 
@@ -198,7 +200,7 @@ function onReaderGroupsListed(
   goog.log.info(
       logger,
       'Listed reader groups: ' +
-          goog.iter.join(goog.iter.map(readerGroups, dump), ', '));
+          goog.iter.join(goog.iter.map(readerGroups, debugDumpFull), ', '));
   if (!readerGroups) {
     goog.log.warning(logger, 'failed: no reader groups found');
     onDemoFailed();
@@ -221,7 +223,8 @@ function onReadersListed(
     api, onDemoSucceeded, onDemoFailed, sCardContext, readers) {
   goog.log.info(
       logger,
-      'Listed readers: ' + goog.iter.join(goog.iter.map(readers, dump), ', '));
+      'Listed readers: ' +
+          goog.iter.join(goog.iter.map(readers, debugDumpFull), ', '));
   if (!readers) {
     goog.log.warning(logger, 'failed: no readers found');
     onDemoFailed();
@@ -236,7 +239,7 @@ function waitForCardRemoval(
   goog.log.info(
       logger,
       'Waiting ' + TIMEOUT_SECONDS + ' seconds for card removal ' +
-          'from ' + dump(readerName) + ' reader...');
+          'from ' + debugDumpFull(readerName) + ' reader...');
   api.SCardGetStatusChange(
          sCardContext, TIMEOUT_SECONDS * 1000,
          [API.createSCardReaderStateIn(readerName, API.SCARD_STATE_PRESENT)])
@@ -254,7 +257,7 @@ function waitForCardRemoval(
 function onCardRemoved(
     api, onDemoSucceeded, onDemoFailed, sCardContext, readerName,
     readerStates) {
-  goog.log.info(logger, 'Caught card removal: ' + dump(readerStates));
+  goog.log.info(logger, 'Caught card removal: ' + debugDumpFull(readerStates));
   waitForCardInsertion(
       api, onDemoSucceeded, onDemoFailed, sCardContext, readerName);
 }
@@ -275,7 +278,7 @@ function waitForCardInsertion(
   goog.log.info(
       logger,
       'Waiting ' + TIMEOUT_SECONDS + ' seconds for card insertion ' +
-          'into ' + dump(readerName) + ' reader...');
+          'into ' + debugDumpFull(readerName) + ' reader...');
   api.SCardGetStatusChange(
          sCardContext, TIMEOUT_SECONDS * 1000,
          [API.createSCardReaderStateIn(readerName, API.SCARD_STATE_EMPTY)])
@@ -291,7 +294,8 @@ function waitForCardInsertion(
 function onCardInserted(
     api, onDemoSucceeded, onDemoFailed, sCardContext, readerName,
     readerStates) {
-  goog.log.info(logger, 'Caught card insertion: ' + dump(readerStates));
+  goog.log.info(
+      logger, 'Caught card insertion: ' + debugDumpFull(readerStates));
   waitAndCancel(api, onDemoSucceeded, onDemoFailed, sCardContext, readerName);
 }
 
@@ -299,7 +303,7 @@ function waitAndCancel(
     api, onDemoSucceeded, onDemoFailed, sCardContext, readerName) {
   goog.log.info(
       logger,
-      'Started waiting for card removal from ' + dump(readerName) +
+      'Started waiting for card removal from ' + debugDumpFull(readerName) +
           ' reader...');
   api.SCardGetStatusChange(
          sCardContext, TIMEOUT_SECONDS * 1000,
@@ -342,7 +346,8 @@ function onCancelSucceeded() {
 }
 
 function connect(api, onDemoSucceeded, onDemoFailed, sCardContext, readerName) {
-  goog.log.info(logger, 'Connecting to the reader ' + dump(readerName) + '...');
+  goog.log.info(
+      logger, 'Connecting to the reader ' + debugDumpFull(readerName) + '...');
   api.SCardConnect(
          sCardContext, readerName, API.SCARD_SHARE_SHARED,
          API.SCARD_PROTOCOL_ANY)
@@ -359,7 +364,7 @@ function onConnected(
     activeProtocol) {
   goog.log.info(
       logger,
-      'Successfully connected, handle is: ' + dump(sCardHandle) +
+      'Successfully connected, handle is: ' + debugDumpFull(sCardHandle) +
           ', active protocol is: ' +
           getProtocolDebugRepresentation(activeProtocol));
   reconnect(api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle);
@@ -403,9 +408,11 @@ function onStatusGot(
     state, protocol, atr) {
   goog.log.info(
       logger,
-      'Card status obtained: reader name is ' + dump(readerName) + ', ' +
-          'state is ' + dump(state) + ', protocol is ' +
-          getProtocolDebugRepresentation(protocol) + ', atr is ' + dump(atr));
+      'Card status obtained: reader name is ' + debugDumpFull(readerName) +
+          ', ' +
+          'state is ' + debugDumpFull(state) + ', protocol is ' +
+          getProtocolDebugRepresentation(protocol) + ', atr is ' +
+          debugDumpFull(atr));
   getAttrs(
       api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol,
       0);
@@ -422,14 +429,15 @@ function getAttrs(
     return;
   }
   const attrName = attrNames[attrIndex];
-  goog.log.fine(logger, 'Requesting the ' + dump(attrName) + ' attribute...');
+  goog.log.fine(
+      logger, 'Requesting the ' + debugDumpFull(attrName) + ' attribute...');
   api.SCardGetAttrib(sCardHandle, API[attrName]).then(function(result) {
     result.get(
         function(attrValue) {
           goog.log.info(
               logger,
-              'The ' + dump(attrName) +
-                  ' attribute value is: ' + dump(attrValue));
+              'The ' + debugDumpFull(attrName) +
+                  ' attribute value is: ' + debugDumpFull(attrValue));
           getAttrs(
               api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle,
               protocol, attrIndex + 1);
@@ -454,7 +462,8 @@ function setAttr(
   const ATTR_VALUE = [0x54, 0x65, 0x73, 0x74];
   goog.log.info(
       logger,
-      'Setting the ' + dump(ATTR_NAME) + ' attribute to ' + dump(ATTR_VALUE));
+      'Setting the ' + debugDumpFull(ATTR_NAME) + ' attribute to ' +
+          debugDumpFull(ATTR_VALUE));
   api.SCardSetAttrib(sCardHandle, API[ATTR_NAME], ATTR_VALUE)
       .then(function(result) {
         result.get(
@@ -479,8 +488,8 @@ function onAttrSetFailed(
     errorCode) {
   goog.log.info(
       logger,
-      'The attribute set was unsuccessful (error code: ' + dump(errorCode) +
-          ')');
+      'The attribute set was unsuccessful (error code: ' +
+          debugDumpFull(errorCode) + ')');
   beginTransaction(
       api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol);
 }
@@ -524,7 +533,7 @@ function onControlCommandSent(
   goog.log.info(
       logger,
       'The CM_IOCTL_GET_FEATURE_REQUEST control command returned: ' +
-          dump(responseData));
+          debugDumpFull(responseData));
   sendTransmitCommand(
       api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle, protocol);
 }
@@ -535,7 +544,7 @@ function sendTransmitCommand(
   goog.log.info(
       logger,
       'Sending the transmit command with "list dir" APDU ' +
-          dump(LIST_DIR_APDU) + '...');
+          debugDumpFull(LIST_DIR_APDU) + '...');
   api.SCardTransmit(
          sCardHandle,
          protocol == API.SCARD_PROTOCOL_T0 ? API.SCARD_PCI_T0 :
@@ -555,9 +564,10 @@ function onTransmitCommandSent(
     responseProtocolInformation, responseData) {
   goog.log.info(
       logger,
-      'The transmit command returned: ' + dump(responseData) + ', the ' +
+      'The transmit command returned: ' + debugDumpFull(responseData) +
+          ', the ' +
           'response protocol information is: ' +
-          dump(responseProtocolInformation));
+          debugDumpFull(responseProtocolInformation));
   endTransaction(api, onDemoSucceeded, onDemoFailed, sCardContext, sCardHandle);
 }
 
@@ -611,7 +621,8 @@ function onContextReleased(api, onDemoSucceeded, onDemoFailed) {
 }
 
 function onPcscLiteError(api, onDemoFailed, errorCode) {
-  goog.log.warning(logger, 'failed: PC/SC-Lite error: ' + dump(errorCode));
+  goog.log.warning(
+      logger, 'failed: PC/SC-Lite error: ' + debugDumpFull(errorCode));
   api.pcsc_stringify_error(errorCode).then(
       function(errorText) {
         goog.log.warning(logger, 'PC/SC-Lite error text: ' + errorText);
@@ -639,6 +650,6 @@ function getProtocolDebugRepresentation(protocol) {
   if (protocol == API.SCARD_PROTOCOL_T1)
     return 'T1';
   GSC.Logging.failWithLogger(
-      logger, 'Unknown protocol value: ' + dump(protocol));
+      logger, 'Unknown protocol value: ' + debugDumpFull(protocol));
 }
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
+++ b/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
@@ -184,7 +184,7 @@ ReaderTracker.prototype.fireOnUpdateListeners_ = function() {
   goog.log.fine(
       this.logger_,
       'Firing readers updated listeners with data ' +
-          GSC.DebugDump.dump(readers));
+          GSC.DebugDump.debugDumpFull(readers));
   for (const listener of this.updateListeners_) {
     try {
       listener(readers);
@@ -284,7 +284,7 @@ TrackerThroughPcscServerHook.prototype.readerFinishAddListener_ = function(
   /** @type {number} */
   const returnCode = GSC.MessagingCommon.extractKey(message, 'returnCode');
 
-  const returnCodeHex = GSC.DebugDump.dump(returnCode);
+  const returnCodeHex = GSC.DebugDump.debugDumpFull(returnCode);
 
   /** @type {!ReaderInfo} */
   let readerInfo = new ReaderInfo(name, ReaderStatus.SUCCESS);

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/admin-policy-service.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/admin-policy-service.js
@@ -137,7 +137,7 @@ AdminPolicyService.prototype.managedStorageLoadedCallback_ = function(items) {
   goog.log.info(
       this.logger,
       'Loaded the following data from the managed storage: ' +
-          GSC.DebugDump.dump(items));
+          GSC.DebugDump.debugDumpFull(items));
 
   this.updateAdminPolicyFromStorageData_(items);
 };

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
@@ -257,7 +257,7 @@ ClientHandler.prototype.handleRequest_ = function(payload) {
     goog.log.warning(
         this.logger,
         'Failed to parse the received request payload: ' +
-            GSC.DebugDump.debugDump(payload));
+            GSC.DebugDump.debugDumpSanitized(payload));
     return goog.Promise.reject(
         new Error('Failed to parse the received request payload'));
   }

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
@@ -123,14 +123,14 @@ ManagedRegistry.prototype.managedStorageLoadedCallback_ = function(items) {
   goog.log.fine(
       this.logger,
       'Loaded the following data from the managed storage: ' +
-          GSC.DebugDump.dump(items));
+          GSC.DebugDump.debugDumpFull(items));
 
   if (this.setAllowedClientOriginsFromStorageData_(
           goog.object.get(items, MANAGED_STORAGE_KEY, []))) {
     goog.log.info(
         this.logger,
         'Loaded managed storage data with the allowed client origins: ' +
-            GSC.DebugDump.dump(this.allowedClientOrigins_));
+            GSC.DebugDump.debugDumpFull(this.allowedClientOrigins_));
     this.managedStoragePromiseResolver_.resolve();
   } else {
     this.managedStoragePromiseResolver_.reject(new Error(
@@ -156,7 +156,7 @@ ManagedRegistry.prototype.storageChangedListener_ = function(
   goog.log.fine(
       this.logger,
       'Received the managed storage update event: ' +
-          GSC.DebugDump.dump(changes));
+          GSC.DebugDump.debugDumpFull(changes));
 
   if (changes[MANAGED_STORAGE_KEY]) {
     if (this.setAllowedClientOriginsFromStorageData_(
@@ -164,7 +164,8 @@ ManagedRegistry.prototype.storageChangedListener_ = function(
       goog.log.info(
           this.logger,
           'Loaded the updated managed storage data with the allowed client ' +
-              'origins: ' + GSC.DebugDump.dump(this.allowedClientOrigins_));
+              'origins: ' +
+              GSC.DebugDump.debugDumpFull(this.allowedClientOrigins_));
     }
   }
 };
@@ -181,7 +182,7 @@ ManagedRegistry.prototype.setAllowedClientOriginsFromStorageData_ = function(
         this.logger,
         'Failed to load the allowed client origins data from the managed ' +
             'storage: expected an array, instead got: ' +
-            GSC.DebugDump.dump(storageData));
+            GSC.DebugDump.debugDumpFull(storageData));
     return false;
   }
 
@@ -193,7 +194,7 @@ ManagedRegistry.prototype.setAllowedClientOriginsFromStorageData_ = function(
           this.logger,
           'Failed to load the allowed client origin from the managed ' +
               'storage item: expected a string, instead got: ' +
-              GSC.DebugDump.dump(item));
+              GSC.DebugDump.debugDumpFull(item));
       success = false;
       return;
     }

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/policy-or-prompting-permissions-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/policy-or-prompting-permissions-checker.js
@@ -78,8 +78,8 @@ GSC.Pcsc.PolicyOrPromptingPermissionsChecker =
   check(clientOrigin) {
     goog.log.log(
         logger, goog.log.Level.FINER,
-        'Checking permissions for client ' + GSC.DebugDump.dump(clientOrigin) +
-            '...');
+        'Checking permissions for client ' +
+            GSC.DebugDump.debugDumpFull(clientOrigin) + '...');
 
     if (clientOrigin === null) {
       goog.log.log(

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
@@ -254,7 +254,7 @@ TrustedClientsRegistryImpl.prototype.parseJsonAndApply_ = function(json) {
       goog.log.warning(
           this.logger,
           'Failed to parse the following trusted clients registry JSON item: ' +
-              'key="' + key + '", value=' + GSC.DebugDump.dump(value));
+              'key="' + key + '", value=' + GSC.DebugDump.debugDumpFull(value));
       success = false;
     }
   }, this);
@@ -263,7 +263,7 @@ TrustedClientsRegistryImpl.prototype.parseJsonAndApply_ = function(json) {
     goog.log.fine(
         this.logger,
         'Successfully loaded registry from JSON file: ' +
-            GSC.DebugDump.dump(originToInfoMap));
+            GSC.DebugDump.debugDumpFull(originToInfoMap));
     this.promiseResolver_.resolve(originToInfoMap);
   } else {
     this.promiseResolver_.reject(

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
@@ -212,7 +212,7 @@ UserPromptingChecker.prototype.loadLocalStorage_ = async function() {
   goog.log.log(
       this.logger, goog.log.Level.FINER,
       'Loaded the following data from the local storage: ' +
-          GSC.DebugDump.dump(rawData));
+          GSC.DebugDump.debugDumpFull(rawData));
 
   const storedUserSelections = this.parseLocalStorageUserSelections_(rawData);
 
@@ -284,7 +284,7 @@ UserPromptingChecker.prototype.parseLocalStorageUserSelections_ = function(
     goog.log.warning(
         this.logger,
         'Corrupted local storage data - expected an object, received: ' +
-            GSC.DebugDump.dump(contents));
+            GSC.DebugDump.debugDumpFull(contents));
     return storedUserSelections;
   }
   goog.object.forEach(contents, function(userSelection, identifier) {
@@ -292,7 +292,8 @@ UserPromptingChecker.prototype.parseLocalStorageUserSelections_ = function(
       goog.log.warning(
           this.logger,
           'Corrupted local storage entry - expected the object value to ' +
-              'be a boolean, received: ' + GSC.DebugDump.dump(userSelection));
+              'be a boolean, received: ' +
+              GSC.DebugDump.debugDumpFull(userSelection));
       return;
     }
     const clientOrigin = fixupLegacyStoredIdentifier(identifier);
@@ -441,7 +442,7 @@ UserPromptingChecker.prototype.storeUserApproval_ =
   goog.log.log(
       this.logger, goog.log.Level.FINER,
       'Storing the following data in the local storage: ' +
-          GSC.DebugDump.dump(dumpedValue));
+          GSC.DebugDump.debugDumpFull(dumpedValue));
   chrome.storage.local.set(goog.object.create(LOCAL_STORAGE_KEY, dumpedValue));
 };
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/server-request-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/server-request-handler.js
@@ -242,7 +242,7 @@ Pcsc.ServerRequestHandler = class extends goog.Disposable {
         .postRequest(remoteCallMessage.makeRequestPayload())
         .then(
             (result) => {
-              const resultDump = GSC.DebugDump.debugDump(result);
+              const resultDump = GSC.DebugDump.debugDumpSanitized(result);
               goog.log.fine(
                   this.logger,
                   `PC/SC call ${requestDump} completed: ${resultDump}`);


### PR DESCRIPTION
Rename the debug dumping helpers "dump"+"debugDump" to more informative "debugDumpFull"+"debugDumpSanitized".

This mirrors the proposal that's been made during code reviews of similar C++ code some time ago.

It's a pure refactoring change.