### PR TITLE
[c++] Use steady_clock instead of high_resolution

### DIFF
--- a/common/cpp/src/public/requesting/async_request_unittest.cc
+++ b/common/cpp/src/public/requesting/async_request_unittest.cc
@@ -87,7 +87,7 @@ TEST(RequestingAsyncRequestTest, AsyncRequestStateMultiThreading) {
 
     std::vector<std::thread> threads;
     const auto threads_start_time =
-        std::chrono::high_resolution_clock::now() + kThreadsStartTimeout;
+        std::chrono::steady_clock::now() + kThreadsStartTimeout;
     for (int thread_index = 0; thread_index < kThreadCount; ++thread_index) {
       threads.emplace_back([&states, threads_start_time] {
         std::this_thread::sleep_until(threads_start_time);

--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -1006,8 +1006,7 @@ int LibusbJsProxy::LibusbHandleEventsCompleted(libusb_context* ctx,
   ctx = SubstituteDefaultContextIfNull(ctx);
 
   ctx->WaitAndProcessAsyncTransferReceivedResults(
-      std::chrono::time_point<std::chrono::high_resolution_clock>::max(),
-      completed);
+      std::chrono::time_point<std::chrono::steady_clock>::max(), completed);
   return LIBUSB_SUCCESS;
 }
 
@@ -1082,8 +1081,7 @@ int LibusbJsProxy::LibusbHandleEventsWithTimeout(libusb_context* context,
   context = SubstituteDefaultContextIfNull(context);
 
   context->WaitAndProcessAsyncTransferReceivedResults(
-      std::chrono::high_resolution_clock::now() +
-          std::chrono::seconds(timeout_seconds),
+      std::chrono::steady_clock::now() + std::chrono::seconds(timeout_seconds),
       nullptr);
   return LIBUSB_SUCCESS;
 }

--- a/third_party/libusb/webport/src/libusb_opaque_types.cc
+++ b/third_party/libusb/webport/src/libusb_opaque_types.cc
@@ -69,7 +69,7 @@ libusb_context::PrepareTransferJsCallForExecution(
 }
 
 void libusb_context::WaitAndProcessAsyncTransferReceivedResults(
-    const std::chrono::time_point<std::chrono::high_resolution_clock>&
+    const std::chrono::time_point<std::chrono::steady_clock>&
         timeout_time_point,
     int* completed) {
   TransferAsyncRequestStatePtr async_request_state;
@@ -94,7 +94,7 @@ void libusb_context::WaitAndProcessAsyncTransferReceivedResults(
         break;
       }
 
-      const std::chrono::time_point<std::chrono::high_resolution_clock>
+      const std::chrono::time_point<std::chrono::steady_clock>
           min_transfer_timeout = GetMinTransferTimeout();
 
       // Wait until a transfer result arrives, or some transfer times out, or we
@@ -105,7 +105,7 @@ void libusb_context::WaitAndProcessAsyncTransferReceivedResults(
       condition_.wait_until(lock, wait_until_time_point);
 
       // Immediately exit if we timed out according to `timeout_time_point`.
-      if (std::chrono::high_resolution_clock::now() >= timeout_time_point)
+      if (std::chrono::steady_clock::now() >= timeout_time_point)
         return;
     }
   }
@@ -199,13 +199,12 @@ void libusb_context::AddTransferInFlight(
     RemoteCallAsyncRequest prepared_js_call) {
   GOOGLE_SMART_CARD_CHECK(async_request_state);
 
-  std::chrono::time_point<std::chrono::high_resolution_clock> timeout;
+  std::chrono::time_point<std::chrono::steady_clock> timeout;
   if (transfer->timeout == 0) {
     // A zero timeout field denotes an infinite timeout.
-    timeout =
-        std::chrono::time_point<std::chrono::high_resolution_clock>::max();
+    timeout = std::chrono::time_point<std::chrono::steady_clock>::max();
   } else {
-    timeout = std::chrono::high_resolution_clock::now() +
+    timeout = std::chrono::steady_clock::now() +
               std::chrono::milliseconds(transfer->timeout);
   }
 
@@ -239,10 +238,10 @@ void libusb_context::RemoveTransferInFlight(
   }
 }
 
-std::chrono::time_point<std::chrono::high_resolution_clock>
+std::chrono::time_point<std::chrono::steady_clock>
 libusb_context::GetMinTransferTimeout() const {
   if (transfers_in_flight_.empty())
-    return std::chrono::time_point<std::chrono::high_resolution_clock>::max();
+    return std::chrono::time_point<std::chrono::steady_clock>::max();
   return transfers_in_flight_.GetWithMinTimeout().timeout;
 }
 
@@ -283,7 +282,7 @@ bool libusb_context::ExtractTimedOutTransfer(
     return false;
   UsbTransfersParametersStorage::Info nearest =
       transfers_in_flight_.GetWithMinTimeout();
-  if (std::chrono::high_resolution_clock::now() < nearest.timeout)
+  if (std::chrono::steady_clock::now() < nearest.timeout)
     return false;
   *async_request_state = nearest.async_request_state;
   // TODO(#47): Use a common constant here that can be checked in

--- a/third_party/libusb/webport/src/libusb_opaque_types.h
+++ b/third_party/libusb/webport/src/libusb_opaque_types.h
@@ -108,7 +108,7 @@ struct libusb_context final
   // particular, the role of the completed argument), refer to
   // <http://libusb.org/static/api-1.0/mtasync.html>.
   void WaitAndProcessAsyncTransferReceivedResults(
-      const std::chrono::time_point<std::chrono::high_resolution_clock>&
+      const std::chrono::time_point<std::chrono::steady_clock>&
           timeout_time_point,
       int* completed);
 
@@ -145,8 +145,8 @@ struct libusb_context final
   void RemoveTransferInFlight(
       const TransferAsyncRequestState* async_request_state);
 
-  std::chrono::time_point<std::chrono::high_resolution_clock>
-  GetMinTransferTimeout() const;
+  std::chrono::time_point<std::chrono::steady_clock> GetMinTransferTimeout()
+      const;
 
   bool ExtractAsyncTransferStateUpdate(
       TransferAsyncRequestStatePtr* async_request_state,

--- a/third_party/libusb/webport/src/usb_transfers_parameters_storage.cc
+++ b/third_party/libusb/webport/src/usb_transfers_parameters_storage.cc
@@ -119,8 +119,7 @@ void UsbTransfersParametersStorage::Add(
     const UsbTransferDestination& transfer_destination,
     libusb_transfer* transfer,
     RemoteCallAsyncRequest prepared_js_call,
-    const std::chrono::time_point<std::chrono::high_resolution_clock>&
-        timeout) {
+    const std::chrono::time_point<std::chrono::steady_clock>& timeout) {
   GOOGLE_SMART_CARD_CHECK(async_request_state);
   GOOGLE_SMART_CARD_CHECK(transfer);
   auto stored_item = MakeUnique<Item>();

--- a/third_party/libusb/webport/src/usb_transfers_parameters_storage.h
+++ b/third_party/libusb/webport/src/usb_transfers_parameters_storage.h
@@ -61,7 +61,7 @@ class UsbTransfersParametersStorage final {
     TransferAsyncRequestStatePtr async_request_state;
     UsbTransferDestination transfer_destination;
     libusb_transfer* transfer = nullptr;
-    std::chrono::time_point<std::chrono::high_resolution_clock> timeout;
+    std::chrono::time_point<std::chrono::steady_clock> timeout;
   };
 
   bool empty() const;
@@ -70,8 +70,7 @@ class UsbTransfersParametersStorage final {
            const UsbTransferDestination& transfer_destination,
            libusb_transfer* transfer,
            RemoteCallAsyncRequest prepared_js_call,
-           const std::chrono::time_point<std::chrono::high_resolution_clock>&
-               timeout);
+           const std::chrono::time_point<std::chrono::steady_clock>& timeout);
 
   bool ContainsWithAsyncRequestState(
       const TransferAsyncRequestState* async_request_state) const;
@@ -127,7 +126,7 @@ class UsbTransfersParametersStorage final {
   std::map<UsbTransferDestination, std::deque<Item*>>
       async_destination_mapping_;
   std::map<const libusb_transfer*, Item*> async_libusb_transfer_mapping_;
-  std::map<std::chrono::time_point<std::chrono::high_resolution_clock>,
+  std::map<std::chrono::time_point<std::chrono::steady_clock>,
            std::deque<Item*>>
       timeout_mapping_;
   // Contains items which still have nonempty `prepared_js_call`.

--- a/third_party/pcsc-lite/webport/server/src/winscard_msg_webport.cc
+++ b/third_party/pcsc-lite/webport/server/src/winscard_msg_webport.cc
@@ -139,11 +139,11 @@ INTERNAL LONG MessageReceiveTimeout(uint32_t /*command*/,
                                     long timeOut) {
   GOOGLE_SMART_CARD_CHECK(buffer_void);
 
-  const auto start_time_point = std::chrono::high_resolution_clock::now();
+  const auto start_time_point = std::chrono::steady_clock::now();
   uint8_t* current_buffer_begin = static_cast<uint8_t*>(buffer_void);
   int64_t left_size = static_cast<int64_t>(buffer_size);
   while (left_size > 0) {
-    const auto current_time_point = std::chrono::high_resolution_clock::now();
+    const auto current_time_point = std::chrono::steady_clock::now();
     const int64_t milliseconds_passed =
         std::chrono::duration_cast<std::chrono::milliseconds>(
             current_time_point - start_time_point)


### PR DESCRIPTION
std::chrono::high_resolution_clock can, according to the Standard, be non-steady, i.e., non-monotonic, which isn't valid for our use cases when we measure operation timeouts.

In reality this is a pure cosmetic change now, given that Emscripten's C++ standard library defines high_resolution_clock as a steady_clock.