### PR TITLE
[ci] Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -59,13 +59,17 @@ jobs:
       with:
         path: built_app_packages
 
+    # Run upload rules only for one packaging mode, to avoid uploded file name
+    # clashes (the actual library code doesn't depend on the packaging).
     - name: Upload example JS standalone smart card client library
+      if: ${{ matrix.packaging == 'extension' }}
       uses: actions/upload-artifact@v4
       with:
         # Suffix the file name with ".debug" for Debug builds.
         name: google-smart-card-client-library${{ matrix.build-config == 'Debug' && '.debug' || '' }}.js
         path: example_js_standalone_smart_card_client_library/out/example_js_standalone_smart_card_client_library/google-smart-card-client-library.js
     - name: Upload example JS standalone smart card client library ES module
+      if: ${{ matrix.packaging == 'extension' }}
       uses: actions/upload-artifact@v4
       with:
         # Suffix the file name with ".debug" for Debug builds.


### PR DESCRIPTION
Github deprecates v3:

> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/upload-artifact@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

The commit additionally tweaks the CI rule to avoid uploading the same-named file multiple times: this is forbidden in upload-artifact v4.