### PR TITLE
[mv3] Support logs export

### DIFF
--- a/common/js/src/clipboard.js
+++ b/common/js/src/clipboard.js
@@ -44,10 +44,18 @@ const logger = GSC.Logging.getScopedLogger('Clipboard');
  * @return {boolean}
  */
 GSC.Clipboard.copyToClipboard = function(text) {
-  const element = goog.dom.createDom('textarea', {'textContent': text});
+  // Create a DOM node with the text.
+  const element = goog.dom.createDom('textarea');
+  element.textContent = text;
   document.body.appendChild(element);
-  element['select']();
+
+  // Select and copy the text.
+  element.select();
   const success = document.execCommand('copy');
+
+  // Clean up the DOM node. Deleting the text isn't strictly necessary, but in
+  // practice helps reduce the RAM consumption quickly.
+  element.textContent = '';
   document.body.removeChild(element);
 
   if (!success) {

--- a/common/js/src/logging/log-buffer.js
+++ b/common/js/src/logging/log-buffer.js
@@ -54,28 +54,7 @@ class State {
     this['skippedLogCount'] = skippedLogCount;
     this['formattedLogsSuffix'] = formattedLogsSuffix;
   }
-
-  /**
-   * Returns the textual dump of the internal state.
-   *
-   * The dump contains the formatted log messages, together with the information
-   * about the dropped log messages (if there are any).
-   * @return {string}
-   */
-  getAsText() {
-    const prefix = goog.iter.join(this['formattedLogsPrefix'], '');
-    const suffix = goog.iter.join(this['formattedLogsSuffix'], '');
-
-    let result = prefix;
-    if (this['skippedLogCount'])
-      result +=
-          '\n... skipped ' + this['skippedLogCount'] + ' messages ...\n\n';
-    result += suffix;
-    return result;
-  }
 }
-
-goog.exportProperty(State.prototype, 'getAsText', State.prototype.getAsText);
 
 /**
  * This class is the log buffer that allows to keep the log messages emitted by

--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -328,15 +328,15 @@ GSC.Logging.getLogBuffer = function() {
 
 /**
  * Returns all logs that have been accumulated from all pages so far.
- * @return {!Promise<!Array<string>>}
+ * @return {!Promise<!string>}
  */
 GSC.Logging.getLogsForExport = async function() {
   const port = chrome.runtime.connect({'name': LOGS_EXPORT_PORT_NAME});
-  const logs = [];
+  let logs = '';
   return new Promise((resolve) => {
     // Read out messages until the port is closed, which denotes the end.
     port.onMessage.addListener((message) => {
-      logs.push(message);
+      logs += message;
     });
     port.onDisconnect.addListener(() => {
       resolve(logs);

--- a/common/js/src/logging/logging.js
+++ b/common/js/src/logging/logging.js
@@ -110,6 +110,12 @@ const LOG_BUFFER_CAPACITY = goog.DEBUG ? 20 * 1000 : 2000;
 const LOG_MESSAGES_PORT_NAME = 'logs';
 
 /**
+ * Name of the port that's used for exporting all collected logs from the
+ * Service Worker or Background Page to another page.
+ */
+const LOGS_EXPORT_PORT_NAME = 'logs_export';
+
+/**
  * @type {!goog.log.Logger}
  */
 const rootLogger =
@@ -188,6 +194,7 @@ GSC.Logging.setupLogging = function() {
     GSC.LogBuffer.attachBufferToLogger(
         logBuffer, rootLogger, getDocumentLocation());
     setupLogReceiving();
+    listenForLogExportRequests();
     setupSystemLogLogging();
   } else {
     // Forward our logs to the "collector" page.
@@ -317,6 +324,24 @@ GSC.Logging.failWithLogger = function(logger, opt_message) {
  */
 GSC.Logging.getLogBuffer = function() {
   return logBuffer;
+};
+
+/**
+ * Returns all logs that have been accumulated from all pages so far.
+ * @return {!Promise<!Array<string>>}
+ */
+GSC.Logging.getLogsForExport = async function() {
+  const port = chrome.runtime.connect({'name': LOGS_EXPORT_PORT_NAME});
+  const logs = [];
+  return new Promise((resolve) => {
+    // Read out messages until the port is closed, which denotes the end.
+    port.onMessage.addListener((message) => {
+      logs.push(message);
+    });
+    port.onDisconnect.addListener(() => {
+      resolve(logs);
+    });
+  });
 };
 
 /**
@@ -468,6 +493,34 @@ function onLogMessageReceived(documentLocation, logRecord) {
       logRecord.getLoggerName(), logRecord.getMillis(),
       logRecord.getSequenceNumber());
   addToSystemLog(documentLocation, logRecord);
+}
+
+/**
+ * Handles incoming port connections that request exporting logs.
+ */
+function listenForLogExportRequests() {
+  if (!chrome || !chrome.runtime || !chrome.runtime.onConnect) {
+    // This should only happen in tests.
+    return;
+  }
+  chrome.runtime.onConnect.addListener((port) => {
+    if (port.name !== LOGS_EXPORT_PORT_NAME) {
+      return;
+    }
+    const snapshot = logBuffer.getState();
+    // Send all logs as messages and close the port to signal about the end.
+    for (const log of snapshot['formattedLogsPrefix']) {
+      port.postMessage(log);
+    }
+    if (snapshot['skippedLogCount'] > 0) {
+      port.postMessage(
+          `... skipped ${snapshot['skippedLogCount']} messages ...\n`);
+    }
+    for (const log of snapshot['formattedLogsSuffix']) {
+      port.postMessage(log);
+    }
+    port.disconnect();
+  });
 }
 
 GSC.Logging.setupLogging();

--- a/smart_card_connector_app/src/window-logs-exporting.js
+++ b/smart_card_connector_app/src/window-logs-exporting.js
@@ -67,19 +67,14 @@ function exportLogsClickListener(e) {
   goog.Timer.callOnce(exportLogs);
 }
 
-function exportLogs() {
-  const logBuffer = GSC.Logging.getLogBuffer();
-  // Note: calling methods by indexing properties via strings, since the log
-  // buffer comes from the background page, where due to code minification the
-  // minified method name might be different.
-  const logBufferState = logBuffer['getState'].call(logBuffer);
-  const dumpedLogs = logBufferState['getAsText'].call(logBufferState);
+async function exportLogs() {
+  const logs = await GSC.Logging.getLogsForExport();
+  const dumpedLogs = logs.join('');
 
   goog.log.fine(
       logger,
-      'Prepared a (possibly truncated) dump of ' + logBufferState['logCount'] +
-          ' log messages from the log buffer, the dump size is ' +
-          dumpedLogs.length + ' characters');
+      `Prepared a (possibly truncated) dump of log messages, the size is ${
+          dumpedLogs.length} characters`);
   const copyingSuccess = GSC.Clipboard.copyToClipboard(dumpedLogs);
 
   if (copyingSuccess) {

--- a/smart_card_connector_app/src/window-logs-exporting.js
+++ b/smart_card_connector_app/src/window-logs-exporting.js
@@ -69,13 +69,12 @@ function exportLogsClickListener(e) {
 
 async function exportLogs() {
   const logs = await GSC.Logging.getLogsForExport();
-  const dumpedLogs = logs.join('');
 
   goog.log.fine(
       logger,
       `Prepared a (possibly truncated) dump of log messages, the size is ${
-          dumpedLogs.length} characters`);
-  const copyingSuccess = GSC.Clipboard.copyToClipboard(dumpedLogs);
+          logs.length} characters`);
+  const copyingSuccess = GSC.Clipboard.copyToClipboard(logs);
 
   if (copyingSuccess) {
     exportLogsElement.textContent =


### PR DESCRIPTION
Make the log export UI mv3-compatible, by switching it from directly inspecting the background page's log buffer to using message passing.