### PR TITLE
[js style] await instead of returning promise

### DIFF
--- a/third_party/libusb/webport/src/libusb-proxy-hook.js
+++ b/third_party/libusb/webport/src/libusb-proxy-hook.js
@@ -59,56 +59,57 @@ GSC.LibusbProxyHook = class extends GSC.LibusbToJsApiAdaptor {
 
   /** @override */
   async listDevices() {
-    return this.getDelegateOrThrow().listDevices();
+    return await this.getDelegateOrThrow().listDevices();
   }
 
   /** @override */
   async getConfigurations(deviceId) {
-    return this.getDelegateOrThrow().getConfigurations(deviceId);
+    return await this.getDelegateOrThrow().getConfigurations(deviceId);
   }
 
   /** @override */
   async openDeviceHandle(deviceId) {
-    return this.getDelegateOrThrow().openDeviceHandle(deviceId);
+    return await this.getDelegateOrThrow().openDeviceHandle(deviceId);
   }
 
   /** @override */
   async closeDeviceHandle(deviceId, deviceHandle) {
-    return this.getDelegateOrThrow().closeDeviceHandle(deviceId, deviceHandle);
+    return await this.getDelegateOrThrow().closeDeviceHandle(
+        deviceId, deviceHandle);
   }
 
   /** @override */
   async claimInterface(deviceId, deviceHandle, interfaceNumber) {
-    return this.getDelegateOrThrow().claimInterface(
+    return await this.getDelegateOrThrow().claimInterface(
         deviceId, deviceHandle, interfaceNumber);
   }
 
   /** @override */
   async releaseInterface(deviceId, deviceHandle, interfaceNumber) {
-    return this.getDelegateOrThrow().releaseInterface(
+    return await this.getDelegateOrThrow().releaseInterface(
         deviceId, deviceHandle, interfaceNumber);
   }
 
   /** @override */
   async resetDevice(deviceId, deviceHandle) {
-    return this.getDelegateOrThrow().resetDevice(deviceId, deviceHandle);
+    return await this.getDelegateOrThrow().resetDevice(deviceId, deviceHandle);
   }
 
   /** @override */
   async controlTransfer(deviceId, deviceHandle, parameters) {
-    return this.getDelegateOrThrow().controlTransfer(
+    return await this.getDelegateOrThrow().controlTransfer(
         deviceId, deviceHandle, parameters);
   }
 
   /** @override */
   async bulkTransfer(deviceId, deviceHandle, parameters) {
-    return this.getDelegateOrThrow().bulkTransfer(
+    return await this.getDelegateOrThrow().bulkTransfer(
         deviceId, deviceHandle, parameters);
   }
 
   /** @override */
   async interruptTransfer(deviceId, deviceHandle, parameters) {
-    return this.getDelegateOrThrow().interruptTransfer(
+    return await this.getDelegateOrThrow().interruptTransfer(
         deviceId, deviceHandle, parameters);
   }
 };

--- a/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
@@ -144,13 +144,13 @@ GSC.LibusbToChromeUsbAdaptor = class extends GSC.LibusbToJsApiAdaptor {
 
   /** @override */
   async bulkTransfer(deviceId, deviceHandle, parameters) {
-    return this.genericTransfer_(
+    return await this.genericTransfer_(
         chrome.usb.bulkTransfer, deviceId, deviceHandle, parameters);
   }
 
   /** @override */
   async interruptTransfer(deviceId, deviceHandle, parameters) {
-    return this.genericTransfer_(
+    return await this.genericTransfer_(
         chrome.usb.interruptTransfer, deviceId, deviceHandle, parameters);
   }
 

--- a/third_party/libusb/webport/src/libusb-to-webusb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-webusb-adaptor.js
@@ -232,12 +232,12 @@ GSC.LibusbToWebusbAdaptor = class extends GSC.LibusbToJsApiAdaptor {
 
   /** @override */
   async bulkTransfer(deviceId, deviceHandle, parameters) {
-    return this.genericTransfer_(deviceId, deviceHandle, parameters);
+    return await this.genericTransfer_(deviceId, deviceHandle, parameters);
   }
 
   /** @override */
   async interruptTransfer(deviceId, deviceHandle, parameters) {
-    return this.genericTransfer_(deviceId, deviceHandle, parameters);
+    return await this.genericTransfer_(deviceId, deviceHandle, parameters);
   }
 
   /**

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
@@ -346,7 +346,7 @@ UserPromptingChecker.prototype.promptUserForTrustedClient_ =
       this.logger,
       'Showing the user prompt for the known client ' + clientOrigin +
           ' named "' + trustedClientInfo.name + '"...');
-  return this.runPromptDialog_(clientOrigin, {
+  return await this.runPromptDialog_(clientOrigin, {
     'is_client_known': true,
     'client_info_link': getClientInfoLink(clientOrigin),
     'client_name': trustedClientInfo.name
@@ -364,7 +364,7 @@ UserPromptingChecker.prototype.promptUserForUntrustedClient_ =
       this.logger,
       'Showing the warning user prompt for the unknown client ' + clientOrigin +
           '...');
-  return this.runPromptDialog_(clientOrigin, {
+  return await this.runPromptDialog_(clientOrigin, {
     'is_client_known': false,
     'client_info_link': getClientInfoLink(clientOrigin),
     'client_name': getNameToShowForUnknownClient(clientOrigin)


### PR DESCRIPTION
Explicitly do "await" instead of returning a promise obtained from another function.

It's considered best practice, as it makes asynchronous points more explicit and also captures the current frame in the promise's stack trace.

This commit was prepared by enabling the "require-await" ESLint diagnostic, however we don't commit it because it has lots of false positives (on abstract classes, on functions returning "new Promise", on overrides that return result synchronously, etc.).