### PR TITLE
[hid5021] Wire up the driver

### DIFF
--- a/smart_card_connector_app/build/executable_module/Makefile
+++ b/smart_card_connector_app/build/executable_module/Makefile
@@ -39,6 +39,7 @@ LIBS := \
 	google_smart_card_pcsc_lite_server \
 	google_smart_card_pcsc_lite_common \
 	google_smart_card_ccid \
+	google_smart_card_driver_hid5021 \
 	google_smart_card_libusb \
 	google_smart_card_common \
 

--- a/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
+++ b/smart_card_connector_app/build/executable_module/cpp_unittests/Makefile
@@ -49,6 +49,7 @@ LIBS := \
   google_smart_card_pcsc_lite_server \
   google_smart_card_pcsc_lite_common \
   google_smart_card_ccid \
+  google_smart_card_driver_hid5021 \
   google_smart_card_libusb \
   google_smart_card_common \
 

--- a/smart_card_connector_app/build/js_to_cxx_tests/Makefile
+++ b/smart_card_connector_app/build/js_to_cxx_tests/Makefile
@@ -58,6 +58,7 @@ LIBS := \
   google_smart_card_pcsc_lite_server \
   google_smart_card_pcsc_lite_common \
   google_smart_card_ccid \
+  google_smart_card_driver_hid5021 \
   google_smart_card_libusb \
   google_smart_card_common \
 

--- a/smart_card_connector_app/src/application.cc
+++ b/smart_card_connector_app/src/application.cc
@@ -28,6 +28,7 @@
 #include "common/cpp/src/public/value.h"
 #include "common/cpp/src/public/value_conversion.h"
 #include "third_party/ccid/webport/src/ccid_pcsc_driver_adaptor.h"
+#include "third_party/driver-hid5021/webport/src/hid5021_pcsc_driver_adaptor.h"
 #include "third_party/libusb/webport/src/public/libusb_web_port_service.h"
 #include "third_party/pcsc-lite/webport/driver_interface/src/pcsc_driver_adaptor.h"
 #include "third_party/pcsc-lite/webport/server/src/public/pcsc_lite_server_web_port_service.h"
@@ -42,6 +43,7 @@ namespace {
 std::vector<std::unique_ptr<PcscDriverAdaptor>> GetDriverAdaptors() {
   std::vector<std::unique_ptr<PcscDriverAdaptor>> drivers;
   drivers.push_back(MakeUnique<CcidPcscDriverAdaptor>());
+  drivers.push_back(MakeUnique<Hid5021PcscDriverAdaptor>());
   return drivers;
 }
 

--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -95,6 +95,9 @@ ${if PACKAGING=app}
     "usb",
     {
       "usbDevices": [
+        # HID 5021-CL - we have a special driver for it.
+        {"vendorId": 1899, "productId": 21280},
+
         # Allowlist the ACS ACR122U PICC reader. It's not officially supported
         # due to various issues, hence we don't patch the CCID Free Driver's
         # config to include it, but we allow deployments that are willing to use


### PR DESCRIPTION
Link the driver into Smart Card Connector's executable and instantiate the "adaptor" code to let our PC/SC-Lite webport actually make commands to it.