### PR TITLE
[pcsc] Fix unnecessary build_configuration rebuild

### DIFF
--- a/third_party/pcsc-lite/naclport/build_configuration/Makefile
+++ b/third_party/pcsc-lite/naclport/build_configuration/Makefile
@@ -48,7 +48,7 @@ all: build.stamp
 #   systems to control processes that have smart card access. On ChromeOS, the
 #   permission systems by the browser and by the Smart Card Connector extension
 #   are used instead.
-build.stamp: $(shell find ../../src)
+build.stamp: $(shell git ls-tree -r HEAD --name-only ../../src)
 	@rm -f build.stamp
 	@git clean -fX ../../src
 	cd ../../src && ./bootstrap && ./configure --disable-polkit


### PR DESCRIPTION
Change the "build_configuration" target's makefile to only look at the files tracked in Git, instead of looking at all files and folders.

The current behavior was subject for unrelated changes (e.g., when a temporary file is created by some other build step) that were triggering unnecessary rebuilds.