### PR TITLE
[mv3] Put Wasm module into Offscreen Document

### DIFF
--- a/common/js/src/executable-module/emscripten-in-offscreen-doc-main-script.js
+++ b/common/js/src/executable-module/emscripten-in-offscreen-doc-main-script.js
@@ -43,6 +43,10 @@ const moduleName =
     url.searchParams.get(GSC.OffscreenDocEmscriptenModule.URL_PARAM);
 GSC.Logging.check(moduleName);
 goog.asserts.assert(moduleName);
+// A quick sanity check against malicious URL parameters (in case the user was
+// tricked into opening our page via chrome-extension://). We don't want to
+// allow loading&executing arbitrary URLs.
+GSC.Logging.check(/^[0-9a-zA-Z_]+$/.test(moduleName));
 
 const emscriptenModule = new GSC.EmscriptenModule(moduleName);
 

--- a/common/js/src/executable-module/emscripten-in-offscreen-doc-main-script.js
+++ b/common/js/src/executable-module/emscripten-in-offscreen-doc-main-script.js
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview This file contains code to be directly executed in the
+ * Offscreen Document in order to load an Emscripten module.
+ *
+ * This is to be treated an internal implementation detail of
+ * offscreen-doc-emscripten-module.js and shouldn't be called by client code
+ * directly. It's expected to be compiled and packaged as the file called
+ * "emscripten-offscreen-doc.js" (see "emscripten-offscreen-doc.html").
+ */
+
+goog.provide('GoogleSmartCard.EmscriptenInOffscreenDocMain');
+
+goog.require('GoogleSmartCard.EmscriptenModule');
+goog.require('GoogleSmartCard.Logging');
+goog.require('GoogleSmartCard.OffscreenDocEmscriptenModule');
+goog.require('GoogleSmartCard.PortMessageChannel');
+goog.require('goog.asserts');
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+// The URL parameters specify the name of the Emscripten module to be loaded.
+const url = new URL(globalThis.location.href);
+const moduleName =
+    url.searchParams.get(GSC.OffscreenDocEmscriptenModule.URL_PARAM);
+GSC.Logging.check(moduleName);
+goog.asserts.assert(moduleName);
+
+const emscriptenModule = new GSC.EmscriptenModule(moduleName);
+
+// Pipe the module's messaging channel to the port to the opener.
+const moduleChannel = emscriptenModule.getMessageChannel();
+const portChannel = new GSC.PortMessageChannel(chrome.runtime.connect(
+    {'name': GSC.OffscreenDocEmscriptenModule.MESSAGING_PORT_NAME}));
+portChannel.registerDefaultService((serviceName, payload) => {
+  moduleChannel.send(serviceName, payload);
+});
+moduleChannel.registerDefaultService((serviceName, payload) => {
+  portChannel.send(serviceName, payload);
+});
+
+// Announce the module's status via a special port to the opener.
+const statusChannel = new GSC.PortMessageChannel(chrome.runtime.connect(
+    {'name': GSC.OffscreenDocEmscriptenModule.STATUS_PORT_NAME}));
+emscriptenModule.getLoadPromise().then(() => {
+  statusChannel.send(GSC.OffscreenDocEmscriptenModule.STATUS_LOADED, {});
+});
+emscriptenModule.addOnDisposeCallback(() => {
+  statusChannel.send(GSC.OffscreenDocEmscriptenModule.STATUS_DISPOSED, {});
+});
+
+// Start the module startup after we set all listeners.
+emscriptenModule.startLoading();
+});

--- a/common/js/src/executable-module/emscripten-module.js
+++ b/common/js/src/executable-module/emscripten-module.js
@@ -52,6 +52,9 @@ const WRAPPER_SUBLOGGER_SCOPE = 'Wrapper';
  * @extends GSC.ExecutableModule
  */
 GSC.EmscriptenModule = class extends GSC.ExecutableModule {
+  /**
+   * @param {string} moduleName
+   */
   constructor(moduleName) {
     super();
     /** @type {string} @const @private */

--- a/common/js/src/executable-module/emscripten-offscreen-doc.html
+++ b/common/js/src/executable-module/emscripten-offscreen-doc.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<!--
+Copyright 2024 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<script src="emscripten-offscreen-doc.js"></script>

--- a/common/js/src/executable-module/offscreen-doc-emscripten-module.js
+++ b/common/js/src/executable-module/offscreen-doc-emscripten-module.js
@@ -1,0 +1,250 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview This file provides a wrapper around the GSC.EmscriptenModule
+ * class that hosts the Emscripten module in an Offscreen Document.
+ *
+ * This is useful for loading multi-threaded modules with background code in
+ * manifest v3 extensions, since Workers aren't currently allowed by Chrome in
+ * Service Workers. The GSC.OffscreenDocEmscriptenModule class is a facade that
+ * lets the Service Worker use the convenient GSC.ExecutableModule interface,
+ * meanwhile behind the scenes the module lives in an Offscreen Document.
+ *
+ * Note: it's expected that the emscripten-in-offscreen-doc-main-script.js is
+ * compiled into a separate JavaScript file "emscripten-offscreen-doc.js", and
+ * the "emscripten-offscreen-doc.html" file is packaged as well.
+ */
+
+goog.provide('GoogleSmartCard.OffscreenDocEmscriptenModule');
+
+goog.require('GoogleSmartCard.ExecutableModule');
+goog.require('GoogleSmartCard.Logging');
+goog.require('GoogleSmartCard.PortMessageChannel');
+goog.require('GoogleSmartCard.PromiseHelpers');
+goog.require('goog.Promise');
+goog.require('goog.log');
+goog.require('goog.log.Logger');
+goog.require('goog.messaging.AbstractChannel');
+goog.require('goog.object');
+goog.require('goog.promise.Resolver');
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+const OFFSCREEN_DOC_URL = '/emscripten-offscreen-doc.html';
+// See
+// <https://developer.chrome.com/docs/extensions/reference/api/offscreen#type-Reason>:
+const OFFSCREEN_DOC_REASONS = ['WORKERS'];
+const OFFSCREEN_DOC_JUSTIFICATION = 'running a WebAssembly module';
+const URL_PARAM = 'google_smart_card_emscripten_module_name';
+// The name of the port that the Offscreen Document should use for exchanging
+// the module's messages with us.
+const MESSAGING_PORT_NAME = 'offscreen_doc_emscripten_messages';
+// The name of the port that the Offscreen Document should use for signaling the
+// status.
+const STATUS_PORT_NAME = 'offscreen_doc_emscripten_status';
+// Status messages to be sent over the `STATUS_PORT_NAME` port.
+const STATUS_LOADED = 'loaded';
+const STATUS_DISPOSED = 'disposed';
+
+GSC.OffscreenDocEmscriptenModule = class extends GSC.ExecutableModule {
+  /**
+   * @param {string} moduleName
+   */
+  constructor(moduleName) {
+    super();
+    /** @type {string} @const @private */
+    this.moduleName_ = moduleName;
+    /** @type {!goog.log.Logger} @const @private */
+    this.logger_ = GSC.Logging.getScopedLogger('OffscreenDocEmscriptenModule');
+    /** @type {boolean} @private */
+    this.offscreenDocActive_ = false;
+    /** @type {!OffscreenDocMessageChannel} @const @private */
+    this.messageChannel_ = new OffscreenDocMessageChannel();
+    /** @type {!GSC.PortMessageChannel|null} @private */
+    this.statusChannel_ = null;
+    /** @type {!goog.promise.Resolver<void>} @const @private */
+    this.loadPromiseResolver_ = goog.Promise.withResolver();
+    GSC.PromiseHelpers.suppressUnhandledRejectionError(
+        this.loadPromiseResolver_.promise);
+  }
+
+  /** @override */
+  getLogger() {
+    return this.logger_;
+  }
+
+  /** @override */
+  startLoading() {
+    chrome.runtime.onConnect.addListener((port) => this.onConnect_(port));
+
+    const url = new URL(OFFSCREEN_DOC_URL, globalThis.location.href);
+    url.searchParams.append(URL_PARAM, this.moduleName_);
+    chrome.offscreen.createDocument(
+        {
+          'url': url.toString(),
+          'reasons': OFFSCREEN_DOC_REASONS,
+          'justification': OFFSCREEN_DOC_JUSTIFICATION,
+        },
+        () => this.onOffscreenDocCreated_());
+  }
+
+  /** @override */
+  getLoadPromise() {
+    return this.loadPromiseResolver_.promise;
+  }
+
+  /** @override */
+  getMessageChannel() {
+    return this.messageChannel_;
+  }
+
+  /** @override */
+  disposeInternal() {
+    if (this.offscreenDocActive_)
+      chrome.offscreen.closeDocument();
+    this.messageChannel_.dispose();
+    if (this.statusChannel_)
+      this.statusChannel_.dispose();
+    this.loadPromiseResolver_.reject();
+    super.disposeInternal();
+  }
+
+  /** @private */
+  onOffscreenDocCreated_() {
+    if (chrome && chrome.runtime && chrome.runtime.lastError) {
+      const error =
+          goog.object.get(chrome.runtime.lastError, 'message', 'Unknown error');
+      goog.log.warning(
+          this.logger_, `Failed to load the offscreen document: ${error}`);
+    } else {
+      this.offscreenDocActive_ = true;
+    }
+
+    if (this.offscreenDocActive_ && this.isDisposed()) {
+      // Edge case: we got destroyed while waiting for the
+      // `chrome.offscreen.createDocument()` completion; make sure to not leave
+      // the doc in that case as well.
+      chrome.offscreen.closeDocument();
+    } else if (!this.offscreenDocActive_) {
+      this.dispose();
+    }
+  }
+
+  /**
+   * @param {!Port} port
+   * @private
+   */
+  onConnect_(port) {
+    if (this.isDisposed())
+      return;
+    if (port.name === MESSAGING_PORT_NAME) {
+      // This connection is for exchanging messages with the executable module
+      // in the Offscreen Document.
+      this.messageChannel_.resolve(new GSC.PortMessageChannel(port));
+    } else if (port.name === STATUS_PORT_NAME) {
+      // This connection is for signaling the module's status.
+      this.statusChannel_ = new GSC.PortMessageChannel(port);
+      this.statusChannel_.registerService(
+          STATUS_LOADED, () => this.onLoadedInOffscreen_());
+      this.statusChannel_.registerService(
+          STATUS_DISPOSED, () => this.onDisposedInOffscreen_());
+    } else {
+      // Ignore - this is a connection originating from some other component.
+    }
+  }
+
+  /** @private */
+  onLoadedInOffscreen_() {
+    this.loadPromiseResolver_.resolve();
+  }
+
+  /** @private */
+  onDisposedInOffscreen_() {
+    this.dispose();
+  }
+};
+
+GSC.OffscreenDocEmscriptenModule.URL_PARAM = URL_PARAM;
+GSC.OffscreenDocEmscriptenModule.MESSAGING_PORT_NAME = MESSAGING_PORT_NAME;
+GSC.OffscreenDocEmscriptenModule.STATUS_PORT_NAME = STATUS_PORT_NAME;
+GSC.OffscreenDocEmscriptenModule.STATUS_LOADED = STATUS_LOADED;
+GSC.OffscreenDocEmscriptenModule.STATUS_DISPOSED = STATUS_DISPOSED;
+
+/**
+ * Initially accumulates all sent messages, and once resolved to a channel,
+ * starts acting as a proxy to it.
+ */
+class OffscreenDocMessageChannel extends goog.messaging.AbstractChannel {
+  constructor() {
+    super();
+    /** @type {!goog.messaging.AbstractChannel|null} @private */
+    this.underlyingChannel_ = null;
+    /** @type {!Array<!{serviceName: string, payload: (string|!Object)}>} @private */
+    this.pendingOutgoingMessages_ = [];
+  }
+
+  /** @override */
+  send(serviceName, payload) {
+    if (this.isDisposed())
+      return;
+    if (!this.underlyingChannel_ || this.pendingOutgoingMessages_.length > 0) {
+      // Enqueue the message until the proxied channel is set and all previously
+      // enqueued messages are sent.
+      this.pendingOutgoingMessages_.push({serviceName, payload});
+      return;
+    }
+    this.underlyingChannel_.send(serviceName, payload);
+  }
+
+  /**
+   * Makes ourselves to behave as a proxy to the given channel. Previously
+   * enqueued messages are sent immediately.
+   * @param {!goog.messaging.AbstractChannel} offscreenDocChannel
+   */
+  resolve(offscreenDocChannel) {
+    GSC.Logging.check(!this.underlyingChannel_);
+
+    this.underlyingChannel_ = offscreenDocChannel;
+
+    // Let ourselves receive all (unhandled) messages that are received on
+    // `offscreenDocChannel`.
+    offscreenDocChannel.registerDefaultService((serviceName, payload) => {
+      this.deliver(serviceName, payload);
+    });
+
+    // Send all previously enqueued messages. Note that, in theory, new items
+    // might be added to the array while we're iterating over it, which should
+    // be fine as the for-of loop will visit all of them.
+    for (const message of this.pendingOutgoingMessages_)
+      offscreenDocChannel.send(message.serviceName, message.payload);
+    this.pendingOutgoingMessages_ = [];
+  }
+
+  /** @override */
+  disposeInternal() {
+    this.pendingOutgoingMessages_ = [];
+    if (this.underlyingChannel_) {
+      this.underlyingChannel_.dispose();
+      this.underlyingChannel_ = null;
+    }
+    super.disposeInternal();
+  }
+}
+});  // goog.scope

--- a/common/js/src/executable-module/offscreen-doc-emscripten-module.js
+++ b/common/js/src/executable-module/offscreen-doc-emscripten-module.js
@@ -65,6 +65,11 @@ const STATUS_PORT_NAME = 'offscreen_doc_emscripten_status';
 const STATUS_LOADED = 'loaded';
 const STATUS_DISPOSED = 'disposed';
 
+/**
+ * Runs the Emscripten module in an Offscreen Document.
+ *
+ * See the file comment above for the details.
+ */
 GSC.OffscreenDocEmscriptenModule = class extends GSC.ExecutableModule {
   /**
    * @param {string} moduleName

--- a/common/js/src/executable-module/offscreen-doc-emscripten-module.js
+++ b/common/js/src/executable-module/offscreen-doc-emscripten-module.js
@@ -92,8 +92,12 @@ GSC.OffscreenDocEmscriptenModule = class extends GSC.ExecutableModule {
 
   /** @override */
   startLoading() {
+    // Listen for incoming message channels from the Offscreen Document once
+    // it's loaded.
     chrome.runtime.onConnect.addListener((port) => this.onConnect_(port));
 
+    // Load the Offscreen Document. The loading arguments are passed via URL
+    // query parameters.
     const url = new URL(OFFSCREEN_DOC_URL, globalThis.location.href);
     url.searchParams.append(URL_PARAM, this.moduleName_);
     chrome.offscreen.createDocument(
@@ -103,6 +107,8 @@ GSC.OffscreenDocEmscriptenModule = class extends GSC.ExecutableModule {
           'justification': OFFSCREEN_DOC_JUSTIFICATION,
         },
         () => this.onOffscreenDocCreated_());
+    // Once the document is loaded, it'll immediately start loading the
+    // Emscripten module and report the status to us via m
   }
 
   /** @override */

--- a/common/js/src/executable-module/offscreen-doc-emscripten-module.js
+++ b/common/js/src/executable-module/offscreen-doc-emscripten-module.js
@@ -162,7 +162,8 @@ GSC.OffscreenDocEmscriptenModule = class extends GSC.ExecutableModule {
 
     // Wait until the Offscreen Document signals us about the module's
     // loaded/disposed status (whichever comes first).
-    await Promise.all([this.waitLoadedMessage_(), this.waitDisposedMessage_()]);
+    await Promise.race(
+        [this.waitForLoadedMessage_(), this.waitForDisposedMessage_()]);
 
     // Connect pipes for exchanging messages with the executable module in the
     // Offscreen Document.
@@ -179,8 +180,8 @@ GSC.OffscreenDocEmscriptenModule = class extends GSC.ExecutableModule {
    * @return {!Promise<void>}
    * @private
    */
-  async waitLoadedMessage_() {
-    await this.waitMessage_(STATUS_LOADED);
+  async waitForLoadedMessage_() {
+    await this.waitForMessage_(STATUS_LOADED);
   }
 
   /**
@@ -189,8 +190,8 @@ GSC.OffscreenDocEmscriptenModule = class extends GSC.ExecutableModule {
    * @return {!Promise<void>}
    * @private
    */
-  async waitDisposedMessage_() {
-    await this.waitMessage_(STATUS_DISPOSED);
+  async waitForDisposedMessage_() {
+    await this.waitForMessage_(STATUS_DISPOSED);
     this.dispose();
     throw new Error('Disposed');
   }
@@ -200,7 +201,7 @@ GSC.OffscreenDocEmscriptenModule = class extends GSC.ExecutableModule {
    * @return {!Promise<void>}
    * @private
    */
-  waitMessage_(awaitedMessageType) {
+  waitForMessage_(awaitedMessageType) {
     return new Promise((resolve) => {
       this.statusChannel_.registerService(awaitedMessageType, () => {
         resolve();

--- a/common/js/src/executable-module/offscreen-doc-emscripten-module.js
+++ b/common/js/src/executable-module/offscreen-doc-emscripten-module.js
@@ -94,8 +94,11 @@ GSC.OffscreenDocEmscriptenModule = class extends GSC.ExecutableModule {
 
   /** @override */
   startLoading() {
-    // Start the asynchronous load operation.
-    this.load_();
+    // Start the asynchronous load operation. Tie the load promise with its
+    // result.
+    this.load_().then(
+        () => this.loadPromiseResolver_.resolve(),
+        (error) => this.loadPromiseResolver_.reject(error));
   }
 
   /** @override */

--- a/smart_card_connector_app/build/Makefile
+++ b/smart_card_connector_app/build/Makefile
@@ -82,7 +82,16 @@ JS_COMPILER_BACKGROUND_INPUT_PATHS := \
 	$(JS_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \
 
 $(eval $(call BUILD_JS_SCRIPT,background.js,$(JS_COMPILER_BACKGROUND_INPUT_PATHS),GoogleSmartCard.ConnectorApp.BackgroundMain,$(JS_COMPILER_FLAGS)))
+
+#
+# Rules for compiling the emscripten-offscreen-doc.js file.
+#
+
+ifeq ($(TOOLCHAIN),emscripten)
+ifeq ($(PACKAGING),extension)
 $(eval $(call BUILD_JS_SCRIPT,emscripten-offscreen-doc.js,$(JS_COMPILER_BACKGROUND_INPUT_PATHS),GoogleSmartCard.EmscriptenInOffscreenDocMain,$(JS_COMPILER_FLAGS)))
+endif
+endif
 
 
 #
@@ -148,7 +157,12 @@ $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/window.css))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/card-present.png))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/about-window.html))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/about-window.css))
+
+ifeq ($(TOOLCHAIN),emscripten)
+ifeq ($(PACKAGING),extension)
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(ROOT_PATH)/common/js/src/executable-module/emscripten-offscreen-doc.html))
+endif
+endif
 
 
 # Rules for the background page unload preventing feature. This feature is only

--- a/smart_card_connector_app/build/Makefile
+++ b/smart_card_connector_app/build/Makefile
@@ -82,6 +82,7 @@ JS_COMPILER_BACKGROUND_INPUT_PATHS := \
 	$(JS_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \
 
 $(eval $(call BUILD_JS_SCRIPT,background.js,$(JS_COMPILER_BACKGROUND_INPUT_PATHS),GoogleSmartCard.ConnectorApp.BackgroundMain,$(JS_COMPILER_FLAGS)))
+$(eval $(call BUILD_JS_SCRIPT,emscripten-offscreen-doc.js,$(JS_COMPILER_BACKGROUND_INPUT_PATHS),GoogleSmartCard.EmscriptenInOffscreenDocMain,$(JS_COMPILER_FLAGS)))
 
 
 #
@@ -147,6 +148,7 @@ $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/window.css))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/card-present.png))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/about-window.html))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/about-window.css))
+$(eval $(call COPY_TO_OUT_DIR_RULE,$(ROOT_PATH)/common/js/src/executable-module/emscripten-offscreen-doc.html))
 
 
 # Rules for the background page unload preventing feature. This feature is only

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -31,6 +31,7 @@ goog.require('GoogleSmartCard.MessageChannelPool');
 goog.require('GoogleSmartCard.MessagingCommon');
 goog.require('GoogleSmartCard.MessagingOrigin');
 goog.require('GoogleSmartCard.NaclModule');
+goog.require('GoogleSmartCard.OffscreenDocEmscriptenModule');
 goog.require('GoogleSmartCard.Packaging');
 goog.require('GoogleSmartCard.PcscLiteServer.ReaderTracker');
 goog.require('GoogleSmartCard.PcscLiteServerClientsManagement.AdminPolicyService');
@@ -87,7 +88,10 @@ function createExecutableModule() {
       return new GSC.NaclModule(
           'executable_module.nmf', GSC.NaclModule.Type.PNACL);
     case GSC.ExecutableModule.Toolchain.EMSCRIPTEN:
-      return new GSC.EmscriptenModule('executable_module');
+      if (GSC.Packaging.MODE === GSC.Packaging.Mode.EXTENSION)
+        return new GSC.OffscreenDocEmscriptenModule('executable_module');
+      else
+        return new GSC.EmscriptenModule('executable_module');
   }
   GSC.Logging.fail(
       `Cannot load executable module: unknown toolchain ` +

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -88,10 +88,14 @@ function createExecutableModule() {
       return new GSC.NaclModule(
           'executable_module.nmf', GSC.NaclModule.Type.PNACL);
     case GSC.ExecutableModule.Toolchain.EMSCRIPTEN:
-      if (GSC.Packaging.MODE === GSC.Packaging.Mode.EXTENSION)
+      if (GSC.Packaging.MODE === GSC.Packaging.Mode.EXTENSION) {
+        // Multi-threading in WebAssembly requires spawning Workers, which for
+        // Extensions Manifest v3 is only allowed from an Offscreen Document but
+        // not from a Service Worker (as of Chrome M126).
         return new GSC.OffscreenDocEmscriptenModule('executable_module');
-      else
+      } else {
         return new GSC.EmscriptenModule('executable_module');
+      }
   }
   GSC.Logging.fail(
       `Cannot load executable module: unknown toolchain ` +

--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -75,9 +75,9 @@ ${if PACKAGING=app}
   "minimum_chrome_version": "81",
 ${endif}
 ${if PACKAGING=extension}
-  # The earliest version containing the needed adjustments in WebUSB and
-  # WebAssembly.
-  "minimum_chrome_version": "96",
+  # The version in which Offscreen Documents were introduced. This is needed for
+  # the background multi-threaded WebAssembly modules to work.
+  "minimum_chrome_version": "109",
 ${endif}
 
   "default_locale": "en",
@@ -119,6 +119,12 @@ ${endif}
     # Needed for detecting the ChromeOS Lock Screen state (used for disabling
     # the USB communication if we run in-session and the screen is locked).
     "loginState",
+
+${if PACKAGING=extension}
+    # Offscreen Documents are needed for running the background multi-threaded
+    # WebAssembly module.
+    "offscreen",
+${endif}
 
     # Needed to answer to PCSC requests from the browser. This is part of the
     # Web Smart Card API implementation.


### PR DESCRIPTION
When built in the Emscripten+Extension mode, run the Emscripten module in the Offscreen Document instead of the Service Worker.

This is needed because multi-threaded Emscripten modules require creating Workers, which Chrome doesn't currently support from Service Workers - see https://crbug.com/40772041. Hence this commit moves the module into a separate Offscreen Document which doesn't have this limitation. The rest of the background logic remains in the Service Worker because Offscreen Documents have their own strict limitations (most importantly, only chrome.runtime APIs are exposed to them).