### PR TITLE
Chrome API provider: Use ArrayBuffer type for ATR

### DIFF
--- a/smart_card_connector_app/src/chrome-api-provider.js
+++ b/smart_card_connector_app/src/chrome-api-provider.js
@@ -45,7 +45,7 @@ const STATE_FLAGS_MASK = 0x0000FFFF;
  *
  * This is needed due to a difference in how the Emscripten module is hosted
  * between the legacy Chrome App and the Manifest V3 extension.
- * Reference: `createExecutableModule` function in 
+ * Reference: `createExecutableModule` function in
  *   `smart_card_connector_app/src/background.js`
  *
  * In the Manifest V3 extension, the WebAssembly module runs in an Offscreen
@@ -242,7 +242,7 @@ function convertReaderStateOut(readerState) {
     reader: readerState['reader_name'],
     eventState: readerStateFlags,
     eventCount: eventCount,
-    atr: readerState['atr']
+    atr: convertToArrayBuffer(readerState['atr'])
   };
 }
 
@@ -447,7 +447,14 @@ function createRequestListener(callback, reportResultFunction, nameForLogs) {
         logger,
         `Reporting result for the event with id ${requestId}, ` +
             `${nameForLogs}(${argsDebug}): [${resultDebug}]`);
-    reportResultFunction(requestId, ...result);
+    try {
+      reportResultFunction(requestId, ...result);
+    } catch (error) {
+      goog.log.error(
+          logger,
+          `Failed to report result for the event with id ${requestId}, ` +
+              `${nameForLogs}(${argsDebug}). Error: ${JSON.stringify(error)}`);
+    }
   };
 }
 
@@ -1079,7 +1086,7 @@ GSC.ConnectorApp.ChromeApiProvider = class extends goog.Disposable {
             resultReaderName = readerName;
             resultState = convertConnectionStateToEnum(state);
             resultProtocol = convertProtocolToEnum(protocol);
-            resultAtr = atr;
+            resultAtr = convertToArrayBuffer(atr);
             resultCode = chrome.smartCardProviderPrivate.ResultCode.SUCCESS;
           },
           (errorCode) => {


### PR DESCRIPTION
Due to changes introduced by migration to extension, the returned binary data type changed from `ArrayBufer` to `Uint8Array`, which does not align with the type that Chrome expects.

This is essentially the same as
https://github.com/GoogleChromeLabs/chromeos_smart_card_connector/pull/1274

Also, added a `try`-`catch` so that such problems do not cause silent crashes.