### PR TITLE
[JS-to-C++ test] Test SCardConnect protocol mismatch

### DIFF
--- a/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
@@ -1029,7 +1029,7 @@ goog.exportSymbol('testPcscApi', {
             fail(`Unexpected error in first SCardConnect: ${errorCode}`);
           });
       assertTrue(called);
-      assertEquals(secondResult.getErrorCode(), API.SCARD_E_PROTO_MISMATCH);
+      assertEquals(secondResult.getErrorCode(), API.SCARD_S_SUCCESS);
     },
 
     // Test `SCardConnect()` fails for dwShareMode `SCARD_SHARE_SHARED` when


### PR DESCRIPTION
Add test cases for the successful/broken scenarios when the SCardConnect() is called multiple times with different protocols requested.