### PR TITLE
[ci] Complete "Switch to ubuntu-24.04"

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -80,7 +80,7 @@ jobs:
 
   # Run unit tests under ASan.
   test-asan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 100
     strategy:
       matrix:
@@ -118,7 +118,7 @@ jobs:
 
   # Run ESLint for JavaScript code.
   lint-js:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     steps:
@@ -152,7 +152,7 @@ jobs:
 
   # Collect code coverage statistics.
   collect-coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       LINE_COVERAGE_PERCENT: ${{ steps.build-coverage.outputs.LINE_COVERAGE_PERCENT }}
     timeout-minutes: 60
@@ -190,7 +190,7 @@ jobs:
 
   # An empty job whose steps display the short summary of the run.
   summary:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Depend on all other jobs, so that we aren't triggered if something fails.
     needs: [build-emscripten, test-asan, collect-coverage, lint-js]
 

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   # The version of libstdc++ to install for analysis builds.
-  ANALYSIS_LIBSTDCPP_VERSION: 12
+  ANALYSIS_LIBSTDCPP_VERSION: 13
 
 jobs:
   # Build and test in WebAssembly mode.


### PR DESCRIPTION
The previous commit #1244 only applied to Emscripten builds; now do the same for all other jobs as well.

We had to update libstdc++ from 12 to 13 as well.