### PR TITLE
[wasm] Drop the legacy DEMANGLE_SUPPORT option

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -173,13 +173,11 @@ EMSCRIPTEN_COMMON_FLAGS += \
 #
 # Explanation:
 # ASSERTIONS: Enable runtime checks, like for memory allocation errors.
-# DEMANGLE_SUPPORT: Demangle C++ function names in stack traces.
 # SAFE_HEAP: Enable memory access checks.
 # Wno-limited-postlink-optimizations: Suppress a warning about limited
 #   optimizations.
 EMSCRIPTEN_LINKER_FLAGS += \
   -s ASSERTIONS=2 \
-  -s DEMANGLE_SUPPORT=1 \
   -s SAFE_HEAP=1 \
   -Wno-limited-postlink-optimizations \
 


### PR DESCRIPTION
Emscripten's DEMANGLE_SUPPORT option got deprecated and became no-op in 3.1.54
(https://github.com/emscripten-core/emscripten/commit/971e903181da8ce09b3a9c17c284f692b392f9ae).