### PR TITLE
[wasm] Update Emscripten to 3.1.71

### DIFF
--- a/env/constants.sh
+++ b/env/constants.sh
@@ -16,4 +16,4 @@
 
 
 EMSCRIPTEN_SDK_REPOSITORY_URL="https://github.com/emscripten-core/emsdk.git"
-EMSCRIPTEN_VERSION="3.1.70"
+EMSCRIPTEN_VERSION="3.1.71"


### PR DESCRIPTION
This brings long-awaited fixes for -sINCOMING_MODULE_JS_API and -sSTRICT.