### PR TITLE
Delete unneeded chrome.runtime.onConnect listener

### DIFF
--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -151,7 +151,6 @@ executableModule.startLoading();
 if (GSC.Packaging.MODE === GSC.Packaging.Mode.APP)
   chrome.app.runtime.onLaunched.addListener(launchedListener);
 
-chrome.runtime.onConnect.addListener(connectionListener);
 chrome.runtime.onConnectExternal.addListener(externalConnectionListener);
 chrome.runtime.onMessageExternal.addListener(externalMessageListener);
 
@@ -212,24 +211,6 @@ function addOnExecutableModuleDisposedListener(listener) {
 function launchedListener() {
   goog.log.fine(logger, 'Received onLaunched event, opening window...');
   GSC.ConnectorApp.Background.MainWindowManaging.openWindowDueToUserRequest();
-}
-
-/**
- * Called when the onConnect event is received.
- * @param {!Port} port
- */
-function connectionListener(port) {
-  goog.log.fine(logger, 'Received onConnect event');
-  if (port.name === GSC.BackgroundPageUnloadPreventing.MESSAGING_PORT_NAME) {
-    // The opener is the iframe that's loaded by
-    // `GSC.BackgroundPageUnloadPreventing.enable()`. That component sets up its
-    // own onConnect event listener and manages the port itself, so just ignore
-    // it here.
-    return;
-  }
-  // The opener will send PC/SC commands - create a handler for processing them.
-  const portMessageChannel = new GSC.PortMessageChannel(port);
-  createClientHandler(portMessageChannel, undefined);
 }
 
 /**


### PR DESCRIPTION
The Smart Card Connector's background script doesn't currently need to listen for chrome.runtime.onConnect events.

In the past it was needed for wiring up PC/SC calls that happen within the application (namely, from the ReaderTracker class), but they were later migrated to directly send messages to the executable module's channel.

This cleanup is useful in the context of manifestv3 migration, since we'll need to open and listen for a bunch of message pipes in various places, and this old code would've thrown asserts for them.