### PR TITLE
[wasm] Allow passing GTest filter via command line

### DIFF
--- a/common/cpp_unit_test_runner/src/build_emscripten.mk
+++ b/common/cpp_unit_test_runner/src/build_emscripten.mk
@@ -15,6 +15,11 @@
 # This file contains the implementation of the ../include.mk interface that
 # builds the C++ unit test runner using the Emscripten toolchain.
 
+# Allow passing additional parameters to GTest via setting this environment
+# variable. E.g.:
+#   GTEST_ARGS="--gtest_filter=*Foo" make test
+GTEST_ARGS ?=
+
 # Documented in ../include.mk.
 #
 # Explanation:
@@ -91,4 +96,4 @@ $(GOOGLETEST_LIBS_PATTERN):
 # DISPLAY: Workaround against "Permission denied" Node.js issue.
 run_test: all
 	cd $(OUT_DIR_PATH) && DISPLAY= \
-		node $(TARGET).js
+		node $(TARGET).js $(GTEST_ARGS)


### PR DESCRIPTION
Like this: GTEST_ARGS="--gtest_filter=*Foo" make test

This is something we already supported in the "analysis" builds (e.g., TOOLCHAIN=asan_testing), so this commit just expands this to another build configuration. Note that JS-based tests, including JS-to-C++ tests, don't use GTest and ignore this parameter.