### PR TITLE
[pcsc] Let drivers export their methods themselves

### DIFF
--- a/third_party/ccid/webport/build/Makefile
+++ b/third_party/ccid/webport/build/Makefile
@@ -112,6 +112,19 @@ CCID_TOWITOKO_CPPFLAGS := \
 
 $(foreach src,$(CCID_TOWITOKO_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CCID_TOWITOKO_CPPFLAGS))))
 
+# Rules for compiling webport helper C++ sources:
+
+CCID_WEBPORT_SOURCES := \
+	$(CCID_NACL_SOURCES_PATH)/ccid_pcsc_driver_adaptor.cc \
+
+CCID_WEBPORT_CPPFLAGS := \
+	$(COMMON_CPPFLAGS) \
+	-I$(ROOT_PATH) \
+	-I$(CCID_SOURCES_PATH) \
+	-I$(PCSC_LITE_ORIGINAL_HEADERS_DIR_PATH) \
+
+$(foreach src,$(CCID_WEBPORT_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CCID_WEBPORT_CPPFLAGS))))
+
 
 # Variable containing the list of all source files whose compiled object files
 # will have to be linked together
@@ -120,6 +133,7 @@ SOURCES := \
 	$(CCID_SOURCES) \
 	$(CCID_OPENCT_SOURCES) \
 	$(CCID_TOWITOKO_SOURCES) \
+	$(CCID_WEBPORT_SOURCES) \
 
 
 # Rules for building the driver config file and putting it into the resulting

--- a/third_party/ccid/webport/src/ccid_pcsc_driver_adaptor.cc
+++ b/third_party/ccid/webport/src/ccid_pcsc_driver_adaptor.cc
@@ -1,0 +1,70 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "third_party/ccid/webport/src/ccid_pcsc_driver_adaptor.h"
+
+#include <string>
+#include <vector>
+
+extern "C" {
+#include "ifdhandler.h"
+}
+
+namespace google_smart_card {
+
+namespace {
+
+// Constructed as the concatenation of:
+// * path where the Info.plist config is installed at
+//   //smart_card_connector_app/build/executable_module/Makefile;
+// * the "Linux" string;
+// * the file name passed via "--target" to create_Info_plist.pl at
+//   ../build/Makefile.
+constexpr char kDriverFilePath[] =
+    "executable-module-filesystem/pcsc/drivers/ifd-ccid.bundle/Contents/Linux/"
+    "libccid.so";
+
+}  // namespace
+
+CcidPcscDriverAdaptor::CcidPcscDriverAdaptor()
+    : kFilePath_(kDriverFilePath),
+      kFunctionPointers_({
+          {"IFDHCloseChannel", reinterpret_cast<void*>(&IFDHCloseChannel)},
+          {"IFDHControl", reinterpret_cast<void*>(&IFDHControl)},
+          {"IFDHCreateChannel", reinterpret_cast<void*>(&IFDHCreateChannel)},
+          {"IFDHCreateChannelByName",
+           reinterpret_cast<void*>(&IFDHCreateChannelByName)},
+          {"IFDHGetCapabilities",
+           reinterpret_cast<void*>(&IFDHGetCapabilities)},
+          {"IFDHICCPresence", reinterpret_cast<void*>(&IFDHICCPresence)},
+          {"IFDHPowerICC", reinterpret_cast<void*>(&IFDHPowerICC)},
+          {"IFDHSetCapabilities",
+           reinterpret_cast<void*>(&IFDHSetCapabilities)},
+          {"IFDHSetProtocolParameters",
+           reinterpret_cast<void*>(&IFDHSetProtocolParameters)},
+          {"IFDHTransmitToICC", reinterpret_cast<void*>(&IFDHTransmitToICC)},
+      }) {}
+
+CcidPcscDriverAdaptor::~CcidPcscDriverAdaptor() = default;
+
+const std::string& CcidPcscDriverAdaptor::GetDriverFilePath() const {
+  return kFilePath_;
+}
+
+const std::vector<CcidPcscDriverAdaptor::FunctionNameAndAddress>&
+CcidPcscDriverAdaptor::GetFunctionPointersTable() const {
+  return kFunctionPointers_;
+}
+
+}  // namespace google_smart_card

--- a/third_party/ccid/webport/src/ccid_pcsc_driver_adaptor.h
+++ b/third_party/ccid/webport/src/ccid_pcsc_driver_adaptor.h
@@ -1,0 +1,43 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_SMART_CARD_THIRD_PARTY_CCID_CCID_PCSC_DRIVER_ADAPTOR_H_
+#define GOOGLE_SMART_CARD_THIRD_PARTY_CCID_CCID_PCSC_DRIVER_ADAPTOR_H_
+
+#include <string>
+#include <vector>
+
+#include "third_party/pcsc-lite/naclport/driver_interface/src/pcsc_driver_adaptor.h"
+
+namespace google_smart_card {
+
+// Implementation of the adaptor to allow plugging the CCID driver into our
+// PC/SC-Lite webport.
+class CcidPcscDriverAdaptor : public PcscDriverAdaptor {
+ public:
+  CcidPcscDriverAdaptor();
+  ~CcidPcscDriverAdaptor() override;
+
+  const std::string& GetDriverFilePath() const override;
+  const std::vector<FunctionNameAndAddress>& GetFunctionPointersTable()
+      const override;
+
+ private:
+  const std::string kFilePath_;
+  const std::vector<FunctionNameAndAddress> kFunctionPointers_;
+};
+
+}  // namespace google_smart_card
+
+#endif  // GOOGLE_SMART_CARD_THIRD_PARTY_CCID_CCID_PCSC_DRIVER_ADAPTOR_H_

--- a/third_party/pcsc-lite/naclport/driver_interface/src/pcsc_driver_adaptor.h
+++ b/third_party/pcsc-lite/naclport/driver_interface/src/pcsc_driver_adaptor.h
@@ -1,0 +1,53 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_SMART_CARD_THIRD_PARTY_PCSC_LITE_DRIVER_INTERFACE_PCSC_DRIVER_ADAPTOR_H_
+#define GOOGLE_SMART_CARD_THIRD_PARTY_PCSC_LITE_DRIVER_INTERFACE_PCSC_DRIVER_ADAPTOR_H_
+
+#include <string>
+#include <vector>
+
+namespace google_smart_card {
+
+// Represents a driver for smart card readers, to be plugged into our webport of
+// PC/SC-Lite.
+//
+// This replaces the shared library loading mechanism that's used by PC/SC-Lite
+// on *nix systems. In our webport, the drivers are all linked statically
+// together with the PC/SC-Lite.
+class PcscDriverAdaptor {
+ public:
+  // Represents the driver's exported function.
+  struct FunctionNameAndAddress {
+    std::string name;
+    void* address;
+  };
+
+  virtual ~PcscDriverAdaptor() = default;
+
+  // Returns the path to the driver .so file.
+  //
+  // This is expected to exactly match the string that PC/SC-Lite constructs,
+  // based on the Info.plist config file location and the "CFBundleExecutable"
+  // value in it.
+  virtual const std::string& GetDriverFilePath() const = 0;
+
+  // Returns to the driver's exported functions table.
+  virtual const std::vector<FunctionNameAndAddress>& GetFunctionPointersTable()
+      const = 0;
+};
+
+}  // namespace google_smart_card
+
+#endif  // GOOGLE_SMART_CARD_THIRD_PARTY_PCSC_LITE_DRIVER_INTERFACE_PCSC_DRIVER_ADAPTOR_H_

--- a/third_party/pcsc-lite/naclport/server/src/dyn_webport.cc
+++ b/third_party/pcsc-lite/naclport/server/src/dyn_webport.cc
@@ -39,55 +39,29 @@
 #include <string>
 
 extern "C" {
-#include "config.h"
-#include "pcsclite.h"
-#include "dyn_generic.h"
-#include "ifdhandler.h"
 #include "misc.h"
+#include "pcsclite.h"
+#include "wintypes.h"
 
 // "misc.h" defines a "min" macro which is incompatible with C++.
 #undef min
 }
 
 #include "common/cpp/src/public/logging/logging.h"
+#include "third_party/pcsc-lite/naclport/driver_interface/src/pcsc_driver_adaptor.h"
+#include "third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.h"
 
-namespace {
-
-// This is a fake value that we supply instead of the dynamically loaded library
-// handles which are used by pcsc-lite normally.
-constexpr char kFakeLHandle[] = "fake_pcsclite_lhandle";
-
-struct FunctionNameAndAddress {
-  const char* name;
-  void* address;
-};
-
-// Fake export table of the driver functions (the function pointers here point
-// directly to the statically linked driver functions).
-const FunctionNameAndAddress kDriverIfdhandlerFunctions[] = {
-    {"IFDHCreateChannelByName",
-     reinterpret_cast<void*>(&IFDHCreateChannelByName)},
-    {"IFDHCreateChannel", reinterpret_cast<void*>(&IFDHCreateChannel)},
-    {"IFDHCloseChannel", reinterpret_cast<void*>(&IFDHCloseChannel)},
-    {"IFDHGetCapabilities", reinterpret_cast<void*>(&IFDHGetCapabilities)},
-    {"IFDHSetCapabilities", reinterpret_cast<void*>(&IFDHSetCapabilities)},
-    {"IFDHSetProtocolParameters",
-     reinterpret_cast<void*>(&IFDHSetProtocolParameters)},
-    {"IFDHPowerICC", reinterpret_cast<void*>(&IFDHPowerICC)},
-    {"IFDHTransmitToICC", reinterpret_cast<void*>(&IFDHTransmitToICC)},
-    {"IFDHControl", reinterpret_cast<void*>(&IFDHControl)},
-    {"IFDHICCPresence", reinterpret_cast<void*>(&IFDHICCPresence)},
-};
-
-}  // namespace
+namespace google_smart_card {
 
 // Stub for the function defined in PC/SC-Lite dyn_generic.h.
 //
 // Its real implementation loads a shared library with a driver, but our
-// implementation here does nothing because in Smart Card Connector we link
-// against the driver statically.
-INTERNAL void* DYN_LoadLibrary(const char* pcLibrary) {
-  return static_cast<void*>(const_cast<char*>(kFakeLHandle));
+// implementation here simply identifies the PcscDriverAdaptor object in an
+// in-memory data structure (in Smart Card Connector we link against drivers
+// statically).
+extern "C" INTERNAL void* DYN_LoadLibrary(const char* pcLibrary) {
+  return PcscLiteServerWebPortService::GetInstance()->FindDriverByFilePath(
+      pcLibrary);
 }
 
 // Stub for the function defined in PC/SC-Lite dyn_generic.h.
@@ -95,8 +69,8 @@ INTERNAL void* DYN_LoadLibrary(const char* pcLibrary) {
 // Its real implementation unloads the shared library that's loaded by
 // `DYN_LoadLibrary()`; in Smart Card Connector we don't need to do that (see
 // that function's comment above).
-INTERNAL LONG DYN_CloseLibrary(void* pvLHandle) {
-  GOOGLE_SMART_CARD_CHECK(pvLHandle == kFakeLHandle);
+extern "C" INTERNAL LONG DYN_CloseLibrary(void* pvLHandle) {
+  GOOGLE_SMART_CARD_CHECK(pvLHandle);
   return SCARD_S_SUCCESS;
 }
 
@@ -106,20 +80,24 @@ INTERNAL LONG DYN_CloseLibrary(void* pvLHandle) {
 // given shared library; as we link statically against the driver in Smart Card
 // Connector, we only need to traverse a hardcoded map from names to function
 // addresses.
-INTERNAL LONG DYN_GetAddress(void* pvLHandle,
-                             void** pvFHandle,
-                             const char* pcFunction,
-                             bool /*mayfail*/) {
-  GOOGLE_SMART_CARD_CHECK(pvLHandle == kFakeLHandle);
+extern "C" INTERNAL LONG DYN_GetAddress(void* pvLHandle,
+                                        void** pvFHandle,
+                                        const char* pcFunction,
+                                        bool /*mayfail*/) {
+  GOOGLE_SMART_CARD_CHECK(pvLHandle);
+  // This cast is correct - see the implementation of `DYN_LoadLibrary()` above.
+  const PcscDriverAdaptor* const driver_adaptor =
+      reinterpret_cast<const PcscDriverAdaptor*>(pvLHandle);
 
-  std::string function = pcFunction;
-  for (const FunctionNameAndAddress& driver_ifdhandler_function :
-       kDriverIfdhandlerFunctions) {
-    if (function == driver_ifdhandler_function.name) {
-      *pvFHandle = driver_ifdhandler_function.address;
+  for (const PcscDriverAdaptor::FunctionNameAndAddress& pointer :
+       driver_adaptor->GetFunctionPointersTable()) {
+    if (pointer.name == pcFunction) {
+      *pvFHandle = pointer.address;
       return SCARD_S_SUCCESS;
     }
   }
   *pvFHandle = nullptr;
   return SCARD_F_UNKNOWN_ERROR;
 }
+
+}  // namespace google_smart_card

--- a/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
+++ b/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
@@ -33,9 +33,11 @@
 
 #include <cstdio>
 #include <limits>
+#include <memory>
 #include <string>
 #include <thread>
 #include <utility>
+#include <vector>
 
 #include "common/cpp/src/public/ipc_emulation.h"
 #include "common/cpp/src/public/logging/logging.h"
@@ -44,6 +46,7 @@
 #include "common/cpp/src/public/value.h"
 #include "common/cpp/src/public/value_conversion.h"
 #include "third_party/libusb/webport/src/public/constants.h"
+#include "third_party/pcsc-lite/naclport/driver_interface/src/pcsc_driver_adaptor.h"
 #include "third_party/pcsc-lite/naclport/server/src/server_sockets_manager.h"
 
 #ifdef __EMSCRIPTEN__
@@ -270,9 +273,11 @@ StructValueDescriptor<ReaderRemoveMessageData>::GetDescription() {
 
 PcscLiteServerWebPortService::PcscLiteServerWebPortService(
     GlobalContext* global_context,
-    LibusbWebPortService* libusb_web_port_service)
+    LibusbWebPortService* libusb_web_port_service,
+    std::vector<std::unique_ptr<PcscDriverAdaptor>> drivers)
     : global_context_(global_context),
-      libusb_web_port_service_(libusb_web_port_service) {
+      libusb_web_port_service_(libusb_web_port_service),
+      drivers_(std::move(drivers)) {
   GOOGLE_SMART_CARD_CHECK(global_context_);
   GOOGLE_SMART_CARD_CHECK(libusb_web_port_service_);
   GOOGLE_SMART_CARD_CHECK(!g_pcsc_lite_server);
@@ -387,6 +392,16 @@ void PcscLiteServerWebPortService::ShutDownAndWait() {
   // Shut down the global state created in `InitializeAndRunDaemonThread()`.
   PcscLiteServerSocketsManager::DestroyGlobalInstance();
   IpcEmulation::DestroyGlobalInstance();
+}
+
+PcscDriverAdaptor* PcscLiteServerWebPortService::FindDriverByFilePath(
+    const std::string& driver_file_path) {
+  for (const auto& driver : drivers_) {
+    if (driver->GetDriverFilePath() == driver_file_path) {
+      return driver.get();
+    }
+  }
+  return nullptr;
 }
 
 void PcscLiteServerWebPortService::PostReaderInitAddMessage(

--- a/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.h
+++ b/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.h
@@ -26,12 +26,15 @@
 #ifndef GOOGLE_SMART_CARD_PCSC_LITE_SERVER_WEB_PORT_SERVICE_H_
 #define GOOGLE_SMART_CARD_PCSC_LITE_SERVER_WEB_PORT_SERVICE_H_
 
+#include <memory>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "common/cpp/src/public/global_context.h"
 #include "common/cpp/src/public/value.h"
 #include "third_party/libusb/webport/src/public/libusb_web_port_service.h"
+#include "third_party/pcsc-lite/naclport/driver_interface/src/pcsc_driver_adaptor.h"
 
 namespace google_smart_card {
 
@@ -46,8 +49,10 @@ namespace google_smart_card {
 //       concurrent to class construction or destruction are not thread safe.
 class PcscLiteServerWebPortService final {
  public:
-  PcscLiteServerWebPortService(GlobalContext* global_context,
-                               LibusbWebPortService* libusb_web_port_service);
+  PcscLiteServerWebPortService(
+      GlobalContext* global_context,
+      LibusbWebPortService* libusb_web_port_service,
+      std::vector<std::unique_ptr<PcscDriverAdaptor>> drivers);
   PcscLiteServerWebPortService(const PcscLiteServerWebPortService&) = delete;
   PcscLiteServerWebPortService& operator=(const PcscLiteServerWebPortService&) =
       delete;
@@ -71,6 +76,10 @@ class PcscLiteServerWebPortService final {
   //
   // Must be called after `InitializeAndRunDaemonThread()`.
   void ShutDownAndWait();
+
+  // Returns the driver with the specified .so file path, or `nullptr` if
+  // there's none found.
+  PcscDriverAdaptor* FindDriverByFilePath(const std::string& driver_file_path);
 
   void PostReaderInitAddMessage(const char* reader_name,
                                 int port,
@@ -107,6 +116,7 @@ class PcscLiteServerWebPortService final {
 
   GlobalContext* const global_context_;
   LibusbWebPortService* const libusb_web_port_service_;
+  const std::vector<std::unique_ptr<PcscDriverAdaptor>> drivers_;
   std::thread daemon_thread_;
 };
 


### PR DESCRIPTION
Add an abstraction that represents a driver, and change PC/SC-Lite to call it instead of directly referencing CCID's functions.

This is a refactoring that prepares us for introducing multiple drivers in the application. Note that on *nix PC/SC-Lite achieves the same by dynamically loading each driver's .so file - something we cannot do in the webport.