### PR TITLE
[example] Switch to manifest v3 extension

### DIFF
--- a/example_cpp_smart_card_client_app/src/background.js
+++ b/example_cpp_smart_card_client_app/src/background.js
@@ -125,7 +125,7 @@ goog.log.info(
     logger,
     `The extension (id "${chrome.runtime.id}", version ` +
         `${extensionManifest.version}) background script started. Browser ` +
-        `version: "${window.navigator.appVersion}". System time: ` +
+        `version: "${globalThis.navigator.appVersion}". System time: ` +
         `"${formattedStartupTime}"`);
 
 /**
@@ -207,12 +207,14 @@ const builtInPinDialogBackend = new SmartCardClientApp.BuiltInPinDialog.Backend(
 // in advance.
 executableModule.startLoading();
 
-// Open the UI window when the user launches the app.
-chrome.app.runtime.onLaunched.addListener(() => {
-  GSC.PopupOpener.createWindow(MAIN_WINDOW_URL, MAIN_WINDOW_OPTIONS, {
-    'executableModuleMessageChannel': executableModule.getMessageChannel(),
+if (GSC.Packaging.MODE === GSC.Packaging.Mode.APP) {
+  // Open the UI window when the user launches the app.
+  chrome.app.runtime.onLaunched.addListener(() => {
+    GSC.PopupOpener.createWindow(MAIN_WINDOW_URL, MAIN_WINDOW_OPTIONS, {
+      'executableModuleMessageChannel': executableModule.getMessageChannel(),
+    });
   });
-});
+}
 
 // Automatically load the App (in the background) with Chrome startup.
 GSC.AppUtils.enableSelfAutoLoading();

--- a/example_cpp_smart_card_client_app/src/manifest.json
+++ b/example_cpp_smart_card_client_app/src/manifest.json
@@ -1,20 +1,18 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "__MSG_appName__",
   "description": "__MSG_appDesc__",
   "version": "0.0.0.0",
-  "app": {
-    "background": {
-      "persistent": false,
-      "scripts": [
-        "background.js"
-      ]
-    }
+  "background": {
+    "service_worker": "background.js"
   },
   "minimum_chrome_version": "89",
   "default_locale": "en",
   "permissions": [
     "certificateProvider",
     "offscreen"
-  ]
+  ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
+  }
 }


### PR DESCRIPTION
Change the manifest to use the manifest v3 format of Chrome Extensions. Also fix some Apps-specific code to work as mv3 Extensions.