### PR TITLE
[hid5021] Fix the missing .mk include

### DIFF
--- a/third_party/driver-hid5021/webport/build/Makefile
+++ b/third_party/driver-hid5021/webport/build/Makefile
@@ -18,6 +18,9 @@ TARGET := google_smart_card_driver_hid5021
 
 include ../../../../common/make/common.mk
 include $(ROOT_PATH)/common/make/executable_building.mk
+include $(ROOT_PATH)/third_party/pcsc-lite/webport/common/include.mk
+# Depends on pcsc-lite/webport/common/include.mk.
+include $(ROOT_PATH)/third_party/driver-hid5021/webport/include.mk
 
 # C/C++ compiler flags used for all source files below:
 #


### PR DESCRIPTION
The SO_INSTALLATION_PATH constant wasn't passed correctly because the driver's makefile didn't include the corresponding include.mk.