### PR TITLE
[mv3] Send device list to window via messages

### DIFF
--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -246,8 +246,8 @@ function onMessagePortConnected(port) {
   if (port.name ===
       GSC.ConnectorApp.Window.Constants.DEVICES_MESSAGING_PORT_NAME) {
     setUpSendingDeviceList(port);
-    return;
   }
+  // Ignore the port otherwise.
 }
 
 /**

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -244,7 +244,7 @@ function externalMessageListener(message, sender) {
  */
 function onMessagePortConnected(port) {
   if (port.name ===
-      GSC.ConnectorApp.Window.Constants.DEVICES_MESSAGING_PORT_NAME) {
+      GSC.ConnectorApp.Window.Constants.DEVICE_LIST_MESSAGING_PORT_NAME) {
     setUpSendingDeviceList(port);
   }
   // Ignore the port otherwise.

--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -20,6 +20,7 @@ goog.provide('GoogleSmartCard.ConnectorApp.BackgroundMain');
 goog.require('GoogleSmartCard.BackgroundPageUnloadPreventing');
 goog.require('GoogleSmartCard.ConnectorApp.Background.MainWindowManaging');
 goog.require('GoogleSmartCard.ConnectorApp.ChromeApiProvider');
+goog.require('GoogleSmartCard.ConnectorApp.Window.Constants');
 goog.require('GoogleSmartCard.EmscriptenModule');
 goog.require('GoogleSmartCard.ExecutableModule');
 goog.require('GoogleSmartCard.LibusbLoginStateHook');
@@ -120,6 +121,7 @@ executableModule.startLoading();
 if (GSC.Packaging.MODE === GSC.Packaging.Mode.APP)
   chrome.app.runtime.onLaunched.addListener(launchedListener);
 
+chrome.runtime.onConnect.addListener(onMessagePortConnected);
 chrome.runtime.onConnectExternal.addListener(externalConnectionListener);
 chrome.runtime.onMessageExternal.addListener(externalMessageListener);
 
@@ -236,6 +238,37 @@ function externalMessageListener(message, sender) {
 }
 
 /**
+ * Called when another page within our extension opened a port to us (the
+ * Service Worker or, if we're a Chrome App, the Background Page).
+ * @param {!Port} port
+ */
+function onMessagePortConnected(port) {
+  if (port.name ===
+      GSC.ConnectorApp.Window.Constants.DEVICES_MESSAGING_PORT_NAME) {
+    setUpSendingDeviceList(port);
+    return;
+  }
+}
+
+/**
+ * Start sending the current list of devices over the given port (it's created
+ * by the window).
+ * @param {!Port} port
+ */
+function setUpSendingDeviceList(port) {
+  const channel = new GSC.PortMessageChannel(port);
+
+  function onReadersUpdated(readers) {
+    channel.send('', readers);
+  }
+
+  readerTracker.addOnUpdateListener(onReadersUpdated);
+  channel.addOnDisposeCallback(() => {
+    readerTracker.removeOnUpdateListener(onReadersUpdated);
+  });
+}
+
+/**
  * Returns a single message based channel instance that talks to the specified
  * extension - either returns an existing instance if there's one, or creates a
  * new one otherwise. May return null if the channel becomes immediately
@@ -329,10 +362,6 @@ function exposeGlobalsForMainWindow() {
       messageChannelPool.addOnUpdateListener.bind(messageChannelPool);
   goog.global['googleSmartCard_clientAppListUpdateUnsubscriber'] =
       messageChannelPool.removeOnUpdateListener.bind(messageChannelPool);
-  goog.global['googleSmartCard_readerTrackerSubscriber'] =
-      readerTracker.addOnUpdateListener.bind(readerTracker);
-  goog.global['googleSmartCard_readerTrackerUnsubscriber'] =
-      readerTracker.removeOnUpdateListener.bind(readerTracker);
 }
 
 exposeGlobalsForMainWindow();

--- a/smart_card_connector_app/src/window-constants.js
+++ b/smart_card_connector_app/src/window-constants.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Constants shared between the Connector App's window and
+ * background page.
+ */
+
+goog.provide('GoogleSmartCard.ConnectorApp.Window.Constants');
+
+goog.scope(function() {
+
+const GSC = GoogleSmartCard;
+
+/**
+ * We open a message port with this name to the background page, to learn about
+ * the available devices.
+ */
+GSC.ConnectorApp.Window.Constants.DEVICES_MESSAGING_PORT_NAME =
+    'available-devices';
+});  // goog.scope

--- a/smart_card_connector_app/src/window-constants.js
+++ b/smart_card_connector_app/src/window-constants.js
@@ -30,6 +30,6 @@ const GSC = GoogleSmartCard;
  * We open a message port with this name to the background page, to learn about
  * the available devices.
  */
-GSC.ConnectorApp.Window.Constants.DEVICES_MESSAGING_PORT_NAME =
+GSC.ConnectorApp.Window.Constants.DEVICE_LIST_MESSAGING_PORT_NAME =
     'available-devices';
 });  // goog.scope

--- a/smart_card_connector_app/src/window-devices-displaying.js
+++ b/smart_card_connector_app/src/window-devices-displaying.js
@@ -282,8 +282,9 @@ function onWebusbDeviceSelectionFailed(exc) {
 }
 
 GSC.ConnectorApp.Window.DevicesDisplaying.initialize = function() {
-  const port = new GSC.PortMessageChannel(chrome.runtime.connect(
-      {'name': GSC.ConnectorApp.Window.Constants.DEVICES_MESSAGING_PORT_NAME}));
+  const port = new GSC.PortMessageChannel(chrome.runtime.connect({
+    'name': GSC.ConnectorApp.Window.Constants.DEVICE_LIST_MESSAGING_PORT_NAME
+  }));
   port.registerService('', (data) => {
     const readers = /** @type !Array.<!GSC.PcscLiteServer.ReaderInfo> */ (data);
     onReadersChanged(readers);

--- a/smart_card_connector_app/src/window-devices-displaying.js
+++ b/smart_card_connector_app/src/window-devices-displaying.js
@@ -22,6 +22,7 @@
 
 goog.provide('GoogleSmartCard.ConnectorApp.Window.DevicesDisplaying');
 
+goog.require('GoogleSmartCard.ConnectorApp.Window.Constants');
 goog.require('GoogleSmartCard.DebugDump');
 goog.require('GoogleSmartCard.I18n');
 goog.require('GoogleSmartCard.Logging');
@@ -280,47 +281,13 @@ function onWebusbDeviceSelectionFailed(exc) {
   goog.log.info(logger, `WebUSB selection dialog failed: ${exc}`);
 }
 
-/**
- * @param {!Window=} backgroundPage
- */
-function initializeWithBackgroundPage(backgroundPage) {
-  GSC.Logging.checkWithLogger(logger, backgroundPage);
-  goog.asserts.assert(backgroundPage);
-
-  /**
-   * Points to the "addOnUpdateListener" method of the ReaderTracker instance
-   * that is owned by the background page.
-   */
-  const readerTrackerSubscriber =
-      /** @type {function(function(!Array.<!GSC.PcscLiteServer.ReaderInfo>))} */
-      (GSC.ObjectHelpers.extractKey(
-          backgroundPage, 'googleSmartCard_readerTrackerSubscriber'));
-  // Start tracking the current list of readers.
-  readerTrackerSubscriber(onReadersChanged);
-
-  /**
-   * Points to the "removeOnUpdateListener" method of the ReaderTracker instance
-   * that is owned by the background page.
-   */
-  const readerTrackerUnsubscriber =
-      /** @type {function(function(!Array.<!GSC.PcscLiteServer.ReaderInfo>))} */
-      (GSC.ObjectHelpers.extractKey(
-          backgroundPage, 'googleSmartCard_readerTrackerUnsubscriber'));
-
-  // Stop tracking the current list of readers when our window gets closed.
-  if (GSC.Packaging.MODE === GSC.Packaging.Mode.APP) {
-    chrome.app.window.current().onClosed.addListener(function() {
-      readerTrackerUnsubscriber(onReadersChanged);
-    });
-  } else if (GSC.Packaging.MODE === GSC.Packaging.Mode.EXTENSION) {
-    window.addEventListener('unload', function() {
-      readerTrackerUnsubscriber(onReadersChanged);
-    });
-  }
-}
-
 GSC.ConnectorApp.Window.DevicesDisplaying.initialize = function() {
-  chrome.runtime.getBackgroundPage(initializeWithBackgroundPage);
+  const port = new GSC.PortMessageChannel(chrome.runtime.connect(
+      {'name': GSC.ConnectorApp.Window.Constants.DEVICES_MESSAGING_PORT_NAME}));
+  port.registerService('', (data) => {
+    const readers = /** @type !Array.<!GSC.PcscLiteServer.ReaderInfo> */ (data);
+    onReadersChanged(readers);
+  }, /*opt_objectPayload=*/ true);
 
   goog.events.listen(
       addDeviceElement, goog.events.EventType.CLICK, addDeviceClickListener);


### PR DESCRIPTION
This replaces the approach based on injecting functions from the background page into window: this isn't compatible with MV3.

The implementation is actually simpler as well.