### PR TITLE
JS Requester handles disposal-and-exception-while-sending

### DIFF
--- a/common/js/src/requesting/requester-unittest.js
+++ b/common/js/src/requesting/requester-unittest.js
@@ -224,7 +224,8 @@ goog.exportSymbol(
       try {
         await requester.postRequest({});
       } catch (e) {
-        // This is the expected branch.
+        // This is the expected branch. Verify the error message.
+        assertContains('requester is disposed', e.toString());
         return;
       }
       fail('Message posting unexpectedly succeeded');

--- a/common/js/src/requesting/requester-unittest.js
+++ b/common/js/src/requesting/requester-unittest.js
@@ -213,7 +213,8 @@ goog.exportSymbol(
       const mockMessageChannel =
           new goog.testing.messaging.MockMessageChannel(mockControl);
       /** @type {?} */ mockMessageChannel.send;
-      // Set up mock that throws an exception when a message is sent.
+      // Set up mock that throws an exception and disposes of the channel when a
+      // message is sent.
       mockMessageChannel.send(ignoreArgument, ignoreArgument).$does(() => {
         disposeOfMockMessageChannel(mockMessageChannel);
         throw new Error(SEND_ERROR_MESSAGE);

--- a/common/js/src/requesting/requester.js
+++ b/common/js/src/requesting/requester.js
@@ -136,8 +136,11 @@ GSC.Requester = class extends goog.Disposable {
       this.messageChannel_.send(serviceName, messageData);
     } catch (e) {
       // If sending the message triggered an exception, use it to populate the
-      // response.
-      this.rejectRequest_(requestId, e);
+      // response. However, this is already done if the channel got immediately
+      // disposed of, since `disposeInternal()` cancels all ongoing requests.
+      if (!this.isDisposed()) {
+        this.rejectRequest_(requestId, e);
+      }
     }
 
     return promiseResolver.promise;


### PR DESCRIPTION
Improve the JS Requester class to gracefully handle this edge case: the send() call triggers not only an exception, but also the disposal of the message channel. The bug was that we were trying to reject the same request twice (first during disposal, second while handling the exception).

This is follow-up to the crash handling issue fixed in #823.