### PR TITLE
[libusb] Drop check for pre-ChromeOS-51

### DIFF
--- a/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
+++ b/third_party/libusb/webport/src/libusb-to-chrome-usb-adaptor.js
@@ -238,21 +238,15 @@ async function promisify(apiMethod, ...apiArguments) {
  * @return {!LibusbJsDevice}
  */
 function convertChromeUsbDeviceToLibusb(chromeUsbDevice) {
-  /** @type {!LibusbJsDevice} */
-  const libusbJsDevice = {
+  return {
     'deviceId': chromeUsbDevice.device,
     'vendorId': chromeUsbDevice.vendorId,
     'productId': chromeUsbDevice.productId,
     'productName': chromeUsbDevice.productName,
     'manufacturerName': chromeUsbDevice.manufacturerName,
     'serialNumber': chromeUsbDevice.serialNumber,
+    'version': chromeUsbDevice.version,
   };
-  if (chromeUsbDevice.version !== undefined &&
-      chromeUsbDevice.version !== null) {
-    // The "version" field was only added in Chrome 51.
-    libusbJsDevice['version'] = chromeUsbDevice.version;
-  }
-  return libusbJsDevice;
 }
 
 /**


### PR DESCRIPTION
The Device.version field has been provided by chrome.usb since ChromeOS 51 - we don't need to check for the field presence.

The minimum_chrome_version field in manifest.json guarantees that we'll never run on such ancient versions.