### PR TITLE
[ci] Switch to ubuntu-24.04

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   # Build and test in WebAssembly mode.
   build-emscripten:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
       matrix:


### PR DESCRIPTION
Hardcode the CI script to use ubuntu-24.04 instead of "latest".

The main goal is to freeze the known-to-be-compatible version to
make the CI work correctly for a longer time without manual
intervention. Additionally, we switch to a more modern version
proactively ("latest" is still at 22.04).