### PR TITLE
[eslint] Reenable no-floating-promise

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,6 +2,8 @@ env:
   browser: true
   es2020: true
 extends: eslint:recommended
+plugins:
+  - no-floating-promise
 rules:
   # Disabled as the linter doesn't understand Closure Compiler style imports
   # ("goog.require") and Closure Library's global symbols.
@@ -54,6 +56,7 @@ rules:
   prefer-promise-reject-errors: error
   semi-style: error
   semi: error
+  no-floating-promise/no-floating-promise: error
 overrides:
   # Parse specific files as ES Modules (the standard parser would fail).
   - files:


### PR DESCRIPTION
This plugin has been fixed upstream to be compatible with ESLint 9.0.

Hence we can partially revert #1144 to reenable it as part of our lint checks.