### PR TITLE
Release Connector 1.4.0

### DIFF
--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -23,7 +23,7 @@ ${endif}
   "short_name": "__MSG_appShortName__",
   "description": "__MSG_appDesc__",
 
-  "version": "1.3.15.0",
+  "version": "1.4.0",
 
   # Whether an application is an App or an Extension is determined by nesting or
   # not nesting the background script information under the "app" key.


### PR DESCRIPTION
We also switch from the previous four-number version to a proper SemVer: MAJOR.MINOR.PATCH.

Not only SemVer is the more standard versioning scheme, but it also
happens to work better for logging, because groups of four
dot-separated numbers are stripped out from ChromeOS logs by
anonymizer tools.