### PR TITLE
Update minimum Chrome version

### DIFF
--- a/smart_card_connector_app/src/manifest.json.template
+++ b/smart_card_connector_app/src/manifest.json.template
@@ -68,9 +68,7 @@ ${if PACKAGING=extension}
 ${endif}
 
   # Specify the minimum ChromeOS milestone on which we should work fine.
-  # Chosen conservatively as we haven't done much testing on older ChromeOS
-  # versions when we were switching to WebAssembly in production.
-  "minimum_chrome_version": "126",
+  "minimum_chrome_version": "139",
 
   "default_locale": "en",
   "icons": {


### PR DESCRIPTION
This for a beta release on M139.
Soon, this should be updated back to M138.