### PR TITLE
[mv3] Send crash event to window via messages

### DIFF
--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -246,9 +246,14 @@ function onMessagePortConnected(port) {
   if (port.name ===
       GSC.ConnectorApp.Window.Constants.DEVICE_LIST_MESSAGING_PORT_NAME) {
     setUpSendingDeviceList(port);
-  } else if (port.name ===
+  } else if (
+      port.name ===
       GSC.ConnectorApp.Window.Constants.CLIENT_APP_LIST_MESSAGING_PORT_NAME) {
     setUpSendingAppList(port);
+  } else if (
+      port.name ===
+      GSC.ConnectorApp.Window.Constants.CRASH_EVENT_MESSAGING_PORT_NAME) {
+    setUpSendingCrashEvent(port);
   }
   // Ignore the port otherwise.
 }
@@ -286,6 +291,22 @@ function setUpSendingAppList(port) {
   messageChannelPool.addOnUpdateListener(onClientsUpdated);
   channel.addOnDisposeCallback(() => {
     readerTracker.removeOnUpdateListener(onClientsUpdated);
+  });
+}
+
+/**
+ * Start sending the crash notification over the given port (it's created by the
+ * window).
+ * @param {!Port} port
+ */
+function setUpSendingCrashEvent(port) {
+  const channel = new GSC.PortMessageChannel(port);
+
+  executableModule.addOnDisposeCallback(() => {
+    if (channel.isDisposed()) {
+      return;
+    }
+    channel.send('', {});
   });
 }
 
@@ -372,14 +393,4 @@ function createClientHandler(clientMessageChannel, clientOrigin) {
   else
     goog.log.fine(logger, logMessage);
 }
-
-/**
- * Sets global variables to be used by the main window (once it's opened).
- */
-function exposeGlobalsForMainWindow() {
-  goog.global['googleSmartCard_executableModuleDisposalSubscriber'] =
-      addOnExecutableModuleDisposedListener;
-}
-
-exposeGlobalsForMainWindow();
 });  // goog.scope

--- a/smart_card_connector_app/src/window-constants.js
+++ b/smart_card_connector_app/src/window-constants.js
@@ -39,4 +39,10 @@ GSC.ConnectorApp.Window.Constants.DEVICE_LIST_MESSAGING_PORT_NAME =
  */
 GSC.ConnectorApp.Window.Constants.CLIENT_APP_LIST_MESSAGING_PORT_NAME =
     'connected-clients';
+
+/**
+ * We open a message port with this name to the background page, to learn about
+ * the crashes in the application.
+ */
+GSC.ConnectorApp.Window.Constants.CRASH_EVENT_MESSAGING_PORT_NAME = 'crashed';
 });  // goog.scope


### PR DESCRIPTION
This replaces the approach based on injecting functions from the background page into window: this isn't compatible with MV3.