### PR TITLE
[example] Add RSA-PSS algorithms

### DIFF
--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
@@ -602,6 +602,8 @@ function createClientCertificateInfo(executableModuleCertificateInfo) {
 }
 
 /**
+ * Converts the certificate information received from the C++ code into the
+ * (legacy) `CertificateInfo` object.
  * @param {!ExecutableModuleCertificateInfo} executableModuleCertificateInfo
  * @return {!chrome.certificateProvider.CertificateInfo}
  */

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
@@ -606,11 +606,17 @@ function createClientCertificateInfo(executableModuleCertificateInfo) {
  * @return {!chrome.certificateProvider.CertificateInfo}
  */
 function createCertificateInfo(executableModuleCertificateInfo) {
+  const supportedHashes = [];
+  for (const algorithm of
+           executableModuleCertificateInfo['supportedAlgorithms']) {
+    const hash = getHashFromAlgorithm(algorithm);
+    if (hash !== null) {
+      supportedHashes.push(hash);
+    }
+  }
   return {
     certificate: executableModuleCertificateInfo['certificate'],
-    supportedHashes: goog.array.map(
-        executableModuleCertificateInfo['supportedAlgorithms'],
-        getHashFromAlgorithm)
+    supportedHashes: supportedHashes,
   };
 }
 
@@ -628,15 +634,16 @@ function getAlgorithmFromHash(hash) {
 }
 
 /**
+ * Converts the algorithm enum into the legacy hash enum. Returns null for
+ * algorithms that don't have a corresponding hash enum.
  * @param {!chrome.certificateProvider.Algorithm} algorithm
- * @return {!chrome.certificateProvider.Hash}
+ * @return {!chrome.certificateProvider.Hash|null}
  */
 function getHashFromAlgorithm(algorithm) {
   for (const hash of HASH_TO_ALGORITHM_MAPPING.keys()) {
     if (HASH_TO_ALGORITHM_MAPPING.get(hash) === algorithm)
       return /** @type {!chrome.certificateProvider.Hash} */ (hash);
   }
-  GSC.Logging.fail(`Unknown algorithm ${algorithm}`);
-  return chrome.certificateProvider.Hash.SHA1;
+  return null;
 }
 });  // goog.scope

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.cc
@@ -34,7 +34,10 @@ EnumValueDescriptor<ccp::Algorithm>::GetDescription() {
       .WithItem(ccp::Algorithm::kRsassaPkcs1v15Sha384,
                 "RSASSA_PKCS1_v1_5_SHA384")
       .WithItem(ccp::Algorithm::kRsassaPkcs1v15Sha512,
-                "RSASSA_PKCS1_v1_5_SHA512");
+                "RSASSA_PKCS1_v1_5_SHA512")
+      .WithItem(ccp::Algorithm::kRsassaPssSha256, "RSASSA_PSS_SHA256")
+      .WithItem(ccp::Algorithm::kRsassaPssSha384, "RSASSA_PSS_SHA384")
+      .WithItem(ccp::Algorithm::kRsassaPssSha512, "RSASSA_PSS_SHA512");
 }
 
 template <>

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.h
@@ -45,6 +45,9 @@ enum class Algorithm {
   kRsassaPkcs1v15Sha384,
   kRsassaPkcs1v15Sha256,
   kRsassaPkcs1v15Sha512,
+  kRsassaPssSha256,
+  kRsassaPssSha384,
+  kRsassaPssSha512,
 };
 
 // Enumerate that corresponds to types of errors that the extension can report.

--- a/example_cpp_smart_card_client_app/src/manifest.json
+++ b/example_cpp_smart_card_client_app/src/manifest.json
@@ -11,6 +11,7 @@
       ]
     }
   },
+  "minimum_chrome_version": "89",
   "default_locale": "en",
   "permissions": [
     "certificateProvider"


### PR DESCRIPTION
Add the C++ definitions for the RSA-PSS family of signature algorithms into the example_cpp_smart_card_client_app.

These algorithms have been supported by the Chrome Extensions API since version 89. We put the same minimum_chrome_version into the example manifest.json, because this has been long enough to not care about supporting older clients.