### PR TITLE
[JS-to-C++ test] Test crash with active PC/SC client

### DIFF
--- a/common/js/src/async-asserts.js
+++ b/common/js/src/async-asserts.js
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2023 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.provide('GoogleSmartCard.AsyncAsserts');
+
+goog.require('goog.asserts');
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+/**
+ * @param {!Function} func
+ * @return {!Promise<!Error>} Resolves to the exception thrown by the func.
+ */
+GSC.AsyncAsserts.assertThrows = async function (func) {
+  try {
+    await func();
+  } catch (e) {
+    return e;
+  }
+  fail('Unexpectedly no exception in function');
+  // Suppress the "missing return" failure.
+  goog.asserts.fail();
+};
+
+});

--- a/common/js/src/requesting/requester-unittest.js
+++ b/common/js/src/requesting/requester-unittest.js
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+goog.require('GoogleSmartCard.AsyncAsserts');
 goog.require('GoogleSmartCard.Requester');
 goog.require('GoogleSmartCard.RequesterMessage');
 goog.require('GoogleSmartCard.RequesterMessage.RequestMessageData');
@@ -192,14 +193,11 @@ goog.exportSymbol('testRequester_exceptionWhileSending', async function() {
   mockMessageChannel.send.$replay();
   const requester = new Requester(REQUESTER_NAME, mockMessageChannel);
 
-  try {
+  const error = await GSC.AsyncAsserts.assertThrows(async () => {
     await requester.postRequest({});
-  } catch (e) {
-    // This is the expected branch. Verify the error message is passed through.
-    assertContains(SEND_ERROR_MESSAGE, e.toString());
-    return;
-  }
-  fail('Message posting unexpectedly succeeded');
+  });
+
+  assertContains(SEND_ERROR_MESSAGE, error.toString());
 });
 
 // Test that if sending the request message results in immediate disposal and an
@@ -222,13 +220,10 @@ goog.exportSymbol(
       mockMessageChannel.send.$replay();
       const requester = new Requester(REQUESTER_NAME, mockMessageChannel);
 
-      try {
+      const error = await GSC.AsyncAsserts.assertThrows(async () => {
         await requester.postRequest({});
-      } catch (e) {
-        // This is the expected branch. Verify the error message.
-        assertContains('requester is disposed', e.toString());
-        return;
-      }
-      fail('Message posting unexpectedly succeeded');
+      });
+
+      assertContains('requester is disposed', error.toString());
     });
 });  // goog.scope

--- a/smart_card_connector_app/build/js_to_cxx_tests/Makefile
+++ b/smart_card_connector_app/build/js_to_cxx_tests/Makefile
@@ -36,6 +36,7 @@ SOURCE_DIR := $(ROOT_PATH)/smart_card_connector_app/src/
 # targets (for ../executable_module/cpp_unittests/). Get rid of duplicate
 # compilation by putting them into static libraries.
 CXX_SOURCES := \
+  $(ROOT_PATH)/common/cpp/src/logging_integration_test_helper.cc \
   $(SOURCE_DIR)/application_integration_test_helper.cc \
   $(SOURCE_DIR)/testing_smart_card_simulation.cc \
 

--- a/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
@@ -20,6 +20,7 @@
  * Card Connector.
  */
 
+goog.require('GoogleSmartCard.AsyncAsserts');
 goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.IntegrationTestController');
 goog.require('GoogleSmartCard.LibusbProxyReceiver');
@@ -1219,18 +1220,14 @@ goog.exportSymbol('testPcscApi', {
       await client.api.SCardIsValidContext(BAD_CONTEXT);
 
       // Trigger the C++ module crash.
-      try {
-        await testController.sendMessageToCppHelper(
+      const error = await GSC.AsyncAsserts.assertThrows(async () => {
+        return await testController.sendMessageToCppHelper(
             'LoggingTestHelper', 'crash-via-check');
-      } catch (e) {
-        // This is the expected branch. Verify the error message.
-        assertContains('requester is disposed', e.toString());
-        assert(testController.executableModule.isDisposed());
-        assert(client.clientHandler.isDisposed());
-        return;
-      }
+      });
 
-      fail('Unexpectedly proceeded beyond crash');
+      assertContains('requester is disposed', error.toString());
+      assert(testController.executableModule.isDisposed());
+      assert(client.clientHandler.isDisposed());
     },
   },
 

--- a/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
@@ -1223,10 +1223,14 @@ goog.exportSymbol('testPcscApi', {
         await testController.sendMessageToCppHelper(
             'LoggingTestHelper', 'crash-via-check');
       } catch (e) {
-        // This is expected branch - discard the exception.
+        // This is the expected branch. Verify the error message.
+        assertContains('requester is disposed', e.toString());
+        assert(testController.executableModule.isDisposed());
+        assert(client.clientHandler.isDisposed());
+        return;
       }
 
-      assert(client.clientHandler.isDisposed());
+      fail('Unexpectedly proceeded beyond crash');
     },
   },
 


### PR DESCRIPTION
Test that a C++ crash in the executable module gets correctly handled in case there's an active PC/SC client. The module and the client should get disposed of without any unexpected exceptions.

This is a regression test for #823.