### PR TITLE
[pcsc] Compile simclist, tokenparser with PC/SC

### DIFF
--- a/third_party/ccid/webport/build/Makefile
+++ b/third_party/ccid/webport/build/Makefile
@@ -60,7 +60,6 @@ CCID_SOURCES := \
 	$(CCID_SOURCES_PATH)/debug.c \
 	$(CCID_SOURCES_PATH)/ifdhandler.c \
 	$(CCID_SOURCES_PATH)/strlcpy.c \
-	$(CCID_SOURCES_PATH)/tokenparser.c \
 	$(CCID_SOURCES_PATH)/utils.c \
 
 # * BUNDLE constant contains the name of subdirectory under the PC/SC-Lite
@@ -100,24 +99,6 @@ CCID_OPENCT_CPPFLAGS := \
 
 $(foreach src,$(CCID_OPENCT_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CCID_OPENCT_CPPFLAGS))))
 
-CCID_SIMCLIST_SOURCES := \
-	$(CCID_SOURCES_PATH)/simclist.c \
-
-# * log_msg and log_xxd are redefined in order to not collide with the symbols
-#   from the PC/SC-Lite server-side libraries;
-# * SIMCLIST_NO_DUMPRESTORE is defined in order to disable some features of the
-#   simclist library which are not compiling under the NaCl SDK environment;
-# * The "macro-redefined" warning diagnostic is disabled because of some
-#   non-clean code;
-CCID_SIMCLIST_CPPFLAGS := \
-	$(COMMON_CPPFLAGS) \
-	-Dlog_msg=ccid_log_msg \
-	-Dlog_xxd=ccid_log_xxd \
-	-DSIMCLIST_NO_DUMPRESTORE \
-	-Wno-macro-redefined \
-
-$(foreach src,$(CCID_SIMCLIST_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CCID_SIMCLIST_CPPFLAGS))))
-
 CCID_TOWITOKO_SOURCES := \
 	$(CCID_SOURCES_PATH)/towitoko/atr.c \
 	$(CCID_SOURCES_PATH)/towitoko/pps.c \
@@ -138,7 +119,6 @@ $(foreach src,$(CCID_TOWITOKO_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CCID_
 SOURCES := \
 	$(CCID_SOURCES) \
 	$(CCID_OPENCT_SOURCES) \
-	$(CCID_SIMCLIST_SOURCES) \
 	$(CCID_TOWITOKO_SOURCES) \
 
 

--- a/third_party/pcsc-lite/naclport/server/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server/build/Makefile
@@ -238,6 +238,26 @@ PCSC_LITE_SERVER_NACL_CXXFLAGS := \
 
 $(foreach src,$(PCSC_LITE_SERVER_NACL_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_NACL_CXXFLAGS))))
 
+PCSC_LITE_SERVER_SIMCLIST_SOURCES := \
+	$(PCSC_LITE_SOURCES_PATH)/simclist.c \
+
+# * SIMCLIST_NO_DUMPRESTORE is defined in order to disable some features of the
+#   simclist library which are not compiling under the webport environment;
+PCSC_LITE_SERVER_SIMCLIST_CPPFLAGS := \
+	$(COMMON_CPPFLAGS) \
+	-DSIMCLIST_NO_DUMPRESTORE \
+
+$(foreach src,$(PCSC_LITE_SERVER_SIMCLIST_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_SIMCLIST_CPPFLAGS))))
+
+PCSC_LITE_SERVER_TOKENPARSER_SOURCES := \
+	$(PCSC_LITE_SOURCES_PATH)/tokenparser.c \
+
+PCSC_LITE_SERVER_TOKENPARSER_CPPFLAGS := \
+	$(COMMON_CPPFLAGS) \
+	-I$(ROOT_PATH)/third_party/pcsc-lite/naclport/build_configuration/build \
+
+$(foreach src,$(PCSC_LITE_SERVER_TOKENPARSER_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_TOKENPARSER_CPPFLAGS))))
+
 
 # Variable containing the list of all source files whose compiled object files
 # will have to be linked together
@@ -251,6 +271,8 @@ SOURCES := \
 	$(PCSC_LITE_CLIENT_SOURCES) \
 	$(PCSC_LITE_SERVER_NACL_SOURCES) \
 	$(PCSC_LITE_SERVER_READERFACTORY_SOURCES) \
+	$(PCSC_LITE_SERVER_SIMCLIST_SOURCES) \
+	$(PCSC_LITE_SERVER_TOKENPARSER_SOURCES) \
 
 
 # Rules for linking of the compiled object files and installing the resulting

--- a/third_party/pcsc-lite/naclport/server/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server/build/Makefile
@@ -254,7 +254,7 @@ PCSC_LITE_SERVER_TOKENPARSER_SOURCES := \
 
 PCSC_LITE_SERVER_TOKENPARSER_CPPFLAGS := \
 	$(COMMON_CPPFLAGS) \
-	-I$(ROOT_PATH)/third_party/pcsc-lite/naclport/build_configuration/build \
+	-I$(ROOT_PATH)/third_party/pcsc-lite/naclport/server/src \
 
 $(foreach src,$(PCSC_LITE_SERVER_TOKENPARSER_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(PCSC_LITE_SERVER_TOKENPARSER_CPPFLAGS))))
 


### PR DESCRIPTION
Move the compilation of these two mini-libraries from the CCID Driver to PC/SC-Lite.

Unlike in the upstream *nix implementation where both CCID and PC/SC-Lite ship with their own version of these mini-libraries, we have to choose one of the copies since we link everything into a single WebAssembly executable. Previously we semi-aribtrarily chose to put the compilation and linking into the CCID Driver's makefile, however this doesn't work out nicely with the plan to add more drivers. Our PC/SC-Lite Makefile is a better place for a shared thing like this.