### PR TITLE
Refactor out DelayedMessageChannel

### DIFF
--- a/common/js/src/executable-module/emscripten-module.js
+++ b/common/js/src/executable-module/emscripten-module.js
@@ -177,7 +177,8 @@ GSC.EmscriptenModule = class extends GSC.ExecutableModule {
       this.realMessageChannel_.onMessageFromModule(message);
     });
 
-    // Fourth step: Wire up outgoing messages with the module.
+    // Fourth step: Wire up outgoing messages with the module, and send out the
+    // messages that have been delayed from sending.
     // The method name is again a hardcoded convention (see the
     // entry_point_emscripten.cc files).
     // The method is accessed using the square bracket notation, to make sure

--- a/common/js/src/messaging/delayed-message-channel-unittest.js
+++ b/common/js/src/messaging/delayed-message-channel-unittest.js
@@ -1,0 +1,163 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.require('GoogleSmartCard.DelayedMessageChannel');
+goog.require('goog.asserts');
+goog.require('goog.testing.MockControl');
+goog.require('goog.testing.asserts');
+goog.require('goog.testing.jsunit');
+goog.require('goog.testing.messaging.MockMessageChannel');
+
+goog.setTestOnly();
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+const TYPE_1 = 'one';
+const DATA_1 = {
+  'foo': 1
+};
+const TYPE_2 = 'two';
+const DATA_2 = {
+  'bar': 1
+};
+
+/** @type {goog.testing.MockControl} */
+let mockControl = null;
+/** @type {goog.testing.messaging.MockMessageChannel} */
+let underlyingMock = null;
+/** @type {GSC.DelayedMessageChannel} */
+let delayed = null;
+/** @type {!Array<!Array>} */
+let receivedReplies = [];
+
+goog.exportSymbol('testDelayedMessageChannel', {
+  'setUp': function() {
+    mockControl = new goog.testing.MockControl();
+    underlyingMock = new goog.testing.messaging.MockMessageChannel(mockControl);
+    /** @type {?} */ underlyingMock.send;
+
+    delayed = new GSC.DelayedMessageChannel();
+    delayed.registerDefaultService((serviceName, payload) => {
+      receivedReplies.push([serviceName, payload]);
+    });
+  },
+
+  'tearDown': function() {
+    // Check all mock expectations are satisfied.
+    mockControl.$verifyAll();
+    mockControl = null;
+    underlyingMock = null;
+    if (delayed) {
+      delayed.dispose();
+      delayed = null;
+    }
+    receivedReplies = [];
+  },
+
+  // Messages are sent/received immediately if happening after `setReady()`.
+  'testImmediateSendReceiveWhenReady': function() {
+    // Arrange. Expect message 1 to be sent through the mock.
+    underlyingMock.send(TYPE_1, DATA_1);
+    underlyingMock.send.$replay();
+    delayed.setUnderlyingChannel(underlyingMock);
+    delayed.setReady();
+
+    // Act.
+    delayed.send(TYPE_1, DATA_1);
+    underlyingMock.receive(TYPE_2, DATA_2);
+
+    // Assert.
+    assertObjectEquals(receivedReplies, [[TYPE_2, DATA_2]]);
+  },
+
+  // Sent messages are delayed until `setReady()` is called.
+  'testSendDelayedUntilReady': function() {
+    // Hack to convince Closure Compiler that the variable is non-null below.
+    goog.asserts.assert(underlyingMock);
+
+    // Arrange. Call `send()` before setting mock expectations, to verify that
+    // sending is delayed until `setReady()`.
+    delayed.send(TYPE_1, DATA_1);
+    delayed.setUnderlyingChannel(underlyingMock);
+    delayed.send(TYPE_2, DATA_2);
+    underlyingMock.send(TYPE_1, DATA_1);
+    underlyingMock.send(TYPE_2, DATA_2);
+    underlyingMock.send.$replay();
+
+    // Act.
+    delayed.setReady();
+
+    // Assertions happen when verifying mocks in `tearDown()`.
+  },
+
+  // Message receipt happens immediately after `setUnderlyingChannel()`, even if
+  // `setReady()` hasn't been called.
+  'testReceiveImmediateBeforeReady': function() {
+    // Hack to convince Closure Compiler that the variable is non-null below.
+    goog.asserts.assert(underlyingMock);
+
+    // Arrange.
+    delayed.setUnderlyingChannel(underlyingMock);
+
+    // Act.
+    underlyingMock.receive(TYPE_1, DATA_1);
+
+    // Assert.
+    assertObjectEquals(receivedReplies, [[TYPE_1, DATA_1]]);
+  },
+
+  // Test sending the second message from inside the `send()` call for the first
+  // message.
+  'testReentrantSendWhenReady': function() {
+    // Arrange. The mock will reentrantly send message 2 whenever message 1 is
+    // being sent.
+    underlyingMock.send(TYPE_1, DATA_1).$does(() => {
+      delayed.send(TYPE_2, DATA_2);
+    });
+    underlyingMock.send(TYPE_2, DATA_2);
+    underlyingMock.send.$replay();
+    delayed.setUnderlyingChannel(underlyingMock);
+    delayed.setReady();
+
+    // Act.
+    delayed.send(TYPE_1, DATA_1);
+
+    // Assertions happen when verifying mocks in `tearDown()`.
+  },
+
+  // Same as above, but in the scenario when sending is delayed until
+  // `setReady()` is called.
+  'testReentrantSendBeforeReady': function() {
+    // Arrange. The mock will reentrantly send message 2 whenever message 1 is
+    // being sent.
+    underlyingMock.send(TYPE_1, DATA_1).$does(() => {
+      delayed.send(TYPE_2, DATA_2);
+    });
+    underlyingMock.send(TYPE_2, DATA_2);
+    underlyingMock.send.$replay();
+    delayed.setUnderlyingChannel(underlyingMock);
+    delayed.send(TYPE_1, DATA_1);
+
+    // Act.
+    delayed.setReady();
+
+    // Assertions happen when verifying mocks in `tearDown()`.
+  },
+});
+});

--- a/common/js/src/messaging/delayed-message-channel-unittest.js
+++ b/common/js/src/messaging/delayed-message-channel-unittest.js
@@ -78,7 +78,7 @@ goog.exportSymbol('testDelayedMessageChannel', {
     delayed.setUnderlyingChannel(underlyingMock);
     delayed.setReady();
 
-    // Act.
+    // Act. Send messages in both directions.
     delayed.send(TYPE_1, DATA_1);
     underlyingMock.receive(TYPE_2, DATA_2);
 

--- a/common/js/src/messaging/delayed-message-channel.js
+++ b/common/js/src/messaging/delayed-message-channel.js
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.provide('GoogleSmartCard.DelayedMessageChannel');
+
+goog.require('GoogleSmartCard.Logging');
+goog.require('goog.messaging.AbstractChannel');
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+/**
+ * Forwards all communication to the given channel once it's ready for
+ * communication, but remembers all to-be-sent messages until that happens.
+ *
+ * The correct order of operations:
+ * create ==> `setUnderlyingChannel()` ==> `setReady()`.
+ */
+GSC.DelayedMessageChannel = class extends goog.messaging.AbstractChannel {
+  constructor() {
+    super();
+    /** @type {!goog.messaging.AbstractChannel|null} @private */
+    this.underlyingChannel_ = null;
+    /**
+     * @type {!Array<!{serviceName: string, payload:
+     *     (string|!Object)}>} @private
+     */
+    this.pendingOutgoingMessages_ = [];
+    /** @type {boolean} @private */
+    this.ready_ = false;
+  }
+
+  /**
+   * Associates us with the given channel, but doesn't unblock sending messages
+   * to it yet.
+   * @param {!goog.messaging.AbstractChannel} underlyingChannel
+   */
+  setUnderlyingChannel(underlyingChannel) {
+    GSC.Logging.check(!this.underlyingChannel_);
+    this.underlyingChannel_ = underlyingChannel;
+    // Let ourselves receive all (unhandled) messages that were received on
+    // `underlyingChannel`.
+    underlyingChannel.registerDefaultService((serviceName, payload) => {
+      this.deliver(serviceName, payload);
+    });
+  }
+
+  /**
+   * Unblocks sending messages to the underlying channel. Previously accumulated
+   * messages are sent immediately.
+   */
+  setReady() {
+    GSC.Logging.check(this.underlyingChannel_);
+    GSC.Logging.check(!this.ready_);
+    this.ready_ = true;
+    // Send all previously enqueued messages. Note that, in theory, new items
+    // might be added to the array while we're iterating over it, which should
+    // be fine as the for-of loop will visit all of them.
+    for (const message of this.pendingOutgoingMessages_)
+      this.underlyingChannel_.send(message.serviceName, message.payload);
+    this.pendingOutgoingMessages_ = [];
+  }
+
+  /** @override */
+  send(serviceName, payload) {
+    if (this.isDisposed())
+      return;
+    if (!this.ready_ || this.pendingOutgoingMessages_.length > 0) {
+      // Enqueue the message until the proxied channel becomes ready and all
+      // previously enqueued messages are sent.
+      this.pendingOutgoingMessages_.push({serviceName, payload});
+      return;
+    }
+    this.underlyingChannel_.send(serviceName, payload);
+  }
+
+  /** @override */
+  disposeInternal() {
+    this.pendingOutgoingMessages_ = [];
+    if (this.underlyingChannel_) {
+      this.underlyingChannel_.dispose();
+      this.underlyingChannel_ = null;
+    }
+    super.disposeInternal();
+  }
+};
+});

--- a/common/js/src/messaging/delayed-message-channel.js
+++ b/common/js/src/messaging/delayed-message-channel.js
@@ -51,6 +51,8 @@ GSC.DelayedMessageChannel = class extends goog.messaging.AbstractChannel {
    * @param {!goog.messaging.AbstractChannel} underlyingChannel
    */
   setUnderlyingChannel(underlyingChannel) {
+    if (this.isDisposed())
+      return;
     GSC.Logging.check(!this.underlyingChannel_);
     this.underlyingChannel_ = underlyingChannel;
     // Let ourselves receive all (unhandled) messages that were received on
@@ -65,6 +67,8 @@ GSC.DelayedMessageChannel = class extends goog.messaging.AbstractChannel {
    * messages are sent immediately.
    */
   setReady() {
+    if (this.isDisposed())
+      return;
     GSC.Logging.check(this.underlyingChannel_);
     GSC.Logging.check(!this.ready_);
     this.ready_ = true;


### PR DESCRIPTION
Move the logic of delayed message sending out from emscripten-module.js into a separate helper class.

This lets us reuse it in other places, namely for the communication with the Offscreen Document that's currently being implemented for manifestv3. Also this extracted code can be covered with unit tests now.