### PR TITLE
[JS-to-C++ tests] Bulletproof teardowns

### DIFF
--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-integrationtest.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-integrationtest.js
@@ -88,8 +88,12 @@ goog.exportSymbol('testChromeCertificateProviderApiBridge', {
 
   'tearDown': async function() {
     try {
-      bridgeBackend.dispose();
-      await testController.disposeAsync();
+      if (bridgeBackend) {
+        bridgeBackend.dispose();
+      }
+      if (testController) {
+        await testController.disposeAsync();
+      }
     } finally {
       bridgeBackend = null;
       testController = null;

--- a/smart_card_connector_app/src/chrome-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/chrome-api-jstocxxtest.js
@@ -62,8 +62,8 @@ let libusbProxyReceiver;
 let pcscReadinessTracker;
 /** @type {MockChromeApi?} */
 let mockChromeApi;
-/** @type {!goog.testing.MockControl|undefined} */
-let mockControl;
+/** @type {!goog.testing.MockControl|null} */
+let mockControl = null;
 /** @type {ChromeApiProvider?} */
 let chromeApiProvider;
 /** @type {number?} */

--- a/smart_card_connector_app/src/chrome-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/chrome-api-jstocxxtest.js
@@ -1101,6 +1101,7 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
       }
     } finally {
       chromeApiProvider = null;
+      mockControl = null;
       pcscReadinessTracker = null;
       testController = null;
     }

--- a/smart_card_connector_app/src/chrome-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/chrome-api-jstocxxtest.js
@@ -1086,11 +1086,19 @@ goog.exportSymbol('testChromeApiProviderToCpp', {
 
   'tearDown': async function() {
     try {
-      await testController.disposeAsync();
-      pcscReadinessTracker.dispose();
-      assertTrue(chromeApiProvider.isDisposed());
-      // Check all mock expectations are satisfied.
-      mockControl.$verifyAll();
+      if (testController) {
+        await testController.disposeAsync();
+      }
+      if (pcscReadinessTracker) {
+        pcscReadinessTracker.dispose();
+      }
+      if (chromeApiProvider) {
+        assertTrue(chromeApiProvider.isDisposed());
+      }
+      if (mockControl) {
+        // Check all mock expectations are satisfied.
+        mockControl.$verifyAll();
+      }
     } finally {
       chromeApiProvider = null;
       pcscReadinessTracker = null;

--- a/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
+++ b/smart_card_connector_app/src/pcsc-api-jstocxxtest.js
@@ -1330,8 +1330,12 @@ goog.exportSymbol('testPcscApi', {
 
   'tearDown': async function() {
     try {
-      await testController.disposeAsync();
-      pcscReadinessTracker.dispose();
+      if (testController) {
+        await testController.disposeAsync();
+      }
+      if (pcscReadinessTracker) {
+        pcscReadinessTracker.dispose();
+      }
     } finally {
       pcscReadinessTracker = null;
       ClientHandler.overridePermissionsCheckerForTesting(null);


### PR DESCRIPTION
Make the code in test cases' tearDown functions resistant to failures in setUps. This avoids spurious errors like "reading the dispose property of a null object" after the real test failures.

This commit is a no-op for the successfully built tree, it's only intended to improve troubleshooting of test failures.