### PR TITLE
[eslint] Workaround for 9.0.0 update

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,8 +2,6 @@ env:
   browser: true
   es2020: true
 extends: eslint:recommended
-plugins:
-  - no-floating-promise
 rules:
   # Disabled as the linter doesn't understand Closure Compiler style imports
   # ("goog.require") and Closure Library's global symbols.
@@ -56,7 +54,6 @@ rules:
   prefer-promise-reject-errors: error
   semi-style: error
   semi: error
-  no-floating-promise/no-floating-promise: error
 overrides:
   # Parse specific files as ES Modules (the standard parser would fail).
   - files:

--- a/scripts/eslint.py
+++ b/scripts/eslint.py
@@ -18,6 +18,7 @@
 
 import argparse
 from internal import find_files_for_linting
+import os
 import os.path
 import subprocess
 import sys
@@ -42,7 +43,10 @@ def run_linter(path, args):
              '--resolve-plugins-relative-to', env_path]
   if args.fix:
     command += ['--fix']
-  return subprocess.call(command) == 0
+  env = os.environ.copy()
+  # Force the older "eslintrc" config.
+  env['ESLINT_USE_FLAT_CONFIG'] = 'false'
+  return subprocess.call(command, env=env) == 0
 
 def main():
   args = parse_command_line_args()


### PR DESCRIPTION
Set the ESLINT_USE_FLAT_CONFIG=false environment variable when running ESLint. This is to workaround the following errors after ESLint got updated to 9.0.0:

```
  Invalid option '--resolve-plugins-relative-to' - perhaps you meant '--ignore-pattern'?
  You're using eslint.config.js, some command line flags are no longer available. Please see https://eslint.org/docs/latest/use/command-line-interface for details.
```

Also disable the `no-floating-promise` plugin since it starts
failing with the following error in ESLint 9.0.0:

```
  TypeError: context.getScope is not a function
```