### PR TITLE
Fix paths used when preparing Github release files

### DIFF
--- a/prepare-binaries-for-github-release.py
+++ b/prepare-binaries-for-github-release.py
@@ -44,16 +44,16 @@ BINARY_CONTENTS_RELATIVES_PATHS = [
 # archives, accompanied with the relative target file paths.
 PATHS_TO_COPY = [
   ['example_js_standalone_smart_card_client_library/js_build/'
-   'app_emscripten_Debug/google-smart-card-client-library.js',
+   'extension_emscripten_Debug/google-smart-card-client-library.js',
    'google-smart-card-client-library.debug.js'],
   ['example_js_standalone_smart_card_client_library/js_build/'
-   'app_emscripten_Release/google-smart-card-client-library.js',
+   'extension_emscripten_Release/google-smart-card-client-library.js',
    'google-smart-card-client-library.js'],
   ['example_js_standalone_smart_card_client_library/js_build/'
-   'app_emscripten_Debug/google-smart-card-client-library-es-module.js',
+   'extension_emscripten_Debug/google-smart-card-client-library-es-module.js',
    'google-smart-card-client-library-es-module.debug.js'],
   ['example_js_standalone_smart_card_client_library/js_build/'
-   'app_emscripten_Release/google-smart-card-client-library-es-module.js',
+   'extension_emscripten_Release/google-smart-card-client-library-es-module.js',
    'google-smart-card-client-library-es-module.js'],
 ]
 


### PR DESCRIPTION
The prepare-binaries-for-github-release.py script should now use the "extension_emscripten" files, because we stopped compiling the "app_emscripten" variant.

This was forgotten in
https://github.com/GoogleChromeLabs/chromeos_smart_card_connector/pull/1140.