### PR TITLE
[connector] Reduce ChromeOS requirement to 126

### DIFF
--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -70,7 +70,7 @@ ${endif}
   # Specify the minimum ChromeOS milestone on which we should work fine.
   # Chosen conservatively as we haven't done much testing on older ChromeOS
   # versions when we were switching to WebAssembly in production.
-  "minimum_chrome_version": "128",
+  "minimum_chrome_version": "126",
 
   "default_locale": "en",
   "icons": {


### PR DESCRIPTION
Current ChromeOS LTS is 126, so use this as a requirement instead of the previously chosen 128.

This means we'll need to do backwards compatibility check for two more releases into the past.