### PR TITLE
[wasm] Reduce the stack limit to 512 KiB

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -113,10 +113,8 @@ EMSCRIPTEN_COMPILER_FLAGS := \
 # PTHREAD_POOL_SIZE_STRICT: Suppress runtime warnings when a new worker has to
 #   start for a new thread (this warning is confusing and is mostly useful in
 #   early days of development).
-# STACK_SIZE: Increase the initial stack size (Emscripten's default 64KB are
-#   very tight, and while some code in this project calls
-#   pthread_attr_setstacksize() its parameters aren't chosen with Emscripten's
-#   heavy stack consumption in mind).
+# STACK_SIZE: Increase the default stack size to the value determined in
+#   practice.
 # no-pthreads-mem-growth: Suppress the linker warning about the performance of
 #   the "Pthreads + ALLOW_MEMORY_GROWTH" combination.
 EMSCRIPTEN_LINKER_FLAGS := \
@@ -135,7 +133,7 @@ EMSCRIPTEN_LINKER_FLAGS := \
   -s MIN_SAFARI_VERSION=-1 \
   -s MODULARIZE=1 \
   -s PTHREAD_POOL_SIZE_STRICT=0 \
-  -s STACK_SIZE=1048576 \
+  -s STACK_SIZE=524288 \
   -Wno-pthreads-mem-growth \
 
 ifeq ($(CONFIG),Release)


### PR DESCRIPTION
This seems to be the smallest power-of-two that's compatible with PC/SC-Lite and
CCID, since they require at least 256 KB plus some small amount needed by
Emscripten internally, and Emscripten doesn't allow the size to be dynamically
increased beyond the limit.