### PR TITLE
[js] Update Closure Compiler to 20240317

### DIFF
--- a/third_party/closure-compiler-binary/README.google
+++ b/third_party/closure-compiler-binary/README.google
@@ -1,5 +1,5 @@
-URL: https://repo1.maven.org/maven2/com/google/javascript/closure-compiler/v20230802/closure-compiler-v20230802.jar
-Version: 20230802
+URL: https://repo1.maven.org/maven2/com/google/javascript/closure-compiler/v20240317/closure-compiler-v20240317.jar
+Version: 20240317
 License: Apache 2.0
 License File: LICENSE
 Description:


### PR DESCRIPTION
We don't expect any specific improvement, but upstream fixed a few bugs.