### PR TITLE
Helper for waiting for incoming Port connection

### DIFF
--- a/common/js/src/messaging/port-message-channel-waiter-unittest.js
+++ b/common/js/src/messaging/port-message-channel-waiter-unittest.js
@@ -79,7 +79,7 @@ goog.exportSymbol('testPortMessageChannelWaiter', {
     // Act: simulate a port connection.
     simulateOnConnect(mockPort.getFakePort());
 
-    // Assert: the waiter should return the port (wrapper into a channel
+    // Assert: the waiter should return the port (wrapped into a channel
     // object).
     const portChannel = await waiter.getPromise();
     assertEquals(portChannel.getPortForTesting(), mockPort.getFakePort());

--- a/common/js/src/messaging/port-message-channel-waiter-unittest.js
+++ b/common/js/src/messaging/port-message-channel-waiter-unittest.js
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.require('GoogleSmartCard.PortMessageChannelWaiter');
+goog.require('goog.testing.PropertyReplacer');
+goog.require('goog.testing.asserts');
+goog.require('goog.testing.jsunit');
+
+goog.setTestOnly();
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+const propertyReplacer = new goog.testing.PropertyReplacer();
+
+/** @type {function(!Port)|undefined} */
+let interceptedListener;
+
+/**
+ * Stub for `chrome.runtime.onConnect.addListener()`.
+ * @param {function(!Port)} listener
+ */
+function fakeAddListener(listener) {
+  assertUndefined(interceptedListener);
+  interceptedListener = listener;
+}
+
+/**
+ * Stub for `chrome.runtime.onConnect.removeListener()`.
+ * @param {function(!Port)} listener
+ */
+function fakeRemoveListener(listener) {
+  assertEquals(interceptedListener, listener);
+  interceptedListener = undefined;
+}
+
+/**
+ * @param {!Port} port
+ */
+function simulateOnConnect(port) {
+  if (interceptedListener)
+    interceptedListener(port);
+}
+
+goog.exportSymbol('testPortMessageChannelWaiter', {
+  'setUp': function() {
+    propertyReplacer.setPath(
+        'chrome.runtime.onConnect.addListener', fakeAddListener);
+    propertyReplacer.setPath(
+        'chrome.runtime.onConnect.removeListener', fakeRemoveListener);
+  },
+
+  'tearDown': function() {
+    propertyReplacer.reset();
+    interceptedListener = undefined;
+  },
+
+  'testBasic': async function() {
+    // Arrange.
+    const PORT_NAME = 'someport';
+    const waiter = new GSC.PortMessageChannelWaiter(PORT_NAME);
+    const mockPort = new GSC.MockPort(PORT_NAME);
+
+    // Act: simulate a port connection.
+    simulateOnConnect(mockPort.getFakePort());
+
+    // Assert: the waiter should return the port (wrapper into a channel
+    // object).
+    const portChannel = await waiter.getPromise();
+    assertEquals(portChannel.getPortForTesting(), mockPort.getFakePort());
+
+    // Cleanup.
+    waiter.dispose();
+  },
+
+  // When multiple ports with the same name are connected, the waiter returns
+  // the first and ignores others.
+  'testSameNamedPorts': async function() {
+    // Arrange.
+    const PORT_NAME = 'someport';
+    const waiter = new GSC.PortMessageChannelWaiter(PORT_NAME);
+    const mockPort1 = new GSC.MockPort(PORT_NAME);
+    const mockPort2 = new GSC.MockPort(PORT_NAME);
+
+    // Act: simulate port connections.
+    simulateOnConnect(mockPort1.getFakePort());
+    simulateOnConnect(mockPort2.getFakePort());
+
+    // Assert: the waiter should return the first port.
+    const portChannel = await waiter.getPromise();
+    assertEquals(portChannel.getPortForTesting(), mockPort1.getFakePort());
+
+    // Cleanup.
+    waiter.dispose();
+  },
+
+  // The waiter ignores unrelated port connections.
+  'testUnrelatedPortIgnored': async function() {
+    // Arrange.
+    const PORT_NAME = 'someport';
+    const OTHER_PORT_NAME = 'otherport';
+    const waiter = new GSC.PortMessageChannelWaiter(PORT_NAME);
+    const mockOtherPort = new GSC.MockPort(OTHER_PORT_NAME);
+    const mockPort = new GSC.MockPort(PORT_NAME);
+
+    // Act: simulate port connections.
+    simulateOnConnect(mockOtherPort.getFakePort());
+    simulateOnConnect(mockPort.getFakePort());
+
+    // Assert: the waiter should return the needed port.
+    const portChannel = await waiter.getPromise();
+    assertEquals(portChannel.getPortForTesting(), mockPort.getFakePort());
+
+    // Cleanup.
+    waiter.dispose();
+  },
+
+  // The waiter's promise is rejected if no port has been connected by the
+  // disposal time.
+  'testDisposedWithoutPort': async function() {
+    // Arrange.
+    const waiter = new GSC.PortMessageChannelWaiter('someport');
+
+    // Act.
+    waiter.dispose();
+
+    // Assert.
+    await assertRejects(waiter.getPromise());
+
+    // Cleanup.
+    waiter.dispose();
+  },
+});
+});  // goog.scope

--- a/common/js/src/messaging/port-message-channel-waiter.js
+++ b/common/js/src/messaging/port-message-channel-waiter.js
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview A helper for waiting on an incoming message port connection.
+ */
+
+goog.provide('GoogleSmartCard.PortMessageChannelWaiter');
+
+goog.require('GoogleSmartCard.PortMessageChannel');
+goog.require('goog.Disposable');
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+/**
+ * Provides a promise to the `PortMessageChannel` object, resolved when the
+ * `chrome.runtime.onConnect` event with the specified name happens.
+ */
+GSC.PortMessageChannelWaiter = class extends goog.Disposable {
+  /**
+   * @param {string} awaitedPortName
+   */
+  constructor(awaitedPortName) {
+    super();
+
+    /** @const @private */
+    this.awaitedPortName_ = awaitedPortName;
+
+    /** @type {?function(!GSC.PortMessageChannel)} @private */
+    this.resolve_ = null;
+    /** @type {?function(!Error)} @private */
+    this.reject_ = null;
+    /** @type {!Promise<!GSC.PortMessageChannel>} @private */
+    this.promise_ = new Promise((resolve, reject) => {
+      this.resolve_ = resolve;
+      this.reject_ = reject;
+    });
+
+    // Subscribe to the event. Store the bound method in a variable so that we
+    // can remove the listener when needed.
+    /** @type {?function(!Port)} @private */
+    this.listener_ = (port) => this.onConnect_(port);
+    chrome.runtime.onConnect.addListener(this.listener_);
+  }
+
+  /**
+   * @return {!Promise<!GSC.PortMessageChannel>}
+   */
+  getPromise() {
+    return this.promise_;
+  }
+
+  /** @override */
+  disposeInternal() {
+    this.stopListening_();
+
+    // This rejects the promise unless it's already been resolved.
+    this.reject_(new Error('Disposed'));
+
+    super.disposeInternal();
+  }
+
+  /**
+   * @param {!Port} port
+   * @private
+   */
+  onConnect_(port) {
+    if (this.isDisposed())
+      return;
+    if (port.name != this.awaitedPortName_) {
+      // Not the port we're waiting for.
+      return;
+    }
+    this.stopListening_();
+    const portChannel = new GSC.PortMessageChannel(port);
+    this.resolve_(portChannel);
+  }
+
+  /** @private */
+  stopListening_() {
+    if (!this.listener_) {
+      // Already stopped.
+      return;
+    }
+    chrome.runtime.onConnect.removeListener(this.listener_);
+    this.listener_ = null;
+  }
+};
+});

--- a/common/js/src/messaging/port-message-channel.js
+++ b/common/js/src/messaging/port-message-channel.js
@@ -102,6 +102,13 @@ GSC.PortMessageChannel = class extends goog.messaging.AbstractChannel {
     goog.log.fine(this.logger, 'Initialized successfully');
   }
 
+  /**
+   * @return {Port?}
+   */
+  getPortForTesting() {
+    return this.port_;
+  }
+
   /** @override */
   send(serviceName, payload) {
     GSC.Logging.checkWithLogger(this.logger, goog.isObject(payload));


### PR DESCRIPTION
This abstracts away the logic of waiting for a particularly-named chrome.runtime.onConnect event.

This helper will be useful for the mv3 code since all communication between extension's pages (Service Worker, Browser Action, popup windows, Offscreen Document) will need to be switched to message ports.