### PR TITLE
[wasm] Use Emscripten -sSTRICT

### DIFF
--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -140,6 +140,7 @@ EMSCRIPTEN_LINKER_FLAGS := \
   -s MODULARIZE=1 \
   -s PTHREAD_POOL_SIZE_STRICT=0 \
   -s STACK_SIZE=524288 \
+  -s STRICT=1 \
   -Wno-pthreads-mem-growth \
 
 ifeq ($(CONFIG),Release)


### PR DESCRIPTION
This stricter (and more well-optimized) compilation mode is finally working - 
#1237, #1236 were the remaining bits.