### PR TITLE
[libusb] Correct error code for timed out transfer

### DIFF
--- a/third_party/libusb/webport/src/libusb_js_proxy.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy.cc
@@ -878,9 +878,6 @@ libusb_transfer_status FillLibusbTransferResult(
     int data_length,
     unsigned char* data_buffer,
     int* actual_length) {
-  // TODO(#47): Return `LIBUSB_TRANSFER_TIMED_OUT` instead of
-  // `LIBUSB_TRANSFER_ERROR` if the transfer timed out.
-
   int actual_length_value;
   if (js_result.received_data) {
     actual_length_value = std::min(
@@ -1052,6 +1049,8 @@ LibusbJsProxy::WrapLibusbTransferCallback(libusb_transfer* transfer) {
           data_buffer, &transfer->actual_length);
     } else if (request_result.status() == RequestResultStatus::kCanceled) {
       transfer->status = LIBUSB_TRANSFER_CANCELLED;
+    } else if (request_result.error_message() == kLibusbJsProxyTimeoutError) {
+      transfer->status = LIBUSB_TRANSFER_TIMED_OUT;
     } else {
       transfer->status = LIBUSB_TRANSFER_ERROR;
     }

--- a/third_party/libusb/webport/src/libusb_js_proxy_constants.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_constants.cc
@@ -19,5 +19,6 @@
 namespace google_smart_card {
 
 const char kLibusbJsProxyRequesterName[] = "libusb";
+const char kLibusbJsProxyTimeoutError[] = "Timed out";
 
 }  // namespace google_smart_card

--- a/third_party/libusb/webport/src/libusb_js_proxy_constants.h
+++ b/third_party/libusb/webport/src/libusb_js_proxy_constants.h
@@ -26,6 +26,9 @@ namespace google_smart_card {
 // libusb-to-js-api-adaptor.js).
 extern const char kLibusbJsProxyRequesterName[];
 
+// The error message used by libusb_js_proxy when a USB transfer times out.
+extern const char kLibusbJsProxyTimeoutError[];
+
 }  // namespace google_smart_card
 
 #endif  // GOOGLE_SMART_CARD_THIRD_PARTY_LIBUSB_LIBUSB_JS_PROXY_CONSTANTS_H_

--- a/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
+++ b/third_party/libusb/webport/src/libusb_js_proxy_unittest.cc
@@ -1217,7 +1217,7 @@ TEST_P(LibusbJsProxyWithDeviceTest, InputControlTransferTimeout) {
               LIBUSB_ENDPOINT_IN,
           kControlTransferRequest, kControlTransferValue, kControlTransferIndex,
           &received_data[0], received_data.size(), /*timeout=*/1000),
-      LIBUSB_ERROR_OTHER);
+      LIBUSB_ERROR_TIMEOUT);
 }
 
 // Tests `LibusbControlTransfer()` timeout scenario for an output transfer.
@@ -1241,7 +1241,7 @@ TEST_P(LibusbJsProxyWithDeviceTest, OutputControlTransferTimeout) {
                     LIBUSB_ENDPOINT_OUT,
                 kControlTransferRequest, kControlTransferValue,
                 kControlTransferIndex, &data[0], data.size(), /*timeout=*/1000),
-            LIBUSB_ERROR_OTHER);
+            LIBUSB_ERROR_TIMEOUT);
 }
 
 // Test the correctness of work of multiple threads issuing a sequence of

--- a/third_party/libusb/webport/src/libusb_opaque_types.cc
+++ b/third_party/libusb/webport/src/libusb_opaque_types.cc
@@ -22,6 +22,7 @@
 #include "common/cpp/src/public/logging/logging.h"
 #include "common/cpp/src/public/optional.h"
 #include "common/cpp/src/public/requesting/remote_call_async_request.h"
+#include "third_party/libusb/webport/src/libusb_js_proxy_constants.h"
 
 using google_smart_card::optional;
 using google_smart_card::RemoteCallAsyncRequest;
@@ -286,9 +287,8 @@ bool libusb_context::ExtractTimedOutTransfer(
   if (std::chrono::high_resolution_clock::now() < nearest.timeout)
     return false;
   *async_request_state = nearest.async_request_state;
-  // TODO(#47): Use a common constant here that can be checked in
-  // `LibusbJsProxy`, so that it can distinguish timeouts from other failures.
-  *result = TransferRequestResult::CreateFailed("Timed out");
+  *result = TransferRequestResult::CreateFailed(
+      google_smart_card::kLibusbJsProxyTimeoutError);
   return true;
 }
 


### PR DESCRIPTION
Fix our webport of Libusb to report LIBUSB_ERROR_TIMEOUT instead of LIBUSB_TRANSFER_OTHER when a transfer times out.

This hasn't been critical for our existing usages so far (the CCID Driver doesn't really distinguish the timeout error from other errors), but the correct error code makes reading logs easier, and also the new drivers might want to check for this error code directly.

This fixes #47 (the 7-year-old TODO!).