### PR TITLE
[js promise] Use promisify in UserPromptingChecker

### DIFF
--- a/common/js/src/promisify-extension-api.js
+++ b/common/js/src/promisify-extension-api.js
@@ -45,7 +45,7 @@ GSC.PromisifyExtensionApi.promisify = function(
     apiThat, apiMethod, ...apiArguments) {
   return new Promise((resolve, reject) => {
     apiMethod.call(apiThat, ...apiArguments, function(apiResult) {
-      if (chrome.runtime.lastError) {
+      if (chrome && chrome.runtime && chrome.runtime.lastError) {
         const apiError = goog.object.get(
             chrome.runtime.lastError, 'message', 'Unknown error');
         reject(apiError);


### PR DESCRIPTION
Simplify asynchronous code in UserPromptingChecker using the common promisify() helper function.

Also bullet-proof promisify() for environments that don't have full Chrome API definitions like `chrome.runtime` (this is also needed to make unit tests pass).