### PR TITLE
[ci] Drop the double .zip in coverage report

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -185,7 +185,7 @@ jobs:
     - name: Upload coverage report
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-report-detailed.zip
+        name: coverage-report-detailed
         path: coverage-report-detailed/
 
   # An empty job whose steps display the short summary of the run.


### PR DESCRIPTION
Before this commit, the artifact was named "coverage-report-detailed.zip.zip".