### PR TITLE
[libusb] Support proxying through message channels

### DIFF
--- a/common/js/src/container-helpers-unittest.js
+++ b/common/js/src/container-helpers-unittest.js
@@ -76,11 +76,12 @@ goog.exportSymbol('testSubstituteArrayBuffersRecursively', function() {
 
   assertObjectEquals(substituteArrayBufferLikeObjectsRecursively({}), {});
   assertObjectEquals(
-      substituteArrayBufferLikeObjectsRecursively({foo: {bar: 1, baz: null}}),
-      {foo: {bar: 1, baz: null}});
+      substituteArrayBufferLikeObjectsRecursively(
+          {'foo': {'bar': 1, 'baz': null}}),
+      {'foo': {'bar': 1, 'baz': null}});
   assertObjectEquals(
-      substituteArrayBufferLikeObjectsRecursively({foo: buffer12}),
-      {foo: [1, 2]});
+      substituteArrayBufferLikeObjectsRecursively({'foo': buffer12}),
+      {'foo': [1, 2]});
 
   const uint8Array = new Uint8Array([1, 2, 255]);
   assertEquals(

--- a/common/js/src/container-helpers-unittest.js
+++ b/common/js/src/container-helpers-unittest.js
@@ -110,7 +110,7 @@ goog.exportSymbol('testSubstituteDataViewsRecursively', function() {
       ['a', [1, 2, 3, 4]]);
 
   assertObjectEquals(
-      substituteArrayBufferLikeObjectsRecursively({foo: view23}),
-      {foo: [2, 3]});
+      substituteArrayBufferLikeObjectsRecursively({'foo': view23}),
+      {'foo': [2, 3]});
 });
 });  // goog.scope

--- a/common/js/src/container-helpers-unittest.js
+++ b/common/js/src/container-helpers-unittest.js
@@ -46,77 +46,71 @@ goog.exportSymbol('testBuildObjectFromMap', function() {
   });
 });
 
-goog.exportSymbol(
-    'testSubstituteArrayBuffersRecursively', function() {
-      const buffer12 = (new Uint8Array([1, 2])).buffer;
+goog.exportSymbol('testSubstituteArrayBuffersRecursively', function() {
+  const buffer12 = (new Uint8Array([1, 2])).buffer;
 
-      assertObjectEquals(
-          substituteArrayBufferLikeObjectsRecursively(new ArrayBuffer(0)), []);
-      assertObjectEquals(
-          substituteArrayBufferLikeObjectsRecursively(new ArrayBuffer(3)),
-          [0, 0, 0]);
-      assertObjectEquals(
-          substituteArrayBufferLikeObjectsRecursively(buffer12), [1, 2]);
+  assertObjectEquals(
+      substituteArrayBufferLikeObjectsRecursively(new ArrayBuffer(0)), []);
+  assertObjectEquals(
+      substituteArrayBufferLikeObjectsRecursively(new ArrayBuffer(3)),
+      [0, 0, 0]);
+  assertObjectEquals(
+      substituteArrayBufferLikeObjectsRecursively(buffer12), [1, 2]);
 
-      assertEquals(
-          substituteArrayBufferLikeObjectsRecursively(undefined), undefined);
-      assertEquals(substituteArrayBufferLikeObjectsRecursively(null), null);
-      assertEquals(substituteArrayBufferLikeObjectsRecursively(false), false);
-      assertEquals(substituteArrayBufferLikeObjectsRecursively(true), true);
-      assertEquals(substituteArrayBufferLikeObjectsRecursively(123), 123);
-      assertEquals(substituteArrayBufferLikeObjectsRecursively('foo'), 'foo');
+  assertEquals(
+      substituteArrayBufferLikeObjectsRecursively(undefined), undefined);
+  assertEquals(substituteArrayBufferLikeObjectsRecursively(null), null);
+  assertEquals(substituteArrayBufferLikeObjectsRecursively(false), false);
+  assertEquals(substituteArrayBufferLikeObjectsRecursively(true), true);
+  assertEquals(substituteArrayBufferLikeObjectsRecursively(123), 123);
+  assertEquals(substituteArrayBufferLikeObjectsRecursively('foo'), 'foo');
 
-      assertObjectEquals(substituteArrayBufferLikeObjectsRecursively([]), []);
-      assertObjectEquals(
-          substituteArrayBufferLikeObjectsRecursively([-1, 1000]), [-1, 1000]);
-      assertObjectEquals(
-          substituteArrayBufferLikeObjectsRecursively(['a', buffer12]),
-          ['a', [1, 2]]);
-      assertObjectEquals(
-          substituteArrayBufferLikeObjectsRecursively([[buffer12]]),
-          [[[1, 2]]]);
+  assertObjectEquals(substituteArrayBufferLikeObjectsRecursively([]), []);
+  assertObjectEquals(
+      substituteArrayBufferLikeObjectsRecursively([-1, 1000]), [-1, 1000]);
+  assertObjectEquals(
+      substituteArrayBufferLikeObjectsRecursively(['a', buffer12]),
+      ['a', [1, 2]]);
+  assertObjectEquals(
+      substituteArrayBufferLikeObjectsRecursively([[buffer12]]), [[[1, 2]]]);
 
-      assertObjectEquals(substituteArrayBufferLikeObjectsRecursively({}), {});
-      assertObjectEquals(
-          substituteArrayBufferLikeObjectsRecursively(
-              {foo: {bar: 1, baz: null}}),
-          {foo: {bar: 1, baz: null}});
-      assertObjectEquals(
-          substituteArrayBufferLikeObjectsRecursively({foo: buffer12}),
-          {foo: [1, 2]});
+  assertObjectEquals(substituteArrayBufferLikeObjectsRecursively({}), {});
+  assertObjectEquals(
+      substituteArrayBufferLikeObjectsRecursively({foo: {bar: 1, baz: null}}),
+      {foo: {bar: 1, baz: null}});
+  assertObjectEquals(
+      substituteArrayBufferLikeObjectsRecursively({foo: buffer12}),
+      {foo: [1, 2]});
 
-      const uint8Array = new Uint8Array([1, 2, 255]);
-      assertEquals(
-          substituteArrayBufferLikeObjectsRecursively(uint8Array), uint8Array);
+  const uint8Array = new Uint8Array([1, 2, 255]);
+  assertEquals(
+      substituteArrayBufferLikeObjectsRecursively(uint8Array), uint8Array);
 
-      // A function/class isn't a sensible input, but verify such cases anyway.
-      assertEquals(
-          substituteArrayBufferLikeObjectsRecursively(parseInt), parseInt);
-      assertEquals(substituteArrayBufferLikeObjectsRecursively(Array), Array);
-    });
+  // A function/class isn't a sensible input, but verify such cases anyway.
+  assertEquals(substituteArrayBufferLikeObjectsRecursively(parseInt), parseInt);
+  assertEquals(substituteArrayBufferLikeObjectsRecursively(Array), Array);
+});
 
 
-goog.exportSymbol(
-    'testSubstituteDataViewsRecursively', function() {
-      const emptyView = new DataView(new ArrayBuffer(/*length=*/0));
-      const buffer1234 = (new Uint8Array([1, 2, 3, 4])).buffer;
-      const view1234 = new DataView(buffer1234);
-      const view23 = new DataView(buffer1234, /*byteOffset=*/1, /*byteLength=*/2);
+goog.exportSymbol('testSubstituteDataViewsRecursively', function() {
+  const emptyView = new DataView(new ArrayBuffer(/*length=*/ 0));
+  const buffer1234 = (new Uint8Array([1, 2, 3, 4])).buffer;
+  const view1234 = new DataView(buffer1234);
+  const view23 = new DataView(buffer1234, /*byteOffset=*/ 1, /*byteLength=*/ 2);
 
-      assertObjectEquals(
-          substituteArrayBufferLikeObjectsRecursively(emptyView), []);
-      assertObjectEquals(
-          substituteArrayBufferLikeObjectsRecursively(view1234),
-          [1, 2, 3, 4]);
-      assertObjectEquals(
-          substituteArrayBufferLikeObjectsRecursively(view23), [2, 3]);
+  assertObjectEquals(
+      substituteArrayBufferLikeObjectsRecursively(emptyView), []);
+  assertObjectEquals(
+      substituteArrayBufferLikeObjectsRecursively(view1234), [1, 2, 3, 4]);
+  assertObjectEquals(
+      substituteArrayBufferLikeObjectsRecursively(view23), [2, 3]);
 
-      assertObjectEquals(
-          substituteArrayBufferLikeObjectsRecursively(['a', view1234]),
-          ['a', [1, 2, 3, 4]]);
+  assertObjectEquals(
+      substituteArrayBufferLikeObjectsRecursively(['a', view1234]),
+      ['a', [1, 2, 3, 4]]);
 
-      assertObjectEquals(
-          substituteArrayBufferLikeObjectsRecursively({foo: view23}),
-          {foo: [2, 3]});
-    });
+  assertObjectEquals(
+      substituteArrayBufferLikeObjectsRecursively({foo: view23}),
+      {foo: [2, 3]});
+});
 });  // goog.scope

--- a/common/js/src/container-helpers-unittest.js
+++ b/common/js/src/container-helpers-unittest.js
@@ -92,7 +92,6 @@ goog.exportSymbol('testSubstituteArrayBuffersRecursively', function() {
   assertEquals(substituteArrayBufferLikeObjectsRecursively(Array), Array);
 });
 
-
 goog.exportSymbol('testSubstituteDataViewsRecursively', function() {
   const emptyView = new DataView(new ArrayBuffer(/*length=*/ 0));
   const buffer1234 = (new Uint8Array([1, 2, 3, 4])).buffer;

--- a/common/js/src/container-helpers-unittest.js
+++ b/common/js/src/container-helpers-unittest.js
@@ -24,8 +24,8 @@ goog.scope(function() {
 
 const GSC = GoogleSmartCard;
 const buildObjectFromMap = GSC.ContainerHelpers.buildObjectFromMap;
-const substituteArrayBuffersRecursively =
-    GSC.ContainerHelpers.substituteArrayBuffersRecursively;
+const substituteArrayBufferLikeObjectsRecursively =
+    GSC.ContainerHelpers.substituteArrayBufferLikeObjectsRecursively;
 
 goog.exportSymbol('testBuildObjectFromMap', function() {
   assertObjectEquals(buildObjectFromMap(new Map()), {});
@@ -46,40 +46,77 @@ goog.exportSymbol('testBuildObjectFromMap', function() {
   });
 });
 
-goog.exportSymbol('testSubstituteArrayBuffersRecursively', function() {
-  const buffer12 = (new Uint8Array([1, 2])).buffer;
+goog.exportSymbol(
+    'testSubstituteArrayBuffersRecursively', function() {
+      const buffer12 = (new Uint8Array([1, 2])).buffer;
 
-  assertObjectEquals(substituteArrayBuffersRecursively(new ArrayBuffer(0)), []);
-  assertObjectEquals(
-      substituteArrayBuffersRecursively(new ArrayBuffer(3)), [0, 0, 0]);
-  assertObjectEquals(substituteArrayBuffersRecursively(buffer12), [1, 2]);
+      assertObjectEquals(
+          substituteArrayBufferLikeObjectsRecursively(new ArrayBuffer(0)), []);
+      assertObjectEquals(
+          substituteArrayBufferLikeObjectsRecursively(new ArrayBuffer(3)),
+          [0, 0, 0]);
+      assertObjectEquals(
+          substituteArrayBufferLikeObjectsRecursively(buffer12), [1, 2]);
 
-  assertEquals(substituteArrayBuffersRecursively(undefined), undefined);
-  assertEquals(substituteArrayBuffersRecursively(null), null);
-  assertEquals(substituteArrayBuffersRecursively(false), false);
-  assertEquals(substituteArrayBuffersRecursively(true), true);
-  assertEquals(substituteArrayBuffersRecursively(123), 123);
-  assertEquals(substituteArrayBuffersRecursively('foo'), 'foo');
+      assertEquals(
+          substituteArrayBufferLikeObjectsRecursively(undefined), undefined);
+      assertEquals(substituteArrayBufferLikeObjectsRecursively(null), null);
+      assertEquals(substituteArrayBufferLikeObjectsRecursively(false), false);
+      assertEquals(substituteArrayBufferLikeObjectsRecursively(true), true);
+      assertEquals(substituteArrayBufferLikeObjectsRecursively(123), 123);
+      assertEquals(substituteArrayBufferLikeObjectsRecursively('foo'), 'foo');
 
-  assertObjectEquals(substituteArrayBuffersRecursively([]), []);
-  assertObjectEquals(substituteArrayBuffersRecursively([-1, 1000]), [-1, 1000]);
-  assertObjectEquals(
-      substituteArrayBuffersRecursively(['a', buffer12]), ['a', [1, 2]]);
-  assertObjectEquals(
-      substituteArrayBuffersRecursively([[buffer12]]), [[[1, 2]]]);
+      assertObjectEquals(substituteArrayBufferLikeObjectsRecursively([]), []);
+      assertObjectEquals(
+          substituteArrayBufferLikeObjectsRecursively([-1, 1000]), [-1, 1000]);
+      assertObjectEquals(
+          substituteArrayBufferLikeObjectsRecursively(['a', buffer12]),
+          ['a', [1, 2]]);
+      assertObjectEquals(
+          substituteArrayBufferLikeObjectsRecursively([[buffer12]]),
+          [[[1, 2]]]);
 
-  assertObjectEquals(substituteArrayBuffersRecursively({}), {});
-  assertObjectEquals(
-      substituteArrayBuffersRecursively({foo: {bar: 1, baz: null}}),
-      {foo: {bar: 1, baz: null}});
-  assertObjectEquals(
-      substituteArrayBuffersRecursively({foo: buffer12}), {foo: [1, 2]});
+      assertObjectEquals(substituteArrayBufferLikeObjectsRecursively({}), {});
+      assertObjectEquals(
+          substituteArrayBufferLikeObjectsRecursively(
+              {foo: {bar: 1, baz: null}}),
+          {foo: {bar: 1, baz: null}});
+      assertObjectEquals(
+          substituteArrayBufferLikeObjectsRecursively({foo: buffer12}),
+          {foo: [1, 2]});
 
-  const uint8Array = new Uint8Array([1, 2, 255]);
-  assertEquals(substituteArrayBuffersRecursively(uint8Array), uint8Array);
+      const uint8Array = new Uint8Array([1, 2, 255]);
+      assertEquals(
+          substituteArrayBufferLikeObjectsRecursively(uint8Array), uint8Array);
 
-  // A function/class isn't a sensible input, but verify such cases anyway.
-  assertEquals(substituteArrayBuffersRecursively(parseInt), parseInt);
-  assertEquals(substituteArrayBuffersRecursively(Array), Array);
-});
+      // A function/class isn't a sensible input, but verify such cases anyway.
+      assertEquals(
+          substituteArrayBufferLikeObjectsRecursively(parseInt), parseInt);
+      assertEquals(substituteArrayBufferLikeObjectsRecursively(Array), Array);
+    });
+
+
+goog.exportSymbol(
+    'testSubstituteDataViewsRecursively', function() {
+      const emptyView = new DataView(new ArrayBuffer(/*length=*/0));
+      const buffer1234 = (new Uint8Array([1, 2, 3, 4])).buffer;
+      const view1234 = new DataView(buffer1234);
+      const view23 = new DataView(buffer1234, /*byteOffset=*/1, /*byteLength=*/2);
+
+      assertObjectEquals(
+          substituteArrayBufferLikeObjectsRecursively(emptyView), []);
+      assertObjectEquals(
+          substituteArrayBufferLikeObjectsRecursively(view1234),
+          [1, 2, 3, 4]);
+      assertObjectEquals(
+          substituteArrayBufferLikeObjectsRecursively(view23), [2, 3]);
+
+      assertObjectEquals(
+          substituteArrayBufferLikeObjectsRecursively(['a', view1234]),
+          ['a', [1, 2, 3, 4]]);
+
+      assertObjectEquals(
+          substituteArrayBufferLikeObjectsRecursively({foo: view23}),
+          {foo: [2, 3]});
+    });
 });  // goog.scope

--- a/common/js/src/container-helpers.js
+++ b/common/js/src/container-helpers.js
@@ -44,26 +44,33 @@ GSC.ContainerHelpers.buildObjectFromMap = function(map) {
 };
 
 /**
- * Recursively visits the given value and replaces all ArrayBuffer objects with
- * their Array views of bytes. Returns the resulting value after substitutions.
+ * Recursively visits the given value and replaces all ArrayBuffer and DataView
+ * objects with their Array views of bytes. Returns the resulting value after
+ * substitutions.
  * @param {?} value
  * @return {?}
  */
-GSC.ContainerHelpers.substituteArrayBuffersRecursively = function(value) {
-  const substituteArrayBuffersRecursively =
-      GSC.ContainerHelpers.substituteArrayBuffersRecursively;
+GSC.ContainerHelpers.substituteArrayBufferLikeObjectsRecursively = function(
+    value) {
+  const substituteArrayBufferLikeObjectsRecursively =
+      GSC.ContainerHelpers.substituteArrayBufferLikeObjectsRecursively;
   if (value instanceof ArrayBuffer) {
     // Convert the array buffer into an array of bytes.
     return Array.from(new Uint8Array(value));
   }
+  if (value instanceof DataView) {
+    // Convert the data view into an array of bytes.
+    return Array.from(
+        new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
+  }
   if (Array.isArray(value)) {
     // Recursively process array items.
-    return value.map(substituteArrayBuffersRecursively);
+    return value.map(substituteArrayBufferLikeObjectsRecursively);
   }
   if (goog.isObject(value) && !goog.functions.isFunction(value) &&
       !ArrayBuffer.isView(value)) {
     // This is a dictionary-like object; process it recursively.
-    return goog.object.map(value, substituteArrayBuffersRecursively);
+    return goog.object.map(value, substituteArrayBufferLikeObjectsRecursively);
   }
   return value;
 };

--- a/common/js/src/messaging/port-message-channel.js
+++ b/common/js/src/messaging/port-message-channel.js
@@ -108,7 +108,8 @@ GSC.PortMessageChannel = class extends goog.messaging.AbstractChannel {
     goog.asserts.assertObject(payload);
 
     const normalizedPayload =
-        GSC.ContainerHelpers.substituteArrayBuffersRecursively(payload);
+        GSC.ContainerHelpers.substituteArrayBufferLikeObjectsRecursively(
+            payload);
 
     const typedMessage = new GSC.TypedMessage(serviceName, normalizedPayload);
     const message = typedMessage.makeMessage();

--- a/common/js/src/messaging/single-message-based-channel.js
+++ b/common/js/src/messaging/single-message-based-channel.js
@@ -97,7 +97,8 @@ GSC.SingleMessageBasedChannel = class extends goog.messaging.AbstractChannel {
     goog.asserts.assertObject(payload);
 
     const normalizedPayload =
-        GSC.ContainerHelpers.substituteArrayBuffersRecursively(payload);
+        GSC.ContainerHelpers.substituteArrayBufferLikeObjectsRecursively(
+            payload);
 
     const typedMessage = new GSC.TypedMessage(serviceName, normalizedPayload);
     const message = typedMessage.makeMessage();

--- a/third_party/libusb/webport/src/libusb-proxy-data-model.js
+++ b/third_party/libusb/webport/src/libusb-proxy-data-model.js
@@ -172,7 +172,7 @@ const LibusbJsGenericTransferParameters =
 /**
  * The key strings must match the ones in libusb_js_proxy_data_model.cc.
  * @typedef {{
- *            receivedData:(!ArrayBuffer|DataView|!Array<number>|undefined),
+ *            receivedData:(!ArrayBuffer|!DataView|!Array<number>|undefined),
  *          }}
  */
 GSC.LibusbProxyDataModel.LibusbJsTransferResult;

--- a/third_party/libusb/webport/src/libusb-proxy-data-model.js
+++ b/third_party/libusb/webport/src/libusb-proxy-data-model.js
@@ -72,7 +72,7 @@ const LibusbJsEndpointType = GSC.LibusbProxyDataModel.LibusbJsEndpointType;
  *            endpointAddress:number,
  *            direction:!LibusbJsDirection,
  *            type:!LibusbJsEndpointType,
- *            extraData:(!ArrayBuffer|undefined),
+ *            extraData:(!ArrayBuffer|!Array<number>|undefined),
  *            maxPacketSize:number
  *          }}
  */
@@ -88,7 +88,7 @@ const LibusbJsEndpointDescriptor =
  *            interfaceClass:number,
  *            interfaceSubclass:number,
  *            interfaceProtocol:number,
- *            extraData:(!ArrayBuffer|undefined),
+ *            extraData:(!ArrayBuffer|!Array<number>|undefined),
  *            endpoints:!Array<!LibusbJsEndpointDescriptor>
  *          }}
  */
@@ -103,7 +103,7 @@ const LibusbJsInterfaceDescriptor =
  * @typedef {{
  *            active:boolean,
  *            configurationValue:number,
- *            extraData:(!ArrayBuffer|undefined),
+ *            extraData:(!ArrayBuffer|!Array<number>|undefined),
  *            interfaces:!Array<!LibusbJsInterfaceDescriptor>
  *          }}
  */
@@ -147,7 +147,7 @@ const LibusbJsTransferRecipient =
  *            request:number,
  *            value:number,
  *            index:number,
- *            dataToSend:(!ArrayBuffer|undefined),
+ *            dataToSend:(!ArrayBuffer|!Array<number>|undefined),
  *            lengthToReceive:(number|undefined)
  *          }}
  */
@@ -160,7 +160,7 @@ const LibusbJsControlTransferParameters =
  * The key strings must match the ones in libusb_js_proxy_data_model.cc.
  * @typedef {{
  *            endpointAddress:number,
- *            dataToSend:(!ArrayBuffer|undefined),
+ *            dataToSend:(!ArrayBuffer|!Array<number>|undefined),
  *            lengthToReceive:(number|undefined)
  *          }}
  */
@@ -172,7 +172,7 @@ const LibusbJsGenericTransferParameters =
 /**
  * The key strings must match the ones in libusb_js_proxy_data_model.cc.
  * @typedef {{
- *            receivedData:(!ArrayBuffer|undefined),
+ *            receivedData:(!ArrayBuffer|DataView|!Array<number>|undefined),
  *          }}
  */
 GSC.LibusbProxyDataModel.LibusbJsTransferResult;

--- a/third_party/libusb/webport/src/libusb-to-webusb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-webusb-adaptor.js
@@ -570,7 +570,7 @@ async function callWebusbDeviceControlTransferIn(webusbDevice, setup, length) {
 /**
  * @param {!Object} webusbDevice The WebUSB USBDevice object.
  * @param {!Object} setup The WebUSB USBControlTransferParameters value.
- * @param {!ArrayBuffer} data
+ * @param {!ArrayBuffer|!Array<number>} data
  * @return {!Promise<!Object>} The WebUSB USBOutTransferResult value.
  */
 async function callWebusbDeviceControlTransferOut(webusbDevice, setup, data) {
@@ -587,7 +587,7 @@ async function callWebusbDeviceControlTransferOut(webusbDevice, setup, data) {
           debugDumpSanitized(data)}): called`);
   try {
     const transferResult =
-        await webusbDevice['controlTransferOut'](setup, data);
+        await webusbDevice['controlTransferOut'](setup, toArrayBuffer(data));
     goog.log.info(
         logger,
         `${functionLogTitle}(): returned ${
@@ -632,7 +632,7 @@ async function callWebusbDeviceTransferIn(
 /**
  * @param {!Object} webusbDevice The WebUSB USBDevice object.
  * @param {number} endpointNumber
- * @param {!ArrayBuffer} data
+ * @param {!ArrayBuffer|!Array<number>} data
  * @return {!Promise<!Object>} The WebUSB USBOutTransferResult value.
  */
 async function callWebusbDeviceTransferOut(webusbDevice, endpointNumber, data) {
@@ -648,7 +648,7 @@ async function callWebusbDeviceTransferOut(webusbDevice, endpointNumber, data) {
           debugDumpSanitized(data)}): called`);
   try {
     const transferResult =
-        await webusbDevice['transferOut'](endpointNumber, data);
+        await webusbDevice['transferOut'](endpointNumber, toArrayBuffer(data));
     goog.log.info(
         logger,
         `${functionLogTitle}(): returned ${
@@ -934,6 +934,17 @@ async function fetchAndFillConfigurationExtraDataForOpenedDevice(
     // Jump to the next descriptor in the blob.
     offset += descriptorLength;
   }
+}
+
+/**
+ * Converts the array of bytes to an array buffer, if needed.
+ * @param {!ArrayBuffer|!Array<number>} value
+ * @return {!ArrayBuffer}
+ */
+function toArrayBuffer(value) {
+  if (value instanceof ArrayBuffer)
+    return value;
+  return (new Uint8Array(value)).buffer;
 }
 
 /**


### PR DESCRIPTION
Perform data massaging when handling USB requests, so that they can be sent through message pipes. WebUSB uses ArrayBuffer and DataView types for input/output parameters, however for sending via extension messages we have to convert them to/from arrays of integers-bytes.

The underlying motivation is the migration to manifest v3 and WebAssembly, because due to multi-threading issues we have to move the WebAssembly module from the Service Worker (where most API calls, including WebUSB APIs will happen) into a separate Offscreen Document. So each USB request will have to be proxied as a request-response pair of messages between the Offscreen Document and the Service Worker.