### PR TITLE
[pcsc] Retry init on more errors, try USB reset

### DIFF
--- a/smart_card_connector_app/src/application.cc
+++ b/smart_card_connector_app/src/application.cc
@@ -43,7 +43,9 @@ Application::Application(
           MakeUnique<LibusbWebPortService>(global_context_,
                                            typed_message_router_)),
       pcsc_lite_server_web_port_service_(
-          MakeUnique<PcscLiteServerWebPortService>(global_context_)) {
+          MakeUnique<PcscLiteServerWebPortService>(
+              global_context_,
+              libusb_web_port_service_.get())) {
   ScheduleServicesInitialization();
 }
 

--- a/smart_card_connector_app/src/application_unittest.cc
+++ b/smart_card_connector_app/src/application_unittest.cc
@@ -3328,13 +3328,20 @@ INSTANTIATE_TEST_SUITE_P(
             TestingSmartCardSimulation::ErrorMode::kClaimInterfaceError,
             TestingSmartCardSimulation::ErrorCessation::kAfterTwoErrors),
         TransientErrorTestParam(
+            TestingSmartCardSimulation::ErrorMode::kBulkTransferError,
+            TestingSmartCardSimulation::ErrorCessation::kAfterReset),
+        TransientErrorTestParam(
             TestingSmartCardSimulation::ErrorMode::
                 kBulkTransferUnrelatedReplies,
             TestingSmartCardSimulation::ErrorCessation::kAfterOneError),
         TransientErrorTestParam(
             TestingSmartCardSimulation::ErrorMode::
                 kBulkTransferUnrelatedReplies,
-            TestingSmartCardSimulation::ErrorCessation::kAfterTwoErrors)));
+            TestingSmartCardSimulation::ErrorCessation::kAfterTwoErrors),
+        TransientErrorTestParam(
+            TestingSmartCardSimulation::ErrorMode::
+                kBulkTransferUnrelatedReplies,
+            TestingSmartCardSimulation::ErrorCessation::kAfterReset)));
 
 // Reader initialization succeeds after retrying from temporary USB errors.
 TEST_P(SmartCardConnectorApplicationReaderTransientErrorTest,

--- a/smart_card_connector_app/src/testing_smart_card_simulation.h
+++ b/smart_card_connector_app/src/testing_smart_card_simulation.h
@@ -88,6 +88,8 @@ class TestingSmartCardSimulation final : public RequestHandler {
     // The error disappears after being triggered twice. (We don't test ">2"
     // cases because it wouldn't add much more value.)
     kAfterTwoErrors,
+    // The error will disappear after USB "resetDevice".
+    kAfterReset,
   };
 
   // Represents whether an ICC (a smart card) is inserted into the reader and is
@@ -175,6 +177,7 @@ class TestingSmartCardSimulation final : public RequestHandler {
     GenericRequestResult ReleaseInterface(int64_t device_id,
                                           int64_t device_handle,
                                           int64_t interface_number);
+    GenericRequestResult ResetDevice(int64_t device_id, int64_t device_handle);
     GenericRequestResult ControlTransfer(
         int64_t device_id,
         int64_t device_handle,

--- a/third_party/libusb/webport/src/libusb_js_proxy.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy.h
@@ -122,6 +122,10 @@ class LibusbJsProxy final : public LibusbInterface {
   int LibusbHandleEvents(libusb_context* ctx) override;
   int LibusbHandleEventsCompleted(libusb_context* ctx, int* completed) override;
 
+  // Makes the bus number to be reported to the specified value for the given
+  // device.
+  void OverrideBusNumber(int64_t device_address, uint8_t new_bus_number);
+
  private:
   const int kHandleEventsTimeoutSeconds = 60;
 
@@ -151,7 +155,6 @@ class LibusbJsProxy final : public LibusbInterface {
                            int length,
                            int* actual_length,
                            unsigned timeout);
-  void TryApplyTransientAccessErrorWorkaround(libusb_device* dev);
   // Fetches the descriptor from the JS side and stores it in
   // `libusb_device::js_config`.
   void ObtainActiveConfigDescriptor(libusb_device* dev);

--- a/third_party/libusb/webport/src/libusb_js_proxy.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy.h
@@ -122,7 +122,7 @@ class LibusbJsProxy final : public LibusbInterface {
   int LibusbHandleEvents(libusb_context* ctx) override;
   int LibusbHandleEventsCompleted(libusb_context* ctx, int* completed) override;
 
-  // Makes the bus number to be reported to the specified value for the given
+  // Makes the bus number to be reported as the specified value for the given
   // device.
   void OverrideBusNumber(int64_t device_address, uint8_t new_bus_number);
 

--- a/third_party/libusb/webport/src/public/constants.h
+++ b/third_party/libusb/webport/src/public/constants.h
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc.
+// Copyright 2024 Google Inc.
 //
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/third_party/libusb/webport/src/public/constants.h
+++ b/third_party/libusb/webport/src/public/constants.h
@@ -1,0 +1,31 @@
+// Copyright 2016 Google Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef GOOGLE_SMART_CARD_LIBUSB_CONSTANTS_H_
+#define GOOGLE_SMART_CARD_LIBUSB_CONSTANTS_H_
+
+#include <stdint.h>
+
+namespace google_smart_card {
+
+// Stub out the device bus number with this value initially (as the JS API does
+// not provide means of retrieving it). We also allow the client code override
+// this to a different value if needed.
+constexpr uint8_t kDefaultUsbBusNumber = 1;
+
+}  // namespace google_smart_card
+
+#endif  // GOOGLE_SMART_CARD_LIBUSB_CONSTANTS_H_

--- a/third_party/libusb/webport/src/public/libusb_web_port_service.cc
+++ b/third_party/libusb/webport/src/public/libusb_web_port_service.cc
@@ -62,6 +62,8 @@ class LibusbWebPortService::Impl final {
     return &libusb_js_proxy_;
   }
 
+  LibusbJsProxy* libusb_js_proxy() { return &libusb_js_proxy_; }
+
  private:
   LibusbJsProxy libusb_js_proxy_;
   std::unique_ptr<LibusbTracingWrapper> libusb_tracing_wrapper_;
@@ -82,6 +84,11 @@ LibusbWebPortService::~LibusbWebPortService() {
 
 void LibusbWebPortService::ShutDown() {
   impl_->ShutDown();
+}
+
+void LibusbWebPortService::OverrideBusNumber(int64_t device_address,
+                                             uint8_t new_bus_number) {
+  impl_->libusb_js_proxy()->OverrideBusNumber(device_address, new_bus_number);
 }
 
 }  // namespace google_smart_card

--- a/third_party/libusb/webport/src/public/libusb_web_port_service.h
+++ b/third_party/libusb/webport/src/public/libusb_web_port_service.h
@@ -66,6 +66,10 @@ class LibusbWebPortService final {
   // This function is safe to be called from any thread.
   void ShutDown();
 
+  // Makes the bus number to be reported to the specified value for the given
+  // device.
+  void OverrideBusNumber(int64_t device_address, uint8_t new_bus_number);
+
  private:
   // Use the "pimpl" pattern, so that other code can include our .h file without
   // transitively including all of our internal implementation headers (which

--- a/third_party/libusb/webport/src/public/libusb_web_port_service.h
+++ b/third_party/libusb/webport/src/public/libusb_web_port_service.h
@@ -66,7 +66,7 @@ class LibusbWebPortService final {
   // This function is safe to be called from any thread.
   void ShutDown();
 
-  // Makes the bus number to be reported to the specified value for the given
+  // Makes the bus number to be reported as the specified value for the given
   // device.
   void OverrideBusNumber(int64_t device_address, uint8_t new_bus_number);
 

--- a/third_party/pcsc-lite/naclport/server/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server/build/Makefile
@@ -232,6 +232,8 @@ PCSC_LITE_SERVER_NACL_SOURCES := \
 PCSC_LITE_SERVER_NACL_CXXFLAGS := \
 	$(COMMON_CPPFLAGS) \
 	-I$(PCSC_LITE_SOURCES_PATH) \
+	-I$(ROOT_PATH)/third_party/libusb/src/libusb \
+	-I$(ROOT_PATH)/third_party/libusb/webport/src \
 	-std=$(CXX_DIALECT) \
 
 $(foreach src,$(PCSC_LITE_SERVER_NACL_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_NACL_CXXFLAGS))))

--- a/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
+++ b/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
@@ -94,7 +94,9 @@ constexpr char kReaderInitAddMessageType[] = "reader_init_add";
 constexpr char kReaderFinishAddMessageType[] = "reader_finish_add";
 constexpr char kReaderRemoveMessageType[] = "reader_remove";
 
+// How many times we retry connecting to a reader before giving up.
 constexpr int kMaximumReaderRetries = 60;
+// After how many unsuccessful retries we reset the USB device.
 constexpr int kReaderRetriesTillUsbReset = 10;
 
 // Message data for the message that notifies the JavaScript side that a reader


### PR DESCRIPTION
Change the init retry mechanism to be triggered on any reader initialization error, as opposed to only doing it on openDevice/claimInterface errors. Additionally, attempt resetting the USB device after a few unsuccessful retries.

This should fix occasional flaky errors we see in the field, when there's a temporary conflict between the in-session and the login-screen instances of Smart Card Connector, which may cause failures at various USB functions and accidentally receiving a reply for a request sent by a different extension ("Invalid frame detected").