### PR TITLE
[Web API] Remove expose_chrome_smart_card_api policy check

### DIFF
--- a/smart_card_connector_app/src/managed_storage_schema.json
+++ b/smart_card_connector_app/src/managed_storage_schema.json
@@ -3,7 +3,7 @@
   "properties": {
     "expose_chrome_smart_card_api": {
       "title": "Handle requests from chrome.smartCardProviderPrivate API.",
-      "description": "If set to true, the app will subscribe to chrome.smartCardProviderPrivate API events and handle the requests. This is needed for Web Smart Card API.",
+      "description": "DEPRECATED. This is now on by default.",
       "type": "boolean"
     },
     "force_allowed_client_app_ids": {


### PR DESCRIPTION
This CL makes ChromeApiProvider created by default, not guarded by the managed schema policy.