### PR TITLE
[js style] Disable semi-spacing ESLint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -54,7 +54,6 @@ rules:
   no-var: error
   prefer-const: error
   prefer-promise-reject-errors: error
-  semi-spacing: error
   semi-style: error
   semi: error
   no-floating-promise/no-floating-promise: error


### PR DESCRIPTION
This rule disagrees with clang-format in some cases, e.g. the "for(...; ;...)" kind of loop.