### PR TITLE
[pcsc,ccid] Pass install paths from makefiles

### DIFF
--- a/smart_card_connector_app/build/Makefile
+++ b/smart_card_connector_app/build/Makefile
@@ -48,12 +48,14 @@ include $(COMMON_DIR_PATH)/make/packaging_common.mk
 include $(COMMON_DIR_PATH)/make/executable_module_recursive_build.mk
 
 include $(THIRD_PARTY_DIR_PATH)/libusb/webport/include.mk
-include $(THIRD_PARTY_DIR_PATH)/ccid/webport/include.mk
 
 include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/common/include.mk
 include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/js_client/include.mk
 include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/server/include.mk
 include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/server_clients_management/include.mk
+
+# Depends on pcsc-lite/naclport/common/include.mk.
+include $(THIRD_PARTY_DIR_PATH)/ccid/webport/include.mk
 
 
 SOURCES_PATH := ../src

--- a/smart_card_connector_app/build/executable_module/Makefile
+++ b/smart_card_connector_app/build/executable_module/Makefile
@@ -92,7 +92,7 @@ $(eval $(call ADD_RESOURCE_RULE, \
 	executable-module-filesystem/pcsc/fake_socket_file))
 $(eval $(call ADD_RESOURCE_RULE, \
 	$(ROOT_PATH)/third_party/ccid/webport/build/Info.plist, \
-	executable-module-filesystem/pcsc/drivers/ifd-ccid.bundle/Contents/Info.plist))
+	$(CCID_CONFIG_INSTALLATION_PATH)))
 
 # Rules for compiling source files and linking them into an executable binary.
 $(foreach src,$(SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))

--- a/smart_card_connector_app/build/executable_module/Makefile
+++ b/smart_card_connector_app/build/executable_module/Makefile
@@ -17,11 +17,12 @@ TARGET := executable_module
 
 include ../../../common/make/common.mk
 include $(COMMON_DIR_PATH)/make/executable_building.mk
-include $(THIRD_PARTY_DIR_PATH)/ccid/webport/include.mk
 include $(THIRD_PARTY_DIR_PATH)/libusb/webport/include.mk
 include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/common/include.mk
 include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/server/include.mk
 include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/server_clients_management/include.mk
+# Depends on pcsc-lite/naclport/common/include.mk.
+include $(THIRD_PARTY_DIR_PATH)/ccid/webport/include.mk
 
 
 # Common build definitions:

--- a/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
+++ b/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
@@ -19,6 +19,7 @@
 
 include ../../../../common/cpp_unit_test_runner/include.mk
 include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/common/include.mk
+# Depends on pcsc-lite/naclport/common/include.mk.
 include $(ROOT_PATH)/third_party/ccid/webport/include.mk
 
 SOURCES := \

--- a/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
+++ b/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
@@ -18,6 +18,8 @@
 # "cpp_unit_test_runner".
 
 include ../../../../common/cpp_unit_test_runner/include.mk
+include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/common/include.mk
+include $(ROOT_PATH)/third_party/ccid/webport/include.mk
 
 SOURCES := \
 	../../../src/application_unittest.cc \
@@ -53,7 +55,7 @@ $(eval $(call ADD_RESOURCE_RULE, \
 	executable-module-filesystem/pcsc/fake_socket_file))
 $(eval $(call ADD_RESOURCE_RULE, \
 	$(ROOT_PATH)/third_party/ccid/webport/build/Info.plist, \
-	executable-module-filesystem/pcsc/drivers/ifd-ccid.bundle/Contents/Info.plist))
+	$(CCID_CONFIG_INSTALLATION_PATH)))
 
 # Rules for compiling the test source files and linking them into a resulting
 # executable binary.

--- a/smart_card_connector_app/build/js_to_cxx_tests/Makefile
+++ b/smart_card_connector_app/build/js_to_cxx_tests/Makefile
@@ -27,6 +27,7 @@ include $(ROOT_PATH)/third_party/pcsc-lite/naclport/common/include.mk
 include $(ROOT_PATH)/third_party/pcsc-lite/naclport/js_client/include.mk
 include $(ROOT_PATH)/third_party/pcsc-lite/naclport/server/include.mk
 include $(ROOT_PATH)/third_party/pcsc-lite/naclport/server_clients_management/include.mk
+# Depends on pcsc-lite/naclport/common/include.mk.
 include $(ROOT_PATH)/third_party/ccid/webport/include.mk
 
 

--- a/smart_card_connector_app/build/js_to_cxx_tests/Makefile
+++ b/smart_card_connector_app/build/js_to_cxx_tests/Makefile
@@ -22,12 +22,12 @@ include $(ROOT_PATH)/common/make/js_building_common.mk
 include $(ROOT_PATH)/common/make/executable_building.mk
 include $(ROOT_PATH)/common/js/include.mk
 include $(ROOT_PATH)/common/integration_testing/include.mk
-include $(ROOT_PATH)/third_party/ccid/webport/include.mk
 include $(ROOT_PATH)/third_party/libusb/webport/include.mk
 include $(ROOT_PATH)/third_party/pcsc-lite/naclport/common/include.mk
 include $(ROOT_PATH)/third_party/pcsc-lite/naclport/js_client/include.mk
 include $(ROOT_PATH)/third_party/pcsc-lite/naclport/server/include.mk
 include $(ROOT_PATH)/third_party/pcsc-lite/naclport/server_clients_management/include.mk
+include $(ROOT_PATH)/third_party/ccid/webport/include.mk
 
 
 SOURCE_DIR := $(ROOT_PATH)/smart_card_connector_app/src/
@@ -91,7 +91,7 @@ $(eval $(call ADD_RESOURCE_RULE, \
 #   daemon code reads parameters from this config to call into CCID.
 $(eval $(call ADD_RESOURCE_RULE, \
   $(ROOT_PATH)/third_party/ccid/webport/build/Info.plist, \
-  executable-module-filesystem/pcsc/drivers/ifd-ccid.bundle/Contents/Info.plist))
+  $(CCID_CONFIG_INSTALLATION_PATH)))
 
 # Targets that build the resulting executable module and JS tests.
 $(eval $(call BUILD_JS_TO_CXX_TEST,$(CXX_SOURCES),$(LIBS),$(JS_SOURCES_PATHS)))

--- a/third_party/ccid/webport/build/Makefile
+++ b/third_party/ccid/webport/build/Makefile
@@ -45,8 +45,7 @@ CCID_NACL_SOURCES_PATH := ../src
 # * log_msg and log_xxd are redefined in order to not collide with the symbols
 #   from the PC/SC-Lite server-side libraries;
 # * PCSCLITE_HP_DROPDIR constant points to the directory containing the configs
-#   for all PC/SC-Lite server drivers; use a relative path, so that it works
-#   both inside the Smart Card Connector app and in unit tests;
+#   for all PC/SC-Lite server drivers;
 COMMON_CPPFLAGS := \
 	-DIFDHCloseChannel=CCID_IFDHCloseChannel \
 	-DIFDHControl=CCID_IFDHControl \
@@ -61,7 +60,7 @@ COMMON_CPPFLAGS := \
 	-DHAVE_PTHREAD=1 \
 	-Dlog_msg=ccid_log_msg \
 	-Dlog_xxd=ccid_log_xxd \
-	-DPCSCLITE_HP_DROPDIR='"executable-module-filesystem/pcsc/drivers"' \
+	-DPCSCLITE_HP_DROPDIR='"$(PCSC_LITE_DRIVER_INSTALLATION_PATH)"' \
 	-Wall \
 
 CCID_SOURCES := \
@@ -85,7 +84,7 @@ CCID_SOURCES := \
 #   non-clean code;
 CCID_CPPFLAGS := \
 	$(COMMON_CPPFLAGS) \
-	-DBUNDLE='"ifd-ccid.bundle"' \
+	-DBUNDLE='"$(CCID_BUNDLE_NAME)"' \
 	-DUSE_SYSLOG \
 	-DVERSION='"$(CCID_VERSION)"' \
 	-D__linux \
@@ -155,7 +154,7 @@ Info.plist: $(CCID_SOURCES_PATH)/create_Info_plist.pl $(CCID_SUPPORTED_READERS_C
 	$(CCID_SOURCES_PATH)/create_Info_plist.pl \
 		$(CCID_SUPPORTED_READERS_CONFIG_PATH) \
 		$(CCID_SOURCES_PATH)/Info.plist.src \
-		--target=libccid.so \
+		--target=$(CCID_SO_NAME) \
 		--version=$(CCID_VERSION) > Info.plist.build
 	@mv Info.plist.build Info.plist
 

--- a/third_party/ccid/webport/build/Makefile
+++ b/third_party/ccid/webport/build/Makefile
@@ -127,8 +127,11 @@ $(foreach src,$(CCID_TOWITOKO_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CCID_
 CCID_WEBPORT_SOURCES := \
 	$(CCID_NACL_SOURCES_PATH)/ccid_pcsc_driver_adaptor.cc \
 
+# * Pass the "CCID_SO_INSTALLATION_PATH" constant to the C++ code.
+# * Specify include search paths.
 CCID_WEBPORT_CPPFLAGS := \
 	$(COMMON_CPPFLAGS) \
+	-DCCID_SO_INSTALLATION_PATH='"$(CCID_SO_INSTALLATION_PATH)"' \
 	-I$(ROOT_PATH) \
 	-I$(CCID_SOURCES_PATH) \
 	-I$(PCSC_LITE_ORIGINAL_HEADERS_DIR_PATH) \

--- a/third_party/ccid/webport/include.mk
+++ b/third_party/ccid/webport/include.mk
@@ -18,8 +18,9 @@
 #
 # This file contains helper definitions for using this library.
 #
-# /common/make/common.mk and /common/make/executable_building.mk must be
-# included before including this file.
+# /common/make/common.mk, /common/make/executable_building.mk and
+# /third_party/pcsc-lite/naclport/common/include.mk must be included before
+# including this file.
 #
 
 
@@ -27,6 +28,35 @@ CCID_VERSION := 1.5.5
 
 
 CCID_DIR_PATH := $(THIRD_PARTY_DIR_PATH)/ccid
+
+
+# File name of the CCID driver's bundle directory.
+#
+# It could be an arbitrary string, but we just follow what CCID uses on other
+# platforms.
+CCID_BUNDLE_NAME := ifd-ccid.bundle
+
+# File name of the CCID driver's .so file.
+#
+# This value must match the one specified in the "CFBundleExecutable" parameter
+# of the Info.plist config.
+#
+# Note that we don't really create this file in our webport, since all drivers
+# are linked statically, however it's still used by the code to distinguish
+# between calls made to different drivers.
+CCID_SO_NAME := libccid.so
+
+# Path where the CCID driver's config file is to be installed.
+CCID_CONFIG_INSTALLATION_PATH := \
+	$(PCSC_LITE_DRIVER_INSTALLATION_PATH)/$(CCID_BUNDLE_NAME)/Contents/Info.plist
+
+# Path where the CCID driver's .so file is expected to be installed.
+#
+# Note that the .so file doesn't really exist in our webport, since all drivers
+# are linked statically, however it's still used by the code to distinguish
+# between calls made to different drivers.
+CCID_SO_INSTALLATION_PATH := \
+	$(PCSC_LITE_DRIVER_INSTALLATION_PATH)/$(CCID_BUNDLE_NAME)/Contents/$(PCSC_LITE_ARCHITECTURE)/$(CCID_SO_NAME)
 
 
 #

--- a/third_party/ccid/webport/src/ccid_pcsc_driver_adaptor.cc
+++ b/third_party/ccid/webport/src/ccid_pcsc_driver_adaptor.cc
@@ -23,22 +23,8 @@ extern "C" {
 
 namespace google_smart_card {
 
-namespace {
-
-// Constructed as the concatenation of:
-// * path where the Info.plist config is installed at
-//   //smart_card_connector_app/build/executable_module/Makefile;
-// * the "Linux" string;
-// * the file name passed via "--target" to create_Info_plist.pl at
-//   ../build/Makefile.
-constexpr char kDriverFilePath[] =
-    "executable-module-filesystem/pcsc/drivers/ifd-ccid.bundle/Contents/Linux/"
-    "libccid.so";
-
-}  // namespace
-
 CcidPcscDriverAdaptor::CcidPcscDriverAdaptor()
-    : kFilePath_(kDriverFilePath),
+    : kFilePath_(CCID_SO_INSTALLATION_PATH),
       kFunctionPointers_({
           {"IFDHCloseChannel", reinterpret_cast<void*>(&IFDHCloseChannel)},
           {"IFDHControl", reinterpret_cast<void*>(&IFDHControl)},

--- a/third_party/pcsc-lite/naclport/common/include.mk
+++ b/third_party/pcsc-lite/naclport/common/include.mk
@@ -33,12 +33,21 @@
 
 PCSC_LITE_DIR_PATH := $(THIRD_PARTY_DIR_PATH)/pcsc-lite
 
-
 PCSC_LITE_ORIGINAL_HEADERS_DIR_PATH := $(PCSC_LITE_DIR_PATH)/src/src/PCSC
-
 
 PCSC_LITE_COMMON_DIR_PATH := $(PCSC_LITE_DIR_PATH)/naclport/common
 
-
 PCSC_LITE_COMMON_JS_COMPILER_INPUT_DIR_PATHS := \
 	$(PCSC_LITE_COMMON_DIR_PATH)/src
+
+# Path under which driver files are to be put in the resulting application's
+# file system.
+#
+# It's a relative path, so that it works both inside the Smart Card Connector
+# application and in unit tests.
+PCSC_LITE_DRIVER_INSTALLATION_PATH := executable-module-filesystem/pcsc/drivers
+
+# Architecture that PC/SC-Lite is built for.
+#
+# It's currently only used to construct the driver .so file path.
+PCSC_LITE_ARCHITECTURE := Linux

--- a/third_party/pcsc-lite/naclport/server/build/Makefile
+++ b/third_party/pcsc-lite/naclport/server/build/Makefile
@@ -57,6 +57,7 @@ PCSC_LITE_SOURCES_PATH := $(PCSC_LITE_DIR_PATH)/src/src
 #   inside the Smart Card Connector app and in unit tests.
 COMMON_CPPFLAGS := \
 	-DFAKE_PCSC_NACL_SOCKET_FILE_NAME='"executable-module-filesystem/pcsc/fake_socket_file"' \
+	-DPCSC_LITE_DRIVER_INSTALLATION_PATH='"$(PCSC_LITE_DRIVER_INSTALLATION_PATH)"' \
 	-I$(ROOT_PATH) \
 	-I$(PCSC_LITE_ORIGINAL_HEADERS_DIR_PATH) \
 
@@ -66,9 +67,8 @@ COMMON_CPPFLAGS := \
 #   library (its NaCl port is located under the ../../../../libusb directory);
 # * HAVE_SYSLOG_H enables emitting log messages through syslog (which is faked
 #   to use the common logging primitives from the /common/cpp library);
-# * PCSC_ARCH constant tells to use the code corresponding to Linux platform
-#   (actually, in the current NaCl port no functionality is influenced by this
-#   constant);
+# * PCSC_ARCH constant specifies the target architecture (it's used for
+#   constructing the paths for each driver's .so file);
 # * USE_IPCDIR constant is just a stub for making the original PC/SC-Lite code
 #   compiling;
 # * USE_USB definition enables the PC/SC-Lite support of USB readers (as
@@ -78,7 +78,7 @@ PCSC_LITE_COMMON_CPPFLAGS := \
 	-DDEBUG_HOTPLUG \
 	-DHAVE_LIBUSB \
 	-DHAVE_SYSLOG_H \
-	-DPCSC_ARCH='"Linux"' \
+	-DPCSC_ARCH='"$(PCSC_LITE_ARCHITECTURE)"' \
 	-DUSE_IPCDIR='"IPCDIR_is_not_expected_to_be_used"' \
 	-DUSE_USB \
 	-I$(ROOT_PATH)/common/cpp/src/public/logging/syslog \

--- a/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
+++ b/third_party/pcsc-lite/naclport/server/src/public/pcsc_lite_server_web_port_service.cc
@@ -86,8 +86,7 @@ PcscLiteServerWebPortService* g_pcsc_lite_server = nullptr;
 // it's only CCID driver's one).
 // The path must be relative, so that it works both inside the App/Extension as
 // well as in unit tests executed natively.
-constexpr char kDriverConfigPath[] =
-    "executable-module-filesystem/pcsc/drivers";
+constexpr char kDriverConfigPath[] = PCSC_LITE_DRIVER_INSTALLATION_PATH;
 
 constexpr char kLoggingPrefix[] = "[PC/SC-Lite NaCl port] ";
 


### PR DESCRIPTION
Make single central constants for the PC/SC-Lite's driver installation directory and for the CCID config/.so installation paths.

This refactoring gets rid of multiple places in which these constants were previously hardcoded in various variations.