### PR TITLE
[hid5021] Compile driver's C sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ LIBRARY_TARGETS := \
 	common/cpp/build \
 	smart_card_connector_app/build/cpp_lib \
 	third_party/ccid/webport/build \
+	third_party/driver-hid5021/webport/build \
 	third_party/libusb/webport/build \
 	third_party/pcsc-lite/naclport/build_configuration \
 	third_party/pcsc-lite/naclport/common/build \
@@ -48,11 +49,13 @@ example_cpp_smart_card_client_app/build: third_party/pcsc-lite/naclport/cpp_demo
 smart_card_connector_app/build: common/cpp/build
 smart_card_connector_app/build: smart_card_connector_app/build/cpp_lib
 smart_card_connector_app/build: third_party/ccid/webport/build
+smart_card_connector_app/build: third_party/driver-hid5021/webport/build
 smart_card_connector_app/build: third_party/libusb/webport/build
 smart_card_connector_app/build: third_party/pcsc-lite/naclport/common/build
 smart_card_connector_app/build: third_party/pcsc-lite/naclport/server/build
 smart_card_connector_app/build: third_party/pcsc-lite/naclport/server_clients_management/build
 third_party/ccid/webport/build: third_party/pcsc-lite/naclport/build_configuration
+third_party/driver-hid5021/webport/build: third_party/pcsc-lite/naclport/build_configuration
 third_party/pcsc-lite/naclport/common/build: third_party/pcsc-lite/naclport/build_configuration
 third_party/pcsc-lite/naclport/cpp_client/build: third_party/pcsc-lite/naclport/build_configuration
 third_party/pcsc-lite/naclport/cpp_demo/build: third_party/pcsc-lite/naclport/build_configuration
@@ -68,6 +71,7 @@ common/cpp/build/tests: common/cpp/build
 smart_card_connector_app/build/executable_module/cpp_unittests: common/cpp/build
 smart_card_connector_app/build/executable_module/cpp_unittests: smart_card_connector_app/build/cpp_lib
 smart_card_connector_app/build/executable_module/cpp_unittests: third_party/ccid/webport/build
+smart_card_connector_app/build/executable_module/cpp_unittests: third_party/driver-hid5021/webport/build
 smart_card_connector_app/build/executable_module/cpp_unittests: third_party/libusb/webport/build
 smart_card_connector_app/build/executable_module/cpp_unittests: third_party/pcsc-lite/naclport/common/build
 smart_card_connector_app/build/executable_module/cpp_unittests: third_party/pcsc-lite/naclport/server/build
@@ -132,6 +136,7 @@ smart_card_connector_app/build/js_to_cxx_tests: common/cpp/build
 smart_card_connector_app/build/js_to_cxx_tests: common/integration_testing/build
 smart_card_connector_app/build/js_to_cxx_tests: smart_card_connector_app/build/cpp_lib
 smart_card_connector_app/build/js_to_cxx_tests: third_party/ccid/webport/build
+smart_card_connector_app/build/js_to_cxx_tests: third_party/driver-hid5021/webport/build
 smart_card_connector_app/build/js_to_cxx_tests: third_party/libusb/webport/build
 smart_card_connector_app/build/js_to_cxx_tests: third_party/pcsc-lite/naclport/common/build
 smart_card_connector_app/build/js_to_cxx_tests: third_party/pcsc-lite/naclport/server/build

--- a/third_party/ccid/webport/build/Makefile
+++ b/third_party/ccid/webport/build/Makefile
@@ -40,6 +40,8 @@ CCID_NACL_SOURCES_PATH := ../src
 # Rules for invoking the source files compilation into object files
 
 # * rename all IFDH...() functions to avoid symbol clashes with other drivers;
+#   TODO: objcopy --redefine-sym would be more elegant, but is blocked on
+#   https://github.com/llvm/llvm-project/issues/50623 .
 # * HAVE_PTHREAD definition enables the support of working with multiple readers
 #   simultaneously;
 # * log_msg and log_xxd are redefined in order to not collide with the symbols

--- a/third_party/driver-hid5021/webport/build/.gitignore
+++ b/third_party/driver-hid5021/webport/build/.gitignore
@@ -1,0 +1,3 @@
+/out-artifacts-asan_testing/
+/out-artifacts-coverage/
+/out-artifacts-emscripten/

--- a/third_party/driver-hid5021/webport/build/Makefile
+++ b/third_party/driver-hid5021/webport/build/Makefile
@@ -1,0 +1,58 @@
+# Copyright 2024 Google Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+TARGET := google_smart_card_driver_hid5021
+
+include ../../../../common/make/common.mk
+include $(ROOT_PATH)/common/make/executable_building.mk
+
+# C/C++ compiler flags used for all source files below:
+#
+# * rename all IFDH...() functions to avoid symbol clashes with other drivers.
+#   TODO: objcopy --redefine-sym would be more elegant, but is blocked on
+#   https://github.com/llvm/llvm-project/issues/50623 .
+COMMON_CPPFLAGS := \
+	-DIFDHCloseChannel=HID5021_IFDHCloseChannel \
+	-DIFDHControl=HID5021_IFDHControl \
+	-DIFDHCreateChannel=HID5021_IFDHCreateChannel \
+	-DIFDHGetCapabilities=HID5021_IFDHGetCapabilities \
+	-DIFDHICCPresence=HID5021_IFDHICCPresence \
+	-DIFDHPowerICC=HID5021_IFDHPowerICC \
+	-DIFDHSetCapabilities=HID5021_IFDHSetCapabilities \
+	-DIFDHSetProtocolParameters=HID5021_IFDHSetProtocolParameters \
+	-DIFDHTransmitToICC=HID5021_IFDHTransmitToICC \
+
+# Rules for compiling the driver's C sources:
+
+DRIVER_SOURCES := \
+	../../src/ifdhandler.c \
+
+# * Specify header search paths.
+DRIVER_CPPFLAGS := \
+	$(COMMON_CPPFLAGS) \
+	-I$(ROOT_PATH)/third_party/libusb/src/libusb \
+	-I$(ROOT_PATH)/third_party/pcsc-lite/src/src/PCSC \
+
+$(foreach src,$(DRIVER_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(DRIVER_CPPFLAGS))))
+
+# TODO: Add an "adaptor" glue C++ code.
+
+# Rules for producing the resulting static library:
+
+SOURCES := \
+	$(DRIVER_SOURCES) \
+
+$(eval $(call LIB_RULE,$(TARGET),$(SOURCES)))


### PR DESCRIPTION
Add a Makefile that compiles the HID 5021 CL driver's original Linux source code.

Note that the driver still isn't used in the Smart Card Connector for real, since it's not linked into the resulting executable and there's no C++ glue code yet.