### PR TITLE
[ci] Bump actions/setup-python to v5

### DIFF
--- a/.github/actions/build-dependencies-installation/action.yml
+++ b/.github/actions/build-dependencies-installation/action.yml
@@ -29,7 +29,7 @@ runs:
       pkg-config
 
   - name: Set up Python 3
-    uses: actions/setup-python@v4
+    uses: actions/setup-python@v5
     with:
       python-version: 3.9
 


### PR DESCRIPTION
Update the dependency that's used in our Continuous Integration script based on Github Actions.

This is to fix the following warnings:

  Node.js 16 actions are deprecated. Please update the following
  actions to use Node.js 20: actions/setup-python@v4.