### PR TITLE
[hid5021] Exclude 3p code from linting

### DIFF
--- a/scripts/internal/find_files_for_linting.py
+++ b/scripts/internal/find_files_for_linting.py
@@ -31,6 +31,7 @@ _BLOCKLIST = [
   'third_party/closure-compiler-binary/src/',
   'third_party/closure-compiler/src/',
   'third_party/closure-library/src/',
+  'third_party/driver-hid5021/src/',
   'third_party/googletest/src/',
   'third_party/libusb/src/',
   'third_party/nacl_sdk/nacl_sdk/',


### PR DESCRIPTION
We don't want to run linters or formatters on the third-party code for the driver.

We still want them on our "glue" code, hence we only exclude the /src/ subdirectory.