### PR TITLE
[ci] Bump Python to 3.12

### DIFF
--- a/.github/actions/build-dependencies-installation/action.yml
+++ b/.github/actions/build-dependencies-installation/action.yml
@@ -31,7 +31,7 @@ runs:
   - name: Set up Python 3
     uses: actions/setup-python@v4
     with:
-      python-version: 3.9
+      python-version: 3.12
 
   - name: Initialize env
     shell: bash


### PR DESCRIPTION
This changes the Python 3 version used in Continuous Integration
in Github Actions.

The 3.12 version end-of-life is more than 4 years from now, unlike
3.9 which had only about a year left.