### PR TITLE
Rename DriveLock extension in trusted clients

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/known_client_apps.json
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/known_client_apps.json
@@ -1,12 +1,12 @@
 {
   "chrome-extension://dojmlffgommefdofbfdajjpgjgjoffjo": {
-    "name": "Charismathics Smart Card Middleware"
+    "name": "DriveLock Smart Card Middleware (CSSI)"
   },
   "chrome-extension://haeblkpifdemlfnkogkipmghfcbonief": {
-    "name": "CSSI Smart Card Middleware"
+    "name": "DriveLock Smart Card Middleware (CSSI)"
   },
   "chrome-extension://omlchkeefdkmmdndbpbhaapnnemfkobc": {
-    "name": "Charismathics Smart Card Middleware"
+    "name": "DriveLock Smart Card Middleware (CSSI)"
   },
   "chrome-extension://haiffjcadagjlijoggckpgfnoeiflnem": {
     "name": "Citrix Workspace"
@@ -88,7 +88,7 @@
     "name": "ChromeOS Terminal"
   },
   "chrome-extension://nebchommhahdcpcnbjbgmhnodjhnjnpd": {
-    "name": "DriveLock Smart Card Middleware Beta"
+    "name": "DriveLock Smart Card Middleware (CSSI) Beta"
   },
   "chrome-extension://kghimeaijcapoakcbhbelgkcdoiigbmn": {
     "name": "Ujambo Kiosk App",


### PR DESCRIPTION
Use the up-to-date name when displaying prompts about connections from the DriveLock extension (the old title was "Charismathics").