### PR TITLE
[ui] Fix width parameter format in example PIN dlg

### DIFF
--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog-backend.js
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog-backend.js
@@ -47,7 +47,7 @@ const PIN_DIALOG_URL = 'built-in-pin-dialog.html';
 
 const PIN_DIALOG_WINDOW_OPTIONS_OVERRIDES = {
   'alwaysOnTop': false,
-  'innerBounds': {'width': 230}
+  'width': 230,
 };
 
 const GSC = GoogleSmartCard;

--- a/example_js_smart_card_client_app/src/pin-dialog/pin-dialog-server.js
+++ b/example_js_smart_card_client_app/src/pin-dialog/pin-dialog-server.js
@@ -25,7 +25,7 @@ goog.scope(function() {
 const PIN_DIALOG_URL = 'pin-dialog.html';
 
 const PIN_DIALOG_WINDOW_OPTIONS_OVERRIDES = {
-  'innerBounds': {'width': 230}
+  'width': 230,
 };
 
 const GSC = GoogleSmartCard;


### PR DESCRIPTION
The "width" property should be passed without being wrapped into the "innerBounds" property.

This fixes the regression that was introduced in #404. Tracking issue #1126.