### PR TITLE
[PC/SC test] Simulate Yubikey 4C

### DIFF
--- a/smart_card_connector_app/src/testing_smart_card_simulation.h
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.h
@@ -52,9 +52,23 @@ namespace google_smart_card {
 class TestingSmartCardSimulation final : public RequestHandler {
  public:
   // Fake device to simulate.
-  enum class DeviceType { kGemaltoPcTwinReader, kDellSmartCardReaderKeyboard };
-  enum class CardType { kCosmoId70 };
-  enum class CardProfile { kCharismathicsPiv };
+  enum class DeviceType {
+    kGemaltoPcTwinReader,
+    kDellSmartCardReaderKeyboard,
+    kYubikey4C
+  };
+  enum class CardType {
+    // Usable with all non-Yubikey device types.
+    kCosmoId70,
+    // Only usable with Yubikey device types.
+    kYubikey,
+  };
+  enum class CardProfile {
+    // Usable with all non-Yubikey device types.
+    kCharismathicsPiv,
+    // Only usable with Yubikey device types.
+    kYubikey,
+  };
 
   // Represents whether an ICC (a smart card) is inserted into the reader and is
   // powered. Corresponds to "bmICCStatus" from CCID specs.


### PR DESCRIPTION
Implement simulation of a new device - Yubico Yubikey 4C. There's no particular reason this device is chosen, except that to increase test coverage for various types of devices.

The simulation that's added is minimalistic and makes only the basic interactions (plug in/out, obtain ATR) work. More can be added later if necessary.