### PR TITLE
Fix crash when reopening UI

### DIFF
--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -290,7 +290,7 @@ function setUpSendingAppList(port) {
 
   messageChannelPool.addOnUpdateListener(onClientsUpdated);
   channel.addOnDisposeCallback(() => {
-    readerTracker.removeOnUpdateListener(onClientsUpdated);
+    messageChannelPool.removeOnUpdateListener(onClientsUpdated);
   });
 }
 


### PR DESCRIPTION
Remove an update listener where it was registered, not somewhere else.
This was causing a crash when opening the UI another time, since it caused a message to be
sent over the old updater that was no longer valid.