### PR TITLE
Update blog URL in updating-pcsc-lite.md

### DIFF
--- a/docs/updating-ccid.md
+++ b/docs/updating-ccid.md
@@ -84,7 +84,7 @@ Smart Card Connector app via Web Store:
 1. Mention the update of the CCID driver at the Release's description on GitHub.
    It's also nice to add a link to the CCID release notes (which are typically
    published at
-   [https://ludovicrousseau.blogspot.com/](https://ludovicrousseau.blogspot.com/)).
+   [https://blog.apdu.fr/](https://blog.apdu.fr/).
 
 2. File an internal bug to update the
    [https://support.google.com/chrome/a/answer/7014689](https://support.google.com/chrome/a/answer/7014689)

--- a/docs/updating-pcsc-lite.md
+++ b/docs/updating-pcsc-lite.md
@@ -84,4 +84,4 @@ Smart Card Connector app via Web Store:
 1. Mention the update of the PC/SC-Lite daemon at the Release's description on
    GitHub. It's also nice to add a link to the PC/SC-Lite release notes (which
    are typically published at
-   [https://ludovicrousseau.blogspot.com/](https://ludovicrousseau.blogspot.com/)).
+   [https://blog.apdu.fr/](https://blog.apdu.fr/)).


### PR DESCRIPTION
Ludovic Rousseau's blog moved from blogspot.com to apdu.fr See https://blog.apdu.fr/posts/2023/05/blog-moved-to-httpsblogapdufr/