### PR TITLE
Remove app builds from default builds

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         build-config: [Release, Debug]
-        packaging: [app, extension]
+        packaging: [extension]
       fail-fast: false
 
     steps:
@@ -54,7 +54,7 @@ jobs:
       run: >
         source env/activate && make test
 
-    - name: Upload built app packages
+    - name: Upload built extension packages
       uses: actions/upload-artifact@v4
       with:
         name: built_app_packages.${{ matrix.build-config }}.${{ matrix.packaging }}

--- a/common/make/common.mk
+++ b/common/make/common.mk
@@ -35,9 +35,9 @@ CONFIG ?= Release
 # Supported values: "emscripten" (Emscripten/WebAssembly; default),
 # "asan_testing", "coverage".
 TOOLCHAIN ?= emscripten
-# Build parameter that specifies the packaging type. Supported values: "app"
-# (default), "extension".
-PACKAGING ?= app
+# Build parameter that specifies the packaging type. Supported values: "app",
+# "extension (default)".
+PACKAGING ?= extension
 
 
 #

--- a/common/make/common.mk
+++ b/common/make/common.mk
@@ -36,7 +36,7 @@ CONFIG ?= Release
 # "asan_testing", "coverage".
 TOOLCHAIN ?= emscripten
 # Build parameter that specifies the packaging type. Supported values: "app",
-# "extension (default)".
+# "extension" (default).
 PACKAGING ?= extension
 
 

--- a/make-all.sh
+++ b/make-all.sh
@@ -69,5 +69,4 @@ TARGET=${1-all}
 SCRIPTPATH=$(dirname $(realpath ${0}))
 cd ${SCRIPTPATH}
 
-make_all_configs . ${TARGET} emscripten app
 make_all_configs . ${TARGET} emscripten extension


### PR DESCRIPTION
We won't need to release any new app builds.
Disable building and testing app builds by default. App builds are still supported for now, this PR just makes extension the (only) default.