### PR TITLE
WIP fix CCID polling transfer restart

### DIFF
--- a/smart_card_connector_app/src/_locales/en/messages.json
+++ b/smart_card_connector_app/src/_locales/en/messages.json
@@ -1,10 +1,10 @@
 {
   "appName": {
-    "message": "Smart Card Connector",
+    "message": "[BETA] Smart Card Connector",
     "description": "The title of the application, displayed in the web store."
   },
   "appShortName": {
-    "message": "Smart Card Connector",
+    "message": "[BETA] Smart Card Connector",
     "description": "The short version of the application title."
   },
   "appDesc": {
@@ -12,11 +12,11 @@
     "description": "The description of the application, displayed in the web store."
   },
   "mainWindowTitle": {
-    "message": "Smart Card Connector",
+    "message": "[BETA] Smart Card Connector",
     "description": "The title of the main window"
   },
   "mainWindowHeader": {
-    "message": "Smart Card Connector",
+    "message": "[BETA] Smart Card Connector",
     "description": "The header displayed in the main window"
   },
   "crashWarning": {
@@ -108,11 +108,11 @@
     "description": "Title of the link that can be used to copy the logs into the clipboard, shortly after the copying process has finished"
   },
   "pcscClientHandlingUserPromptDialogTitle": {
-    "message": "Smart Card Connector",
+    "message": "[BETA] Smart Card Connector",
     "description": "Window title of the PC/SC-Lite client handling user prompt dialog"
   },
   "pcscClientHandlingUserPromptDialogHeader": {
-    "message": "Smart Card Connector",
+    "message": "[BETA] Smart Card Connector",
     "description": "Caption displayed in the PC/SC-Lite client handling user prompt dialog"
   },
   "pcscClientHandlingUserPromptDialogAllow": {

--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -23,7 +23,7 @@ ${endif}
   "short_name": "__MSG_appShortName__",
   "description": "__MSG_appDesc__",
 
-  "version": "1.4.1",
+  "version": "1.4.1.123",
 
   # Whether an application is an App or an Extension is determined by nesting or
   # not nesting the background script information under the "app" key.


### PR DESCRIPTION
We should support restarting the interrupt transfer after it's been stopped in the past.

This fixes the breakage of the polling transfer after the "insert card => SCardConnect => SCardDisconnect => remove card" scenario, which led the application to actively poll the reader every 400 ms instead of a 10-minute transfer, which in turn led to excessively big number of inflight chrome.usb transfers and various breakages in production.