### PR TITLE
Fix some undeclared JS deps

### DIFF
--- a/common/js/src/executable-module/emscripten-module.js
+++ b/common/js/src/executable-module/emscripten-module.js
@@ -22,6 +22,7 @@
 
 goog.provide('GoogleSmartCard.EmscriptenModule');
 
+goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.ExecutableModule');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PromiseHelpers');

--- a/common/js/src/messaging/common.js
+++ b/common/js/src/messaging/common.js
@@ -22,6 +22,7 @@
 
 goog.provide('GoogleSmartCard.MessagingCommon');
 
+goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.ObjectHelpers');
 goog.require('goog.asserts');

--- a/common/js/src/object-helpers.js
+++ b/common/js/src/object-helpers.js
@@ -22,6 +22,7 @@
 
 goog.provide('GoogleSmartCard.ObjectHelpers');
 
+goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.Logging');
 goog.require('goog.log.Logger');
 goog.require('goog.object');

--- a/example_cpp_smart_card_client_app/src/background.js
+++ b/example_cpp_smart_card_client_app/src/background.js
@@ -49,7 +49,6 @@
 goog.provide('SmartCardClientApp.BackgroundMain');
 
 goog.require('GoogleSmartCard.AppUtils');
-goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.EmscriptenModule');
 goog.require('GoogleSmartCard.ExecutableModule');
 goog.require('GoogleSmartCard.Logging');

--- a/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog-backend.js
+++ b/example_cpp_smart_card_client_app/src/built_in_pin_dialog/built-in-pin-dialog-backend.js
@@ -26,6 +26,7 @@
 
 goog.provide('SmartCardClientApp.BuiltInPinDialog.Backend');
 
+goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PopupOpener');
 goog.require('GoogleSmartCard.RequestReceiver');
 goog.require('goog.Promise');

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
@@ -24,6 +24,7 @@
 
 goog.provide('SmartCardClientApp.CertificateProviderBridge.Backend');
 
+goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.DeferredProcessor');
 goog.require('GoogleSmartCard.ExecutableModule');
 goog.require('GoogleSmartCard.Logging');

--- a/smart_card_connector_app/src/chrome-api-provider.js
+++ b/smart_card_connector_app/src/chrome-api-provider.js
@@ -18,6 +18,7 @@
 goog.provide('GoogleSmartCard.ConnectorApp.ChromeApiProvider');
 
 goog.require('GoogleSmartCard.DebugDump');
+goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.PcscLiteClient.API');
 goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.ServerRequestHandler');
 goog.require('goog.Thenable');

--- a/third_party/libusb/webport/src/libusb-proxy-receiver.js
+++ b/third_party/libusb/webport/src/libusb-proxy-receiver.js
@@ -26,6 +26,7 @@ goog.require('GoogleSmartCard.LibusbToJsApiAdaptor');
 goog.require('GoogleSmartCard.LibusbToWebusbAdaptor');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.RemoteCallMessage');
+goog.require('GoogleSmartCard.RequestReceiver');
 goog.require('GoogleSmartCard.StubLibusbToJsApiAdaptor');
 goog.require('goog.Thenable');
 goog.require('goog.log');

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/permissions_checking/managed-registry.js
@@ -28,6 +28,7 @@
 
 goog.provide('GoogleSmartCard.PcscLiteServerClientsManagement.PermissionsChecking.ManagedRegistry');
 
+goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.ExtensionId');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.MessagingOrigin');


### PR DESCRIPTION
Add missing goog.require() declarations for symbols used in the file.

Sadly, such missing declarations aren't auto-detected by the Closure Compiler, but still lead to compilation errors when the inclusion order changes. This commit fixes some of manually spotted ones (detected via manual inspection and helper Shell scripts).