### PR TITLE
[logging] Downgrade warning in server-request-handler.js

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/server-request-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/server-request-handler.js
@@ -334,7 +334,7 @@ Pcsc.ServerRequestHandler = class extends goog.Disposable {
   serverMessageChannelDisposedListener_() {
     if (this.isDisposed())
       return;
-    goog.log.warning(
+    goog.log.info(
         this.logger, 'Server message channel was disposed, disposing...');
 
     // Note: this assignment is important because it prevents from sending of


### PR DESCRIPTION
The "Server message channel was disposed, disposing..." message should be a regular "info" log rather than "warning". In particular, this prevents warning log spam in the JS-to-C++ integration tests.