### PR TITLE
[pcsc] Move makefile rules for prompt HTML files

### DIFF
--- a/smart_card_connector_app/build/Makefile
+++ b/smart_card_connector_app/build/Makefile
@@ -162,6 +162,8 @@ $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/about-window.html))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/about-window.css))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/trusted_clients.json))
 $(eval $(call COPY_TO_OUT_DIR_RULE,$(ROOT_PATH)/common/js/src/executable-module/emscripten-offscreen-doc.html))
+$(eval $(call COPY_TO_OUT_DIR_RULE,$(ROOT_PATH)/third_party/pcsc-lite/webport/server_clients_management/src/permissions_checking/user-prompt-dialog.html,pcsc_lite_server_clients_management))
+$(eval $(call COPY_TO_OUT_DIR_RULE,$(ROOT_PATH)/third_party/pcsc-lite/webport/server_clients_management/src/permissions_checking/user-prompt-dialog.css,pcsc_lite_server_clients_management))
 
 ifeq ($(TOOLCHAIN),emscripten)
 ifeq ($(PACKAGING),extension)

--- a/third_party/pcsc-lite/webport/server_clients_management/build/Makefile
+++ b/third_party/pcsc-lite/webport/server_clients_management/build/Makefile
@@ -61,10 +61,6 @@ $(foreach src,$(SOURCES),$(eval $(call COMPILE_RULE,$(src),$(CXXFLAGS))))
 $(eval $(call LIB_RULE,$(TARGET),$(SOURCES)))
 
 
-$(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/permissions_checking/user-prompt-dialog.html,pcsc_lite_server_clients_management))
-$(eval $(call COPY_TO_OUT_DIR_RULE,$(SOURCES_PATH)/permissions_checking/user-prompt-dialog.css,pcsc_lite_server_clients_management))
-
-
 JS_COMPILER_INPUT_PATHS := \
 	$(JS_COMMON_JS_COMPILER_INPUT_DIR_PATHS) \
 	$(PCSC_LITE_SERVER_CLIENTS_MANAGEMENT_JS_COMPILER_INPUT_DIR_PATHS) \


### PR DESCRIPTION
Trigger the user-prompt-dialog.* file packaging in Smart Card Connector's makefile instead of the helper library.

This approach is easier to track in the build scripts and we already switched to it everywhere else.