### PR TITLE
[c++] Switch to C++20

### DIFF
--- a/common/cpp/src/public/ipc_emulation.cc
+++ b/common/cpp/src/public/ipc_emulation.cc
@@ -296,7 +296,7 @@ int IpcEmulation::GenerateNewFileDescriptor() {
 
 void IpcEmulation::AddFile(std::shared_ptr<InMemoryFile> file) {
   GOOGLE_SMART_CARD_CHECK(file);
-  GOOGLE_SMART_CARD_CHECK(file.unique());
+  GOOGLE_SMART_CARD_CHECK(file.use_count() == 1);
   const std::unique_lock<std::mutex> lock(mutex_);
   const int file_descriptor = file->file_descriptor();
   GOOGLE_SMART_CARD_CHECK(

--- a/common/make/internal/executable_building_analysis.mk
+++ b/common/make/internal/executable_building_analysis.mk
@@ -133,7 +133,7 @@ $(error Unsupported CONFIG=$(CONFIG) value.)
 endif
 
 # Documented at ../executable_building.mk.
-CXX_DIALECT := c++11
+CXX_DIALECT := c++20
 
 # Documented at ../executable_building.mk. The implementation is mostly similar
 # to the one at executable_building_emscripten.mk.

--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -193,7 +193,7 @@ $(error Unsupported CONFIG=$(CONFIG) value.)
 endif
 
 # Documented at ../executable_building.mk.
-CXX_DIALECT := c++23
+CXX_DIALECT := c++20
 
 # The list of linker flags and dependencies for adding resource files (initially
 # empty, and added by ADD_RESOURCE_RULE).

--- a/common/make/internal/executable_building_emscripten.mk
+++ b/common/make/internal/executable_building_emscripten.mk
@@ -193,7 +193,7 @@ $(error Unsupported CONFIG=$(CONFIG) value.)
 endif
 
 # Documented at ../executable_building.mk.
-CXX_DIALECT := c++11
+CXX_DIALECT := c++23
 
 # The list of linker flags and dependencies for adding resource files (initially
 # empty, and added by ADD_RESOURCE_RULE).

--- a/third_party/libusb/webport/build/tests/Makefile
+++ b/third_party/libusb/webport/build/tests/Makefile
@@ -26,6 +26,7 @@ SOURCES_PATH := ../../src
 SOURCES := \
 	$(SOURCES_PATH)/libusb_js_proxy_unittest.cc \
 
+# TODO: Remove no-deprecated-enum-enum-conversion once the C++ code is updated.
 CXXFLAGS := \
 	-I$(ROOT_PATH) \
 	-I$(ROOT_PATH)/third_party/libusb/src/libusb \

--- a/third_party/libusb/webport/build/tests/Makefile
+++ b/third_party/libusb/webport/build/tests/Makefile
@@ -33,6 +33,7 @@ CXXFLAGS := \
 	-Wall \
 	-Werror \
 	-Wextra \
+	-Wno-deprecated-enum-enum-conversion \
 	-Wno-zero-length-array \
 	-std=$(CXX_DIALECT) \
 	$(TEST_ADDITIONAL_CXXFLAGS) \


### PR DESCRIPTION
Now that we stopped using the legacy NaCl toolchain, we can switch from
C++11 to more recent versions.

The commit enables C++20, since despite C++23 being already supported by
Emscripten we can't easily use it for ASan&coverage builds: CI bots still use
Ubuntu 22.04, and also typical developer machines still have an old Clang as
well.