### PR TITLE
[ci] Stop using ittaakos/upload-artifact-as-is

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -55,9 +55,11 @@ jobs:
         source env/activate && make test
 
     - name: Upload built app packages
-      uses: kittaakos/upload-artifact-as-is@v0
+      uses: actions/upload-artifact@v4
       with:
-        path: built_app_packages
+        name: built_app_packages
+        path: built_app_packages/*
+        if-no-files-found: error
 
     - name: Upload example JS standalone smart card client library
       uses: actions/upload-artifact@v3

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Upload built app packages
       uses: actions/upload-artifact@v4
       with:
-        name: built_app_packages
+        name: built_app_packages.${{ matrix.build-config }}.${{ matrix.packaging }}
         path: built_app_packages/*
         if-no-files-found: error
 


### PR DESCRIPTION
This rule is unmaintained and deprecated.

The visible effect of this commit is that different artifacts are now packed together into combined .zip files, e.g., `built_app_packages.Release.extension.zip` will contain `smart_card_connector_app.zip`, `example_js_smart_card_client_app.zip` and `example_cpp_smart_card_client_app.zip`. This adds a bit of inconvenience but is no more than a cosmetic change.