### PR TITLE
[hid5021] Install Info.plist config file

### DIFF
--- a/smart_card_connector_app/build/executable_module/Makefile
+++ b/smart_card_connector_app/build/executable_module/Makefile
@@ -23,6 +23,8 @@ include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/server/include.mk
 include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/server_clients_management/include.mk
 # Depends on pcsc-lite/naclport/common/include.mk.
 include $(THIRD_PARTY_DIR_PATH)/ccid/webport/include.mk
+# Depends on pcsc-lite/naclport/common/include.mk.
+include $(THIRD_PARTY_DIR_PATH)/driver-hid5021/webport/include.mk
 
 
 # Common build definitions:
@@ -94,6 +96,9 @@ $(eval $(call ADD_RESOURCE_RULE, \
 $(eval $(call ADD_RESOURCE_RULE, \
 	$(ROOT_PATH)/third_party/ccid/webport/build/Info.plist, \
 	$(CCID_CONFIG_INSTALLATION_PATH)))
+$(eval $(call ADD_RESOURCE_RULE, \
+  $(ROOT_PATH)/third_party/driver-hid5021/src/Info.plist, \
+  $(DRIVER5021_CONFIG_INSTALLATION_PATH)))
 
 # Rules for compiling source files and linking them into an executable binary.
 $(foreach src,$(SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))

--- a/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
+++ b/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
@@ -21,6 +21,8 @@ include ../../../../common/cpp_unit_test_runner/include.mk
 include $(THIRD_PARTY_DIR_PATH)/pcsc-lite/naclport/common/include.mk
 # Depends on pcsc-lite/naclport/common/include.mk.
 include $(ROOT_PATH)/third_party/ccid/webport/include.mk
+# Depends on pcsc-lite/naclport/common/include.mk.
+include $(THIRD_PARTY_DIR_PATH)/driver-hid5021/webport/include.mk
 
 SOURCES := \
 	../../../src/application_unittest.cc \
@@ -57,6 +59,9 @@ $(eval $(call ADD_RESOURCE_RULE, \
 $(eval $(call ADD_RESOURCE_RULE, \
 	$(ROOT_PATH)/third_party/ccid/webport/build/Info.plist, \
 	$(CCID_CONFIG_INSTALLATION_PATH)))
+$(eval $(call ADD_RESOURCE_RULE, \
+	$(ROOT_PATH)/third_party/driver-hid5021/src/Info.plist, \
+	$(DRIVER5021_CONFIG_INSTALLATION_PATH)))
 
 # Rules for compiling the test source files and linking them into a resulting
 # executable binary.

--- a/smart_card_connector_app/build/js_to_cxx_tests/Makefile
+++ b/smart_card_connector_app/build/js_to_cxx_tests/Makefile
@@ -29,6 +29,8 @@ include $(ROOT_PATH)/third_party/pcsc-lite/naclport/server/include.mk
 include $(ROOT_PATH)/third_party/pcsc-lite/naclport/server_clients_management/include.mk
 # Depends on pcsc-lite/naclport/common/include.mk.
 include $(ROOT_PATH)/third_party/ccid/webport/include.mk
+# Depends on pcsc-lite/naclport/common/include.mk.
+include $(THIRD_PARTY_DIR_PATH)/driver-hid5021/webport/include.mk
 
 
 SOURCE_DIR := $(ROOT_PATH)/smart_card_connector_app/src/
@@ -88,11 +90,14 @@ $(foreach src,$(CXX_SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
 $(eval $(call ADD_RESOURCE_RULE, \
   $(ROOT_PATH)/third_party/pcsc-lite/naclport/server/src/fake_socket_file, \
   executable-module-filesystem/pcsc/fake_socket_file))
-# * Info.plist: it's a driver config for the CCID driver; at runtime, the PC/SC
-#   daemon code reads parameters from this config to call into CCID.
+# * Info.plist: these are driver configs; at runtime, the PC/SC daemon code
+#   reads parameters from these configs to call into the drivers.
 $(eval $(call ADD_RESOURCE_RULE, \
   $(ROOT_PATH)/third_party/ccid/webport/build/Info.plist, \
   $(CCID_CONFIG_INSTALLATION_PATH)))
+$(eval $(call ADD_RESOURCE_RULE, \
+  $(ROOT_PATH)/third_party/driver-hid5021/src/Info.plist, \
+  $(DRIVER5021_CONFIG_INSTALLATION_PATH)))
 
 # Targets that build the resulting executable module and JS tests.
 $(eval $(call BUILD_JS_TO_CXX_TEST,$(CXX_SOURCES),$(LIBS),$(JS_SOURCES_PATHS)))

--- a/third_party/driver-hid5021/webport/include.mk
+++ b/third_party/driver-hid5021/webport/include.mk
@@ -1,0 +1,27 @@
+# Copyright 2024 Google Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# This file contains common makefile definitions related to the HID 5021 driver.
+
+# File name of the driver's bundle directory.
+#
+# It could be an arbitrary string unique to this driver, but we just follow what
+# the driver uses on other platforms.
+DRIVER5021_BUNDLE_NAME := driver-5021CL.bundle
+
+# Path where the driver's config file is to be installed.
+DRIVER5021_CONFIG_INSTALLATION_PATH := \
+  $(PCSC_LITE_DRIVER_INSTALLATION_PATH)/$(DRIVER5021_BUNDLE_NAME)/Contents/Info.plist


### PR DESCRIPTION
Package the HID 5021 CL driver's config file into the Smart Card Connector extension, as well as into the test targets.