### PR TITLE
[mv3] Use globalThis instead of window

### DIFF
--- a/common/js/src/random.js
+++ b/common/js/src/random.js
@@ -36,12 +36,7 @@ const GSC = GoogleSmartCard;
  */
 GSC.Random.randomIntegerNumber = function() {
   const randomBytes = new Uint8Array(RANDOM_INTEGER_BYTE_COUNT);
-  if (typeof window !== 'undefined') {
-    window.crypto.getRandomValues(randomBytes);
-  } else {
-    // We're likely inside a Service Worker.
-    self.crypto.getRandomValues(randomBytes);
-  }
+  globalThis.crypto.getRandomValues(randomBytes);
   let result = 0;
   goog.array.forEach(randomBytes, function(byteValue) {
     result = result * 256 + byteValue;

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -75,7 +75,7 @@ goog.log.info(
     logger,
     `The Smart Card Connector app (id "${chrome.runtime.id}", version ` +
         `${extensionManifest.version}) background script started. Browser ` +
-        `version: "${window.navigator.appVersion}".`);
+        `version: "${globalThis.navigator.appVersion}".`);
 
 /**
  * Loads the binary executable module depending on the toolchain configuration.


### PR DESCRIPTION
Switch a couple of places that use the "window" object to use "globalThis" instead. The latter is a better equivalent because it works in Manifest V3 Service Workers as well (in a Service Worker, "self" should be used instead of "window"; "globalThis" is an alias to either of those).

This contributes to the effort tracked by #1129.