### PR TITLE
[ui] Fix options passing in runModalDialog

### DIFF
--- a/common/js/src/popup-window/popup-opener.js
+++ b/common/js/src/popup-window/popup-opener.js
@@ -134,6 +134,8 @@ GSC.PopupOpener.createWindow = function(url, windowOptions, opt_data) {
 GSC.PopupOpener.runModalDialog = function(url, opt_windowOptions, opt_data) {
   const createWindowOptions =
       goog.object.clone(DEFAULT_DIALOG_CREATE_WINDOW_OPTIONS);
+  if (opt_windowOptions !== undefined)
+    Object.assign(createWindowOptions, opt_windowOptions);
 
   if (GSC.Packaging.MODE === GSC.Packaging.Mode.EXTENSION)
     lastUsedPopupId++;


### PR DESCRIPTION
Fix the PopupOpener.runModalDialog() function to correctly pass the optional window parameters.

They were ignored (this regressed in #518). One noticeable example was incorrect width of the PIN prompt in the example applications. Tracking issue #1126.