### PR TITLE
[mv3] Support popup windows - via message channels

### DIFF
--- a/common/js/src/messaging/port-message-channel.js
+++ b/common/js/src/messaging/port-message-channel.js
@@ -74,6 +74,7 @@ GSC.PortMessageChannel = class extends goog.messaging.AbstractChannel {
 
     /**
      * @type {!goog.log.Logger}
+     * @public
      * @const
      */
     this.logger = GSC.Logging.getScopedLogger(

--- a/common/js/src/popup-window/popup-constants.js
+++ b/common/js/src/popup-window/popup-constants.js
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.provide('GoogleSmartCard.PopupConstants');
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+/**
+ * Opener passes the ID to the popup under this key.
+ * @const
+ */
+GSC.PopupConstants.POPUP_ID_KEY = 'popup_id';
+
+/**
+ * The popup opens a messaging port with the "<prefix><popupId>" to report its
+ * result.
+ * @const
+ */
+GSC.PopupConstants.PORT_NAME_PREFIX = 'popup_';
+
+/**
+ * The popup sends its result as a message with this type.
+ * @const
+ */
+GSC.PopupConstants.RESULT_MESSAGE_TYPE = 'result';
+
+/**
+ * On success, the popup sends the result as a {<key>: <value>} message.
+ * @const
+ */
+GSC.PopupConstants.RESULT_VALUE_KEY = 'value';
+
+/**
+ * On error, the popup sends the {<key>: <error>} message.
+ * @const
+ */
+GSC.PopupConstants.RESULT_ERROR_KEY = 'error';
+});

--- a/common/js/src/popup-window/popup-opener.js
+++ b/common/js/src/popup-window/popup-opener.js
@@ -232,7 +232,7 @@ async function waitForPopupResult(popupId) {
       port, GSC.PopupConstants.RESULT_MESSAGE_TYPE);
 
   // Extract the result: either an error (needs to be thrown) or a value.
-  if (result.hasOwn(GSC.PopupConstants.RESULT_ERROR_KEY)) {
+  if (Object.hasOwn(result, GSC.PopupConstants.RESULT_ERROR_KEY)) {
     throw result[GSC.PopupConstants.RESULT_ERROR_KEY];
   }
   return result[GSC.PopupConstants.RESULT_VALUE_KEY];

--- a/common/js/src/popup-window/popup-opener.js
+++ b/common/js/src/popup-window/popup-opener.js
@@ -232,7 +232,7 @@ async function waitForPopupResult(popupId) {
       port, GSC.PopupConstants.RESULT_MESSAGE_TYPE);
 
   // Extract the result: either an error (needs to be thrown) or a value.
-  if (result.hasOwnProperty(GSC.PopupConstants.RESULT_ERROR_KEY)) {
+  if (result.hasOwn(GSC.PopupConstants.RESULT_ERROR_KEY)) {
     throw result[GSC.PopupConstants.RESULT_ERROR_KEY];
   }
   return result[GSC.PopupConstants.RESULT_VALUE_KEY];

--- a/common/js/src/popup-window/popup-opener.js
+++ b/common/js/src/popup-window/popup-opener.js
@@ -29,7 +29,6 @@ goog.require('GoogleSmartCard.Packaging');
 goog.require('GoogleSmartCard.PopupConstants');
 goog.require('GoogleSmartCard.PortMessageChannelWaiter');
 goog.require('goog.Promise');
-goog.require('goog.Thenable');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.object');
@@ -155,7 +154,7 @@ GSC.PopupOpener.runModalDialog = function(url, opt_windowOptions, opt_data) {
 
   // Additionally pass the auto-generated popup ID. The popup will use it to
   // talk back to us when sending the result.
-  ++lastUsedPopupId;
+  lastUsedPopupId++;
   const modifiedData = {[GSC.PopupConstants.POPUP_ID_KEY]: lastUsedPopupId};
   if (opt_data !== undefined)
     Object.assign(modifiedData, opt_data);

--- a/example_js_smart_card_client_app/src/pin-dialog/pin-dialog-server.js
+++ b/example_js_smart_card_client_app/src/pin-dialog/pin-dialog-server.js
@@ -18,7 +18,6 @@
 goog.provide('SmartCardClientApp.PinDialog.Server');
 
 goog.require('GoogleSmartCard.PopupOpener');
-goog.require('goog.Thenable');
 
 goog.scope(function() {
 
@@ -31,7 +30,7 @@ const PIN_DIALOG_WINDOW_OPTIONS_OVERRIDES = {
 const GSC = GoogleSmartCard;
 
 /**
- * @return {!goog.Thenable.<string>}
+ * @return {!IThenable.<string>}
  */
 SmartCardClientApp.PinDialog.Server.requestPin = function() {
   return GSC.PopupOpener.runModalDialog(


### PR DESCRIPTION
This adds support of manifest v3 to the "popup-window" helpers. This is
achieved by reimplementing the popup==>background page communication
using message ports.

Previously, we used two other mechanisms for this communication:

* in the Chrome App build mode we injected callbacks into the popup's
  global state using the chrome.app.window.create() callback.
* in the Chrome manifest v2 Extension build mode we used
  "setSelfAsOpener" to let the popup call global functions in the
  opener page itself.

Neither works in manifest v3 Extensions, hence this commit implements a
new approach that should work in all build modes.