### PR TITLE
Resolve permissions check when managed policy gets updated

### DIFF
--- a/common/js/src/popup-window/popup-opener.js
+++ b/common/js/src/popup-window/popup-opener.js
@@ -55,7 +55,7 @@ let WindowOptions;
 GSC.PopupOpener.WindowOptions = WindowOptions;
 
 /** @type {!Map.<string, number>} */
-const clientOriginToWindowId = new Map();
+const windowIdMap = new Map();
 
 /** @type {!GSC.PopupOpener.WindowOptions} */
 const DEFAULT_DIALOG_CREATE_WINDOW_OPTIONS = {
@@ -115,7 +115,7 @@ GSC.PopupOpener.createWindow = function(url, windowOptions, opt_data) {
           'width': windowOptions['width'],
           'setSelfAsOpener': true
         }, (createdWindow) => {
-          clientOriginToWindowId.set(windowOptions['id'], createdWindow.id);
+          windowIdMap.set(windowOptions['id'], createdWindow.id);
         });
     } else {
       GSC.Logging.failWithLogger(
@@ -182,7 +182,7 @@ GSC.PopupOpener.runModalDialog = function(url, opt_windowOptions, opt_data) {
 };
 
 /**
- * Close modal dialog.
+ * Close the modal dialog with the given window ID.
  * @param {string} id The window ID of the window to be closed.
  */
 GSC.PopupOpener.closeModalDialog = async function(id) {
@@ -190,13 +190,12 @@ GSC.PopupOpener.closeModalDialog = async function(id) {
     const window = chrome.app.window.get(id);
     if (window != null){
       window.close();
-      return;
     }
   } else if (GSC.Packaging.MODE === GSC.Packaging.Mode.EXTENSION) {
-    const windowId = clientOriginToWindowId.get(id);
+    const windowId = windowIdMap.get(id);
     if (windowId !== undefined) {
-      clientOriginToWindowId.delete(id);
-      chrome.windows.remove(windowId);
+      windowIdMap.delete(id);
+      await chrome.windows.remove(windowId);
     }
   }
 }

--- a/common/js/src/popup-window/popup-opener.js
+++ b/common/js/src/popup-window/popup-opener.js
@@ -188,7 +188,7 @@ GSC.PopupOpener.runModalDialog = function(url, opt_windowOptions, opt_data) {
 GSC.PopupOpener.closeModalDialog = async function(id) {
   if (GSC.Packaging.MODE === GSC.Packaging.Mode.APP) {
     const window = chrome.app.window.get(id);
-    if (window != null){
+    if (window !== null){
       window.close();
     }
   } else if (GSC.Packaging.MODE === GSC.Packaging.Mode.EXTENSION) {
@@ -198,7 +198,7 @@ GSC.PopupOpener.closeModalDialog = async function(id) {
       await chrome.windows.remove(windowId);
     }
   }
-}
+};
 
 /**
  * @param {!Object} createdWindowExtends

--- a/common/js/src/popup-window/popup-opener.js
+++ b/common/js/src/popup-window/popup-opener.js
@@ -109,14 +109,15 @@ GSC.PopupOpener.createWindow = function(url, windowOptions, opt_data) {
           createWindowCallback.bind(null, createdWindowExtends));
     } else if (GSC.Packaging.MODE === GSC.Packaging.Mode.EXTENSION) {
       chrome.windows.create(
-        {
-          'url': url,
-          'type': 'popup',
-          'width': windowOptions['width'],
-          'setSelfAsOpener': true
-        }, (createdWindow) => {
-          windowIdMap.set(windowOptions['id'], createdWindow.id);
-        });
+          {
+            'url': url,
+            'type': 'popup',
+            'width': windowOptions['width'],
+            'setSelfAsOpener': true
+          },
+          (createdWindow) => {
+            windowIdMap.set(windowOptions['id'], createdWindow.id);
+          });
     } else {
       GSC.Logging.failWithLogger(
           logger, `Unexpected packaging mode ${GSC.Packaging.MODE}`);
@@ -143,8 +144,14 @@ GSC.PopupOpener.runModalDialog = function(url, opt_windowOptions, opt_data) {
   if (opt_windowOptions !== undefined)
     Object.assign(createWindowOptions, opt_windowOptions);
 
-  if (GSC.Packaging.MODE === GSC.Packaging.Mode.EXTENSION)
+  if (GSC.Packaging.MODE === GSC.Packaging.Mode.EXTENSION) {
+    if (lastUsedPopupId === 0) {
+      chrome.windows.onRemoved.addListener((windowId) => {
+        windowIdMap.delete(windowId);
+      });
+    }
     lastUsedPopupId++;
+  }
 
   const promiseResolver = goog.Promise.withResolver();
 
@@ -188,7 +195,7 @@ GSC.PopupOpener.runModalDialog = function(url, opt_windowOptions, opt_data) {
 GSC.PopupOpener.closeModalDialog = async function(id) {
   if (GSC.Packaging.MODE === GSC.Packaging.Mode.APP) {
     const window = chrome.app.window.get(id);
-    if (window !== null){
+    if (window !== null) {
       window.close();
     }
   } else if (GSC.Packaging.MODE === GSC.Packaging.Mode.EXTENSION) {

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
@@ -249,8 +249,8 @@ ManagedRegistry.prototype.updatePendingPermissionResolvers_ = function() {
   const clientOrigins = Array.from(this.pendingPermissionResolvers_.keys());
   goog.array.forEach(clientOrigins, (clientOrigin) => {
     if (this.allowedClientOrigins_.has(clientOrigin)) {
-      const promiseResolver = this.pendingPermissionResolvers_.get(
-          clientOrigin);
+      const promiseResolver =
+          this.pendingPermissionResolvers_.get(clientOrigin);
       if (promiseResolver !== undefined) {
         this.pendingPermissionResolvers_.delete(clientOrigin);
         promiseResolver.resolve();

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
@@ -60,7 +60,7 @@ PermissionsChecking.ManagedRegistry = function() {
    * Map storing promise resolvers per client origin for pending requests.
    * @type {!Map.<string, !goog.promise.Resolver>} @private @const
    */
-  this.pendingPermissionsResolvers_ = new Map();
+  this.pendingPermissionResolvers_ = new Map();
 
   /**
    * @type {!Set.<string>}
@@ -114,22 +114,26 @@ ManagedRegistry.prototype.getByOrigin = function(clientOrigin) {
 };
 
 /**
- * Stores the promise resolver of a pending permissions request.
+ * Adds the passed clientOrigin and promise resolver corresponding to a
+ * currently pending permissions request to a map. If the managed registry is
+ * updated whilst the request is still pending and a permission for the client
+ * origin is added, the promise will be resolved.
  * @param {string} clientOrigin
  * @param {!goog.promise.Resolver} promiseResolver
  */
 ManagedRegistry.prototype.startMonitoringPermissionsForClientOrigin = function(
     clientOrigin, promiseResolver) {
-  this.pendingPermissionsResolvers_.set(clientOrigin, promiseResolver);
+  this.pendingPermissionResolvers_.set(clientOrigin, promiseResolver);
 };
 
 /**
- * Removes the client origin and its corresponding permissions resolver.
+ * Removes the client origin and its corresponding permissions resolver from the
+ * map.
  * @param {string} clientOrigin
  */
 ManagedRegistry.prototype.stopMonitoringPermissionsForClientOrigin = function(
     clientOrigin) {
-  this.pendingPermissionsResolvers_.delete(clientOrigin);
+  this.pendingPermissionResolvers_.delete(clientOrigin);
 };
 
 /** @private */
@@ -193,7 +197,7 @@ ManagedRegistry.prototype.storageChangedListener_ = function(
           'Loaded the updated managed storage data with the allowed client ' +
               'origins: ' +
               GSC.DebugDump.debugDumpFull(this.allowedClientOrigins_));
-      this.updatePendingPermissionsResolvers_();
+      this.updatePendingPermissionResolvers_();
     }
   }
 };
@@ -241,14 +245,14 @@ ManagedRegistry.prototype.setAllowedClientOriginsFromStorageData_ = function(
  * Resolves any pending permissions requests for allowed client origins.
  * @private
  */
-ManagedRegistry.prototype.updatePendingPermissionsResolvers_ = function() {
-  const clientOrigins = Array.from(this.pendingPermissionsResolvers_.keys());
+ManagedRegistry.prototype.updatePendingPermissionResolvers_ = function() {
+  const clientOrigins = Array.from(this.pendingPermissionResolvers_.keys());
   goog.array.forEach(clientOrigins, (clientOrigin) => {
     if (this.allowedClientOrigins_.has(clientOrigin)) {
-      const promiseResolver = this.pendingPermissionsResolvers_.get(
+      const promiseResolver = this.pendingPermissionResolvers_.get(
           clientOrigin);
       if (promiseResolver !== undefined) {
-        this.pendingPermissionsResolvers_.delete(clientOrigin);
+        this.pendingPermissionResolvers_.delete(clientOrigin);
         promiseResolver.resolve();
       }
     }

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
@@ -257,7 +257,7 @@ ManagedRegistry.prototype.updatePendingPermissionResolvers_ = function() {
       }
     }
   });
-}
+};
 
 /**
  * Returns a client origin from the given policy-configured string.

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/policy-or-prompting-permissions-checker-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/policy-or-prompting-permissions-checker-unittest.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2024 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -234,7 +234,7 @@ goog.exportSymbol(
 goog.exportSymbol(
     'testPolicyOrPromptingPermissionChecker_UnrelatedStorageChange',
     runOnStorageChangedTest(
-      CLIENT_ORIGIN,
+        CLIENT_ORIGIN,
         {'foo': {'oldValue': ['bar'], 'newValue': []}} /* storageChanges */,
         'local' /* storageAreaName */, false /* expectPermissionsGranted */));
 });  // goog.scope

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/policy-or-prompting-permissions-checker-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/policy-or-prompting-permissions-checker-unittest.js
@@ -1,0 +1,240 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientInfo');
+goog.require('GoogleSmartCard.PcscLiteServer.TrustedClientsRegistry');
+goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.UserPromptingChecker');
+goog.require('GoogleSmartCard.Pcsc.PolicyOrPromptingPermissionsChecker');
+goog.require('goog.Promise');
+goog.require('goog.Thenable');
+goog.require('goog.asserts');
+goog.require('goog.promise.Resolver');
+goog.require('goog.testing');
+goog.require('goog.testing.MockControl');
+goog.require('goog.testing.PropertyReplacer');
+goog.require('goog.testing.mockmatchers');
+
+goog.setTestOnly();
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+const PolicyOrPromptingPermissionsChecker =
+    GSC.Pcsc.PolicyOrPromptingPermissionsChecker;
+const TrustedClientInfo = GSC.PcscLiteServer.TrustedClientInfo;
+const UserPromptingChecker = GSC.PcscLiteServerClientsManagement
+                                 .PermissionsChecking.UserPromptingChecker;
+
+const ignoreArgument = goog.testing.mockmatchers.ignoreArgument;
+
+const LOCAL_STORAGE_KEY = 'pcsc_lite_clients_user_selections';
+const MANAGED_STORAGE_KEY = 'force_allowed_client_app_ids';
+const MANAGED_STORAGE_AREA_NAME = 'managed';
+
+const CLIENT_EXTENSION_ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const CLIENT_ORIGIN = `chrome-extension://${CLIENT_EXTENSION_ID}`;
+const CLIENT_NAME = 'Application';
+const TRUSTED_CLIENT_INFO =
+    new TrustedClientInfo(CLIENT_ORIGIN, CLIENT_NAME, /* autoapprove= */ false);
+
+/** @implements {GSC.PcscLiteServer.TrustedClientsRegistry} @constructor */
+function FakeTrustedClientsRegistry() {}
+
+/** @override */
+FakeTrustedClientsRegistry.prototype.getByOrigin = function(origin) {
+  if (origin === CLIENT_ORIGIN)
+    return goog.Promise.resolve(TRUSTED_CLIENT_INFO);
+  return goog.Promise.reject();
+};
+
+/** @override */
+FakeTrustedClientsRegistry.prototype.tryGetByOrigins = function(unused) {
+  fail('Unexpected tryGetByOrigins() call');
+  goog.asserts.fail();
+};
+
+/** @type {!Array<function(!Object, string)>} */
+const onStorageChangedListeners = [];
+
+/**
+ * Sets up mocks for get() and addListener() methods of the chrome.storage API.
+ * @param {!goog.testing.MockControl} mockControl
+ * @param {!goog.testing.PropertyReplacer} propertyReplacer
+ */
+function setUpChromeStorageMock(mockControl, propertyReplacer) {
+  propertyReplacer.set(chrome, 'storage', {
+    'local': {
+      'get': mockControl.createFunctionMock('chrome.storage.local.get'),
+    },
+    'managed': {
+      'get': mockControl.createFunctionMock('chrome.storage.managed.get'),
+    },
+    'onChanged': {
+      'addListener': (listener) => {
+        onStorageChangedListeners.push(listener);
+      },
+    }
+  });
+
+  // Suppress compiler's signature verifications locally, to be able to use
+  // mock-specific functionality.
+  /** @type {?} */ chrome.storage.local.get;
+  /** @type {?} */ chrome.storage.managed.get;
+
+  chrome.storage.local.get(LOCAL_STORAGE_KEY, ignoreArgument)
+      .$does(function(key, callback) {
+        callback({});
+      });
+  chrome.storage.managed.get(MANAGED_STORAGE_KEY, ignoreArgument)
+      .$does(function(key, callback) {
+        callback({[MANAGED_STORAGE_KEY]: []});
+      });
+}
+
+/**
+ * Sets up UserPromptingChecker for testing with a fake TrustedClientsRegistry
+ * and a fake implementation for the user prompt dialog.
+ * @param {!Function} runModalDialogFake
+ */
+function setUpUserPromptingChecker(runModalDialogFake) {
+  UserPromptingChecker.overrideTrustedClientsRegistryForTesting(
+      new FakeTrustedClientsRegistry());
+  UserPromptingChecker.overrideModalDialogRunnerForTesting(runModalDialogFake);
+}
+
+/**
+ * Runs a permissions check test for the given client origin. In this test
+ * setup, the managed and local storage are initially empty. When the user
+ * prompt dialog would be shown, it will run a fake implementation that triggers
+ * an onStorageChanged event with the given changes simulating the case where
+ * the storage changes while waiting for the user's response. After the event
+ * listeners are notified, the test will reject the dialog promise simulating
+ * the dialog being closed by the user without granting permissions. This means
+ * that if the storage change should not affect the permissions check result,
+ * |expectPermissionsGranted| should be false.
+ * @param {string} clientOrigin The origin for which to run the permissions
+ *     check test.
+ * @param {!Object} storageChanges Object with newValue and oldValue properties
+ *     describing the change.
+ * @param {string} storageAreaName Name of the storage area that changed.
+ * @param {boolean} expectPermissionsGranted The expected result indicating
+ *     whether permissions for |clientOrigin| were granted or not.
+ * @return {function():!goog.Thenable} The wrapped test function, which returns
+ *     a promise of the test result and the result of cleanup.
+ */
+function runOnStorageChangedTest(
+    clientOrigin, storageChanges, storageAreaName, expectPermissionsGranted) {
+  return function() {
+    const mockControl = new goog.testing.MockControl();
+    const propertyReplacer = new goog.testing.PropertyReplacer();
+
+    function setup() {
+      setUpChromeStorageMock(mockControl, propertyReplacer);
+
+      // Set up a fake method that simulates emitting a chrome.storage.onChanged
+      // event with the given changes when `GSC.PopupOpener.runModalDialog()`
+      // gets called.
+      const runModalDialogFake = function() {
+        for (const listener of onStorageChangedListeners)
+          listener(storageChanges, storageAreaName);
+        return goog.Promise.reject();
+      };
+      setUpUserPromptingChecker(runModalDialogFake);
+
+      mockControl.$replayAll();
+    }
+
+    function cleanup() {
+      mockControl.$tearDown();
+      mockControl.$resetAll();
+      onStorageChangedListeners.length = 0;
+      propertyReplacer.reset();
+      UserPromptingChecker.overrideTrustedClientsRegistryForTesting(null);
+      UserPromptingChecker.overrideModalDialogRunnerForTesting(null);
+    }
+
+    function verifyAndCleanup() {
+      /** @preserveTry */
+      try {
+        mockControl.$verifyAll();
+      } finally {
+        // Cleanup regardless of the mock verification outcome.
+        cleanup();
+      }
+    }
+
+    setup();
+
+    let testPromise;
+    /** @preserveTry */
+    try {
+      const permissionsChecker = new PolicyOrPromptingPermissionsChecker();
+      const permissionsCheckPromise = permissionsChecker.check(clientOrigin);
+      const resolve = function() {
+        // Resolve the test promise - by simply returning from this callback.
+      };
+      const reject = function() {
+        fail('Unexpected permissions check response')
+      };
+      testPromise = expectPermissionsGranted ?
+          permissionsCheckPromise.then(resolve, reject) :
+          permissionsCheckPromise.then(reject, resolve);
+    } catch (exc) {
+      // Cleanup after the test fatally failed synchronously.
+      cleanup();
+      throw exc;
+    }
+    // Verify mocks and cleanup after the test completes or fails.
+    return testPromise.then(verifyAndCleanup, verifyAndCleanup);
+  };
+}
+
+// Regression test for issue #41.
+// Test that the user prompt is automatically closed and permissions are granted
+// when permissions are added to the managed storage.
+goog.exportSymbol(
+    'testPolicyOrPromptingPermissionChecker_OnStorageChanged_ApprovedViaManagedRegistry',
+    runOnStorageChangedTest(
+        CLIENT_ORIGIN, {
+          [MANAGED_STORAGE_KEY]:
+              {'oldValue': [], 'newValue': [CLIENT_EXTENSION_ID]}
+        } /* changes */,
+        MANAGED_STORAGE_AREA_NAME /* storageAreaName */,
+        true /* expectPermissionsGranted */));
+
+// Regression test for issue #41.
+// Test that permissions are not granted on unrelated policy changes.
+goog.exportSymbol(
+    'testPolicyOrPromptingPermissionChecker_OnStorageChanged_UnrelatedOriginChange',
+    runOnStorageChangedTest(
+        CLIENT_ORIGIN, {
+          [MANAGED_STORAGE_KEY]:
+              {'oldValue': [], 'newValue': ['bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb']}
+        } /* storageChanges */,
+        MANAGED_STORAGE_AREA_NAME /* storageAreaName */,
+        false /* expectPermissionsGranted */));
+
+// Regression test for issue #41.
+// Test that permissions are not granted on unrelated policy changes.
+goog.exportSymbol(
+    'testPolicyOrPromptingPermissionChecker_OnStorageChanged_UnrelatedStorageChange',
+    runOnStorageChangedTest(
+      CLIENT_ORIGIN,
+        {'foo': {'oldValue': ['bar'], 'newValue': []}} /* storageChanges */,
+        'local' /* storageAreaName */, false /* expectPermissionsGranted */));
+});  // goog.scope

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/policy-or-prompting-permissions-checker-unittest.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/policy-or-prompting-permissions-checker-unittest.js
@@ -189,7 +189,7 @@ function runOnStorageChangedTest(
         // Resolve the test promise - by simply returning from this callback.
       };
       const reject = function() {
-        fail('Unexpected permissions check response')
+        fail('Unexpected permissions check response');
       };
       testPromise = expectPermissionsGranted ?
           permissionsCheckPromise.then(resolve, reject) :
@@ -208,7 +208,7 @@ function runOnStorageChangedTest(
 // Test that the user prompt is automatically closed and permissions are granted
 // when permissions are added to the managed storage.
 goog.exportSymbol(
-    'testPolicyOrPromptingPermissionChecker_OnStorageChanged_ApprovedViaManagedRegistry',
+    'testPolicyOrPromptingPermissionChecker_ApprovedOnManagedStorageChange',
     runOnStorageChangedTest(
         CLIENT_ORIGIN, {
           [MANAGED_STORAGE_KEY]:
@@ -220,7 +220,7 @@ goog.exportSymbol(
 // Regression test for issue #41.
 // Test that permissions are not granted on unrelated policy changes.
 goog.exportSymbol(
-    'testPolicyOrPromptingPermissionChecker_OnStorageChanged_UnrelatedOriginChange',
+    'testPolicyOrPromptingPermissionChecker_UnrelatedOriginChange',
     runOnStorageChangedTest(
         CLIENT_ORIGIN, {
           [MANAGED_STORAGE_KEY]:
@@ -230,9 +230,9 @@ goog.exportSymbol(
         false /* expectPermissionsGranted */));
 
 // Regression test for issue #41.
-// Test that permissions are not granted on unrelated policy changes.
+// Test that permissions are not granted on unrelated storage changes.
 goog.exportSymbol(
-    'testPolicyOrPromptingPermissionChecker_OnStorageChanged_UnrelatedStorageChange',
+    'testPolicyOrPromptingPermissionChecker_UnrelatedStorageChange',
     runOnStorageChangedTest(
       CLIENT_ORIGIN,
         {'foo': {'oldValue': ['bar'], 'newValue': []}} /* storageChanges */,

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/policy-or-prompting-permissions-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/policy-or-prompting-permissions-checker.js
@@ -136,15 +136,14 @@ GSC.Pcsc.PolicyOrPromptingPermissionsChecker =
     this.managedRegistry_.startMonitoringPermissionsForClientOrigin(
         clientOrigin, promiseResolver);
 
-    checkPromiseResolver.promise.then(() => {
-      this.userPromptingChecker_.cancelUserPromptIfPending(clientOrigin);
-      this.managedRegistry_.stopMonitoringPermissionsForClientOrigin(
-          clientOrigin);
-    },
-    () => {
-      this.managedRegistry_.stopMonitoringPermissionsForClientOrigin(
-          clientOrigin);
-    });
+    checkPromiseResolver.promise
+        .then(() => {
+          this.userPromptingChecker_.cancelUserPromptIfPending(clientOrigin);
+        })
+        .thenAlways(() => {
+          this.managedRegistry_.stopMonitoringPermissionsForClientOrigin(
+              clientOrigin);
+        });
 
     this.userPromptingChecker_.check(clientOrigin)
         .then(checkPromiseResolver.resolve, checkPromiseResolver.reject);

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/policy-or-prompting-permissions-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/policy-or-prompting-permissions-checker.js
@@ -131,6 +131,21 @@ GSC.Pcsc.PolicyOrPromptingPermissionsChecker =
    * @private
    */
   checkByUserPromptingChecker_(clientOrigin, checkPromiseResolver) {
+    const promiseResolver = goog.Promise.withResolver();
+    promiseResolver.promise.then(checkPromiseResolver.resolve);
+    this.managedRegistry_.startMonitoringPermissionsForClientOrigin(
+        clientOrigin, promiseResolver);
+
+    checkPromiseResolver.promise.then(() => {
+      this.userPromptingChecker_.cancelUserPromptIfPending(clientOrigin);
+      this.managedRegistry_.stopMonitoringPermissionsForClientOrigin(
+          clientOrigin);
+    },
+    () => {
+      this.managedRegistry_.stopMonitoringPermissionsForClientOrigin(
+          clientOrigin);
+    });
+
     this.userPromptingChecker_.check(clientOrigin)
         .then(checkPromiseResolver.resolve, checkPromiseResolver.reject);
   }

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
@@ -220,7 +220,7 @@ UserPromptingChecker.prototype.cancelUserPromptIfPending = async function(
     this.pendingClientOrigins_.delete(clientOrigin);
     await GSC.PopupOpener.closeModalDialog(clientOrigin);
   }
-}
+};
 
 /**
  * @return {!Promise<!Map<string, boolean>>}

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
@@ -210,13 +210,13 @@ UserPromptingChecker.prototype.doCheck = async function(clientOrigin) {
  * @param {string} clientOrigin
  * @return {!Promise<void>}
  */
-UserPromptingChecker.prototype.cancelUserPromptIfPending = async function(
-    clientOrigin) {
+UserPromptingChecker.prototype.cancelUserPromptIfPending =
+    async function(clientOrigin) {
   if (this.pendingClientOrigins_.has(clientOrigin)) {
     goog.log.info(
-      this.logger,
-      'Close the prompt dialog for client ' + clientOrigin +
-          ' as permissions have been granted via the managed registry');
+        this.logger,
+        'Close the prompt dialog for client ' + clientOrigin +
+            ' as permissions have been granted via the managed registry');
     this.pendingClientOrigins_.delete(clientOrigin);
     await GSC.PopupOpener.closeModalDialog(clientOrigin);
   }

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/user-prompting-checker.js
@@ -216,7 +216,7 @@ UserPromptingChecker.prototype.cancelUserPromptIfPending = async function(
     goog.log.info(
       this.logger,
       'Close the prompt dialog for client ' + clientOrigin +
-          ' as permissions have already been granted via the managed registry');
+          ' as permissions have been granted via the managed registry');
     this.pendingClientOrigins_.delete(clientOrigin);
     await GSC.PopupOpener.closeModalDialog(clientOrigin);
   }


### PR DESCRIPTION
A permissions prompting dialog should be automatically closed and the permissions check resolved if the managed storage gets updated with the relevant policy value while waiting for a response from the user.