### PR TITLE
[JS-to-C++ test] Test crashes

### DIFF
--- a/common/cpp/src/logging_integration_test_helper.cc
+++ b/common/cpp/src/logging_integration_test_helper.cc
@@ -1,0 +1,61 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/cpp/src/public/logging/logging.h"
+
+#include <string>
+
+#include "common/cpp/src/public/requesting/request_receiver.h"
+#include "common/cpp/src/public/requesting/request_result.h"
+#include "common/cpp/src/public/unique_ptr_utils.h"
+#include "common/cpp/src/public/value.h"
+#include "common/integration_testing/src/public/integration_test_helper.h"
+#include "common/integration_testing/src/public/integration_test_service.h"
+
+namespace google_smart_card {
+
+// The helper that can be used in JS-to-C++ tests to trigger the C++ logging
+// functionality.
+class LoggingTestHelper final : public IntegrationTestHelper {
+ public:
+  // IntegrationTestHelper:
+  std::string GetName() const override;
+  void OnMessageFromJs(
+      Value data,
+      RequestReceiver::ResultCallback result_callback) override;
+};
+
+// Register the class in the service, so that when the JS side requests this
+// helper the service will route requests to it.
+const auto g_smart_card_connector_application_test_helper =
+    IntegrationTestService::RegisterHelper(MakeUnique<LoggingTestHelper>());
+
+std::string LoggingTestHelper::GetName() const {
+  return "LoggingTestHelper";
+}
+
+void LoggingTestHelper::OnMessageFromJs(
+    Value data,
+    RequestReceiver::ResultCallback result_callback) {
+  if (data.GetString() == "crash-via-check") {
+    GOOGLE_SMART_CARD_CHECK(0);
+  } else if (data.GetString() == "crash-via-fatal-log") {
+    GOOGLE_SMART_CARD_LOG_FATAL << "Intentional crash";
+  } else {
+    GOOGLE_SMART_CARD_LOG_FATAL << "";
+  }
+  result_callback(GenericRequestResult::CreateSuccessful(Value()));
+}
+
+}  // namespace google_smart_card

--- a/common/js/build/js_to_cxx_tests/Makefile
+++ b/common/js/build/js_to_cxx_tests/Makefile
@@ -23,6 +23,7 @@ include $(ROOT_PATH)/common/integration_testing/include.mk
 
 
 CXX_SOURCES := \
+  $(ROOT_PATH)/common/cpp/src/logging_integration_test_helper.cc \
 
 CXXFLAGS := \
   -I$(ROOT_PATH) \

--- a/common/js/src/executable-module/executable-module-jstocxxtest.js
+++ b/common/js/src/executable-module/executable-module-jstocxxtest.js
@@ -57,12 +57,13 @@ goog.exportSymbol('testExecutableModule', {
     try {
       await testController.sendMessageToCppHelper(
           'LoggingTestHelper', 'crash-via-check');
-      fail('Unexpectedly proceeded beyond crash');
     } catch (e) {
       // This is expected branch - discard the exception.
+      assert(testController.executableModule.isDisposed());
+      return;
     }
 
-    assert(testController.executableModule.isDisposed());
+    fail('Unexpectedly proceeded beyond crash');
   },
 
   // Test that after the C++ code crashes via `GOOGLE_SMART_CARD_LOG_FATAL`, the
@@ -74,12 +75,13 @@ goog.exportSymbol('testExecutableModule', {
     try {
       await testController.sendMessageToCppHelper(
           'LoggingTestHelper', 'crash-via-fatal-log');
-      fail('Unexpectedly proceeded beyond crash');
     } catch (e) {
       // This is expected branch - discard the exception.
+      assert(testController.executableModule.isDisposed());
+      return;
     }
 
-    assert(testController.executableModule.isDisposed());
+    fail('Unexpectedly proceeded beyond crash');
   },
 });
 });


### PR DESCRIPTION
Add a test that crash in a C++ executable module gets correctly handled on the JS side, in particular marks the module as disposed.

This test verifies a slightly simpler scenario than the regression fixed in #823.