### PR TITLE
[libusb] Avoid duplicate USB transfers

### DIFF
--- a/common/cpp/src/public/requesting/remote_call_adaptor.cc
+++ b/common/cpp/src/public/requesting/remote_call_adaptor.cc
@@ -16,6 +16,7 @@
 
 #include <utility>
 
+#include "common/cpp/src/public/requesting/remote_call_async_request.h"
 #include "common/cpp/src/public/requesting/remote_call_message.h"
 #include "common/cpp/src/public/value_conversion.h"
 
@@ -27,6 +28,12 @@ RemoteCallAdaptor::RemoteCallAdaptor(Requester* requester)
 }
 
 RemoteCallAdaptor::~RemoteCallAdaptor() = default;
+
+void RemoteCallAdaptor::AsyncCall(
+    RemoteCallAsyncRequest remote_call_async_request) {
+  StartAsyncRequest(std::move(remote_call_async_request.request_payload),
+                    remote_call_async_request.callback);
+}
 
 GenericRequestResult RemoteCallAdaptor::PerformSyncRequest(
     RemoteCallRequestPayload payload) {

--- a/common/cpp/src/public/requesting/remote_call_adaptor.h
+++ b/common/cpp/src/public/requesting/remote_call_adaptor.h
@@ -21,6 +21,7 @@
 #include "common/cpp/src/public/logging/logging.h"
 #include "common/cpp/src/public/requesting/async_request.h"
 #include "common/cpp/src/public/requesting/remote_call_arguments_conversion.h"
+#include "common/cpp/src/public/requesting/remote_call_async_request.h"
 #include "common/cpp/src/public/requesting/remote_call_message.h"
 #include "common/cpp/src/public/requesting/request_result.h"
 #include "common/cpp/src/public/requesting/requester.h"
@@ -66,6 +67,8 @@ class RemoteCallAdaptor final {
                                                std::forward<Args>(args)...),
         callback, async_request);
   }
+
+  void AsyncCall(RemoteCallAsyncRequest remote_call_async_request);
 
   template <typename... PayloadFields>
   static bool ExtractResultPayload(GenericRequestResult generic_request_result,

--- a/common/cpp/src/public/requesting/remote_call_async_request.h
+++ b/common/cpp/src/public/requesting/remote_call_async_request.h
@@ -1,0 +1,30 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_SMART_CARD_COMMON_CPP_SRC_PUBLIC_REQUESTING_REMOTE_CALL_ASYNC_REQUEST_H_
+#define GOOGLE_SMART_CARD_COMMON_CPP_SRC_PUBLIC_REQUESTING_REMOTE_CALL_ASYNC_REQUEST_H_
+
+#include "common/cpp/src/public/requesting/async_request.h"
+#include "common/cpp/src/public/requesting/remote_call_message.h"
+
+namespace google_smart_card {
+
+struct RemoteCallAsyncRequest {
+  RemoteCallRequestPayload request_payload;
+  GenericAsyncRequestCallback callback;
+};
+
+}  // namespace google_smart_card
+
+#endif  // GOOGLE_SMART_CARD_COMMON_CPP_SRC_PUBLIC_REQUESTING_REMOTE_CALL_ASYNC_REQUEST_H_

--- a/third_party/libusb/webport/src/libusb_js_proxy.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy.h
@@ -19,6 +19,7 @@
 
 #include <stdint.h>
 
+#include <functional>
 #include <memory>
 #include <unordered_map>
 
@@ -28,10 +29,12 @@
 #include "common/cpp/src/public/messaging/typed_message_router.h"
 #include "common/cpp/src/public/requesting/js_requester.h"
 #include "common/cpp/src/public/requesting/remote_call_adaptor.h"
+#include "common/cpp/src/public/requesting/remote_call_async_request.h"
 #include "common/cpp/src/public/requesting/request_result.h"
 #include "third_party/libusb/webport/src/libusb_contexts_storage.h"
 #include "third_party/libusb/webport/src/libusb_interface.h"
 #include "third_party/libusb/webport/src/libusb_opaque_types.h"
+#include "third_party/libusb/webport/src/usb_transfer_destination.h"
 
 namespace google_smart_card {
 
@@ -128,6 +131,19 @@ class LibusbJsProxy final : public LibusbInterface {
       libusb_transfer* transfer);
   int LibusbHandleEventsWithTimeout(libusb_context* context,
                                     int timeout_seconds);
+  std::function<void(GenericRequestResult)> MakeLibusbJsTransferCallback(
+      const std::string& js_api_name,
+      std::weak_ptr<libusb_context> context,
+      const UsbTransferDestination& transfer_destination,
+      TransferAsyncRequestStatePtr async_request_state);
+  RemoteCallAsyncRequest PrepareTransferJsApiCall(
+      libusb_context* const context,
+      libusb_transfer* transfer,
+      const UsbTransferDestination& transfer_destination,
+      std::shared_ptr<TransferAsyncRequestState> async_request_state);
+  void MaybeStartTransferJsRequest(
+      libusb_context* const context,
+      const UsbTransferDestination& transfer_destination);
   int DoGenericSyncTranfer(libusb_transfer_type transfer_type,
                            libusb_device_handle* device_handle,
                            unsigned char endpoint_address,

--- a/third_party/libusb/webport/src/libusb_opaque_types.cc
+++ b/third_party/libusb/webport/src/libusb_opaque_types.cc
@@ -20,17 +20,50 @@
 #include <utility>
 
 #include "common/cpp/src/public/logging/logging.h"
+#include "common/cpp/src/public/optional.h"
+#include "common/cpp/src/public/requesting/remote_call_async_request.h"
+
+using google_smart_card::optional;
+using google_smart_card::RemoteCallAsyncRequest;
 
 void libusb_context::AddAsyncTransferInFlight(
     TransferAsyncRequestStatePtr async_request_state,
     const UsbTransferDestination& transfer_destination,
-    libusb_transfer* transfer) {
+    libusb_transfer* transfer,
+    RemoteCallAsyncRequest prepared_js_call) {
   GOOGLE_SMART_CARD_CHECK(async_request_state);
   GOOGLE_SMART_CARD_CHECK(transfer);
 
   const std::unique_lock<std::mutex> lock(mutex_);
 
-  AddTransferInFlight(async_request_state, transfer_destination, transfer);
+  AddTransferInFlight(async_request_state, transfer_destination, transfer,
+                      std::move(prepared_js_call));
+}
+
+optional<RemoteCallAsyncRequest>
+libusb_context::PrepareTransferJsCallForExecution(
+    const UsbTransferDestination& transfer_destination) {
+  const std::unique_lock<std::mutex> lock(mutex_);
+
+  if (transfer_destination.IsInputDirection() &&
+      ongoing_input_js_api_transfers_.count(transfer_destination)) {
+    // Avoid making a new input transfer JS API call if there's already an
+    // equivalent one running: starting too many indefinitely-running transfers
+    // will eventually hit implementation limits in the browser or the OS.
+    return {};
+  }
+  optional<RemoteCallAsyncRequest> prepared_js_call =
+      transfers_in_flight_.ExtractPreparedJsCall(transfer_destination);
+  if (!prepared_js_call) {
+    // Nothing to execute at the moment.
+    return {};
+  }
+  if (transfer_destination.IsInputDirection()) {
+    // Mark this transfer destination as having an active JS API call.
+    GOOGLE_SMART_CARD_CHECK(
+        ongoing_input_js_api_transfers_.insert(transfer_destination).second);
+  }
+  return prepared_js_call;
 }
 
 void libusb_context::WaitAndProcessAsyncTransferReceivedResults(
@@ -129,6 +162,10 @@ void libusb_context::OnInputTransferResultReceived(
   received_input_transfer_result_map_[transfer_destination].push(
       std::move(result));
 
+  const auto iter = ongoing_input_js_api_transfers_.find(transfer_destination);
+  GOOGLE_SMART_CARD_CHECK(iter != ongoing_input_js_api_transfers_.end());
+  ongoing_input_js_api_transfers_.erase(iter);
+
   condition_.notify_all();
 }
 
@@ -156,7 +193,8 @@ void libusb_context::OnOutputTransferResultReceived(
 void libusb_context::AddTransferInFlight(
     TransferAsyncRequestStatePtr async_request_state,
     const UsbTransferDestination& transfer_destination,
-    libusb_transfer* transfer) {
+    libusb_transfer* transfer,
+    RemoteCallAsyncRequest prepared_js_call) {
   GOOGLE_SMART_CARD_CHECK(async_request_state);
 
   std::chrono::time_point<std::chrono::high_resolution_clock> timeout;
@@ -170,7 +208,7 @@ void libusb_context::AddTransferInFlight(
   }
 
   transfers_in_flight_.Add(async_request_state, transfer_destination, transfer,
-                           timeout);
+                           std::move(prepared_js_call), timeout);
 
   condition_.notify_all();
 }

--- a/third_party/libusb/webport/src/libusb_opaque_types.cc
+++ b/third_party/libusb/webport/src/libusb_opaque_types.cc
@@ -49,7 +49,9 @@ libusb_context::PrepareTransferJsCallForExecution(
       ongoing_input_js_api_transfers_.count(transfer_destination)) {
     // Avoid making a new input transfer JS API call if there's already an
     // equivalent one running: starting too many indefinitely-running transfers
-    // will eventually hit implementation limits in the browser or the OS.
+    // will eventually hit implementation limits in the browser or the OS. As
+    // all such transfers are considered interchangeable, we'll only start a new
+    // transfer after the previous one completes.
     return {};
   }
   optional<RemoteCallAsyncRequest> prepared_js_call =


### PR DESCRIPTION
Don't make new chrome.usb/WebUSB API calls in case there're already running equivalent ones (for input transfers).

Besides consuming Chrome resources, these extra calls were reportedly leading to hitting the OS kernel limits on the number of active transfers, which completely broke the USB communication in some cases.

This fixes #1104.