### PR TITLE
[example] Drop legacy certificateProvider code

### DIFF
--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.cc
@@ -80,7 +80,7 @@ void ProcessSignatureRequest(
   if (request_handling_mutex)
     lock = std::unique_lock<std::mutex>(*request_handling_mutex);
 
-  GOOGLE_SMART_CARD_LOG_DEBUG << "Processing sign digest request...";
+  GOOGLE_SMART_CARD_LOG_DEBUG << "Processing sign request...";
   std::vector<uint8_t> signature;
   const std::shared_ptr<SignatureRequestHandler>
       locked_signature_request_handler = signature_request_handler.lock();

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/api_bridge.h
@@ -57,9 +57,7 @@ class CertificatesRequestHandler {
 // Handler of the signature request.
 //
 // For the related original JavaScript definition, refer to:
-// <https://developer.chrome.com/extensions/certificateProvider#event-onSignatureRequested>
-// and
-// <https://developer.chrome.com/extensions/certificateProvider#event-onSignDigestRequested>.
+// <https://developer.chrome.com/extensions/certificateProvider#event-onSignatureRequested>.
 class SignatureRequestHandler {
  public:
   virtual ~SignatureRequestHandler() = default;

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.cc
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.cc
@@ -104,7 +104,6 @@ StructValueDescriptor<ccp::SignatureRequest>::GetDescription() {
   return Describe("chrome_certificate_provider::SignatureRequest")
       .WithField(&ccp::SignatureRequest::sign_request_id, "signRequestId")
       .WithField(&ccp::SignatureRequest::input, "input")
-      .WithField(&ccp::SignatureRequest::digest, "digest")
       .WithField(&ccp::SignatureRequest::algorithm, "algorithm")
       .WithField(&ccp::SignatureRequest::certificate, "certificate");
 }

--- a/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.h
+++ b/example_cpp_smart_card_client_app/src/chrome_certificate_provider/types.h
@@ -106,17 +106,11 @@ struct SetCertificatesDetails {
 
 // Structure containing the data of the signature request.
 //
-// Note that either |input| or |digest| will be set (but not both
-// simultaneously).
-//
 // For the corresponding original JavaScript definition, refer to:
-// <https://developer.chrome.com/extensions/certificateProvider#event-onSignatureRequested>
-// and
-// <https://developer.chrome.com/extensions/certificateProvider#event-onSignDigestRequested>.
+// <https://developer.chrome.com/extensions/certificateProvider#event-onSignatureRequested>.
 struct SignatureRequest {
   int sign_request_id;
   std::vector<uint8_t> input;
-  std::vector<uint8_t> digest;  // only used with the legacy API
   Algorithm algorithm;
   std::vector<uint8_t> certificate;
 };


### PR DESCRIPTION
Delete the compatibility code for ChromeOS <=85 from the Example C++ App.
On newer ChromeOS versions, the deleted code was a no-op.

Specifically, a new set of events and functions were added to
chrome.certificateProvider API in ChromeOS 86. Older definitions remained
but it's been preferred to switch away from them; moreover, MV3
extensions can only access new symbols.

We expect that all vendors who use this example have been requiring
"minimum_chrome_version: 86" or higher in manifest.json.