### PR TITLE
[js promise] Use Thenable in type annotations

### DIFF
--- a/common/integration_testing/src/public/integration-test-controller.js
+++ b/common/integration_testing/src/public/integration-test-controller.js
@@ -23,7 +23,7 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.NaclModule');
 goog.require('GoogleSmartCard.RemoteCallMessage');
 goog.require('GoogleSmartCard.Requester');
-goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.asserts');
 goog.require('goog.testing.PropertyReplacer');
 goog.require('goog.testing.TestCase');
@@ -67,7 +67,7 @@ GSC.IntegrationTestController = class {
   }
 
   /**
-   * @return {!goog.Promise<void>}
+   * @return {!goog.Thenable<void>}
    */
   initAsync() {
     this.executableModule.startLoading();
@@ -91,7 +91,7 @@ GSC.IntegrationTestController = class {
    * the setup via the returned promise.
    * @param {string} helperName
    * @param {!Object} helperArgument
-   * @return {!goog.Promise<void>}
+   * @return {!goog.Thenable<void>}
    */
   setUpCppHelper(helperName, helperArgument) {
     return this.callCpp_(
@@ -102,7 +102,7 @@ GSC.IntegrationTestController = class {
    * Sends a message to the given C++ helper; reports the result via a promise.
    * @param {string} helperName
    * @param {*} messageForHelper
-   * @return {!goog.Promise<void>}
+   * @return {!goog.Thenable<void>}
    */
   sendMessageToCppHelper(helperName, messageForHelper) {
     return this.callCpp_(
@@ -114,7 +114,7 @@ GSC.IntegrationTestController = class {
    * response via a promise.
    * @param {string} functionName
    * @param {!Array.<*>} functionArguments
-   * @return {!goog.Promise}
+   * @return {!goog.Thenable}
    */
   callCpp_(functionName, functionArguments) {
     const remoteCallMessage =

--- a/common/js/src/deferred-processor.js
+++ b/common/js/src/deferred-processor.js
@@ -26,6 +26,7 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PromiseHelpers');
 goog.require('goog.Disposable');
 goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.log');
 goog.require('goog.promise.Resolver');
 goog.require('goog.structs.Queue');
@@ -80,7 +81,7 @@ const logger = GSC.Logging.getScopedLogger('DeferredProcessor');
  */
 GSC.DeferredProcessor = class extends goog.Disposable {
   /**
-   * @param {!goog.Promise} awaitedPromise
+   * @param {!goog.Thenable} awaitedPromise
    */
   constructor(awaitedPromise) {
     super();
@@ -119,7 +120,7 @@ GSC.DeferredProcessor = class extends goog.Disposable {
    * gets fulfilled. If the awaited promise gets rejected, or if the deferred
    * processor gets disposed, then the returned promise will be rejected.
    * @param {function()} jobFunction
-   * @return {!goog.Promise}
+   * @return {!goog.Thenable}
    */
   addJob(jobFunction) {
     // Enqueue the job regardless of the state. This allows to deal nicely with

--- a/common/js/src/executable-module/executable-module.js
+++ b/common/js/src/executable-module/executable-module.js
@@ -27,7 +27,7 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 goog.require('goog.Disposable');
-goog.require('goog.Promise');
+goog.require('goog.Thenable');
 
 goog.scope(function() {
 
@@ -85,7 +85,7 @@ GSC.ExecutableModule = class extends goog.Disposable {
    * Returns the promise that gets fulfilled when the module loading completes.
    * The promise will be rejected in case the loading failed.
    * @abstract
-   * @return {!goog.Promise<void>}
+   * @return {!goog.Thenable<void>}
    */
   getLoadPromise() {}
 

--- a/common/js/src/json.js
+++ b/common/js/src/json.js
@@ -18,6 +18,7 @@
 goog.provide('GoogleSmartCard.Json');
 
 goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.json.NativeJsonProcessor');
 
 goog.scope(function() {
@@ -32,7 +33,7 @@ const GSC = GoogleSmartCard;
  * Chrome App environment (it tries to use eval, which is not allowed in
  * packaged Chrome Apps).
  * @param {string} jsonString
- * @return {!goog.Promise.<*>}
+ * @return {!goog.Thenable.<*>}
  */
 GSC.Json.parse = function(jsonString) {
   const processor = new goog.json.NativeJsonProcessor();

--- a/common/js/src/messaging/single-message-based-channel-unittest.js
+++ b/common/js/src/messaging/single-message-based-channel-unittest.js
@@ -19,7 +19,7 @@ goog.require('GoogleSmartCard.MessageChannelPinging.PingResponder');
 goog.require('GoogleSmartCard.MessageChannelPinging.Pinger');
 goog.require('GoogleSmartCard.SingleMessageBasedChannel');
 goog.require('GoogleSmartCard.TypedMessage');
-goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.asserts');
 goog.require('goog.promise.Resolver');
 goog.require('goog.testing');

--- a/common/js/src/popup-window/popup-opener.js
+++ b/common/js/src/popup-window/popup-opener.js
@@ -26,6 +26,7 @@ goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.Packaging');
 goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.object');
@@ -128,7 +129,7 @@ GSC.PopupOpener.createWindow = function(url, windowOptions, opt_data) {
  * @param {string} url
  * @param {!WindowOptions=} opt_windowOptions
  * @param {!Object=} opt_data Optional data to be passed to the created dialog.
- * @return {!goog.Promise}
+ * @return {!goog.Thenable}
  */
 GSC.PopupOpener.runModalDialog = function(url, opt_windowOptions, opt_data) {
   const createWindowOptions =

--- a/common/js/src/promise-helpers.js
+++ b/common/js/src/promise-helpers.js
@@ -22,7 +22,7 @@
 
 goog.provide('GoogleSmartCard.PromiseHelpers');
 
-goog.require('goog.Promise');
+goog.require('goog.Thenable');
 
 goog.scope(function() {
 
@@ -31,7 +31,7 @@ const GSC = GoogleSmartCard;
 /**
  * Disables for the specified promise throwing of an error when it's rejected
  * with no rejection callback attached to it.
- * @param {!goog.Promise} promise
+ * @param {!goog.Thenable} promise
  */
 GSC.PromiseHelpers.suppressUnhandledRejectionError = function(promise) {
   promise.thenCatch(function() {});

--- a/common/js/src/requesting/request-receiver.js
+++ b/common/js/src/requesting/request-receiver.js
@@ -27,7 +27,7 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.RequesterMessage');
 goog.require('GoogleSmartCard.RequesterMessage.RequestMessageData');
 goog.require('GoogleSmartCard.RequesterMessage.ResponseMessageData');
-goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.asserts');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
@@ -55,7 +55,7 @@ GSC.RequestReceiver = class {
    *     by
    * this instance.
    * @param {!goog.messaging.AbstractChannel} messageChannel
-   * @param {function(!Object):(!goog.Promise|!Promise)} requestHandler
+   * @param {function(!Object):(!goog.Thenable|!Promise)} requestHandler
    */
   constructor(name, messageChannel, requestHandler) {
     /**

--- a/common/js/src/requesting/requester.js
+++ b/common/js/src/requesting/requester.js
@@ -31,6 +31,7 @@ goog.require('GoogleSmartCard.RequesterMessage.RequestMessageData');
 goog.require('GoogleSmartCard.RequesterMessage.ResponseMessageData');
 goog.require('goog.Disposable');
 goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.iter');
@@ -100,7 +101,7 @@ GSC.Requester = class extends goog.Disposable {
    * received (if the request was successful, then the promise will be fulfilled
    * with its result - otherwise it will be rejected with some error).
    * @param {!Object} payload
-   * @return {!goog.Promise}
+   * @return {!goog.Thenable}
    */
   postRequest(payload) {
     const requestId = this.requestIdGenerator_.next();

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog-backend.js
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog-backend.js
@@ -29,6 +29,7 @@ goog.provide('SmartCardClientApp.BuiltInPinDialog.Backend');
 goog.require('GoogleSmartCard.PopupOpener');
 goog.require('GoogleSmartCard.RequestReceiver');
 goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
@@ -81,7 +82,7 @@ SmartCardClientApp.BuiltInPinDialog.Backend = class {
 
 /**
  * @param {!Object} payload
- * @return {!goog.Promise}
+ * @return {!goog.Thenable}
  */
 function handleRequest(payload) {
   goog.log.info(logger, 'Starting PIN dialog...');

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
@@ -32,6 +32,7 @@ goog.require('GoogleSmartCard.RequestReceiver');
 goog.require('GoogleSmartCard.Requester');
 goog.require('goog.Disposable');
 goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.array');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
@@ -242,7 +243,7 @@ Backend.prototype.disposeInternal = function() {
 /**
  * Handles a remote call request received from the executable module.
  * @param {!Object} payload
- * @return {!goog.Promise}
+ * @return {!goog.Thenable}
  * @private
  */
 Backend.prototype.handleRequest_ = function(payload) {

--- a/example_js_smart_card_client_app/src/pin-dialog/pin-dialog-server.js
+++ b/example_js_smart_card_client_app/src/pin-dialog/pin-dialog-server.js
@@ -18,7 +18,7 @@
 goog.provide('SmartCardClientApp.PinDialog.Server');
 
 goog.require('GoogleSmartCard.PopupOpener');
-goog.require('goog.Promise');
+goog.require('goog.Thenable');
 
 goog.scope(function() {
 
@@ -31,7 +31,7 @@ const PIN_DIALOG_WINDOW_OPTIONS_OVERRIDES = {
 const GSC = GoogleSmartCard;
 
 /**
- * @return {!goog.Promise.<string>}
+ * @return {!goog.Thenable.<string>}
  */
 SmartCardClientApp.PinDialog.Server.requestPin = function() {
   return GSC.PopupOpener.runModalDialog(

--- a/smart_card_connector_app/src/chrome-api-provider.js
+++ b/smart_card_connector_app/src/chrome-api-provider.js
@@ -20,9 +20,9 @@ goog.provide('GoogleSmartCard.ConnectorApp.ChromeApiProvider');
 goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.PcscLiteClient.API');
 goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.ServerRequestHandler');
-goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.Disposable');
-goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.iter');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
@@ -452,7 +452,7 @@ class ChromeEventListener extends goog.Disposable {
 GSC.ConnectorApp.ChromeApiProvider = class extends goog.Disposable {
   /**
    * @param {!goog.messaging.AbstractChannel} serverMessageChannel
-   * @param {!goog.Promise} serverReadinessTracker
+   * @param {!goog.Thenable} serverReadinessTracker
    */
   constructor(serverMessageChannel, serverReadinessTracker) {
     super();

--- a/smart_card_connector_app/src/chrome-login-state-hook-unittest.js
+++ b/smart_card_connector_app/src/chrome-login-state-hook-unittest.js
@@ -20,7 +20,7 @@ goog.require('GoogleSmartCard.RemoteCallMessage');
 goog.require('GoogleSmartCard.Requester');
 goog.require('GoogleSmartCard.RequestReceiver');
 goog.require('GoogleSmartCard.SingleMessageBasedChannel');
-goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.messaging.AbstractChannel');

--- a/smart_card_connector_app/src/testing-smart-card-simulation-libusb-hook.js
+++ b/smart_card_connector_app/src/testing-smart-card-simulation-libusb-hook.js
@@ -22,7 +22,6 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PromiseHelpers');
 goog.require('GoogleSmartCard.Requester');
 goog.require('GoogleSmartCard.RemoteCallMessage');
-goog.require('goog.Thenable');
 
 goog.setTestOnly();
 
@@ -110,7 +109,7 @@ GSC.TestingLibusbSmartCardSimulationHook = class extends GSC.LibusbProxyHook {
         remoteCallMessage.makeRequestPayload());
     // Hack to prevent spurious "UnhandledPromiseRejection" errors, which happen
     // when using the native `await` against Closure Library's (now-deprecated)
-    // `goog.Thenable` if the latter is rejected.
+    // `goog.Promise` if the latter is rejected.
     GSC.PromiseHelpers.suppressUnhandledRejectionError(outputsPromise);
 
     const outputs = await outputsPromise;

--- a/smart_card_connector_app/src/testing-smart-card-simulation-libusb-hook.js
+++ b/smart_card_connector_app/src/testing-smart-card-simulation-libusb-hook.js
@@ -22,7 +22,7 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PromiseHelpers');
 goog.require('GoogleSmartCard.Requester');
 goog.require('GoogleSmartCard.RemoteCallMessage');
-goog.require('goog.Promise');
+goog.require('goog.Thenable');
 
 goog.setTestOnly();
 
@@ -110,7 +110,7 @@ GSC.TestingLibusbSmartCardSimulationHook = class extends GSC.LibusbProxyHook {
         remoteCallMessage.makeRequestPayload());
     // Hack to prevent spurious "UnhandledPromiseRejection" errors, which happen
     // when using the native `await` against Closure Library's (now-deprecated)
-    // `goog.Promise` if the latter is rejected.
+    // `goog.Thenable` if the latter is rejected.
     GSC.PromiseHelpers.suppressUnhandledRejectionError(outputsPromise);
 
     const outputs = await outputsPromise;

--- a/smart_card_connector_app/src/window-apps-displaying.js
+++ b/smart_card_connector_app/src/window-apps-displaying.js
@@ -29,7 +29,7 @@ goog.require('GoogleSmartCard.ObjectHelpers');
 goog.require('GoogleSmartCard.Packaging');
 goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientInfo');
 goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientsRegistryImpl');
-goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.dom');
@@ -52,12 +52,12 @@ const trustedClientsRegistry =
     new GSC.PcscLiteServer.TrustedClientsRegistryImpl();
 
 /**
- * @type {goog.Promise.<!Array.<!TrustedClientInfo>>?}
+ * @type {goog.Thenable.<!Array.<!TrustedClientInfo>>?}
  */
 let lastTrustedClientInfosPromise = null;
 
 /**
- * @param {!goog.Promise.<!Array.<!TrustedClientInfo>>}
+ * @param {!goog.Thenable.<!Array.<!TrustedClientInfo>>}
  *     trustedClientInfosPromise
  * @param {!Array.<string>} appIds
  * @param {Array.<!TrustedClientInfo>?} trustedClientInfos

--- a/third_party/libusb/webport/src/libusb-proxy-receiver.js
+++ b/third_party/libusb/webport/src/libusb-proxy-receiver.js
@@ -27,7 +27,7 @@ goog.require('GoogleSmartCard.LibusbToWebusbAdaptor');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.RemoteCallMessage');
 goog.require('GoogleSmartCard.StubLibusbToJsApiAdaptor');
-goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.log');
 goog.require('goog.messaging.AbstractChannel');
 

--- a/third_party/pcsc-lite/naclport/cpp_client/src/nacl-client-backend.js
+++ b/third_party/pcsc-lite/naclport/cpp_client/src/nacl-client-backend.js
@@ -36,6 +36,7 @@ goog.require('GoogleSmartCard.PcscLiteClient.NaclClientBackend');
 goog.require('GoogleSmartCard.RemoteCallMessage');
 goog.require('GoogleSmartCard.RequestReceiver');
 goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.Timer');
 goog.require('goog.functions');
 goog.require('goog.log');
@@ -134,7 +135,7 @@ GSC.PcscLiteClient.NaclClientBackend = class {
 
   /**
    * @param {!Object} payload
-   * @return {!goog.Promise}
+   * @return {!goog.Thenable}
    * @private
    */
   handleRequest_(payload) {

--- a/third_party/pcsc-lite/naclport/js_client/src/api.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/api.js
@@ -57,6 +57,7 @@ goog.require('GoogleSmartCard.RemoteCallMessage');
 goog.require('GoogleSmartCard.Requester');
 goog.require('goog.Disposable');
 goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.async.nextTick');
@@ -2219,7 +2220,7 @@ goog.exportProperty(
  *
  * @param {!API.ERROR_CODE} errorCode
  *
- * @return {!goog.Promise.<string>}
+ * @return {!goog.Thenable.<string>}
  */
 API.prototype.pcsc_stringify_error = function(errorCode) {
   const logger = this.logger;
@@ -2262,7 +2263,7 @@ goog.exportProperty(
  * @param {null=} opt_reserved_1 Reserved for future use.
  * @param {null=} opt_reserved_2 Reserved for future use.
  *
- * @return {!goog.Promise.<!API.SCardEstablishContextResult>}
+ * @return {!goog.Thenable.<!API.SCardEstablishContextResult>}
  */
 API.prototype.SCardEstablishContext = function(
     scope, opt_reserved_1, opt_reserved_2) {
@@ -2324,7 +2325,7 @@ goog.exportProperty(
  *
  * @param {!API.SCARDCONTEXT} sCardContext Connection context to be closed.
  *
- * @return {!goog.Promise.<!API.SCardReleaseContextResult>}
+ * @return {!goog.Thenable.<!API.SCardReleaseContextResult>}
  */
 API.prototype.SCardReleaseContext = function(sCardContext) {
   return this.postRequest_(
@@ -2414,7 +2415,7 @@ goog.exportProperty(
  * You can use (SCARD_PROTOCOL_T0 | SCARD_PROTOCOL_T1) if you do not have a
  * preferred protocol.
  *
- * @return {!goog.Promise.<!API.SCardConnectResult>}
+ * @return {!goog.Thenable.<!API.SCardConnectResult>}
  */
 API.prototype.SCardConnect = function(
     sCardContext, reader, shareMode, preferredProtocols) {
@@ -2508,7 +2509,7 @@ goog.exportProperty(
  * - SCARD_UNPOWER_CARD - Power down the card (cold reset).
  * - SCARD_EJECT_CARD - Eject the card.
  *
- * @return {!goog.Promise.<!API.SCardReconnectResult>}
+ * @return {!goog.Thenable.<!API.SCardReconnectResult>}
  */
 API.prototype.SCardReconnect = function(
     sCardHandle, shareMode, preferredProtocols, initialization) {
@@ -2571,7 +2572,7 @@ goog.exportProperty(
  * - SCARD_UNPOWER_CARD - Power down the card (cold reset).
  * - SCARD_EJECT_CARD - Eject the card.
  *
- * @return {!goog.Promise.<!API.SCardDisconnectResult>}
+ * @return {!goog.Thenable.<!API.SCardDisconnectResult>}
  */
 API.prototype.SCardDisconnect = function(sCardHandle, disposition) {
   return this.postRequest_(
@@ -2632,7 +2633,7 @@ goog.exportProperty(
  *
  * @param {!API.SCARDHANDLE} sCardHandle Connection made from SCardConnect.
  *
- * @return {!goog.Promise.<!API.SCardBeginTransactionResult>}
+ * @return {!goog.Thenable.<!API.SCardBeginTransactionResult>}
  */
 API.prototype.SCardBeginTransaction = function(sCardHandle) {
   return this.postRequest_(
@@ -2697,7 +2698,7 @@ goog.exportProperty(
  * - SCARD_UNPOWER_CARD - Power down the card.
  * - SCARD_EJECT_CARD - Eject the card.
  *
- * @return {!goog.Promise.<!API.SCardEndTransactionResult>}
+ * @return {!goog.Thenable.<!API.SCardEndTransactionResult>}
  */
 API.prototype.SCardEndTransaction = function(sCardHandle, disposition) {
   return this.postRequest_(
@@ -2785,7 +2786,7 @@ goog.exportProperty(
  *
  * @param {!API.SCARDHANDLE} sCardHandle Connection made from SCardConnect.
  *
- * @return {!goog.Promise.<!API.SCardStatusResult>}
+ * @return {!goog.Thenable.<!API.SCardStatusResult>}
  */
 API.prototype.SCardStatus = function(sCardHandle) {
   return this.postRequest_(
@@ -2894,7 +2895,7 @@ goog.exportProperty(
  * @param {!Array.<!API.SCARD_READERSTATE_IN>} readerStates Structures of
  * readers with current states.
  *
- * @return {!goog.Promise.<!API.SCardGetStatusChangeResult>}
+ * @return {!goog.Thenable.<!API.SCardGetStatusChangeResult>}
  */
 API.prototype.SCardGetStatusChange = function(
     sCardContext, timeout, readerStates) {
@@ -2971,7 +2972,7 @@ goog.exportProperty(
  * for a list of supported commands by some drivers.
  * @param {!ArrayBuffer} dataToSend Command to send to the reader.
  *
- * @return {!goog.Promise.<!API.SCardControlResult>}
+ * @return {!goog.Thenable.<!API.SCardControlResult>}
  */
 API.prototype.SCardControl = function(sCardHandle, controlCode, dataToSend) {
   return this.postRequest_(
@@ -3086,7 +3087,7 @@ goog.exportProperty(
  * @param {!API.SCARDHANDLE} sCardHandle Connection made from SCardConnect.
  * @param {number} attrId Identifier for the attribute to get.
  *
- * @return {!goog.Promise.<!API.SCardGetAttribResult>}
+ * @return {!goog.Thenable.<!API.SCardGetAttribResult>}
  */
 API.prototype.SCardGetAttrib = function(sCardHandle, attrId) {
   return this.postRequest_(
@@ -3147,7 +3148,7 @@ goog.exportProperty(
  * @param {number} attrId Identifier for the attribute to set.
  * @param {!ArrayBuffer} attr Buffer with the attribute.
  *
- * @return {!goog.Promise.<!API.SCardSetAttribResult>}
+ * @return {!goog.Thenable.<!API.SCardSetAttribResult>}
  */
 API.prototype.SCardSetAttrib = function(sCardHandle, attrId, attr) {
   return this.postRequest_(
@@ -3225,7 +3226,7 @@ goog.exportProperty(
  * @param {!API.SCARD_IO_REQUEST=} opt_receiveProtocolInformation Structure of
  * protocol information.
  *
- * @return {!goog.Promise.<!API.SCardTransmitResult>}
+ * @return {!goog.Thenable.<!API.SCardTransmitResult>}
  */
 API.prototype.SCardTransmit = function(
     sCardHandle, sendProtocolInformation, dataToSend,
@@ -3296,7 +3297,7 @@ goog.exportProperty(
  * Resource Manager.
  * @param {null} groups List of groups to list readers (not used).
  *
- * @return {!goog.Promise.<!API.SCardListReadersResult>}
+ * @return {!goog.Thenable.<!API.SCardListReadersResult>}
  */
 API.prototype.SCardListReaders = function(sCardContext, groups) {
   return this.postRequest_(
@@ -3355,7 +3356,7 @@ goog.exportProperty(
  * @param {!API.SCARDCONTEXT} sCardContext Connection context to the PC/SC
  * Resource Manager.
  *
- * @return {!goog.Promise.<!API.SCardListReaderGroupsResult>}
+ * @return {!goog.Thenable.<!API.SCardListReaderGroupsResult>}
  */
 API.prototype.SCardListReaderGroups = function(sCardContext) {
   return this.postRequest_(
@@ -3411,7 +3412,7 @@ goog.exportProperty(
  * @param {!API.SCARDCONTEXT} sCardContext Connection context to the PC/SC
  * Resource Manager.
  *
- * @return {!goog.Promise.<!API.SCardCancelResult>}
+ * @return {!goog.Thenable.<!API.SCardCancelResult>}
  */
 API.prototype.SCardCancel = function(sCardContext) {
   return this.postRequest_(
@@ -3466,7 +3467,7 @@ goog.exportProperty(
  * @param {!API.SCARDCONTEXT} sCardContext Connection context to the PC/SC
  * Resource Manager.
  *
- * @return {!goog.Promise.<!API.SCardIsValidContextResult>}
+ * @return {!goog.Thenable.<!API.SCardIsValidContextResult>}
  */
 API.prototype.SCardIsValidContext = function(sCardContext) {
   return this.postRequest_(
@@ -3533,7 +3534,7 @@ API.prototype.messageChannelDisposedListener_ = function() {
  * @param {string} functionName
  * @param {!Array} functionArguments
  * @param {function(!Array):*} successfulResultTransformer
- * @return {!goog.Promise}
+ * @return {!goog.Thenable}
  * @private
  */
 API.prototype.postRequest_ = function(

--- a/third_party/pcsc-lite/naclport/js_client/src/reader-tracker-through-pcsc-api.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/reader-tracker-through-pcsc-api.js
@@ -26,6 +26,9 @@ goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PcscLiteClient.API');
 goog.require('GoogleSmartCard.PcscLiteClient.Context');
+goog.require('goog.Promise');
+goog.require('goog.Thenable');
+goog.require('goog.Timer');
 goog.require('goog.array');
 goog.require('goog.async.nextTick');
 goog.require('goog.iter');
@@ -34,8 +37,6 @@ goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
 goog.require('goog.object');
 goog.require('goog.promise.Resolver');
-goog.require('goog.Promise');
-goog.require('goog.Timer');
 
 goog.scope(function() {
 
@@ -131,7 +132,7 @@ ReaderTrackerThroughPcscApi.prototype.startStatusTracking_ = function(
 /**
  * Makes a promise of PC/SC client API instance.
  * @param {!goog.messaging.AbstractChannel} pcscContextMessageChannel
- * @return {!goog.Promise.<!API>}
+ * @return {!goog.Thenable.<!API>}
  * @private
  */
 ReaderTrackerThroughPcscApi.prototype.makeApiPromise_ = function(
@@ -156,7 +157,7 @@ ReaderTrackerThroughPcscApi.prototype.makeApiPromise_ = function(
 /**
  * Makes a promise of the established PC/SC context.
  * @param {!API} api
- * @return {!goog.Promise.<!API.SCARDCONTEXT>}
+ * @return {!goog.Thenable.<!API.SCARDCONTEXT>}
  * @private
  */
 ReaderTrackerThroughPcscApi.prototype.makeSCardContextPromise_ = function(api) {
@@ -201,7 +202,7 @@ ReaderTrackerThroughPcscApi.prototype.startStatusTrackingWithApi_ = function(
 
 /**
  * Attaches a rejection handler to the passed promise.
- * @param {!goog.Promise} promise
+ * @param {!goog.Thenable} promise
  * @private
  */
 ReaderTrackerThroughPcscApi.prototype.addPromiseErrorHandler_ = function(
@@ -259,7 +260,7 @@ ReaderTrackerThroughPcscApi.prototype.runStatusTrackingLoop_ = function(
  * Makes a promise of reader names that are currently reported by PC/SC.
  * @param {!API} api
  * @param {!API.SCARDCONTEXT} sCardContext
- * @return {!goog.Promise.<!Array.<string>>}
+ * @return {!goog.Thenable.<!Array.<string>>}
  * @private
  */
 ReaderTrackerThroughPcscApi.prototype.makeReaderNamesPromise_ = function(
@@ -296,7 +297,8 @@ ReaderTrackerThroughPcscApi.prototype.makeReaderNamesPromise_ = function(
  * @param {!API} api
  * @param {!API.SCARDCONTEXT} sCardContext
  * @param {!Array.<string>} readerNames
- * @return {!goog.Promise.<!Array.<!API.SCARD_READERSTATE_OUT>|null>} Either the
+ * @return {!goog.Thenable.<!Array.<!API.SCARD_READERSTATE_OUT>|null>} Either
+ *     the
  * states of the readers, or the null value in case of intermittent error.
  * @private
  */
@@ -370,7 +372,7 @@ ReaderTrackerThroughPcscApi.prototype.updateResultFromReaderStates_ = function(
  * @param {!API} api
  * @param {!API.SCARDCONTEXT} sCardContext
  * @param {!Array.<!API.SCARD_READERSTATE_OUT>} previousReaderStatesOut
- * @return {!goog.Promise}
+ * @return {!goog.Thenable}
  * @private
  */
 ReaderTrackerThroughPcscApi.prototype.makeReaderStatesChangePromise_ = function(

--- a/third_party/pcsc-lite/naclport/js_client/src/reader-tracker-through-pcsc-api.js
+++ b/third_party/pcsc-lite/naclport/js_client/src/reader-tracker-through-pcsc-api.js
@@ -298,8 +298,7 @@ ReaderTrackerThroughPcscApi.prototype.makeReaderNamesPromise_ = function(
  * @param {!API.SCARDCONTEXT} sCardContext
  * @param {!Array.<string>} readerNames
  * @return {!goog.Thenable.<!Array.<!API.SCARD_READERSTATE_OUT>|null>} Either
- *     the
- * states of the readers, or the null value in case of intermittent error.
+ * the states of the readers, or the null value in case of intermittent error.
  * @private
  */
 ReaderTrackerThroughPcscApi.prototype.makeReaderStatesPromise_ = function(

--- a/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
+++ b/third_party/pcsc-lite/naclport/server/src/reader-tracker.js
@@ -31,7 +31,7 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.MessagingCommon');
 goog.require('GoogleSmartCard.PcscLiteClient.ReaderTrackerThroughPcscApi');
 goog.require('GoogleSmartCard.TypedMessage');
-goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.Timer');
 goog.require('goog.array');
 goog.require('goog.log');

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
@@ -39,6 +39,7 @@ goog.require('GoogleSmartCard.RemoteCallMessage');
 goog.require('GoogleSmartCard.RequestReceiver');
 goog.require('goog.Disposable');
 goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
@@ -126,7 +127,7 @@ function getClientNameForLog(clientOrigin) {
  *    handling of the client requests impossible).
  * @param {!goog.messaging.AbstractChannel} serverMessageChannel Message channel
  * to the PC/SC server into which the PC/SC requests will be forwarded.
- * @param {!goog.Promise} serverReadinessTracker Tracker of the PC/SC server
+ * @param {!goog.Thenable} serverReadinessTracker Tracker of the PC/SC server
  * that allows to delay forwarding of the PC/SC requests to the PC/SC server
  * until it is ready to receive them.
  * @param {!goog.messaging.AbstractChannel} clientMessageChannel Message channel
@@ -243,7 +244,7 @@ ClientHandler.prototype.disposeInternal = function() {
 /**
  * Handles a request received from PC/SC client.
  * @param {!Object} payload
- * @return {!goog.Promise}
+ * @return {!goog.Thenable}
  * @private
  */
 ClientHandler.prototype.handleRequest_ = function(payload) {
@@ -275,7 +276,7 @@ ClientHandler.prototype.handleRequest_ = function(payload) {
 /**
  * Returns a promise that will eventually contain the result of the permissions
  * check for the client.
- * @return {!goog.Promise}
+ * @return {!goog.Thenable}
  * @private
  */
 ClientHandler.prototype.getPermissionsCheckPromise_ = function() {

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
@@ -32,6 +32,7 @@ goog.require('GoogleSmartCard.ExtensionId');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.MessagingOrigin');
 goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.array');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
@@ -80,7 +81,7 @@ ManagedRegistry.prototype.logger =
  * The result is returned asynchronously as a promise (which will eventually be
  * resolved if the permission is granted or rejected otherwise).
  * @param {string} clientOrigin Origin of the client application
- * @return {!goog.Promise}
+ * @return {!goog.Thenable}
  */
 ManagedRegistry.prototype.getByOrigin = function(clientOrigin) {
   const promiseResolver = goog.Promise.withResolver();

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/permissions-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/permissions-checker.js
@@ -28,7 +28,7 @@
 
 goog.provide('GoogleSmartCard.Pcsc.PermissionsChecker');
 
-goog.require('goog.Promise');
+goog.require('goog.Thenable');
 
 goog.scope(function() {
 
@@ -49,7 +49,7 @@ GSC.Pcsc.PermissionsChecker = class {
    * eventually resolved if the permission is granted or rejected otherwise).
    * @param {string|null} clientOrigin Origin of the client application, or null
    * if the client is our own application.
-   * @return {!goog.Promise}
+   * @return {!goog.Thenable}
    * @abstract
    */
   check(clientOrigin) {}

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry-unittest.js
@@ -17,7 +17,7 @@
 
 goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientInfo');
 goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientsRegistryImpl');
-goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.json');
 goog.require('goog.net.HttpStatus');
 goog.require('goog.testing');

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/trusted-clients-registry.js
@@ -34,6 +34,7 @@ goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Json');
 goog.require('GoogleSmartCard.Logging');
 goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.asserts');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
@@ -95,7 +96,7 @@ const TrustedClientsRegistry = GSC.PcscLiteServer.TrustedClientsRegistry;
  * The result is returned asynchronously as a promise (which will be rejected if
  * the given app isn't present in the config).
  * @param {string} origin
- * @return {!goog.Promise.<!TrustedClientInfo>}
+ * @return {!goog.Thenable.<!TrustedClientInfo>}
  */
 TrustedClientsRegistry.prototype.getByOrigin = function(origin) {};
 
@@ -108,7 +109,7 @@ TrustedClientsRegistry.prototype.getByOrigin = function(origin) {};
  * containing either the information for the i-th client in |originList| or
  * |null| if the client isn't present in the config.
  * @param {!Array.<string>} originList
- * @return {!goog.Promise.<!Array.<?TrustedClientInfo>>}
+ * @return {!goog.Thenable.<!Array.<?TrustedClientInfo>>}
  */
 TrustedClientsRegistry.prototype.tryGetByOrigins = function(originList) {};
 

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittest.js
@@ -191,8 +191,7 @@ function negatePromise(promise) {
  * function to be run after the needed setup; must return a promise of the test
  * result.
  * @return {function():!goog.Thenable} The wrapped test function, which returns
- *     a
- * promise of the test result and the result of teardown.
+ * a promise of the test result and the result of teardown.
  */
 function makeTest(
     fakeInitialStorageData, expectedStorageDataToBeWritten,

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker-unittest.js
@@ -22,6 +22,7 @@ goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientsRegistry');
 goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.UserPromptingChecker');
 goog.require('GoogleSmartCard.PopupOpener');
 goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.asserts');
 goog.require('goog.testing');
 goog.require('goog.testing.MockControl');
@@ -189,7 +190,8 @@ function negatePromise(promise) {
  * @param {function(!UserPromptingChecker):!Promise} testCallback The test
  * function to be run after the needed setup; must return a promise of the test
  * result.
- * @return {function():!goog.Promise} The wrapped test function, which returns a
+ * @return {function():!goog.Thenable} The wrapped test function, which returns
+ *     a
  * promise of the test result and the result of teardown.
  */
 function makeTest(

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/readiness-tracker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/readiness-tracker.js
@@ -32,6 +32,7 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PromiseHelpers');
 goog.require('goog.Disposable');
 goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.messaging.AbstractChannel');
@@ -70,7 +71,7 @@ GSC.PcscLiteServerClientsManagement.ReadinessTracker = function(
   /**
    * Promise that is fulfilled once the PC/SC-Lite server gets ready, or is
    * rejected if it failed to initialize.
-   * @type {!goog.Promise} @const
+   * @type {!goog.Thenable} @const
    */
   this.promise = this.promiseResolver_.promise;
   GSC.PromiseHelpers.suppressUnhandledRejectionError(this.promise);

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/server-request-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/server-request-handler.js
@@ -34,7 +34,7 @@ goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.RemoteCallMessage');
 goog.require('GoogleSmartCard.Requester');
 goog.require('goog.Disposable');
-goog.require('goog.Promise');
+goog.require('goog.Thenable');
 goog.require('goog.asserts');
 goog.require('goog.iter');
 goog.require('goog.iter.Iterator');
@@ -131,7 +131,7 @@ Pcsc.ServerRequestHandler = class extends goog.Disposable {
    * @param {!goog.messaging.AbstractChannel} serverMessageChannel Message
    *     channel
    * to the PC/SC server into which the PC/SC requests will be forwarded.
-   * @param {!goog.Promise} serverReadinessTracker Tracker of the PC/SC server
+   * @param {!goog.Thenable} serverReadinessTracker Tracker of the PC/SC server
    * that allows to delay forwarding of the PC/SC requests to the PC/SC server
    * until it is ready to receive them.
    * @param {string} clientNameForLog
@@ -216,7 +216,7 @@ Pcsc.ServerRequestHandler = class extends goog.Disposable {
    * The request result will be passed through the returned promise.
    * @param {!RemoteCallMessage} remoteCallMessage The remote call message
    * containing the request contents.
-   * @return {!goog.Promise}
+   * @return {!goog.Thenable}
    */
   handleRequest(remoteCallMessage) {
     return this.deferredProcessor_.addJob(
@@ -229,7 +229,7 @@ Pcsc.ServerRequestHandler = class extends goog.Disposable {
    * The request result will be passed through the returned promise.
    * @param {!RemoteCallMessage} remoteCallMessage The remote call message
    * containing the request contents.
-   * @return {!goog.Promise}
+   * @return {!goog.Thenable}
    * @private
    */
   postRequestToServer_(remoteCallMessage) {


### PR DESCRIPTION
Replace "goog.Promise" with "goog.Thenable" in type annotations.

The latter is more generic and allows both the (Closure-specific, now-deprecated) goog.Promise as well as the standard ECMAScript Promise. As we're trying to migrate the codebase to the latter, the more generic type annotation helps start this gradually.