### PR TITLE
Increase dead message channel timeout

### DIFF
--- a/common/js/src/messaging/message-channel-pinging.js
+++ b/common/js/src/messaging/message-channel-pinging.js
@@ -58,7 +58,7 @@ const PING_RESPONDER_CHANNEL_ID = generateChannelId();
  * This constant represents the timeout in milliseconds after which the channel
  * is considered dead.
  */
-const PINGER_TIMEOUT_MILLISECONDS = goog.DEBUG ? 20 * 1000 : 600 * 1000;
+const PINGER_TIMEOUT_MILLISECONDS = 600 * 1000;
 
 /**
  * This constant represents the time in milliseconds between consecutive ping


### PR DESCRIPTION
Consider a message channel dead only after 10 min of silence, regardless of Debug or Release build mode.

This should fix the observed rare event in Debug build, when communication between client extensions and Smart Card Connector was considered dead despite the pages staying alive seemingly. This problem is especially disruptive in the manifest v3 extension build mode, since closing message ports can lead to the termination of service workers.