### PR TITLE
Refactor message awaiting

### DIFF
--- a/common/js/src/executable-module/offscreen-doc-emscripten-module.js
+++ b/common/js/src/executable-module/offscreen-doc-emscripten-module.js
@@ -35,6 +35,7 @@ goog.provide('GoogleSmartCard.OffscreenDocEmscriptenModule');
 goog.require('GoogleSmartCard.DelayedMessageChannel');
 goog.require('GoogleSmartCard.ExecutableModule');
 goog.require('GoogleSmartCard.Logging');
+goog.require('GoogleSmartCard.MessageWaiter');
 goog.require('GoogleSmartCard.PortMessageChannel');
 goog.require('GoogleSmartCard.PortMessageChannelWaiter');
 goog.require('GoogleSmartCard.PromiseHelpers');
@@ -187,7 +188,7 @@ GSC.OffscreenDocEmscriptenModule = class extends GSC.ExecutableModule {
    * @private
    */
   async waitForLoadedMessage_() {
-    await this.waitForMessage_(STATUS_LOADED);
+    await GSC.MessageWaiter.wait(this.statusChannel_, STATUS_LOADED);
   }
 
   /**
@@ -197,22 +198,9 @@ GSC.OffscreenDocEmscriptenModule = class extends GSC.ExecutableModule {
    * @private
    */
   async waitForDisposedMessage_() {
-    await this.waitForMessage_(STATUS_DISPOSED);
+    await GSC.MessageWaiter.wait(this.statusChannel_, STATUS_DISPOSED);
     this.dispose();
     throw new Error('Disposed');
-  }
-
-  /**
-   * @param {string} awaitedMessageType
-   * @return {!Promise<void>}
-   * @private
-   */
-  waitForMessage_(awaitedMessageType) {
-    return new Promise((resolve) => {
-      this.statusChannel_.registerService(awaitedMessageType, () => {
-        resolve();
-      });
-    });
   }
 };
 

--- a/common/js/src/messaging/message-waiter-unittest.js
+++ b/common/js/src/messaging/message-waiter-unittest.js
@@ -83,7 +83,7 @@ goog.exportSymbol('testMessageWaiter', {
     // Act.
     disposeChannel();
     // Assert.
-    assertRejects(promise);
+    await assertRejects(promise);
   },
 
   'testAlreadyDisposed': async function() {
@@ -92,7 +92,7 @@ goog.exportSymbol('testMessageWaiter', {
     // Act.
     const promise = GSC.MessageWaiter.wait(channel, 'foo');
     // Assert.
-    assertRejects(promise);
+    await assertRejects(promise);
   },
 });
 });

--- a/common/js/src/messaging/message-waiter-unittest.js
+++ b/common/js/src/messaging/message-waiter-unittest.js
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.require('GoogleSmartCard.MessageWaiter');
+goog.require('goog.reflect');
+goog.require('goog.testing.MockControl');
+goog.require('goog.testing.asserts');
+goog.require('goog.testing.jsunit');
+goog.require('goog.testing.messaging.MockMessageChannel');
+
+goog.setTestOnly();
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+/** @type {goog.testing.MockControl} */
+let mockControl = null;
+/** @type {goog.testing.messaging.MockMessageChannel} */
+let channel = null;
+
+goog.exportSymbol('testMessageWaiter', {
+  'setUp': function() {
+    mockControl = new goog.testing.MockControl();
+    channel = new goog.testing.messaging.MockMessageChannel(mockControl);
+  },
+
+  'tearDown': function() {
+    channel = null;
+    mockControl.$verifyAll();
+    mockControl = null;
+  },
+
+  'testBasic': async function() {
+    const TYPE = 'foo';
+    const VALUE = {};
+    // Arrange.
+    const promise = GSC.MessageWaiter.wait(channel, TYPE);
+    // Act.
+    channel.receive(TYPE, VALUE);
+    // Assert.
+    assertObjectEquals(await promise, VALUE);
+  },
+
+  'testUnrelatedMessage': async function() {
+    const TYPE = 'foo';
+    const VALUE = {'x': 1};
+    const WRONG_TYPE = 'bar';
+    const WRONG_VALUE = {'y': 2};
+    // Arrange.
+    const promise = GSC.MessageWaiter.wait(channel, TYPE);
+    // Act.
+    channel.receive(WRONG_TYPE, WRONG_VALUE);
+    channel.receive(TYPE, VALUE);
+    // Assert.
+    assertObjectEquals(await promise, VALUE);
+  },
+
+  'testDisposal': async function() {
+    // Arrange.
+    const promise = GSC.MessageWaiter.wait(channel, 'foo');
+    // Act. Hack: call the protected disposeInternal() method in order to
+    // trigger the disposal notifications; MockMessageChannel.dispose() doesn't
+    // call them.
+    channel.dispose();
+    channel[goog.reflect.objectProperty('disposeInternal', channel)]();
+    // Assert.
+    assertRejects(promise);
+  },
+});
+});

--- a/common/js/src/messaging/message-waiter.js
+++ b/common/js/src/messaging/message-waiter.js
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview A helper for waiting for an incoming message with the specified
+ * type.
+ */
+
+goog.provide('GoogleSmartCard.MessageWaiter');
+
+goog.require('goog.messaging.AbstractChannel');
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+/**
+ * Waits for the message with the specified type to arrive on the given channel,
+ * and returns it. Rejects the promise if the channel is disposed of.
+ * @param {goog.messaging.AbstractChannel} channel
+ * @param {string} awaitedMessageType
+ * @return {!Promise}
+ */
+GSC.MessageWaiter.wait = function(channel, awaitedMessageType) {
+  return new Promise((resolve, reject) => {
+    // Listen for the message.
+    channel.registerService(awaitedMessageType, (data) => {
+      resolve(data);
+    }, /*opt_objectPayload=*/ true);
+
+    // Listen for the disposal event.
+    channel.addOnDisposeCallback(
+        () => reject(new Error('Message channel disposed of')));
+  });
+};
+});


### PR DESCRIPTION
Create a small library function for for waiting on a specific incoming message. Cover it with unit tests.

This code will be reused for implementing the communication with popup dialogs in the manifest v3 mode.