### PR TITLE
[example] Put Emscripten module into offscreen doc

### DIFF
--- a/example_cpp_smart_card_client_app/build/Makefile
+++ b/example_cpp_smart_card_client_app/build/Makefile
@@ -55,6 +55,12 @@ $(eval $(call BUILD_JS_SCRIPT,background.js,$(JS_COMPILER_INPUT_PATHS),SmartCard
 $(eval $(call BUILD_JS_SCRIPT,window.js,$(JS_COMPILER_INPUT_PATHS),SmartCardClientApp.WindowMain,$(JS_COMPILER_FLAGS)))
 $(eval $(call BUILD_JS_SCRIPT,built-in-pin-dialog.js,$(JS_COMPILER_INPUT_PATHS),SmartCardClientApp.BuiltInPinDialog.Main,$(JS_COMPILER_FLAGS)))
 
+ifeq ($(TOOLCHAIN),emscripten)
+ifeq ($(PACKAGING),extension)
+$(eval $(call BUILD_JS_SCRIPT,emscripten-offscreen-doc.js,$(JS_COMPILER_INPUT_PATHS),GoogleSmartCard.EmscriptenInOffscreenDocMain,$(JS_COMPILER_FLAGS)))
+endif
+endif
+
 
 # Rules for invoking recursive make files that build the app's binary executable
 # module (build rules for it can be found at ./executable_module/Makefile).
@@ -70,3 +76,9 @@ $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/window.html))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/window.css))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/built_in_pin_dialog/built-in-pin-dialog.css))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/built_in_pin_dialog/built-in-pin-dialog.html))
+
+ifeq ($(TOOLCHAIN),emscripten)
+ifeq ($(PACKAGING),extension)
+$(eval $(call COPY_TO_OUT_DIR_RULE,$(ROOT_PATH)/common/js/src/executable-module/emscripten-offscreen-doc.html))
+endif
+endif

--- a/example_cpp_smart_card_client_app/src/background.js
+++ b/example_cpp_smart_card_client_app/src/background.js
@@ -50,6 +50,8 @@ goog.require('GoogleSmartCard.EmscriptenModule');
 goog.require('GoogleSmartCard.ExecutableModule');
 goog.require('GoogleSmartCard.Logging');
 goog.require('GoogleSmartCard.NaclModule');
+goog.require('GoogleSmartCard.OffscreenDocEmscriptenModule');
+goog.require('GoogleSmartCard.Packaging');
 goog.require('GoogleSmartCard.PcscLiteClient.NaclClientBackend');
 goog.require('GoogleSmartCard.PcscLiteCommon.Constants');
 goog.require('GoogleSmartCard.PopupOpener');
@@ -136,7 +138,10 @@ function createExecutableModule() {
       return new GSC.NaclModule(
           'executable_module.nmf', GSC.NaclModule.Type.PNACL);
     case GSC.ExecutableModule.Toolchain.EMSCRIPTEN:
-      return new GSC.EmscriptenModule('executable_module');
+      if (GSC.Packaging.MODE === GSC.Packaging.Mode.EXTENSION)
+        return new GSC.OffscreenDocEmscriptenModule('executable_module');
+      else
+        return new GSC.EmscriptenModule('executable_module');
   }
   GSC.Logging.fail(
       `Cannot load executable module: unknown toolchain ` +

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/bridge-backend.js
@@ -463,8 +463,10 @@ Backend.prototype.processSignatureRequest_ = function(request) {
             this.logger,
             'Responding to the signature request with the created signature: ' +
                 GSC.DebugDump.debugDumpSanitized(signature));
-        chrome.certificateProvider.reportSignature(
-            {signRequestId: request.signRequestId, signature: signature});
+        chrome.certificateProvider.reportSignature({
+          signRequestId: request.signRequestId,
+          signature: toArrayBuffer(signature)
+        });
       },
       function() {
         goog.log.info(
@@ -544,7 +546,7 @@ Backend.prototype.processSignDigestRequest_ = function(
             this.logger,
             'Responding to the digest sign request with the created ' +
                 'signature: ' + GSC.DebugDump.debugDumpSanitized(signature));
-        reportCallback(signature);
+        reportCallback(toArrayBuffer(signature));
       },
       function() {
         goog.log.info(
@@ -596,7 +598,8 @@ function transformFunctionArguments(functionName, functionArguments) {
  */
 function createClientCertificateInfo(executableModuleCertificateInfo) {
   return {
-    certificateChain: [executableModuleCertificateInfo['certificate']],
+    certificateChain:
+        [toArrayBuffer(executableModuleCertificateInfo['certificate'])],
     supportedAlgorithms: executableModuleCertificateInfo['supportedAlgorithms']
   };
 }
@@ -607,7 +610,7 @@ function createClientCertificateInfo(executableModuleCertificateInfo) {
  */
 function createCertificateInfo(executableModuleCertificateInfo) {
   return {
-    certificate: executableModuleCertificateInfo['certificate'],
+    certificate: toArrayBuffer(executableModuleCertificateInfo['certificate']),
     supportedHashes: goog.array.map(
         executableModuleCertificateInfo['supportedAlgorithms'],
         getHashFromAlgorithm)
@@ -638,5 +641,16 @@ function getHashFromAlgorithm(algorithm) {
   }
   GSC.Logging.fail(`Unknown algorithm ${algorithm}`);
   return chrome.certificateProvider.Hash.SHA1;
+}
+
+/**
+ * Converts the array of bytes to an array buffer, if needed.
+ * @param {!ArrayBuffer|!Array<number>} value
+ * @return {!ArrayBuffer}
+ */
+function toArrayBuffer(value) {
+  if (value instanceof ArrayBuffer)
+    return value;
+  return (new Uint8Array(value)).buffer;
 }
 });  // goog.scope

--- a/example_cpp_smart_card_client_app/src/manifest.json
+++ b/example_cpp_smart_card_client_app/src/manifest.json
@@ -13,6 +13,7 @@
   },
   "default_locale": "en",
   "permissions": [
-    "certificateProvider"
+    "certificateProvider",
+    "offscreen"
   ]
 }

--- a/smart_card_connector_app/build/Makefile
+++ b/smart_card_connector_app/build/Makefile
@@ -82,6 +82,7 @@ JS_COMPILER_BACKGROUND_INPUT_PATHS := \
 	$(JS_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \
 
 $(eval $(call BUILD_JS_SCRIPT,background.js,$(JS_COMPILER_BACKGROUND_INPUT_PATHS),GoogleSmartCard.ConnectorApp.BackgroundMain,$(JS_COMPILER_FLAGS)))
+$(eval $(call BUILD_JS_SCRIPT,emscripten-offscreen-doc.js,$(JS_COMPILER_BACKGROUND_INPUT_PATHS),GoogleSmartCard.EmscriptenInOffscreenDocMain,$(JS_COMPILER_FLAGS)))
 
 #
 # Rules for compiling the emscripten-offscreen-doc.js file.
@@ -157,6 +158,7 @@ $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/window.css))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/card-present.png))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/about-window.html))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/about-window.css))
+$(eval $(call COPY_TO_OUT_DIR_RULE,$(ROOT_PATH)/common/js/src/executable-module/emscripten-offscreen-doc.html))
 
 ifeq ($(TOOLCHAIN),emscripten)
 ifeq ($(PACKAGING),extension)


### PR DESCRIPTION
Similarly to #1141 and #1160, we move the
example_cpp_smart_card_client_app's Emscripten module into an Offscreen Document when building in the PACKAGING=extension mode. The goal is to allow the WebAssembly module create background threads despite the manifest v3 restrictions.